### PR TITLE
fix(confluence): honor context path for Server/Data Center instances

### DIFF
--- a/apps/cli/src/commands/auth.ts
+++ b/apps/cli/src/commands/auth.ts
@@ -450,8 +450,11 @@ Commands:
   delete <name>     Delete profile entirely
 
 Options:
-  --site <url>       Atlassian site URL (root only, e.g. https://company.atlassian.net;
-                     do not include /wiki — Confluence appends it automatically)
+  --site <url>       Atlassian site URL.
+                     Cloud: root only, e.g. https://company.atlassian.net
+                     (do not include /wiki — Confluence appends it automatically).
+                     Server/Data Center: include the context path if your
+                     instance uses one, e.g. https://confluence.company.com/confluence
   --bearer           Use Bearer auth with PAT (for Server/Data Center)
   --token <token>    API token or PAT
   --username <user>  Username (for keychain lookup with --bearer)

--- a/packages/confluence/src/client.test.ts
+++ b/packages/confluence/src/client.test.ts
@@ -317,6 +317,101 @@ describe("ConfluenceClient", () => {
     });
   });
 
+  describe("context path handling (Cloud vs Data Center)", () => {
+    // Regression coverage for the hardcoded `/wiki` path. Atlassian Cloud
+    // serves Confluence under `/wiki`, while Server/Data Center instances are
+    // served from their own context path (e.g. `/confluence`) that is already
+    // part of the configured site URL. The client must not blindly append
+    // `/wiki` for the latter, otherwise REST requests hit a non-existent path
+    // (manifesting as 404/405 page create/update failures).
+
+    // Mock fetch to return `body`, run `call` against a client for `baseUrl`,
+    // and return the URL the client actually requested.
+    async function captureRequestUrl(
+      baseUrl: string,
+      body: unknown,
+      call: (client: ConfluenceClient) => Promise<unknown>
+    ): Promise<string> {
+      let capturedUrl = "";
+      globalThis.fetch = mock((url: string) => {
+        capturedUrl = url;
+        return Promise.resolve(new Response(JSON.stringify(body), { status: 200 }));
+      }) as unknown as typeof fetch;
+
+      await call(new ConfluenceClient({ ...mockProfile, baseUrl }));
+      return capturedUrl;
+    }
+
+    const pageBody = { id: "123", title: "Test", version: { number: 1 }, space: { key: "TEST" } };
+
+    // REST v1 path building: Cloud appends /wiki; a DC context path is honored
+    // verbatim; trailing slashes are normalized.
+    for (const { name, baseUrl } of [
+      { name: "Cloud bare host appends /wiki", baseUrl: "https://test.atlassian.net" },
+      { name: "DC context path is honored", baseUrl: "https://confluence.example.com/confluence" },
+      { name: "DC trailing slash is normalized", baseUrl: "https://confluence.example.com/confluence/" },
+    ]) {
+      test(`getPage URL — ${name}`, async () => {
+        const isCloud = baseUrl.includes("atlassian.net");
+        const expectedBase = isCloud
+          ? "https://test.atlassian.net/wiki"
+          : "https://confluence.example.com/confluence";
+        const url = await captureRequestUrl(baseUrl, pageBody, (c) => c.getPage("123"));
+        expect(url).toContain(`${expectedBase}/rest/api/content/123`);
+        if (!isCloud) expect(url).not.toContain("/wiki/");
+      });
+    }
+
+    // A mutation (the originally-reported HTTP 405 failure) must also route
+    // through the context path rather than /wiki on Data Center.
+    test("updatePage targets the DC context path, not /wiki", async () => {
+      const url = await captureRequestUrl(
+        "https://confluence.example.com/confluence",
+        pageBody,
+        (c) => c.updatePage({ id: "123", title: "Updated", storage: "<p>new</p>", version: 2 })
+      );
+      expect(url).toContain("/confluence/rest/api/content/123");
+      expect(url).not.toContain("/wiki/");
+    });
+
+    test("v2 API requests honor the DC context path", async () => {
+      const url = await captureRequestUrl(
+        "https://confluence.example.com/confluence",
+        { results: [] },
+        (c) => c.getPageDirectChildren("123")
+      );
+      expect(url).toContain("/confluence/api/v2/pages/123/direct-children");
+      expect(url).not.toContain("/wiki/");
+    });
+
+    // Web UI links reconstructed from a relative `_links.webui` (v2 endpoints
+    // that omit `_links.base`) must use the same context path as REST requests.
+    test("web UI links use the DC context path", async () => {
+      globalThis.fetch = mock(() =>
+        Promise.resolve(
+          new Response(
+            JSON.stringify({
+              results: [
+                { id: "999", title: "Child", type: "page", _links: { webui: "/spaces/TEST/pages/999/Child" } },
+              ],
+            }),
+            { status: 200 }
+          )
+        )
+      ) as unknown as typeof fetch;
+
+      const client = new ConfluenceClient({
+        ...mockProfile,
+        baseUrl: "https://confluence.example.com/confluence",
+      });
+      const children = await client.getPageDirectChildren("123");
+
+      expect(children[0]?.url).toBe(
+        "https://confluence.example.com/confluence/spaces/TEST/pages/999/Child"
+      );
+    });
+  });
+
   describe("label operations", () => {
     test("getLabels fetches labels for a page", async () => {
       let capturedUrl = "";

--- a/packages/confluence/src/client.ts
+++ b/packages/confluence/src/client.ts
@@ -115,6 +115,13 @@ export interface AttachmentInfo {
 
 export class ConfluenceClient {
   private baseUrl: string;
+  /**
+   * Path segment inserted between the site URL and the Confluence REST/web
+   * roots. `/wiki` for Atlassian Cloud (`https://x.atlassian.net` + `/wiki/...`),
+   * or "" for Server/Data Center, whose context path (e.g. `/confluence`) is
+   * already part of the site URL. Derived once from the immutable base URL.
+   */
+  private apiBasePath: string;
   private authHeader: string;
   private maxRetries = 3;
   private baseDelayMs = 1000;
@@ -122,6 +129,9 @@ export class ConfluenceClient {
 
   constructor(profile: Profile) {
     this.baseUrl = profile.baseUrl.replace(/\/+$/, "");
+    // If the site URL already carries a path, the API hangs directly off it;
+    // otherwise default to Cloud's `/wiki` (the long-standing behavior).
+    this.apiBasePath = new URL(this.baseUrl).pathname.replace(/\/+$/, "") ? "" : "/wiki";
     if (profile.auth.type === "oauth") {
       throw new Error("OAuth is not implemented yet. Use API token or bearer auth.");
     }
@@ -132,6 +142,15 @@ export class ConfluenceClient {
   /** Get the Confluence instance base URL */
   getInstanceUrl(): string {
     return this.baseUrl;
+  }
+
+  /**
+   * Build an absolute web (browser) URL from a Confluence `_links.webui` path,
+   * honoring the instance context path. Returns undefined when no path is given.
+   */
+  private buildWebUrl(webuiPath: string | undefined): string | undefined {
+    if (!webuiPath) return undefined;
+    return `${this.baseUrl}${this.apiBasePath}${webuiPath}`;
   }
 
   /** Sleep utility for rate limiting */
@@ -153,7 +172,7 @@ export class ConfluenceClient {
       body?: unknown;
     } = {}
   ): Promise<unknown> {
-    const url = new URL(`${this.baseUrl}/wiki/rest/api${path}`);
+    const url = new URL(`${this.baseUrl}${this.apiBasePath}/rest/api${path}`);
     if (options.query) {
       for (const [key, value] of Object.entries(options.query)) {
         if (value === undefined) continue;
@@ -272,7 +291,7 @@ export class ConfluenceClient {
       body?: unknown;
     } = {}
   ): Promise<unknown> {
-    const url = new URL(`${this.baseUrl}/wiki/api/v2${path}`);
+    const url = new URL(`${this.baseUrl}${this.apiBasePath}/api/v2${path}`);
     if (options.query) {
       for (const [key, value] of Object.entries(options.query)) {
         if (value === undefined) continue;
@@ -922,7 +941,7 @@ export class ConfluenceClient {
           type: item.type === "folder" ? "folder" : item.type === "page" ? "page" : item.type,
           spaceId: item.spaceId,
           parentId: pageId,
-          url: item._links?.webui ? `${this.baseUrl}/wiki${item._links.webui}` : undefined,
+          url: this.buildWebUrl(item._links?.webui),
         });
       }
 
@@ -1419,7 +1438,7 @@ export class ConfluenceClient {
     path: string,
     formData: FormData
   ): Promise<any> {
-    const url = new URL(`${this.baseUrl}/wiki/rest/api${path}`);
+    const url = new URL(`${this.baseUrl}${this.apiBasePath}/rest/api${path}`);
 
     const logger = getLogger();
     const requestId = generateRequestId();
@@ -1522,7 +1541,7 @@ export class ConfluenceClient {
    * Request helper for binary downloads.
    */
   private async requestBinary(downloadPath: string): Promise<Buffer> {
-    const url = new URL(`${this.baseUrl}/wiki${downloadPath}`);
+    const url = new URL(`${this.baseUrl}${this.apiBasePath}${downloadPath}`);
 
     const logger = getLogger();
     const requestId = generateRequestId();
@@ -1723,7 +1742,7 @@ export class ConfluenceClient {
       body?: unknown;
     } = {}
   ): Promise<unknown> {
-    const url = new URL(`${this.baseUrl}/wiki/rest/webhooks/1.0${path}`);
+    const url = new URL(`${this.baseUrl}${this.apiBasePath}/rest/webhooks/1.0${path}`);
 
     let lastError: Error | null = null;
 
@@ -2309,7 +2328,7 @@ export class ConfluenceClient {
       title: data.title,
       spaceId: data.spaceId,
       parentId: data.parentId ?? null,
-      url: data._links?.webui ? `${this.baseUrl}/wiki${data._links.webui}` : undefined,
+      url: this.buildWebUrl(data._links?.webui),
       createdAt: data.createdAt,
     };
   }
@@ -2387,7 +2406,7 @@ export class ConfluenceClient {
           type: item.type === "folder" ? "folder" : "page",
           spaceId: item.spaceId,
           parentId: folderId,
-          url: item._links?.webui ? `${this.baseUrl}/wiki${item._links.webui}` : undefined,
+          url: this.buildWebUrl(item._links?.webui),
         });
       }
 
@@ -2471,7 +2490,7 @@ export class ConfluenceClient {
       title: data.title,
       spaceId: data.spaceId,
       parentId: data.parentId ?? null,
-      url: data._links?.webui ? `${this.baseUrl}/wiki${data._links.webui}` : undefined,
+      url: this.buildWebUrl(data._links?.webui),
       createdAt: data.createdAt,
     };
   }

--- a/src/content/docs/authentication.md
+++ b/src/content/docs/authentication.md
@@ -87,6 +87,23 @@ atlcli auth login --bearer --site https://jira.company.internal \
   --token YOUR_PAT --ca-file /etc/ssl/certs/company-ca.pem
 ```
 
+:::note[Context paths]
+Atlassian Cloud serves Confluence under `/wiki`, which atlcli appends
+automatically — so Cloud `--site` URLs are bare hosts
+(`https://company.atlassian.net`).
+
+Server/Data Center instances are often served from a custom context path such
+as `/confluence`. Include that path in `--site` and atlcli will route REST
+requests through it:
+
+```bash
+atlcli auth login --bearer --site https://confluence.company.com/confluence \
+  --token YOUR_PAT
+```
+
+Do **not** add `/wiki` to a Data Center URL — that is Cloud-only.
+:::
+
 Options:
 
 | Flag | Description |
@@ -474,6 +491,30 @@ To re-authenticate:
 
 ```bash
 atlcli auth login --bearer --site https://jira.company.com --token YOUR_NEW_PAT
+```
+
+### Confluence page operations fail on Server/Data Center (404 / 405)
+
+```
+Error: HTTP 405
+NOT NULL constraint failed: pages.title
+```
+
+If reads work but `wiki page create`, `wiki page update`, or `wiki docs`
+commands fail on a Server/Data Center instance, your site is likely served
+from a context path that is missing from the profile URL.
+
+atlcli appends `/wiki` (Cloud's context path) only when the `--site` URL has no
+path of its own. A Data Center instance hosted at
+`https://confluence.company.com/confluence` must include `/confluence` in the
+site URL, otherwise requests are sent to a non-existent
+`/confluence/wiki/rest/api/...` path.
+
+Re-create the profile with the full context path:
+
+```bash
+atlcli auth login --bearer --site https://confluence.company.com/confluence \
+  --token YOUR_PAT
 ```
 
 ### Keychain Issues (macOS)


### PR DESCRIPTION
## Summary

The Confluence client hardcoded `/wiki` into every URL it builds (REST v1, REST v2, binary downloads, webhooks, and web-UI links). That path is correct for Atlassian **Cloud** (`https://your-domain.atlassian.net/wiki/rest/api/...`), but it breaks **Server/Data Center** instances that are served from a custom context path such as `https://confluence.example.com/confluence`. On those instances atlcli sent requests to `/confluence/wiki/rest/api/...` instead of the correct `/confluence/rest/api/...`.

Symptoms on an affected Data Center instance: page reads sometimes succeeded, but mutations failed with confusing errors — `HTTP 405` on `wiki page update`, silent/no-op page and child creation, and a downstream `NOT NULL constraint failed: pages.title` during `wiki docs pull`.

## Fix

- Derive an `apiBasePath` field once in the `ConfluenceClient` constructor: `/wiki` **only** when the configured site URL is a bare host (preserving today's Cloud behavior), and `""` when the site URL already carries a path (e.g. `/confluence`), so the API hangs directly off the context path.
- Route every URL builder (`request`, `requestV2`, `requestMultipart`, `requestBinary`, webhook helper) through it.
- Add a `buildWebUrl()` helper so `_links.webui` browser links also respect the context path.

This is intentionally conservative and fully backward compatible:
- Cloud (`https://x.atlassian.net`) → unchanged, still uses `/wiki`.
- Data Center with a context path (`.../confluence`) → now correct.

Root-served Data Center on a bare host still defaults to `/wiki` (unchanged), since a bare host cannot be reliably distinguished from a Cloud custom domain — that case is out of scope for this fix.

## Tests

Adds a `context path handling (Cloud vs Data Center)` block in `client.test.ts` covering:
- Cloud bare host → `/wiki/rest/api/...` (unchanged)
- Data Center context path → `/confluence/rest/api/...`, no `/wiki`
- trailing-slash normalization
- `updatePage` targeting the context path (the reported 405 path)
- v2 endpoints honoring the context path
- web-UI link construction

The Data Center assertions fail against the pre-fix code and pass after it.

## Docs

- `auth` help text now explains the Cloud (omit `/wiki`) vs Server/Data Center (include the context path) distinction.
- `authentication.md` gets a "Context paths" note and a troubleshooting entry for the 404/405 page-operation failure mode.

## Validation

- `bun test packages/confluence/src/client.test.ts` → 34 pass
- `bun run typecheck` → clean
- `bun run build` → clean
- Full `bun test` → only pre-existing, environment-related failures (git/keychain/temp-dir), unrelated to this change.
- **Live smoke test** against a real Data Center instance under `/confluence` (bearer/PAT auth): page read, child-page create, page update, and delete all succeed, each hitting `…/confluence/rest/api/…` (confirmed via the request log). The same operations returned 404/405 before the fix.

## Scope / follow-up

This PR fixes the REST API client — the data plane that caused the 404/405 failures. A handful of spots in `apps/cli` still build *browser/display* URLs directly from `profile.baseUrl` with a hardcoded `/wiki` (e.g. `wiki page open`, and some Jira remote-link / icon URLs). Most are masked now that the client returns correct `url`s, but `wiki page open` still opens a `/wiki` URL on Data Center. Fixing those cleanly means lifting the context-path derivation into a shared `@atlcli/core` helper and reusing it across commands — left as a focused follow-up to keep this change reviewable.
