### PR TITLE
fix(confluence): handle undefined page title crash in slugifyTitle

### DIFF
--- a/packages/confluence/src/atlcli-dir.ts
+++ b/packages/confluence/src/atlcli-dir.ts
@@ -736,7 +736,8 @@ export async function deleteBaseContent(
 /**
  * Convert a page title to a clean filename (slug).
  */
-export function slugifyTitle(title: string): string {
+export function slugifyTitle(title: string | undefined | null): string {
+  if (!title) return "";
   return title
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "-") // Replace non-alphanumeric with dash

--- a/packages/confluence/src/hierarchy.test.ts
+++ b/packages/confluence/src/hierarchy.test.ts
@@ -118,6 +118,22 @@ describe("hierarchy utilities", () => {
 
       expect(result.relativePath).toBe("page.md");
     });
+
+    test("handles undefined title without crashing (API may omit title)", () => {
+      // Simulates a page returned from the Confluence API with a missing title,
+      // which causes: "undefined is not an object (evaluating 'title.toLowerCase')"
+      const page = {
+        id: "100",
+        title: undefined as unknown as string,
+        parentId: null,
+        ancestors: [],
+      } as PageHierarchyInfo;
+      const ancestorTitles = new Map<string, string>();
+
+      const result = computeFilePath(page, ancestorTitles);
+
+      expect(result.relativePath).toBe("page.md");
+    });
   });
 
   describe("parseFilePath", () => {


### PR DESCRIPTION
## Summary

Fixes a crash when pulling Confluence pages where the API returns a page with a missing (undefined) title:

```
undefined is not an object (evaluating 'title.toLowerCase')
```

This happened because `slugifyTitle` unconditionally called `.toLowerCase()` on its argument, but the Confluence API can return pages without a `title` field at runtime despite the TypeScript typing.

## Changes

**Commit 1 — failing test** (`packages/confluence/src/hierarchy.test.ts`):
- Adds a test that passes `undefined` as the page title to `computeFilePath`, reproducing the crash

**Commit 2 — fix** (`packages/confluence/src/atlcli-dir.ts`):
- Changes `slugifyTitle` signature from `title: string` to `title: string | undefined | null`
- Returns `""` early for falsy input so the existing `|| "page"` fallback in `computeFilePath` handles it gracefully
