### PR TITLE
feat(core): add TLS/CA certificate support for self-signed certificates

### DIFF
--- a/apps/cli/src/commands/auth.test.ts
+++ b/apps/cli/src/commands/auth.test.ts
@@ -16,6 +16,8 @@ type Profile = {
   name: string;
   baseUrl: string;
   auth: AuthConfig;
+  tlsCaFile?: string;
+  tlsSkipVerify?: boolean;
 };
 
 type Config = {
@@ -223,5 +225,42 @@ describe("auth command", () => {
     expect(deleteKeychainToken).toHaveBeenCalledWith("atlcli", "testuser");
     const result = lastOutput as { warning?: string };
     expect(result?.warning).toBeUndefined();
+  });
+
+  test("saves tlsCaFile to profile when --ca-file is provided", async () => {
+    await handleAuth(
+      ["login"],
+      { bearer: true, site: "https://jira.company.com", token: "mytoken", "ca-file": "/path/to/ca.pem" },
+      opts
+    );
+
+    const profiles = Object.values(config.profiles);
+    expect(profiles).toHaveLength(1);
+    expect(profiles[0]?.tlsCaFile).toBe("/path/to/ca.pem");
+  });
+
+  test("saves tlsSkipVerify to profile when --insecure is provided", async () => {
+    await handleAuth(
+      ["login"],
+      { bearer: true, site: "https://jira.company.com", token: "mytoken", insecure: true },
+      opts
+    );
+
+    const profiles = Object.values(config.profiles);
+    expect(profiles).toHaveLength(1);
+    expect(profiles[0]?.tlsSkipVerify).toBe(true);
+  });
+
+  test("does not set tlsCaFile or tlsSkipVerify when TLS flags are absent", async () => {
+    await handleAuth(
+      ["login"],
+      { bearer: true, site: "https://jira.company.com", token: "mytoken" },
+      opts
+    );
+
+    const profiles = Object.values(config.profiles);
+    expect(profiles).toHaveLength(1);
+    expect(profiles[0]?.tlsCaFile).toBeUndefined();
+    expect(profiles[0]?.tlsSkipVerify).toBeUndefined();
   });
 });

--- a/apps/cli/src/commands/auth.ts
+++ b/apps/cli/src/commands/auth.ts
@@ -103,6 +103,10 @@ async function handleLoginWithMode(
     slugify(new URL(baseUrl).hostname || "default") ||
     "default";
 
+  // TLS options (optional, for on-premises / self-signed certificates)
+  const tlsCaFile = getFlag(flags, "ca-file");
+  const tlsSkipVerify = hasFlag(flags, "insecure") || undefined;
+
   const config = await loadConfig();
 
   if (useBearer) {
@@ -153,6 +157,8 @@ async function handleLoginWithMode(
         username: username || undefined,
         pat: pat || undefined, // Only set if not using keychain
       },
+      tlsCaFile,
+      tlsSkipVerify,
     });
     setCurrentProfile(config, profileName);
     await saveConfig(config);
@@ -206,6 +212,8 @@ async function handleLoginWithMode(
         email,
         token,
       },
+      tlsCaFile,
+      tlsSkipVerify,
     });
     setCurrentProfile(config, profileName);
     await saveConfig(config);
@@ -256,6 +264,14 @@ async function handleStatus(flags: Record<string, string | boolean | string[]>, 
     result.email = profile.auth.email;
     result.hasTokenInConfig = !!profile.auth.token;
     result.hasEnvToken = !!process.env.ATLCLI_API_TOKEN;
+  }
+
+  // Show TLS settings if configured
+  if (profile.tlsCaFile) {
+    result.tlsCaFile = profile.tlsCaFile;
+  }
+  if (profile.tlsSkipVerify) {
+    result.tlsSkipVerify = profile.tlsSkipVerify;
   }
 
   output(result, opts);
@@ -441,6 +457,10 @@ Options:
   --email <email>    Email (for Cloud Basic auth)
   --profile <name>   Profile name for new login
   --delete-keychain  Delete keychain credentials when deleting a profile
+  --ca-file <path>   Path to a custom CA certificate file (PEM) for
+                     self-signed or private CA certificates
+  --insecure         Skip TLS certificate verification (not recommended
+                     for production use)
 
 Token Resolution Priority:
   1. ATLCLI_API_TOKEN environment variable (highest)
@@ -453,6 +473,12 @@ Examples:
 
   # Server/Data Center (Bearer auth with PAT)
   atlcli auth login --bearer --site https://jira.company.com
+
+  # Server with self-signed certificate (Linux/macOS)
+  atlcli auth login --bearer --site https://jira.company.com --ca-file /etc/ssl/certs/company-ca.pem
+
+  # Server with self-signed certificate (Windows)
+  atlcli auth login --bearer --site https://jira.company.com --ca-file C:\certs\company-ca.pem
 
   # Server with keychain storage
   atlcli auth login --bearer --site https://jira.company.com --username myuser

--- a/packages/confluence/src/client.ts
+++ b/packages/confluence/src/client.ts
@@ -1,4 +1,4 @@
-import { Profile, getLogger, generateRequestId, redactSensitive, buildAuthHeader } from "@atlcli/core";
+import { Profile, getLogger, generateRequestId, redactSensitive, buildAuthHeader, buildTlsOptions, TlsOptions } from "@atlcli/core";
 
 export type ConfluencePage = {
   id: string;
@@ -118,6 +118,7 @@ export class ConfluenceClient {
   private authHeader: string;
   private maxRetries = 3;
   private baseDelayMs = 1000;
+  private tlsOptions: TlsOptions | undefined;
 
   constructor(profile: Profile) {
     this.baseUrl = profile.baseUrl.replace(/\/+$/, "");
@@ -125,6 +126,7 @@ export class ConfluenceClient {
       throw new Error("OAuth is not implemented yet. Use API token or bearer auth.");
     }
     this.authHeader = buildAuthHeader(profile);
+    this.tlsOptions = buildTlsOptions(profile);
   }
 
   /** Get the Confluence instance base URL */
@@ -135,6 +137,12 @@ export class ConfluenceClient {
   /** Sleep utility for rate limiting */
   private sleep(ms: number): Promise<void> {
     return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  /** Merge TLS options into fetch RequestInit when a custom TLS config is present. */
+  private applyTls(init: RequestInit): RequestInit {
+    if (!this.tlsOptions) return init;
+    return { ...init, tls: this.tlsOptions } as RequestInit;
   }
 
   private async request(
@@ -175,7 +183,7 @@ export class ConfluenceClient {
     let lastError: Error | null = null;
 
     for (let attempt = 0; attempt <= this.maxRetries; attempt++) {
-      const res = await fetch(url.toString(), {
+      const res = await fetch(url.toString(), this.applyTls({
         method,
         headers: {
           Authorization: this.authHeader,
@@ -183,7 +191,7 @@ export class ConfluenceClient {
           "Content-Type": "application/json",
         },
         body: options.body ? JSON.stringify(options.body) : undefined,
-      });
+      }));
 
       // Handle rate limiting (429)
       if (res.status === 429) {
@@ -294,7 +302,7 @@ export class ConfluenceClient {
     let lastError: Error | null = null;
 
     for (let attempt = 0; attempt <= this.maxRetries; attempt++) {
-      const res = await fetch(url.toString(), {
+      const res = await fetch(url.toString(), this.applyTls({
         method,
         headers: {
           Authorization: this.authHeader,
@@ -302,7 +310,7 @@ export class ConfluenceClient {
           "Content-Type": "application/json",
         },
         body: options.body ? JSON.stringify(options.body) : undefined,
-      });
+      }));
 
       if (res.status === 429) {
         const retryAfter = res.headers.get("Retry-After");
@@ -1434,7 +1442,7 @@ export class ConfluenceClient {
     let lastError: Error | null = null;
 
     for (let attempt = 0; attempt <= this.maxRetries; attempt++) {
-      const res = await fetch(url.toString(), {
+      const res = await fetch(url.toString(), this.applyTls({
         method: "POST",
         headers: {
           Authorization: this.authHeader,
@@ -1443,7 +1451,7 @@ export class ConfluenceClient {
           // Note: Do NOT set Content-Type - fetch will set it with boundary
         },
         body: formData,
-      });
+      }));
 
       if (res.status === 429) {
         const retryAfter = res.headers.get("Retry-After");
@@ -1534,12 +1542,12 @@ export class ConfluenceClient {
     let lastError: Error | null = null;
 
     for (let attempt = 0; attempt <= this.maxRetries; attempt++) {
-      const res = await fetch(url.toString(), {
+      const res = await fetch(url.toString(), this.applyTls({
         method: "GET",
         headers: {
           Authorization: this.authHeader,
         },
-      });
+      }));
 
       if (res.status === 429) {
         const retryAfter = res.headers.get("Retry-After");
@@ -1720,7 +1728,7 @@ export class ConfluenceClient {
     let lastError: Error | null = null;
 
     for (let attempt = 0; attempt <= this.maxRetries; attempt++) {
-      const res = await fetch(url.toString(), {
+      const res = await fetch(url.toString(), this.applyTls({
         method: options.method ?? "GET",
         headers: {
           Authorization: this.authHeader,
@@ -1728,7 +1736,7 @@ export class ConfluenceClient {
           "Content-Type": "application/json",
         },
         body: options.body ? JSON.stringify(options.body) : undefined,
-      });
+      }));
 
       if (res.status === 429) {
         const retryAfter = res.headers.get("Retry-After");

--- a/packages/core/src/config.test.ts
+++ b/packages/core/src/config.test.ts
@@ -207,4 +207,41 @@ describe("config", () => {
       expect(profile).toBeUndefined();
     });
   });
+
+  describe("Profile TLS fields", () => {
+    test("profile accepts tlsCaFile field", () => {
+      const profile: Profile = {
+        name: "dc",
+        baseUrl: "https://jira.company.com",
+        auth: { type: "bearer", pat: "token" },
+        tlsCaFile: "/etc/ssl/certs/company-ca.pem",
+      };
+      expect(profile.tlsCaFile).toBe("/etc/ssl/certs/company-ca.pem");
+    });
+
+    test("profile accepts tlsSkipVerify field", () => {
+      const profile: Profile = {
+        name: "dc",
+        baseUrl: "https://jira.company.com",
+        auth: { type: "bearer", pat: "token" },
+        tlsSkipVerify: true,
+      };
+      expect(profile.tlsSkipVerify).toBe(true);
+    });
+
+    test("TLS fields are preserved through setProfile and getProfile", () => {
+      const config = createTestConfig();
+      const newProfile: Profile = {
+        name: "dc",
+        baseUrl: "https://jira.company.com",
+        auth: { type: "bearer", pat: "token" },
+        tlsCaFile: "/path/to/ca.pem",
+        tlsSkipVerify: false,
+      };
+      setProfile(config, newProfile);
+      const retrieved = getProfile(config, "dc");
+      expect(retrieved?.tlsCaFile).toBe("/path/to/ca.pem");
+      expect(retrieved?.tlsSkipVerify).toBe(false);
+    });
+  });
 });

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -28,6 +28,10 @@ export type Profile = {
   space?: string;
   /** Profile-specific Jira board ID */
   board?: number;
+  /** Path to a custom CA certificate file (PEM format) for self-signed/private CA certificates */
+  tlsCaFile?: string;
+  /** Skip TLS certificate verification. Not recommended for production use. */
+  tlsSkipVerify?: boolean;
 };
 
 import type { LogLevel } from "./logger.js";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,6 +5,7 @@ export * from "./keychain.js";
 export * from "./logger.js";
 export * from "./prompt.js";
 export * from "./redact.js";
+export * from "./tls.js";
 export * from "./update.js";
 export * from "./utils.js";
 export * from "./templates/index.js";

--- a/packages/core/src/tls.test.ts
+++ b/packages/core/src/tls.test.ts
@@ -1,0 +1,70 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { writeFileSync, rmSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+import { buildTlsOptions } from "./tls.js";
+import type { Profile } from "./config.js";
+
+function makeProfile(overrides: Partial<Profile> = {}): Profile {
+  return {
+    name: "test",
+    baseUrl: "https://jira.company.com",
+    auth: { type: "bearer", pat: "token" },
+    ...overrides,
+  };
+}
+
+describe("buildTlsOptions", () => {
+  test("returns undefined when no TLS settings are configured", () => {
+    const profile = makeProfile();
+    expect(buildTlsOptions(profile)).toBeUndefined();
+  });
+
+  test("sets rejectUnauthorized=false when tlsSkipVerify is true", () => {
+    const profile = makeProfile({ tlsSkipVerify: true });
+    const opts = buildTlsOptions(profile);
+    expect(opts).toBeDefined();
+    expect(opts?.rejectUnauthorized).toBe(false);
+  });
+
+  test("returns undefined when tlsSkipVerify is false (default)", () => {
+    const profile = makeProfile({ tlsSkipVerify: false });
+    expect(buildTlsOptions(profile)).toBeUndefined();
+  });
+
+  describe("tlsCaFile", () => {
+    let tmpDir: string;
+    let caFilePath: string;
+
+    beforeEach(() => {
+      tmpDir = join(tmpdir(), `atlcli-tls-test-${randomUUID()}`);
+      mkdirSync(tmpDir, { recursive: true });
+      caFilePath = join(tmpDir, "ca.pem");
+      writeFileSync(caFilePath, "-----BEGIN CERTIFICATE-----\nFAKECA\n-----END CERTIFICATE-----\n", "utf8");
+    });
+
+    afterEach(() => {
+      rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    test("reads CA file and sets ca field", () => {
+      const profile = makeProfile({ tlsCaFile: caFilePath });
+      const opts = buildTlsOptions(profile);
+      expect(opts).toBeDefined();
+      expect(opts?.ca).toContain("FAKECA");
+    });
+
+    test("combines tlsCaFile and tlsSkipVerify", () => {
+      const profile = makeProfile({ tlsCaFile: caFilePath, tlsSkipVerify: true });
+      const opts = buildTlsOptions(profile);
+      expect(opts?.ca).toContain("FAKECA");
+      expect(opts?.rejectUnauthorized).toBe(false);
+    });
+
+    test("throws when CA file does not exist", () => {
+      const profile = makeProfile({ tlsCaFile: "/nonexistent/path/ca.pem" });
+      expect(() => buildTlsOptions(profile)).toThrow(/Failed to read CA certificate file/);
+    });
+  });
+});

--- a/packages/core/src/tls.ts
+++ b/packages/core/src/tls.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from "node:fs";
+import type { Profile } from "./config.js";
+
+/**
+ * TLS options passed to Bun's non-standard `tls` field on `fetch()` options.
+ */
+export type TlsOptions = {
+  /** Custom CA certificate(s) in PEM format */
+  ca?: string;
+  /** When false, skips TLS certificate verification. Not recommended for production. */
+  rejectUnauthorized?: boolean;
+};
+
+/**
+ * Build TLS options from a profile's TLS configuration.
+ * Returns `undefined` when no custom TLS settings are needed.
+ *
+ * @throws {Error} When the CA certificate file cannot be read.
+ */
+export function buildTlsOptions(profile: Profile): TlsOptions | undefined {
+  const opts: TlsOptions = {};
+  let hasOpts = false;
+
+  if (profile.tlsSkipVerify) {
+    opts.rejectUnauthorized = false;
+    hasOpts = true;
+  }
+
+  if (profile.tlsCaFile) {
+    try {
+      opts.ca = readFileSync(profile.tlsCaFile, "utf8");
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new Error(`Failed to read CA certificate file '${profile.tlsCaFile}': ${msg}`);
+    }
+    hasOpts = true;
+  }
+
+  return hasOpts ? opts : undefined;
+}

--- a/packages/jira/src/client.ts
+++ b/packages/jira/src/client.ts
@@ -1,4 +1,4 @@
-import { Profile, getLogger, generateRequestId, redactSensitive, buildAuthHeader } from "@atlcli/core";
+import { Profile, getLogger, generateRequestId, redactSensitive, buildAuthHeader, buildTlsOptions, TlsOptions } from "@atlcli/core";
 import type {
   JiraProject,
   JiraIssue,
@@ -41,6 +41,7 @@ export class JiraClient {
   private maxRetries = 3;
   private baseDelayMs = 1000;
   private isCloud: boolean;
+  private tlsOptions: TlsOptions | undefined;
 
   constructor(profile: Profile) {
     this.baseUrl = profile.baseUrl.replace(/\/+$/, "");
@@ -50,6 +51,7 @@ export class JiraClient {
       throw new Error("OAuth is not implemented yet. Use API token or bearer auth.");
     }
     this.authHeader = buildAuthHeader(profile);
+    this.tlsOptions = buildTlsOptions(profile);
   }
 
   /** API version path - v3 for Cloud, v2 for Server */
@@ -65,6 +67,12 @@ export class JiraClient {
   /** Sleep utility for rate limiting */
   private sleep(ms: number): Promise<void> {
     return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  /** Merge TLS options into fetch RequestInit when a custom TLS config is present. */
+  private applyTls(init: RequestInit): RequestInit {
+    if (!this.tlsOptions) return init;
+    return { ...init, tls: this.tlsOptions } as RequestInit;
   }
 
   /**
@@ -111,7 +119,7 @@ export class JiraClient {
     let lastError: Error | null = null;
 
     for (let attempt = 0; attempt <= this.maxRetries; attempt++) {
-      const res = await fetch(url.toString(), {
+      const res = await fetch(url.toString(), this.applyTls({
         method,
         headers: {
           Authorization: this.authHeader,
@@ -119,7 +127,7 @@ export class JiraClient {
           "Content-Type": "application/json",
         },
         body: options.body ? JSON.stringify(options.body) : undefined,
-      });
+      }));
 
       // Handle rate limiting (429)
       if (res.status === 429) {
@@ -1545,12 +1553,12 @@ export class JiraClient {
     let lastError: Error | undefined;
     for (let attempt = 0; attempt < this.maxRetries; attempt++) {
       try {
-        const res = await fetch(contentUrl, {
+        const res = await fetch(contentUrl, this.applyTls({
           method: "GET",
           headers: {
             Authorization: this.authHeader,
           },
-        });
+        }));
 
         if (res.status === 429) {
           const retryAfter = res.headers.get("Retry-After");
@@ -1620,14 +1628,14 @@ export class JiraClient {
     let lastError: Error | undefined;
     for (let attempt = 0; attempt < this.maxRetries; attempt++) {
       try {
-        const res = await fetch(url, {
+        const res = await fetch(url, this.applyTls({
           method: "POST",
           headers: {
             Authorization: this.authHeader,
             "X-Atlassian-Token": "no-check", // Required for attachment uploads
           },
           body: formData,
-        });
+        }));
 
         if (res.status === 429) {
           const retryAfter = res.headers.get("Retry-After");


### PR DESCRIPTION
Hi Björn, 

I ran into "self signed certificate in certificate chain" error with a "data center" version of Jira, so this is Copilot's proposed solution.:

feat(core): add TLS/CA certificate support for self-signed certificates

Add `tlsCaFile` and `tlsSkipVerify` to Profile type, build TLS utility, apply to all fetch calls in JiraClient and ConfluenceClient, and expose --ca-file and --insecure flags on auth login/init commands.

/David