### PR TITLE
docs: update README to note Jira and Confluence Data Center (on-prem) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 # atlcli
 
-A blazingly fast CLI for Atlassian products. Sync Confluence pages as markdown, manage Jira issues from your terminal.
+A blazingly fast CLI for Atlassian products. Sync Confluence pages as markdown, manage Jira issues from your terminal. Works with both Atlassian Cloud and Data Center (on-premises) deployments.
 
 ## Key Features
 
@@ -66,8 +66,8 @@ bun install && bun run build
 ## Requirements
 
 - macOS, Linux, or Windows (x64)
-- Atlassian Cloud instance (Server/Data Center not supported)
-- API token from [id.atlassian.com](https://id.atlassian.com/manage-profile/security/api-tokens)
+- Atlassian Cloud **or** Data Center (on-premises) instance
+- API token from [id.atlassian.com](https://id.atlassian.com/manage-profile/security/api-tokens) (Cloud) or a Personal Access Token from your Data Center instance
 
 See [Getting Started](https://atlcli.sh/getting-started/) for detailed setup instructions.
 


### PR DESCRIPTION
## Summary

The README previously stated that only Atlassian Cloud was supported and that Server/Data Center was not. This PR corrects that by updating two places:

1. **Intro line** — now mentions both Cloud and Data Center (on-premises) deployments.
2. **Requirements section** — replaces "Atlassian Cloud instance (Server/Data Center not supported)" with "Atlassian Cloud **or** Data Center (on-premises) instance", and clarifies the two types of API tokens (Cloud API token vs. Data Center Personal Access Token).

## Changes

- `README.md`: intro sentence updated to mention Data Center support
- `README.md`: Requirements bullet updated to cover both Cloud and Data Center, with correct token guidance for each