### PR TITLE
fix: serve install.sh via docs site and add checksum verification

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,8 @@ on:
     paths:
       - 'src/content/**'
       - 'src/styles/**'
+      - 'src/components/**'
+      - 'public/**'
       - 'astro.config.mjs'
       - 'package.json'
       - '.github/workflows/docs.yml'

--- a/public/install.sh
+++ b/public/install.sh
@@ -34,17 +34,63 @@ get_latest_version() {
     | sed -E 's/.*"([^"]+)".*/\1/'
 }
 
+verify_checksum() {
+  local file="$1"
+  local checksums_url="$2"
+
+  local checksums
+  checksums=$(curl -fsSL "$checksums_url" 2>/dev/null) || {
+    warn "Could not download checksums — skipping verification"
+    return 0
+  }
+
+  local expected
+  expected=$(echo "$checksums" | grep "$(basename "$file")" | awk '{print $1}')
+  if [ -z "$expected" ]; then
+    warn "No checksum found for $(basename "$file") — skipping verification"
+    return 0
+  fi
+
+  local actual
+  if command -v sha256sum >/dev/null 2>&1; then
+    actual=$(sha256sum "$file" | awk '{print $1}')
+  elif command -v shasum >/dev/null 2>&1; then
+    actual=$(shasum -a 256 "$file" | awk '{print $1}')
+  else
+    warn "Neither sha256sum nor shasum available — skipping verification"
+    return 0
+  fi
+
+  if [ "$actual" != "$expected" ]; then
+    rm -f "$file"
+    error "Checksum mismatch (expected $expected, got $actual)"
+  fi
+
+  info "Checksum verified ✓"
+}
+
 install_atlcli() {
   local version="${1:-$(get_latest_version)}"
   local target=$(detect_platform)
-  local url="https://github.com/$REPO/releases/download/$version/atlcli-$target.tar.gz"
+  local asset="atlcli-$target.tar.gz"
+  local base_url="https://github.com/$REPO/releases/download/$version"
 
   info "Installing atlcli $version ($target)..."
 
   mkdir -p "$BIN_DIR"
 
-  if ! curl -fsSL "$url" | tar -xz -C "$BIN_DIR"; then
-    error "Failed to download from $url"
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  trap 'rm -rf "$tmpdir"' EXIT
+
+  if ! curl -fsSL -o "$tmpdir/$asset" "$base_url/$asset"; then
+    error "Failed to download from $base_url/$asset"
+  fi
+
+  verify_checksum "$tmpdir/$asset" "$base_url/checksums.txt"
+
+  if ! tar -xzf "$tmpdir/$asset" -C "$BIN_DIR"; then
+    error "Failed to extract archive"
   fi
 
   chmod +x "$BIN_DIR/atlcli"

--- a/public/install.sh
+++ b/public/install.sh
@@ -45,7 +45,7 @@ verify_checksum() {
   }
 
   local expected
-  expected=$(echo "$checksums" | grep "$(basename "$file")" | awk '{print $1}')
+  expected=$(echo "$checksums" | grep -F "$(basename "$file")" | awk '{print $1}')
   if [ -z "$expected" ]; then
     warn "No checksum found for $(basename "$file") — skipping verification"
     return 0
@@ -81,7 +81,7 @@ install_atlcli() {
 
   local tmpdir
   tmpdir=$(mktemp -d)
-  trap 'rm -rf "$tmpdir"' EXIT
+  trap "rm -rf '$tmpdir'" EXIT
 
   if ! curl -fsSL -o "$tmpdir/$asset" "$base_url/$asset"; then
     error "Failed to download from $base_url/$asset"


### PR DESCRIPTION
## Summary

- Moves `install.sh` from repo root to `public/` so Astro includes it in the docs build output, **fixing the 404** at `https://atlcli.sh/install.sh`
- Adds **SHA-256 checksum verification** against the `checksums.txt` published with each release
- Adds `public/**` and `src/components/**` to the docs workflow path trigger so static asset changes trigger a redeploy

## Details

The install script was lost during the MkDocs → Astro Starlight migration. Astro serves files from `public/` verbatim at the site root, so `public/install.sh` → `https://atlcli.sh/install.sh`.

The checksum verification downloads the archive to a temp directory, verifies the SHA-256 hash, then extracts — failing hard on mismatch. It gracefully degrades when checksums or `sha256sum`/`shasum` are unavailable (warns and continues).

Fixes #4

## Test plan

- [ ] `bun run docs:build` produces `dist/install.sh`
- [ ] After deploy, `curl -fsSL https://atlcli.sh/install.sh` returns the script (no 404)
- [ ] `curl -fsSL https://atlcli.sh/install.sh | bash` installs successfully with checksum verification
- [ ] Script degrades gracefully when checksums.txt is unavailable (e.g. pre-release versions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)