### PR TITLE
fix(confluence): preserve Markdown table rows on pull

### DIFF
--- a/packages/confluence/src/markdown.test.ts
+++ b/packages/confluence/src/markdown.test.ts
@@ -140,6 +140,41 @@ describe("storageToMarkdown", () => {
     expect(md).toContain("World");
   });
 
+  test("converts paragraph-wrapped Confluence table cells to valid markdown", () => {
+    const storage = `<table><tbody><tr><th><p>TaskID</p></th><th><p>Task Type</p></th><th><p>Description</p></th><th><p>JIRA link</p></th></tr><tr><td><p>I0BB-2565</p></td><td><p>Story</p></td><td><p>some text</p></td><td><p>some text</p></td></tr></tbody></table>`;
+
+    const md = storageToMarkdown(storage);
+
+    expect(md).toBe(
+      "| TaskID | Task Type | Description | JIRA link |\n" +
+      "| --- | --- | --- | --- |\n" +
+      "| I0BB-2565 | Story | some text | some text |\n"
+    );
+  });
+
+  test("keeps table rows valid when cells contain formatting, pipes, or line breaks", () => {
+    const storage = `<table><tbody><tr><th><p>Type</p></th><th><p>Description</p></th></tr><tr><td><p><strong>Story</strong></p></td><td><p>First line<br />Second | line</p></td></tr></tbody></table>`;
+
+    const md = storageToMarkdown(storage);
+
+    expect(md).toBe(
+      "| Type | Description |\n" +
+      "| --- | --- |\n" +
+      "| **Story** | First line<br>Second \\| line |\n"
+    );
+  });
+
+  test("round-trips markdown tables without adding cell whitespace", () => {
+    const original =
+      "| TaskID | Task Type | Description | JIRA link |\n" +
+      "| --- | --- | --- | --- |\n" +
+      "| I0BB-2565 | Story | some text | some text |";
+
+    const roundtrip = storageToMarkdown(markdownToStorage(original));
+
+    expect(roundtrip).toBe(original + "\n");
+  });
+
   test("converts code blocks back to fenced syntax", () => {
     const html = '<pre><code class="language-js">const x = 1;</code></pre>';
     const md = storageToMarkdown(html);

--- a/packages/confluence/src/markdown.ts
+++ b/packages/confluence/src/markdown.ts
@@ -2375,6 +2375,29 @@ export function storageToMarkdown(storage: string, options?: ConversionOptions):
   });
   service.use(gfm);
 
+  // Confluence wraps table-cell content in block elements such as <p>. Turndown
+  // renders those blocks with surrounding newlines, while the GFM table plugin
+  // inserts the result verbatim between pipes. Normalize only table cells so a
+  // logical row always remains a single Markdown line.
+  service.addRule("normalizedTableCell", {
+    filter: ["th", "td"],
+    replacement: (content, node) => {
+      const normalizedContent = content
+        .trim()
+        .replace(/[ \t]*\n+[ \t]*/g, "<br>")
+        .replace(/\\*\|/g, (match) => {
+          const backslashes = match.slice(0, -1);
+          return backslashes.length % 2 === 0 ? `${backslashes}\\|` : match;
+        });
+
+      const siblingCells = Array.from((node.parentNode as any)?.childNodes ?? [])
+        .filter((sibling: any) => sibling.nodeName === "TH" || sibling.nodeName === "TD");
+      const prefix = siblingCells[0] === node ? "| " : " ";
+
+      return `${prefix}${normalizedContent} |`;
+    },
+  });
+
   // Handle inline status macro
   service.addRule("statusMacro", {
     filter: (node) => {


### PR DESCRIPTION
## Summary

- normalize Confluence `<th>`/`<td>` content before the GFM table plugin writes Markdown rows
- remove paragraph-generated boundary whitespace while preserving intentional internal line breaks as `<br>`
- escape literal pipe characters inside table cells
- add exact regression and round-trip coverage

## Root cause

Confluence commonly wraps table-cell text in block elements such as `<p>`. Turndown converts those blocks to content surrounded by newlines, and `turndown-plugin-gfm` inserts that content verbatim between pipe delimiters. The resulting logical table row is split across multiple physical lines and no longer parses as valid Markdown.

The new rule is scoped to table cells so content outside tables is unaffected.

## Validation

- `bun test packages/confluence/src/markdown.test.ts`: 219 passed
- `git diff --check`: passed
- real Confluence E2E in the `DOCSY` space:
  - one paragraph-wrapped table pulled as valid compact GFM
  - two paragraph-wrapped tables with four rows each pulled correctly on one page
  - both temporary pages and local fixtures cleaned up
- the unrelated post-write sync DB failure discovered during E2E is tracked separately in #16

Fixes #15
