### PR TITLE
docs: note that Confluence appends /wiki to the site URL in auth help text

### DIFF
--- a/apps/cli/src/commands/auth.ts
+++ b/apps/cli/src/commands/auth.ts
@@ -450,7 +450,8 @@ Commands:
   delete <name>     Delete profile entirely
 
 Options:
-  --site <url>       Atlassian site URL
+  --site <url>       Atlassian site URL (root only, e.g. https://company.atlassian.net;
+                     do not include /wiki — Confluence appends it automatically)
   --bearer           Use Bearer auth with PAT (for Server/Data Center)
   --token <token>    API token or PAT
   --username <user>  Username (for keychain lookup with --bearer)


### PR DESCRIPTION
## Summary

The Confluence client automatically appends `/wiki` to the `baseUrl` stored in the authentication profile when building API request URLs (e.g. `${baseUrl}/wiki/rest/api/...`). This behavior was undocumented, which could confuse users who include `/wiki` in their `--site` value and end up with doubled paths.

## Changes

- Updated the `--site` option description in the `atlcli auth` built-in help text to clarify that the URL should be the root instance URL (e.g. `https://company.atlassian.net`) and that `/wiki` must **not** be included — Confluence appends it automatically.