### PR TITLE
fix(confluence): complete deployment-aware URL handling

### DIFF
--- a/apps/cli/src/commands/auth.test.ts
+++ b/apps/cli/src/commands/auth.test.ts
@@ -15,6 +15,7 @@ type AuthConfig = {
 type Profile = {
   name: string;
   baseUrl: string;
+  deploymentType?: "cloud" | "data-center";
   auth: AuthConfig;
   tlsCaFile?: string;
   tlsSkipVerify?: boolean;
@@ -262,5 +263,54 @@ describe("auth command", () => {
     expect(profiles).toHaveLength(1);
     expect(profiles[0]?.tlsCaFile).toBeUndefined();
     expect(profiles[0]?.tlsSkipVerify).toBeUndefined();
+  });
+
+  test("defaults bearer profiles to Data Center deployment", async () => {
+    await handleAuth(
+      ["login"],
+      { bearer: true, site: "https://confluence.company.com", token: "mytoken" },
+      opts
+    );
+
+    expect(Object.values(config.profiles)[0]?.deploymentType).toBe("data-center");
+  });
+
+  test("defaults API-token profiles to Cloud deployment", async () => {
+    await handleAuth(
+      ["login"],
+      {
+        site: "https://company.atlassian.net",
+        email: "user@example.com",
+        token: "mytoken",
+      },
+      opts
+    );
+
+    expect(Object.values(config.profiles)[0]?.deploymentType).toBe("cloud");
+  });
+
+  test("allows an explicit deployment override", async () => {
+    await handleAuth(
+      ["login"],
+      {
+        bearer: true,
+        site: "https://confluence.company.com/wiki",
+        token: "mytoken",
+        deployment: "cloud",
+      },
+      opts
+    );
+
+    expect(Object.values(config.profiles)[0]?.deploymentType).toBe("cloud");
+  });
+
+  test("rejects an invalid deployment type", async () => {
+    await expect(
+      handleAuth(
+        ["login"],
+        { site: "https://company.atlassian.net", deployment: "server" },
+        opts
+      )
+    ).rejects.toThrow(/deployment/i);
   });
 });

--- a/apps/cli/src/commands/auth.ts
+++ b/apps/cli/src/commands/auth.ts
@@ -17,6 +17,7 @@ import {
   promptConfirm,
   promptInput,
   removeProfile,
+  resolveDeploymentType,
   renameProfile,
   saveConfig,
   setCurrentProfile,
@@ -84,6 +85,15 @@ async function handleLoginWithMode(
   }
 
   const useBearer = hasFlag(flags, "bearer");
+  const deploymentFlag = getFlag(flags, "deployment");
+  if (deploymentFlag && deploymentFlag !== "cloud" && deploymentFlag !== "data-center") {
+    fail(opts, 1, ERROR_CODES.USAGE, "--deployment must be 'cloud' or 'data-center'.");
+  }
+  const deploymentType = deploymentFlag === "cloud" || deploymentFlag === "data-center"
+    ? deploymentFlag
+    : useBearer
+      ? "data-center"
+      : "cloud";
 
   const baseUrl = normalizeBaseUrl(
     getFlag(flags, "site") ||
@@ -152,6 +162,7 @@ async function handleLoginWithMode(
     setProfile(config, {
       name: profileName,
       baseUrl,
+      deploymentType,
       auth: {
         type: "bearer",
         username: username || undefined,
@@ -170,6 +181,7 @@ async function handleLoginWithMode(
       username: username || undefined,
       baseUrl,
       authType: "bearer",
+      deploymentType,
       keychainUsed: storedInKeychain,
     });
 
@@ -179,6 +191,7 @@ async function handleLoginWithMode(
         profile: profileName,
         site: baseUrl,
         authType: "bearer",
+        deploymentType,
         keychainUsed: storedInKeychain,
         configPath: getConfigPath(),
       },
@@ -207,6 +220,7 @@ async function handleLoginWithMode(
     setProfile(config, {
       name: profileName,
       baseUrl,
+      deploymentType,
       auth: {
         type: "apiToken",
         email,
@@ -224,6 +238,7 @@ async function handleLoginWithMode(
       profile: profileName,
       email,
       baseUrl,
+      deploymentType,
     });
 
     output(
@@ -231,6 +246,7 @@ async function handleLoginWithMode(
         ok: true,
         profile: profileName,
         site: baseUrl,
+        deploymentType,
         configPath: getConfigPath(),
       },
       opts
@@ -250,6 +266,7 @@ async function handleStatus(flags: Record<string, string | boolean | string[]>, 
     profile: profile.name,
     site: profile.baseUrl,
     authType: profile.auth.type,
+    deploymentType: resolveDeploymentType(profile),
   };
 
   // Show auth details based on type
@@ -283,6 +300,7 @@ async function handleList(opts: OutputOptions): Promise<void> {
     name: p.name,
     site: p.baseUrl,
     authType: p.auth.type,
+    deploymentType: resolveDeploymentType(p),
     active: config.currentProfile === p.name,
   }));
   output({ profiles }, opts);
@@ -453,9 +471,10 @@ Options:
   --site <url>       Atlassian site URL.
                      Cloud: root only, e.g. https://company.atlassian.net
                      (do not include /wiki — Confluence appends it automatically).
-                     Server/Data Center: include the context path if your
-                     instance uses one, e.g. https://confluence.company.com/confluence
+                     Server/Data Center: use the exact Confluence base URL,
+                     including any configured context path.
   --bearer           Use Bearer auth with PAT (for Server/Data Center)
+  --deployment <type> Hosting model: cloud or data-center
   --token <token>    API token or PAT
   --username <user>  Username (for keychain lookup with --bearer)
   --email <email>    Email (for Cloud Basic auth)

--- a/apps/cli/src/commands/docs.ts
+++ b/apps/cli/src/commands/docs.ts
@@ -2062,7 +2062,7 @@ async function pushFile(params: {
       // Confluence API doesn't support folder rename (returns 501)
       // User must rename in Confluence UI, then pull
       if (!opts.json) {
-        const folderUrl = `${client.getInstanceUrl()}/wiki/spaces/${space}/folder/${pageId}`;
+        const folderUrl = `${client.getInstanceUrl()}/spaces/${space}/folder/${pageId}`;
         output(`Warning: Folder rename not supported by Confluence API. Rename "${existingFolderState?.title}" in Confluence UI, then pull: ${folderUrl}`, opts);
       }
       return "skipped";

--- a/apps/cli/src/commands/doctor.ts
+++ b/apps/cli/src/commands/doctor.ts
@@ -17,6 +17,7 @@ import {
   hasFlag,
   loadConfig,
   getActiveProfile,
+  getConfluenceBaseUrl,
   type Profile,
 } from "@atlcli/core";
 import type { OutputOptions } from "@atlcli/core";
@@ -310,7 +311,7 @@ async function checkConfluenceApi(profile: Profile): Promise<CheckResult> {
     await client.getCurrentUser();
     const latency = Date.now() - start;
 
-    const wikiUrl = `${profile.baseUrl}/wiki`;
+    const wikiUrl = getConfluenceBaseUrl(profile);
 
     if (latency > LATENCY_WARN_THRESHOLD) {
       return {

--- a/apps/cli/src/commands/export.ts
+++ b/apps/cli/src/commands/export.ts
@@ -7,6 +7,7 @@ import {
   ERROR_CODES,
   OutputOptions,
   fail,
+  getConfluenceBaseUrl,
   getActiveProfile,
   getFlag,
   hasFlag,
@@ -91,7 +92,7 @@ export async function handleExport(
   // Resolve page ID from reference
   const pageId = await resolvePageId(client, pageRef, opts);
 
-  const baseUrl = profile.baseUrl.replace(/\/+$/, "");
+  const baseUrl = getConfluenceBaseUrl(profile);
 
   // Fetch page data (with metadata for export)
   const page = await client.getPageDetails(pageId);
@@ -110,7 +111,7 @@ export async function handleExport(
 
   // Get space info (if we have the space key)
   let spaceName = spaceKey;
-  let spaceUrl = `${baseUrl}/wiki/spaces/${spaceKey}`;
+  let spaceUrl = `${baseUrl}/spaces/${spaceKey}`;
   try {
     const space = await client.getSpace(spaceKey);
     spaceName = space.name;
@@ -180,7 +181,7 @@ export async function handleExport(
     childrenMacro = children.map(child => ({
       title: child.title,
       pageId: child.id,
-      pageUrl: child.url ?? `${baseUrl}/wiki/spaces/${spaceKey}/pages/${child.id}`,
+      pageUrl: child.url ?? `${baseUrl}/spaces/${spaceKey}/pages/${child.id}`,
     }));
 
     if (includeChildren) {
@@ -224,7 +225,7 @@ export async function handleExport(
             created: childPage.created ?? "",
             modified: childPage.modified ?? "",
             pageId: child.id,
-            pageUrl: childPage.url ?? `${baseUrl}/wiki/spaces/${spaceKey}/pages/${child.id}`,
+            pageUrl: childPage.url ?? `${baseUrl}/spaces/${spaceKey}/pages/${child.id}`,
             tinyUrl: childPage.tinyUrl ?? "",
             labels: childPage.labels ?? [],
             attachments: childAttachmentData,
@@ -257,7 +258,7 @@ export async function handleExport(
     created: page.created ?? "",
     modified: page.modified ?? "",
     pageId: page.id,
-    pageUrl: page.url ?? `${baseUrl}/wiki/spaces/${spaceKey}/pages/${page.id}`,
+    pageUrl: page.url ?? `${baseUrl}/spaces/${spaceKey}/pages/${page.id}`,
     tinyUrl: page.tinyUrl ?? "",
     labels: page.labels ?? [],
     spaceKey,
@@ -646,7 +647,7 @@ async function resolveContentByLabel(
     const items = search.results.map(item => ({
       title: item.title,
       pageId: item.id,
-      pageUrl: item.url ?? `${baseUrl}/wiki/spaces/${item.spaceKey ?? fallbackSpaceKey}/pages/${item.id}`,
+      pageUrl: item.url ?? `${baseUrl}/spaces/${item.spaceKey ?? fallbackSpaceKey}/pages/${item.id}`,
     }));
 
     results.push({

--- a/apps/cli/src/commands/jira.ts
+++ b/apps/cli/src/commands/jira.ts
@@ -4,11 +4,13 @@ import {
   ERROR_CODES,
   OutputOptions,
   fail,
+  buildConfluenceUrl,
   getActiveProfile,
   getFlag,
   getFlags,
   hasFlag,
   loadConfig,
+  isConfluencePageUrl,
   output,
   resolveDefaults,
 } from "@atlcli/core";
@@ -821,7 +823,10 @@ async function handleIssueLinkPage(
   }
 
   // Build page URL
-  const pageUrl = `${profile.baseUrl}/wiki/spaces/${page.spaceKey}/pages/${page.id}`;
+  const pageUrl = page.url ?? buildConfluenceUrl(
+    profile,
+    `/spaces/${page.spaceKey}/pages/${page.id}`
+  );
 
   // Create remote link
   const globalId = `atlcli-confluence-${pageId}`;
@@ -837,7 +842,7 @@ async function handleIssueLinkPage(
       title: page.title,
       summary: page.spaceKey ? `Space: ${page.spaceKey}` : undefined,
       icon: {
-        url16x16: `${profile.baseUrl}/wiki/s/en_US/8401/3fdbb97e2e96088ced3b2b3f17e76d58_7d885fcef5/1000.0.0-01291bfc605/_/images/icons/contenttypes/page-default.svg`,
+        url16x16: buildConfluenceUrl(profile, "/favicon.ico"),
         title: "Confluence Page",
       },
     },
@@ -871,6 +876,11 @@ async function handleIssuePages(
   }
 
   const client = await getClient(flags, opts);
+  const config = await loadConfig();
+  const profile = getActiveProfile(config, getFlag(flags, "profile"));
+  if (!profile) {
+    fail(opts, 1, ERROR_CODES.CONFIG, "No active profile. Run: atlcli auth login");
+  }
   const remoteLinks = await client.getRemoteLinks(key);
 
   // Filter for Confluence pages
@@ -878,7 +888,7 @@ async function handleIssuePages(
     (link) =>
       link.application?.type === "com.atlassian.confluence" ||
       link.globalId?.startsWith("atlcli-confluence-") ||
-      link.object.url.includes("/wiki/")
+      isConfluencePageUrl(profile, link.object.url)
   );
 
   output({
@@ -3232,7 +3242,7 @@ async function handleBulkLinkPage(
   const confluenceClient = new ConfluenceClient(profile);
 
   // Fetch page details
-  let page: { id: string; title: string; _links?: { webui?: string; base?: string } };
+  let page: { id: string; title: string; url?: string };
   try {
     page = await confluenceClient.getPage(pageId);
   } catch (err) {
@@ -3241,9 +3251,7 @@ async function handleBulkLinkPage(
     return;
   }
 
-  const pageUrl = page._links?.base && page._links?.webui
-    ? `${page._links.base}${page._links.webui}`
-    : `${profile.baseUrl}/wiki/spaces/pages/${page.id}`;
+  const pageUrl = page.url ?? buildConfluenceUrl(profile, `/pages/${page.id}`);
   const globalId = `atlcli-confluence-${page.id}`;
 
   // Dry run - show preview
@@ -3278,7 +3286,7 @@ async function handleBulkLinkPage(
         url: pageUrl,
         title: page.title,
         icon: {
-          url16x16: `${profile.baseUrl}/wiki/favicon.ico`,
+          url16x16: buildConfluenceUrl(profile, "/favicon.ico"),
           title: "Confluence",
         },
       },

--- a/apps/cli/src/commands/page.ts
+++ b/apps/cli/src/commands/page.ts
@@ -2,6 +2,7 @@ import {
   ERROR_CODES,
   OutputOptions,
   fail,
+  buildConfluenceUrl,
   getActiveProfile,
   getFlag,
   hasFlag,
@@ -1607,8 +1608,13 @@ async function handleOpen(
     return;
   }
 
-  // Construct URL - Confluence Cloud page URL
-  const url = `${profile.baseUrl}/wiki/pages/${id}`;
+  let url = buildConfluenceUrl(profile, `/pages/${id}`);
+  try {
+    const page = await new ConfluenceClient(profile).getPage(id);
+    url = page.url ?? url;
+  } catch {
+    // Keep the deployment-aware fallback URL when the page cannot be fetched.
+  }
 
   // Always display the URL first (for headless environments)
   output(url, opts);
@@ -1681,7 +1687,7 @@ async function handleLinkIssue(
   const confluenceClient = new ConfluenceClient(profile);
 
   // Fetch page details
-  let page: { id: string; title: string; _links?: { webui?: string; base?: string } };
+  let page: { id: string; title: string; url?: string };
   try {
     page = await confluenceClient.getPage(pageId);
   } catch (err) {
@@ -1690,9 +1696,7 @@ async function handleLinkIssue(
     return;
   }
 
-  const pageUrl = page._links?.base && page._links?.webui
-    ? `${page._links.base}${page._links.webui}`
-    : `${profile.baseUrl}/wiki/spaces/pages/${page.id}`;
+  const pageUrl = page.url ?? buildConfluenceUrl(profile, `/pages/${page.id}`);
   const globalId = `atlcli-confluence-${page.id}`;
 
   // Get Jira client and create remote link
@@ -1710,7 +1714,7 @@ async function handleLinkIssue(
       url: pageUrl,
       title: page.title,
       icon: {
-        url16x16: `${profile.baseUrl}/wiki/favicon.ico`,
+        url16x16: buildConfluenceUrl(profile, "/favicon.ico"),
         title: "Confluence",
       },
     },

--- a/packages/confluence/src/client.test.ts
+++ b/packages/confluence/src/client.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect, mock, afterEach } from "bun:test";
+import type { Profile } from "@atlcli/core";
 import { ConfluenceClient } from "./client.js";
 
 // Mock profile for testing
@@ -330,7 +331,8 @@ describe("ConfluenceClient", () => {
     async function captureRequestUrl(
       baseUrl: string,
       body: unknown,
-      call: (client: ConfluenceClient) => Promise<unknown>
+      call: (client: ConfluenceClient) => Promise<unknown>,
+      profileOverrides: Partial<Profile> = {}
     ): Promise<string> {
       let capturedUrl = "";
       globalThis.fetch = mock((url: string) => {
@@ -338,7 +340,7 @@ describe("ConfluenceClient", () => {
         return Promise.resolve(new Response(JSON.stringify(body), { status: 200 }));
       }) as unknown as typeof fetch;
 
-      await call(new ConfluenceClient({ ...mockProfile, baseUrl }));
+      await call(new ConfluenceClient({ ...mockProfile, baseUrl, ...profileOverrides }));
       return capturedUrl;
     }
 
@@ -382,6 +384,65 @@ describe("ConfluenceClient", () => {
       );
       expect(url).toContain("/confluence/api/v2/pages/123/direct-children");
       expect(url).not.toContain("/wiki/");
+    });
+
+    test("an explicit Data Center profile supports a root deployment", async () => {
+      const url = await captureRequestUrl(
+        "https://confluence.example.com",
+        pageBody,
+        (c) => c.getPage("123"),
+        { deploymentType: "data-center" }
+      );
+      expect(url).toContain("https://confluence.example.com/rest/api/content/123");
+      expect(url).not.toContain("/wiki/");
+    });
+
+    test("Data Center may legitimately use /wiki as its configured context path", async () => {
+      const url = await captureRequestUrl(
+        "https://confluence.example.com/wiki",
+        pageBody,
+        (c) => c.getPage("123"),
+        { deploymentType: "data-center" }
+      );
+      expect(url).toContain("https://confluence.example.com/wiki/rest/api/content/123");
+      expect(url).not.toContain("/wiki/wiki/");
+    });
+
+    test("multipart uploads honor the Data Center context path", async () => {
+      const url = await captureRequestUrl(
+        "https://confluence.example.com/confluence",
+        {
+          id: "att123",
+          title: "test.txt",
+          version: { number: 1 },
+          extensions: { fileSize: 4, mediaType: "text/plain" },
+          _links: { download: "/download/attachments/123/test.txt" },
+        },
+        (c) => c.uploadAttachment({
+          pageId: "123",
+          filename: "test.txt",
+          data: new TextEncoder().encode("test"),
+        })
+      );
+      expect(url).toContain("/confluence/rest/api/content/123/child/attachment");
+    });
+
+    test("binary downloads honor the Data Center context path", async () => {
+      const url = await captureRequestUrl(
+        "https://confluence.example.com/confluence",
+        "attachment data",
+        (c) => c.downloadAttachment({ downloadUrl: "/download/attachments/123/test.txt" })
+      );
+      expect(url).toContain("/confluence/download/attachments/123/test.txt");
+    });
+
+    test("webhook requests honor the Data Center context path", async () => {
+      const url = await captureRequestUrl(
+        "https://confluence.example.com/confluence",
+        { id: "hook-1", name: "Docs", url: "https://hooks.example.com", events: [] },
+        (c) => c.registerWebhook({ name: "Docs", url: "https://hooks.example.com", events: [] })
+      );
+      expect(url).toContain("/confluence/rest/webhooks/1.0/webhook");
     });
 
     // Web UI links reconstructed from a relative `_links.webui` (v2 endpoints

--- a/packages/confluence/src/client.ts
+++ b/packages/confluence/src/client.ts
@@ -1,4 +1,13 @@
-import { Profile, getLogger, generateRequestId, redactSensitive, buildAuthHeader, buildTlsOptions, TlsOptions } from "@atlcli/core";
+import {
+  Profile,
+  getLogger,
+  generateRequestId,
+  redactSensitive,
+  buildAuthHeader,
+  buildTlsOptions,
+  getConfluenceBaseUrl,
+  TlsOptions,
+} from "@atlcli/core";
 
 export type ConfluencePage = {
   id: string;
@@ -105,7 +114,7 @@ export interface AttachmentInfo {
   version: number;
   /** Page ID this attachment belongs to */
   pageId: string;
-  /** Download URL (relative to wiki base) */
+  /** Download URL relative to the resolved Confluence base */
   downloadUrl: string;
   /** Full webui URL for viewing */
   url?: string;
@@ -114,24 +123,14 @@ export interface AttachmentInfo {
 }
 
 export class ConfluenceClient {
-  private baseUrl: string;
-  /**
-   * Path segment inserted between the site URL and the Confluence REST/web
-   * roots. `/wiki` for Atlassian Cloud (`https://x.atlassian.net` + `/wiki/...`),
-   * or "" for Server/Data Center, whose context path (e.g. `/confluence`) is
-   * already part of the site URL. Derived once from the immutable base URL.
-   */
-  private apiBasePath: string;
+  private confluenceBaseUrl: string;
   private authHeader: string;
   private maxRetries = 3;
   private baseDelayMs = 1000;
   private tlsOptions: TlsOptions | undefined;
 
   constructor(profile: Profile) {
-    this.baseUrl = profile.baseUrl.replace(/\/+$/, "");
-    // If the site URL already carries a path, the API hangs directly off it;
-    // otherwise default to Cloud's `/wiki` (the long-standing behavior).
-    this.apiBasePath = new URL(this.baseUrl).pathname.replace(/\/+$/, "") ? "" : "/wiki";
+    this.confluenceBaseUrl = getConfluenceBaseUrl(profile);
     if (profile.auth.type === "oauth") {
       throw new Error("OAuth is not implemented yet. Use API token or bearer auth.");
     }
@@ -141,7 +140,7 @@ export class ConfluenceClient {
 
   /** Get the Confluence instance base URL */
   getInstanceUrl(): string {
-    return this.baseUrl;
+    return this.confluenceBaseUrl;
   }
 
   /**
@@ -150,7 +149,7 @@ export class ConfluenceClient {
    */
   private buildWebUrl(webuiPath: string | undefined): string | undefined {
     if (!webuiPath) return undefined;
-    return `${this.baseUrl}${this.apiBasePath}${webuiPath}`;
+    return `${this.confluenceBaseUrl}${webuiPath}`;
   }
 
   /** Sleep utility for rate limiting */
@@ -172,7 +171,7 @@ export class ConfluenceClient {
       body?: unknown;
     } = {}
   ): Promise<unknown> {
-    const url = new URL(`${this.baseUrl}${this.apiBasePath}/rest/api${path}`);
+    const url = new URL(`${this.confluenceBaseUrl}/rest/api${path}`);
     if (options.query) {
       for (const [key, value] of Object.entries(options.query)) {
         if (value === undefined) continue;
@@ -281,7 +280,7 @@ export class ConfluenceClient {
 
   /**
    * Request helper for v2 API endpoints.
-   * v2 API uses /wiki/api/v2 instead of /wiki/rest/api
+   * v2 API uses /api/v2 below the resolved Confluence base.
    */
   private async requestV2(
     path: string,
@@ -291,7 +290,7 @@ export class ConfluenceClient {
       body?: unknown;
     } = {}
   ): Promise<unknown> {
-    const url = new URL(`${this.baseUrl}${this.apiBasePath}/api/v2${path}`);
+    const url = new URL(`${this.confluenceBaseUrl}/api/v2${path}`);
     if (options.query) {
       for (const [key, value] of Object.entries(options.query)) {
         if (value === undefined) continue;
@@ -909,7 +908,7 @@ export class ConfluenceClient {
   /**
    * Get all direct children of a page (including folders, whiteboards, etc.).
    *
-   * GET /wiki/api/v2/pages/{id}/direct-children
+   * GET /api/v2/pages/{id}/direct-children
    *
    * Unlike getChildren(), this returns ALL content types, not just pages.
    * Useful for detecting folders nested under pages.
@@ -947,7 +946,7 @@ export class ConfluenceClient {
 
       // v2 API uses cursor-based pagination
       if (data._links?.next) {
-        const nextUrl = new URL(data._links.next, this.baseUrl);
+        const nextUrl = new URL(data._links.next, this.confluenceBaseUrl);
         cursor = nextUrl.searchParams.get("cursor") ?? undefined;
       } else {
         break;
@@ -1225,7 +1224,7 @@ export class ConfluenceClient {
       }
 
       if (data._links?.next) {
-        const nextUrl = new URL(data._links.next, this.baseUrl);
+        const nextUrl = new URL(data._links.next, this.confluenceBaseUrl);
         cursor = nextUrl.searchParams.get("cursor") ?? undefined;
       } else {
         break;
@@ -1438,7 +1437,7 @@ export class ConfluenceClient {
     path: string,
     formData: FormData
   ): Promise<any> {
-    const url = new URL(`${this.baseUrl}${this.apiBasePath}/rest/api${path}`);
+    const url = new URL(`${this.confluenceBaseUrl}/rest/api${path}`);
 
     const logger = getLogger();
     const requestId = generateRequestId();
@@ -1541,7 +1540,7 @@ export class ConfluenceClient {
    * Request helper for binary downloads.
    */
   private async requestBinary(downloadPath: string): Promise<Buffer> {
-    const url = new URL(`${this.baseUrl}${this.apiBasePath}${downloadPath}`);
+    const url = new URL(`${this.confluenceBaseUrl}${downloadPath}`);
 
     const logger = getLogger();
     const requestId = generateRequestId();
@@ -1742,7 +1741,7 @@ export class ConfluenceClient {
       body?: unknown;
     } = {}
   ): Promise<unknown> {
-    const url = new URL(`${this.baseUrl}${this.apiBasePath}/rest/webhooks/1.0${path}`);
+    const url = new URL(`${this.confluenceBaseUrl}/rest/webhooks/1.0${path}`);
 
     let lastError: Error | null = null;
 
@@ -2008,7 +2007,7 @@ export class ConfluenceClient {
   /**
    * Get footer (page-level) comments for a page.
    *
-   * GET /wiki/api/v2/pages/{id}/footer-comments
+   * GET /api/v2/pages/{id}/footer-comments
    */
   async getFooterComments(
     pageId: string,
@@ -2037,7 +2036,7 @@ export class ConfluenceClient {
   /**
    * Get replies to a footer comment.
    *
-   * GET /wiki/api/v2/footer-comments/{id}/children
+   * GET /api/v2/footer-comments/{id}/children
    */
   async getFooterCommentReplies(
     commentId: string,
@@ -2064,7 +2063,7 @@ export class ConfluenceClient {
   /**
    * Get inline comments for a page.
    *
-   * GET /wiki/api/v2/pages/{id}/inline-comments
+   * GET /api/v2/pages/{id}/inline-comments
    */
   async getInlineComments(
     pageId: string,
@@ -2093,7 +2092,7 @@ export class ConfluenceClient {
   /**
    * Get replies to an inline comment.
    *
-   * GET /wiki/api/v2/inline-comments/{id}/children
+   * GET /api/v2/inline-comments/{id}/children
    */
   async getInlineCommentReplies(
     commentId: string,
@@ -2182,7 +2181,7 @@ export class ConfluenceClient {
   /**
    * Create a footer (page-level) comment.
    *
-   * POST /wiki/api/v2/footer-comments
+   * POST /api/v2/footer-comments
    */
   async createFooterComment(params: {
     pageId: string;
@@ -2216,7 +2215,7 @@ export class ConfluenceClient {
   /**
    * Create an inline comment on specific text.
    *
-   * POST /wiki/api/v2/inline-comments
+   * POST /api/v2/inline-comments
    */
   async createInlineComment(params: {
     pageId: string;
@@ -2265,7 +2264,7 @@ export class ConfluenceClient {
   /**
    * Resolve a comment (mark as resolved).
    *
-   * PUT /wiki/api/v2/{type}-comments/{id}
+   * PUT /api/v2/{type}-comments/{id}
    */
   async resolveComment(
     commentId: string,
@@ -2298,7 +2297,7 @@ export class ConfluenceClient {
   /**
    * Delete a comment.
    *
-   * DELETE /wiki/api/v2/{type}-comments/{id}
+   * DELETE /api/v2/{type}-comments/{id}
    */
   async deleteComment(
     commentId: string,
@@ -2316,7 +2315,7 @@ export class ConfluenceClient {
   /**
    * Get a folder by ID.
    *
-   * GET /wiki/api/v2/folders/{id}
+   * GET /api/v2/folders/{id}
    *
    * Note: Folders are a Confluence Cloud feature introduced in Sept 2024.
    */
@@ -2375,7 +2374,7 @@ export class ConfluenceClient {
   /**
    * Get direct children of a folder.
    *
-   * GET /wiki/api/v2/folders/{id}/direct-children
+   * GET /api/v2/folders/{id}/direct-children
    *
    * Returns mixed content types (pages and folders).
    */
@@ -2413,7 +2412,7 @@ export class ConfluenceClient {
       // v2 API uses cursor-based pagination
       if (data._links?.next) {
         // Extract cursor from next link
-        const nextUrl = new URL(data._links.next, this.baseUrl);
+        const nextUrl = new URL(data._links.next, this.confluenceBaseUrl);
         cursor = nextUrl.searchParams.get("cursor") ?? undefined;
       } else {
         break;
@@ -2462,7 +2461,7 @@ export class ConfluenceClient {
   /**
    * Create a folder in a space.
    *
-   * POST /wiki/api/v2/folders
+   * POST /api/v2/folders
    */
   async createFolder(params: {
     spaceId: string;
@@ -2498,7 +2497,7 @@ export class ConfluenceClient {
   /**
    * Delete a folder.
    *
-   * DELETE /wiki/api/v2/folders/{id}
+   * DELETE /api/v2/folders/{id}
    */
   async deleteFolder(folderId: string): Promise<void> {
     await this.requestV2(`/folders/${folderId}`, {
@@ -2596,7 +2595,7 @@ export class ConfluenceClient {
    * Move a page into a folder.
    *
    * Note: v2 API doesn't support folder as parent directly. We use
-   * PUT /wiki/rest/api/content/{id}/move to move into a folder.
+   * PUT /rest/api/content/{id}/move to move into a folder.
    */
   async movePageToFolder(pageId: string, folderId: string): Promise<ConfluencePage> {
     // Use the v1 move endpoint - move page to be a child of the folder
@@ -2613,7 +2612,7 @@ export class ConfluenceClient {
   /**
    * Get user information by account ID.
    *
-   * GET /wiki/rest/api/user?accountId=xxx
+   * GET /rest/api/user?accountId=xxx
    *
    * @param accountId - Atlassian account ID
    * @returns User info or null if not found
@@ -2731,7 +2730,7 @@ export class ConfluenceClient {
   /**
    * Get the editor version for a page.
    *
-   * GET /wiki/rest/api/content/{id}?expand=metadata.properties.editor
+   * GET /rest/api/content/{id}?expand=metadata.properties.editor
    *
    * @param pageId - The page ID
    * @returns 'v2' for new editor, 'v1' for legacy, or null if not set

--- a/packages/confluence/src/markdown.test.ts
+++ b/packages/confluence/src/markdown.test.ts
@@ -1027,7 +1027,7 @@ describe("smart links", () => {
       expect(html).toContain(">PROJ-123</a>");
     });
 
-    test("converts Confluence URL to inline smart link", () => {
+  test("converts Confluence URL to inline smart link", () => {
       const md = "[Page Title](https://example.atlassian.net/wiki/spaces/TEAM/pages/12345)";
       const html = markdownToStorage(md, { baseUrl });
       expect(html).toContain('data-card-appearance="inline"');
@@ -1072,6 +1072,20 @@ describe("smart links", () => {
       expect(html).not.toContain('data-card-appearance');
       expect(html).toContain('<a href="https://example.atlassian.net/browse/PROJ-123">');
     });
+  });
+
+  test("converts Data Center Confluence URLs with custom context paths to smart links", () => {
+    const md = "[Page](https://confluence.example.com/confluence/spaces/TEAM/pages/123)";
+    const html = markdownToStorage(md, { baseUrl: "https://confluence.example.com/confluence" });
+    expect(html).toContain('href="https://confluence.example.com/confluence/spaces/TEAM/pages/123"');
+    expect(html).toContain('data-card-appearance="inline"');
+  });
+
+  test("converts legacy Data Center display URLs to smart links", () => {
+    const md = "[Page](https://confluence.example.com/confluence/display/TEAM/Page+Title)";
+    const html = markdownToStorage(md, { baseUrl: "https://confluence.example.com/confluence" });
+    expect(html).toContain('href="https://confluence.example.com/confluence/display/TEAM/Page+Title"');
+    expect(html).toContain('data-card-appearance="inline"');
   });
 
   describe("legacy jira macro with baseUrl", () => {

--- a/packages/confluence/src/markdown.ts
+++ b/packages/confluence/src/markdown.ts
@@ -25,7 +25,8 @@ export interface ConversionOptions {
 /** URL patterns for detecting Atlassian product URLs */
 const ATLASSIAN_URL_PATTERNS = {
   jira: /\/browse\/([A-Z][A-Z0-9]*-\d+)/i,
-  confluence: /\/wiki\/spaces\/([^\/]+)\/pages\/(\d+)/i,
+  confluence: /\/spaces\/([^\/]+)\/pages\/(\d+)/i,
+  confluenceDisplay: /\/display\/([^\/]+)\//i,
   trello: /^https?:\/\/trello\.com\/(c|b)\/([a-zA-Z0-9]+)/i,
   bitbucket: /^https?:\/\/bitbucket\.org\/([^\/]+)\/([^\/]+)/i,
 };
@@ -50,6 +51,7 @@ function isAtlassianUrl(url: string): boolean {
   return (
     ATLASSIAN_URL_PATTERNS.jira.test(url) ||
     ATLASSIAN_URL_PATTERNS.confluence.test(url) ||
+    ATLASSIAN_URL_PATTERNS.confluenceDisplay.test(url) ||
     ATLASSIAN_URL_PATTERNS.trello.test(url) ||
     ATLASSIAN_URL_PATTERNS.bitbucket.test(url)
   );

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -5,6 +5,8 @@ import os from "node:os";
 
 export type AuthType = "apiToken" | "bearer" | "oauth";
 
+export type DeploymentType = "cloud" | "data-center";
+
 export type AuthConfig = {
   type: AuthType;
   // Basic auth (Cloud)
@@ -20,6 +22,8 @@ export type AuthConfig = {
 export type Profile = {
   name: string;
   baseUrl: string;
+  /** Atlassian hosting model. Optional for backwards compatibility with existing profiles. */
+  deploymentType?: DeploymentType;
   auth: AuthConfig;
   cloudId?: string;
   /** Profile-specific Jira project key */

--- a/packages/core/src/confluence-url.test.ts
+++ b/packages/core/src/confluence-url.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildConfluenceUrl,
+  getConfluenceBaseUrl,
+  isConfluencePageUrl,
+  resolveDeploymentType,
+} from "./confluence-url.js";
+import type { Profile } from "./config.js";
+
+function profile(overrides: Partial<Profile> = {}): Profile {
+  return {
+    name: "test",
+    baseUrl: "https://example.atlassian.net",
+    deploymentType: "cloud",
+    auth: { type: "apiToken", email: "test@example.com", token: "token" },
+    ...overrides,
+  };
+}
+
+describe("Confluence URL handling", () => {
+  test("Cloud profiles append /wiki", () => {
+    const value = profile();
+    expect(getConfluenceBaseUrl(value)).toBe("https://example.atlassian.net/wiki");
+    expect(buildConfluenceUrl(value, "/rest/api/content/123")).toBe(
+      "https://example.atlassian.net/wiki/rest/api/content/123"
+    );
+  });
+
+  test("Cloud profiles do not duplicate an existing /wiki path", () => {
+    const value = profile({ baseUrl: "https://example.atlassian.net/wiki/" });
+    expect(getConfluenceBaseUrl(value)).toBe("https://example.atlassian.net/wiki");
+  });
+
+  test("Data Center supports a root deployment", () => {
+    const value = profile({
+      baseUrl: "https://confluence.example.com/",
+      deploymentType: "data-center",
+      auth: { type: "bearer", pat: "token" },
+    });
+    expect(getConfluenceBaseUrl(value)).toBe("https://confluence.example.com");
+    expect(buildConfluenceUrl(value, "rest/api/content/123")).toBe(
+      "https://confluence.example.com/rest/api/content/123"
+    );
+  });
+
+  test("Data Center preserves arbitrary context paths, including /wiki", () => {
+    for (const contextPath of ["confluence", "wiki", "internal/docs"]) {
+      const value = profile({
+        baseUrl: `https://confluence.example.com/${contextPath}/`,
+        deploymentType: "data-center",
+        auth: { type: "bearer", pat: "token" },
+      });
+      expect(getConfluenceBaseUrl(value)).toBe(`https://confluence.example.com/${contextPath}`);
+    }
+  });
+
+  test("legacy bearer profiles resolve as Data Center, including at the root", () => {
+    const value = profile({
+      baseUrl: "https://confluence.example.com",
+      deploymentType: undefined,
+      auth: { type: "bearer", pat: "token" },
+    });
+    expect(resolveDeploymentType(value)).toBe("data-center");
+    expect(getConfluenceBaseUrl(value)).toBe("https://confluence.example.com");
+  });
+
+  test("legacy API-token profiles preserve context-path detection", () => {
+    const value = profile({
+      baseUrl: "https://confluence.example.com/confluence",
+      deploymentType: undefined,
+    });
+    expect(resolveDeploymentType(value)).toBe("data-center");
+  });
+
+  test("identifies Cloud and Data Center page URLs for a profile", () => {
+    const cloud = profile();
+    const dataCenter = profile({
+      baseUrl: "https://confluence.example.com/confluence",
+      deploymentType: "data-center",
+      auth: { type: "bearer", pat: "token" },
+    });
+
+    expect(isConfluencePageUrl(cloud, "https://example.atlassian.net/wiki/spaces/DOC/pages/123")).toBe(true);
+    expect(isConfluencePageUrl(dataCenter, "https://confluence.example.com/confluence/display/DOC/Page")).toBe(true);
+    expect(isConfluencePageUrl(dataCenter, "https://confluence.example.com/confluence/browse/DOC-1")).toBe(false);
+    expect(isConfluencePageUrl(dataCenter, "https://other.example.com/confluence/spaces/DOC/pages/123")).toBe(false);
+  });
+});

--- a/packages/core/src/confluence-url.ts
+++ b/packages/core/src/confluence-url.ts
@@ -1,0 +1,60 @@
+import type { DeploymentType, Profile } from "./config.js";
+
+type ConfluenceProfile = Pick<Profile, "baseUrl" | "auth" | "deploymentType">;
+
+function normalizeUrl(url: string): string {
+  return url.replace(/\/+$/, "");
+}
+
+function hasConfiguredPath(baseUrl: string): boolean {
+  return new URL(baseUrl).pathname.replace(/\/+$/, "") !== "";
+}
+
+/**
+ * Resolve the hosting model for new and legacy profiles.
+ *
+ * New profiles persist an explicit value. Legacy bearer profiles are Data
+ * Center profiles by convention; legacy profiles with a configured path keep
+ * the context-path behavior introduced in #14. Everything else retains the
+ * historical Cloud default.
+ */
+export function resolveDeploymentType(profile: ConfluenceProfile): DeploymentType {
+  if (profile.deploymentType) return profile.deploymentType;
+  if (profile.auth.type === "bearer") return "data-center";
+  return hasConfiguredPath(normalizeUrl(profile.baseUrl)) ? "data-center" : "cloud";
+}
+
+/** Return the exact browser/API root for Confluence. */
+export function getConfluenceBaseUrl(profile: ConfluenceProfile): string {
+  const baseUrl = normalizeUrl(profile.baseUrl);
+  if (resolveDeploymentType(profile) === "data-center") return baseUrl;
+
+  const pathname = new URL(baseUrl).pathname.replace(/\/+$/, "");
+  return pathname.endsWith("/wiki") ? baseUrl : `${baseUrl}/wiki`;
+}
+
+/** Build an absolute URL below the resolved Confluence root. */
+export function buildConfluenceUrl(profile: ConfluenceProfile, path = ""): string {
+  const baseUrl = getConfluenceBaseUrl(profile);
+  if (!path) return baseUrl;
+  return `${baseUrl}/${path.replace(/^\/+/, "")}`;
+}
+
+/** Identify a Confluence page URL belonging to this profile. */
+export function isConfluencePageUrl(profile: ConfluenceProfile, candidate: string): boolean {
+  try {
+    const base = new URL(getConfluenceBaseUrl(profile));
+    const url = new URL(candidate);
+    if (url.origin !== base.origin) return false;
+
+    const basePath = base.pathname.replace(/\/+$/, "");
+    if (basePath && url.pathname !== basePath && !url.pathname.startsWith(`${basePath}/`)) {
+      return false;
+    }
+
+    const relativePath = url.pathname.slice(basePath.length) || "/";
+    return /^\/(?:spaces|pages|display)\//i.test(relativePath);
+  } catch {
+    return false;
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./auth.js";
 export * from "./config.js";
+export * from "./confluence-url.js";
 export * from "./flags.js";
 export * from "./keychain.js";
 export * from "./logger.js";

--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -103,6 +103,7 @@ export interface AuthChangeData {
   username?: string;
   baseUrl?: string;
   authType?: string;
+  deploymentType?: "cloud" | "data-center";
   keychainUsed?: boolean;
   keychainDeleted?: boolean;
   details?: unknown;

--- a/src/content/docs/authentication.md
+++ b/src/content/docs/authentication.md
@@ -92,16 +92,23 @@ Atlassian Cloud serves Confluence under `/wiki`, which atlcli appends
 automatically — so Cloud `--site` URLs are bare hosts
 (`https://company.atlassian.net`).
 
-Server/Data Center instances are often served from a custom context path such
-as `/confluence`. Include that path in `--site` and atlcli will route REST
-requests through it:
+For Server/Data Center, `--site` is the exact Confluence base URL. It may be a
+bare host for a root deployment, or include any configured context path such
+as `/confluence` or `/wiki`:
 
 ```bash
+# Root deployment
+atlcli auth login --bearer --site https://confluence.company.com \
+  --token YOUR_PAT
+
+# Custom context path
 atlcli auth login --bearer --site https://confluence.company.com/confluence \
   --token YOUR_PAT
 ```
 
-Do **not** add `/wiki` to a Data Center URL — that is Cloud-only.
+`--bearer` defaults the profile to `data-center`; API-token authentication
+defaults it to `cloud`. Use `--deployment cloud|data-center` when authentication
+alone does not describe the hosting model.
 :::
 
 Options:
@@ -112,6 +119,7 @@ Options:
 | `--email` | Account email (Cloud) |
 | `--token` | API token (Cloud) or PAT (Server/DC) |
 | `--bearer` | Use Bearer auth with PAT (for Server/DC) |
+| `--deployment` | Hosting model: `cloud` or `data-center` |
 | `--username` | Username for keychain lookup (Server/DC) |
 | `--profile` | Profile name to create/update |
 | `--ca-file` | Path to a custom CA certificate (PEM) for self-signed or internal CAs |
@@ -287,6 +295,7 @@ Credentials are stored at `~/.atlcli/credentials.json`:
     "default": {
       "name": "default",
       "baseUrl": "https://company.atlassian.net",
+      "deploymentType": "cloud",
       "email": "you@company.com",
       "apiToken": "ATATT3x..."
     },
@@ -299,6 +308,7 @@ Credentials are stored at `~/.atlcli/credentials.json`:
     "onprem": {
       "name": "onprem",
       "baseUrl": "https://jira.company.internal",
+      "deploymentType": "data-center",
       "authType": "bearer",
       "username": "myuser",
       "tlsCaFile": "/etc/ssl/certs/company-ca.pem"
@@ -307,7 +317,10 @@ Credentials are stored at `~/.atlcli/credentials.json`:
 }
 ```
 
-For Server/Data Center profiles using Bearer auth, the profile includes `authType: "bearer"` and may include a `username` for keychain lookup and optional `tlsCaFile` / `tlsSkipVerify` fields for TLS configuration.
+New profiles persist `deploymentType` as either `cloud` or `data-center`.
+Server/Data Center profiles using Bearer auth include `authType: "bearer"` and
+may include a `username` for keychain lookup and optional `tlsCaFile` /
+`tlsSkipVerify` fields for TLS configuration.
 
 :::caution[Security]
 Protect this file with appropriate permissions:
@@ -504,16 +517,17 @@ If reads work but `wiki page create`, `wiki page update`, or `wiki docs`
 commands fail on a Server/Data Center instance, your site is likely served
 from a context path that is missing from the profile URL.
 
-atlcli appends `/wiki` (Cloud's context path) only when the `--site` URL has no
-path of its own. A Data Center instance hosted at
-`https://confluence.company.com/confluence` must include `/confluence` in the
-site URL, otherwise requests are sent to a non-existent
-`/confluence/wiki/rest/api/...` path.
+For a Data Center profile, atlcli treats `--site` as the exact Confluence root.
+An instance hosted at `https://confluence.company.com/confluence` must include
+`/confluence` in the site URL. If it is omitted, requests target
+`https://confluence.company.com/rest/api/...` instead of the required
+`https://confluence.company.com/confluence/rest/api/...` path.
 
 Re-create the profile with the full context path:
 
 ```bash
-atlcli auth login --bearer --site https://confluence.company.com/confluence \
+atlcli auth login --bearer --deployment data-center \
+  --site https://confluence.company.com/confluence \
   --token YOUR_PAT
 ```
 


### PR DESCRIPTION
## Summary

Completes the Data Center URL work started in #14 while keeping Atlassian Cloud behavior unchanged.

- adds an explicit `deploymentType` profile setting (`cloud` or `data-center`)
- treats a Data Center `--site` as the exact Confluence base URL, supporting root deployments and arbitrary context paths such as `/confluence` or `/wiki`
- centralizes Confluence base URL construction in `@atlcli/core`
- preserves backward compatibility for profiles created before `deploymentType` existed
- removes remaining hardcoded Cloud `/wiki` paths from page opening, exports, doctor checks, folder links, attachment URLs, and Jira–Confluence remote links
- recognizes Data Center `/spaces/...` and legacy `/display/...` links as smart links
- corrects the context-path documentation introduced in #14

## Why

PR #14 fixed REST requests for Data Center instances with a configured path, but path-presence inference could not support root-served Data Center installations. Several CLI browser/display URLs also continued to append `/wiki` directly.

New profiles now persist the hosting model. Bearer/PAT login defaults to Data Center, API-token login defaults to Cloud, and `--deployment cloud|data-center` provides an explicit override. Legacy bearer profiles resolve as Data Center, while legacy API-token profiles retain the path-based behavior from #14.

## Impact

The supported matrix is now:

| Deployment | Configured site | Confluence REST root |
|---|---|---|
| Cloud | `https://x.atlassian.net` | `/wiki/rest/api` |
| Data Center root | `https://confluence.example.com` | `/rest/api` |
| Data Center context | `https://confluence.example.com/confluence` | `/confluence/rest/api` |
| Data Center `/wiki` context | `https://confluence.example.com/wiki` | `/wiki/rest/api` |

## Validation

- focused URL, client, Markdown, and auth suites: **279 passed**
- typecheck: `bunx tsc --noEmit --typeRoots node_modules/.bun/bun-types@1.3.5/node_modules` passed
- production CLI build passed
- full suite: **1057 passed**, 16 unchanged environment-dependent failures (macOS `/var` aliasing, keychain access, and sandbox socket binding)
- read-only live Atlassian Cloud smoke test using profile `mayflower` and space `DOCSY`:
  - space lookup returned `https://mayflowergmbh.atlassian.net/wiki/spaces/DOCSY`
  - page lookup returned `https://mayflowergmbh.atlassian.net/wiki/spaces/DOCSY/overview`
- documentation content sync and client build passed; the existing docs build still fails during static 404 generation because it resolves an incompatible parent `zod` installation
