### PR TITLE
fix(plugin): bundle git plugin

### DIFF
--- a/apps/cli/src/commands/plugin.test.ts
+++ b/apps/cli/src/commands/plugin.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const cliPath = join(import.meta.dir, "..", "index.ts");
+let testHome: string | null = null;
+
+async function runCli(...args: string[]): Promise<{
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}> {
+  if (!testHome) {
+    testHome = await mkdtemp(join(tmpdir(), "atlcli-plugin-command-test-"));
+  }
+
+  const proc = Bun.spawn([process.execPath, "run", cliPath, ...args], {
+    cwd: testHome,
+    env: {
+      ...process.env,
+      HOME: testHome,
+      USERPROFILE: testHome,
+      ATLCLI_DISABLE_UPDATE_CHECK: "1",
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+
+  return { exitCode, stdout, stderr };
+}
+
+afterEach(async () => {
+  if (testHome) {
+    await rm(testHome, { recursive: true, force: true });
+    testHome = null;
+  }
+});
+
+describe("plugin command", () => {
+  test("enables and disables the bundled git plugin on a fresh install", async () => {
+    const initialList = await runCli("plugin", "list");
+    expect(initialList.exitCode).toBe(0);
+    expect(initialList.stdout).toContain("git@1.0.0 (disabled)");
+    expect(initialList.stdout).toContain("Source: builtin (builtin:git)");
+
+    const enabled = await runCli("plugin", "enable", "git");
+    expect(enabled).toEqual({
+      exitCode: 0,
+      stdout: "Enabled plugin: git\n",
+      stderr: "",
+    });
+
+    const config = JSON.parse(
+      await readFile(join(testHome!, ".atlcli", "plugins.json"), "utf-8"),
+    );
+    expect(config.plugins).toContainEqual({
+      name: "git",
+      version: "1.0.0",
+      source: "builtin",
+      location: "builtin:git",
+      enabled: true,
+    });
+
+    const enabledList = await runCli("plugin", "list");
+    expect(enabledList.exitCode).toBe(0);
+    expect(enabledList.stdout).toContain("git@1.0.0 (enabled)");
+
+    const disabled = await runCli("plugin", "disable", "git");
+    expect(disabled).toEqual({
+      exitCode: 0,
+      stdout: "Disabled plugin: git\n",
+      stderr: "",
+    });
+
+    const disabledList = await runCli("plugin", "list");
+    expect(disabledList.exitCode).toBe(0);
+    expect(disabledList.stdout).toContain("git@1.0.0 (disabled)");
+  });
+});

--- a/apps/cli/src/commands/plugin.test.ts
+++ b/apps/cli/src/commands/plugin.test.ts
@@ -68,6 +68,13 @@ describe("plugin command", () => {
       enabled: true,
     });
 
+    const command = await runCli("git", "hook", "status");
+    expect(command).toEqual({
+      exitCode: 0,
+      stdout: "Status: Not a git repository\n",
+      stderr: "",
+    });
+
     const enabledList = await runCli("plugin", "list");
     expect(enabledList.exitCode).toBe(0);
     expect(enabledList.stdout).toContain("git@1.0.0 (enabled)");

--- a/apps/cli/src/commands/plugin.ts
+++ b/apps/cli/src/commands/plugin.ts
@@ -24,6 +24,9 @@ import {
   loadPluginConfig,
   savePluginConfig,
   loadPluginFromPath,
+  createBuiltinPluginMetadata,
+  getBuiltinPlugin,
+  getBuiltinPlugins,
 } from "../plugins/loader.js";
 import type { PluginMetadata } from "@atlcli/plugin-api";
 
@@ -63,9 +66,24 @@ export async function handlePlugin(
 
 async function handleList(opts: OutputOptions): Promise<void> {
   const registry = getPluginRegistry();
+  const config = await loadPluginConfig();
+  const builtins = getBuiltinPlugins();
+  const builtinNames = new Set(builtins.map((plugin) => plugin.name));
+  const plugins = [
+    ...builtins.map((plugin) =>
+      registry.getPlugin(plugin.name) ?? {
+        plugin,
+        metadata:
+          config.find(
+            (candidate) => candidate.source === "builtin" && candidate.name === plugin.name,
+          ) ?? createBuiltinPluginMetadata(plugin, false),
+      },
+    ),
+    ...registry.getAllPlugins().filter(({ plugin }) => !builtinNames.has(plugin.name)),
+  ];
 
   if (opts.json) {
-    const plugins = registry.getAllPlugins().map((p) => ({
+    const serialized = plugins.map((p) => ({
       name: p.plugin.name,
       version: p.plugin.version,
       description: p.plugin.description,
@@ -73,11 +91,9 @@ async function handleList(opts: OutputOptions): Promise<void> {
       enabled: p.metadata.enabled,
       commands: p.plugin.commands?.map((c) => c.name) ?? [],
     }));
-    output(JSON.stringify(plugins, null, 2), opts);
+    output(JSON.stringify(serialized, null, 2), opts);
     return;
   }
-
-  const plugins = registry.getAllPlugins();
 
   if (plugins.length === 0) {
     output("No plugins installed.", opts);
@@ -130,6 +146,9 @@ async function handleInstall(
 
   // Check if already installed
   const config = await loadPluginConfig();
+  if (getBuiltinPlugin(plugin.name)) {
+    fail(opts, 1, ERROR_CODES.CONFIG, `Plugin "${plugin.name}" is bundled with atlcli`);
+  }
   const existing = config.find((p) => p.name === plugin.name);
   if (existing) {
     fail(opts, 1, ERROR_CODES.CONFIG, `Plugin "${plugin.name}" is already installed`);
@@ -185,6 +204,10 @@ async function handleRemove(args: string[], opts: OutputOptions): Promise<void> 
     fail(opts, 1, ERROR_CODES.USAGE, "Usage: atlcli plugin remove <name>");
   }
 
+  if (getBuiltinPlugin(name)) {
+    fail(opts, 1, ERROR_CODES.CONFIG, `Plugin "${name}" is built in and cannot be removed`);
+  }
+
   const config = await loadPluginConfig();
   const index = config.findIndex((p) => p.name === name);
 
@@ -226,7 +249,15 @@ async function handleEnable(args: string[], opts: OutputOptions): Promise<void> 
   }
 
   const config = await loadPluginConfig();
-  const plugin = config.find((p) => p.name === name);
+  let plugin = config.find((p) => p.name === name);
+
+  if (!plugin) {
+    const builtin = getBuiltinPlugin(name);
+    if (builtin) {
+      plugin = createBuiltinPluginMetadata(builtin, false);
+      config.push(plugin);
+    }
+  }
 
   if (!plugin) {
     fail(opts, 1, ERROR_CODES.CONFIG, `Plugin "${name}" is not installed`);
@@ -242,7 +273,13 @@ async function handleEnable(args: string[], opts: OutputOptions): Promise<void> 
 
   // Load into current session
   try {
-    const loadedPlugin = await loadPluginFromPath(plugin.location);
+    const loadedPlugin =
+      plugin.source === "builtin"
+        ? getBuiltinPlugin(plugin.name)
+        : await loadPluginFromPath(plugin.location);
+    if (!loadedPlugin) {
+      throw new Error(`Built-in plugin "${plugin.name}" is unavailable`);
+    }
     if (loadedPlugin.initialize) {
       await loadedPlugin.initialize();
     }
@@ -269,6 +306,10 @@ async function handleDisable(args: string[], opts: OutputOptions): Promise<void>
   const plugin = config.find((p) => p.name === name);
 
   if (!plugin) {
+    if (getBuiltinPlugin(name)) {
+      output(`Plugin "${name}" is already disabled`, opts);
+      return;
+    }
     fail(opts, 1, ERROR_CODES.CONFIG, `Plugin "${name}" is not installed`);
   }
 

--- a/apps/cli/src/plugins/loader.ts
+++ b/apps/cli/src/plugins/loader.ts
@@ -10,6 +10,7 @@ import { join } from "node:path";
 import { readdir, readFile, stat } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
+import gitPlugin from "../../../../plugins/plugin-git/src/index.js";
 import type {
   AtlcliPlugin,
   CommandDefinition,
@@ -17,6 +18,32 @@ import type {
   PluginHooks,
   CommandContext,
 } from "@atlcli/plugin-api";
+
+const BUILTIN_PLUGINS: readonly AtlcliPlugin[] = [gitPlugin];
+
+/** Get all plugins compiled into the atlcli executable. */
+export function getBuiltinPlugins(): AtlcliPlugin[] {
+  return [...BUILTIN_PLUGINS];
+}
+
+/** Get a compiled-in plugin by its canonical name. */
+export function getBuiltinPlugin(name: string): AtlcliPlugin | null {
+  return BUILTIN_PLUGINS.find((plugin) => plugin.name === name) ?? null;
+}
+
+/** Create the persisted metadata used to enable or disable a built-in plugin. */
+export function createBuiltinPluginMetadata(
+  plugin: AtlcliPlugin,
+  enabled: boolean,
+): PluginMetadata {
+  return {
+    name: plugin.name,
+    version: plugin.version,
+    source: "builtin",
+    location: `builtin:${plugin.name}`,
+    enabled,
+  };
+}
 
 /** Loaded plugin with metadata */
 export interface LoadedPlugin {
@@ -251,9 +278,33 @@ export async function discoverLocalPlugins(): Promise<Array<{ path: string; name
 
 /** Load all configured and discovered plugins */
 export async function loadAllPlugins(registry: PluginRegistry): Promise<void> {
-  // Load from config
   const config = await loadPluginConfig();
+
+  // Built-in plugins are available in every binary but remain disabled until
+  // explicitly enabled in the user's plugin config.
+  for (const plugin of BUILTIN_PLUGINS) {
+    const meta = config.find(
+      (candidate) => candidate.source === "builtin" && candidate.name === plugin.name,
+    );
+    if (!meta?.enabled) continue;
+
+    try {
+      if (plugin.initialize) {
+        await plugin.initialize();
+      }
+      registry.register(plugin, {
+        ...meta,
+        version: plugin.version,
+        location: `builtin:${plugin.name}`,
+      });
+    } catch (err) {
+      console.error(`Warning: Failed to load built-in plugin "${plugin.name}": ${err}`);
+    }
+  }
+
+  // Load configured external plugins.
   for (const meta of config) {
+    if (meta.source === "builtin") continue;
     if (!meta.enabled) continue;
 
     try {

--- a/plugins/plugin-git/README.md
+++ b/plugins/plugin-git/README.md
@@ -18,10 +18,10 @@ atlcli plugin enable git
 
 ### Auto-commit (automatic)
 
-After installing the plugin, any `docs pull` that brings in changes will automatically commit them to git:
+After installing the plugin, any `wiki docs pull` that brings in changes will automatically commit them to git:
 
 ```bash
-atlcli docs pull ./docs
+atlcli wiki docs pull ./docs
 # [plugin-git] Auto-committed 3 file(s) from Confluence pull
 
 git log -1
@@ -64,8 +64,8 @@ atlcli git hook remove [dir]
 ### Auto-commit on Pull
 
 1. Plugin registers an `afterCommand` hook
-2. After `docs pull` completes, checks for git changes
-3. Stages all changes and commits with descriptive message
+2. After `wiki docs pull` completes, checks for git changes
+3. Stages changes within the selected docs directory and commits them with a descriptive message
 4. Commit message format: `sync(confluence): pull N page(s) from Confluence`
 
 ### Auto-push on Commit
@@ -73,12 +73,12 @@ atlcli git hook remove [dir]
 1. User installs post-commit hook via `atlcli git hook install`
 2. Hook script is created at `.git/hooks/post-commit`
 3. On each commit, hook checks for sync daemon lockfile
-4. If no lockfile, runs `atlcli docs push` to sync to Confluence
+4. If no lockfile, runs `atlcli wiki docs push` to sync to Confluence
 5. Push failures are non-blocking (commit succeeds regardless)
 
 ### Lockfile Detection
 
-When the sync daemon (`atlcli docs sync`) is running, it creates a lockfile at `.atlcli/.sync.lock`. The post-commit hook detects this and skips the push to avoid conflicts.
+When the sync daemon (`atlcli wiki docs sync`) is running, it creates a lockfile at `.atlcli/.sync.lock`. The post-commit hook detects this and skips the push to avoid conflicts.
 
 ## Commit Message Format
 

--- a/plugins/plugin-git/README.md
+++ b/plugins/plugin-git/README.md
@@ -11,7 +11,7 @@ Git integration plugin for atlcli Confluence sync.
 ## Installation
 
 ```bash
-atlcli plugin install ./plugins/plugin-git
+atlcli plugin enable git
 ```
 
 ## Usage

--- a/plugins/plugin-git/src/auto-commit.test.ts
+++ b/plugins/plugin-git/src/auto-commit.test.ts
@@ -27,10 +27,10 @@ describe("autoCommitAfterPull", () => {
 
   function createContext(overrides: Partial<CommandContext> = {}): CommandContext {
     return {
-      command: ["docs", "pull", tempDir],
-      args: ["pull", tempDir],
+      command: ["wiki", "docs", "pull", tempDir],
+      args: ["docs", "pull", tempDir],
       flags: {},
-      output: { json: false, quiet: false },
+      output: { json: false },
       ...overrides,
     };
   }
@@ -50,7 +50,10 @@ describe("autoCommitAfterPull", () => {
     test("skips docs commands other than pull", async () => {
       await writeFile(join(tempDir, "new.txt"), "content");
 
-      const ctx = createContext({ command: ["docs", "push", tempDir], args: ["push", tempDir] });
+      const ctx = createContext({
+        command: ["wiki", "docs", "push", tempDir],
+        args: ["docs", "push", tempDir],
+      });
       await autoCommitAfterPull(ctx);
 
       const { stdout } = await gitExec(tempDir, ["status", "--porcelain"]);
@@ -60,7 +63,10 @@ describe("autoCommitAfterPull", () => {
     test("skips docs sync command", async () => {
       await writeFile(join(tempDir, "new.txt"), "content");
 
-      const ctx = createContext({ command: ["docs", "sync", tempDir], args: ["sync", tempDir] });
+      const ctx = createContext({
+        command: ["wiki", "docs", "sync", tempDir],
+        args: ["docs", "sync", tempDir],
+      });
       await autoCommitAfterPull(ctx);
 
       const { stdout } = await gitExec(tempDir, ["status", "--porcelain"]);
@@ -85,8 +91,8 @@ describe("autoCommitAfterPull", () => {
       await writeFile(join(nonGitDir, "file.txt"), "content");
 
       const ctx = createContext({
-        command: ["docs", "pull", nonGitDir],
-        args: ["pull", nonGitDir],
+        command: ["wiki", "docs", "pull", nonGitDir],
+        args: ["docs", "pull", nonGitDir],
       });
 
       // Should not throw
@@ -118,6 +124,35 @@ describe("autoCommitAfterPull", () => {
 
       const { stdout } = await gitExec(tempDir, ["log", "-1", "--format=%s"]);
       expect(stdout).toContain("sync(confluence): pull");
+    });
+
+    test("preserves staged work outside the docs directory", async () => {
+      const docsDir = join(tempDir, "docs");
+      await mkdir(docsDir);
+      await writeFile(join(docsDir, "pulled.md"), "# From Confluence");
+      await writeFile(join(tempDir, "unrelated.txt"), "user work");
+      await gitExec(tempDir, ["add", "unrelated.txt"]);
+
+      const ctx = createContext({
+        command: ["wiki", "docs", "pull", docsDir],
+        args: ["docs", "pull", docsDir],
+      });
+      await autoCommitAfterPull(ctx);
+
+      const { stdout: committed } = await gitExec(tempDir, [
+        "show",
+        "--pretty=format:",
+        "--name-only",
+        "HEAD",
+      ]);
+      expect(committed.trim()).toBe("docs/pulled.md");
+
+      const { stdout: stillStaged } = await gitExec(tempDir, [
+        "diff",
+        "--cached",
+        "--name-only",
+      ]);
+      expect(stillStaged.trim()).toBe("unrelated.txt");
     });
   });
 
@@ -177,10 +212,10 @@ describe("autoCommitAfterPull", () => {
 
       try {
         const ctx: CommandContext = {
-          command: ["docs", "pull"],
-          args: ["pull"],
+          command: ["wiki", "docs", "pull"],
+          args: ["docs", "pull"],
           flags: {},
-          output: { json: false, quiet: false },
+          output: { json: false },
         };
         await autoCommitAfterPull(ctx);
 

--- a/plugins/plugin-git/src/auto-commit.ts
+++ b/plugins/plugin-git/src/auto-commit.ts
@@ -42,32 +42,16 @@ function buildCommitMessage(changes: FileChange[], direction: "pull" | "push"): 
  * This is called as an afterCommand hook.
  */
 export async function autoCommitAfterPull(ctx: CommandContext): Promise<void> {
-  // 1. Check if this is a docs pull or docs sync command
-  const [cmd, subcmd] = ctx.command;
+  // Hooks receive the complete root command path from the CLI.
+  const [rootCommand, namespace, action, commandDir] = ctx.command;
 
-  // Only trigger for docs pull and docs sync
-  if (cmd !== "docs") {
+  if (rootCommand !== "wiki" || namespace !== "docs" || action !== "pull") {
     return;
   }
 
-  if (subcmd !== "pull" && subcmd !== "sync") {
-    return;
-  }
-
-  // For sync command, we only auto-commit after it stops (not while running)
-  // The sync daemon handles its own commits differently
-  // For now, skip sync to avoid complications with the running daemon
-  if (subcmd === "sync") {
-    // Sync daemon runs continuously, so we don't auto-commit here
-    // Instead, the sync engine should handle commits during operation
-    return;
-  }
-
-  // 2. Get the directory from args
-  // ctx.command = ["docs", "pull", dir] or ["docs", "pull"]
-  // ctx.args = ["pull", dir] or ["pull"]
-  // So the directory is at ctx.args[1] or ctx.command[2]
-  const dir = ctx.args[1] ? resolve(ctx.args[1]) : process.cwd();
+  // ctx.command = ["wiki", "docs", "pull", dir]
+  // ctx.args = ["docs", "pull", dir]
+  const dir = resolve(commandDir ?? ctx.args[2] ?? process.cwd());
 
   // 3. Check if directory is a git repo
   if (!(await isGitRepo(dir))) {
@@ -84,9 +68,11 @@ export async function autoCommitAfterPull(ctx: CommandContext): Promise<void> {
 
   // 5. Stage all changes and commit
   try {
-    await gitAddAll(dir);
+    // Limit both staging and the commit to the selected docs directory. Using
+    // --only for the commit preserves unrelated changes already in the index.
+    await gitAddAll(dir, ".");
     const message = buildCommitMessage(changes, "pull");
-    await gitCommit(dir, message);
+    await gitCommit(dir, message, ["."]);
 
     // Output success message (unless --quiet flag is set)
     if (!ctx.flags.quiet) {

--- a/plugins/plugin-git/src/git-hooks.test.ts
+++ b/plugins/plugin-git/src/git-hooks.test.ts
@@ -32,7 +32,7 @@ describe("git hooks", () => {
       command: ["git", "hook", "install"],
       args: [tempDir],
       flags: {},
-      output: { json: false, quiet: false },
+      output: { json: false },
       ...overrides,
     };
   }
@@ -45,6 +45,19 @@ describe("git hooks", () => {
       expect(existsSync(hookPath)).toBe(true);
       const content = await readFile(hookPath, "utf-8");
       expect(content).toContain("atlcli-plugin-git hook");
+      expect(content).toContain("atlcli wiki docs push");
+      expect(content).toContain("DOCS_RELATIVE='.'");
+    });
+
+    test("retains a nested docs directory in the installed hook", async () => {
+      const docsDir = join(tempDir, "docs with spaces");
+      await mkdir(join(docsDir, ".atlcli"), { recursive: true });
+
+      await installHookHandler(createContext({ args: [docsDir] }));
+
+      const content = await readFile(hookPath, "utf-8");
+      expect(content).toContain("DOCS_RELATIVE='docs with spaces'");
+      expect(content).toContain('DOCS_DIR="$REPO_ROOT/$DOCS_RELATIVE"');
     });
 
     test("makes hook executable", async () => {
@@ -130,7 +143,7 @@ describe("git hooks", () => {
     });
 
     test("outputs JSON when requested", async () => {
-      const ctx = createContext({ output: { json: true, quiet: false } });
+      const ctx = createContext({ output: { json: true } });
 
       // Capture console output
       const logs: string[] = [];
@@ -206,7 +219,7 @@ describe("git hooks", () => {
 
       const ctx = createContext({
         command: ["git", "hook", "remove"],
-        output: { json: true, quiet: false },
+        output: { json: true },
       });
 
       const logs: string[] = [];
@@ -226,7 +239,7 @@ describe("git hooks", () => {
     test("reports not installed", async () => {
       const ctx = createContext({
         command: ["git", "hook", "status"],
-        output: { json: true, quiet: false },
+        output: { json: true },
       });
 
       const logs: string[] = [];
@@ -247,7 +260,7 @@ describe("git hooks", () => {
 
       const ctx = createContext({
         command: ["git", "hook", "status"],
-        output: { json: true, quiet: false },
+        output: { json: true },
       });
 
       const logs: string[] = [];
@@ -265,7 +278,7 @@ describe("git hooks", () => {
     test("reports atlcli initialized status", async () => {
       const ctx = createContext({
         command: ["git", "hook", "status"],
-        output: { json: true, quiet: false },
+        output: { json: true },
       });
 
       const logs: string[] = [];
@@ -286,7 +299,7 @@ describe("git hooks", () => {
 
       const ctx = createContext({
         command: ["git", "hook", "status"],
-        output: { json: true, quiet: false },
+        output: { json: true },
       });
 
       const logs: string[] = [];
@@ -308,7 +321,7 @@ describe("git hooks", () => {
 
       const ctx = createContext({
         command: ["git", "hook", "status"],
-        output: { json: true, quiet: false },
+        output: { json: true },
       });
 
       const logs: string[] = [];
@@ -330,7 +343,7 @@ describe("git hooks", () => {
       const ctx = createContext({
         command: ["git", "hook", "status"],
         args: [nonGitDir],
-        output: { json: true, quiet: false },
+        output: { json: true },
       });
 
       const logs: string[] = [];

--- a/plugins/plugin-git/src/git-hooks.ts
+++ b/plugins/plugin-git/src/git-hooks.ts
@@ -4,8 +4,8 @@
  * Installs/removes/checks post-commit hooks for auto-pushing to Confluence.
  */
 
-import { readFile, writeFile, unlink, chmod, stat } from "node:fs/promises";
-import { join, resolve } from "node:path";
+import { readFile, writeFile, unlink, chmod, realpath, stat } from "node:fs/promises";
+import { isAbsolute, join, relative, resolve, sep } from "node:path";
 import { existsSync } from "node:fs";
 import type { CommandContext } from "./types.js";
 import { isGitRepo, getGitRoot } from "./utils.js";
@@ -13,14 +13,25 @@ import { isGitRepo, getGitRoot } from "./utils.js";
 /** Marker comment to identify our hook */
 const HOOK_MARKER = "# atlcli-plugin-git hook";
 
-/** The post-commit hook script */
-const HOOK_SCRIPT = `#!/bin/sh
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", `'"'"'`)}'`;
+}
+
+/** Build a post-commit hook that retains the selected docs directory. */
+function buildHookScript(relativeDocsDir: string): string {
+  return `#!/bin/sh
 ${HOOK_MARKER}
 # Auto-push to Confluence on commit
 # Installed by: atlcli git hook install
 
-# Get the directory containing .atlcli
-DOCS_DIR="$(git rev-parse --show-toplevel)"
+# Resolve the configured docs directory from the current repository location.
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+DOCS_RELATIVE=${shellQuote(relativeDocsDir)}
+if [ "$DOCS_RELATIVE" = "." ]; then
+  DOCS_DIR="$REPO_ROOT"
+else
+  DOCS_DIR="$REPO_ROOT/$DOCS_RELATIVE"
+fi
 
 # Skip if sync daemon is running (lockfile exists)
 LOCKFILE="$DOCS_DIR/.atlcli/.sync.lock"
@@ -36,13 +47,14 @@ fi
 
 # Push changes to Confluence
 echo "[atlcli-git] Auto-pushing to Confluence..."
-atlcli docs push "$DOCS_DIR" --quiet 2>&1 || {
+atlcli wiki docs push "$DOCS_DIR" --quiet 2>&1 || {
   echo "[atlcli-git] Push failed (non-blocking)"
 }
 
 # Always exit 0 - don't block commits
 exit 0
 `;
+}
 
 /**
  * Get the path to the post-commit hook.
@@ -88,7 +100,7 @@ async function hasExistingHook(hookPath: string): Promise<boolean> {
  * Install the post-commit hook.
  */
 export async function installHookHandler(ctx: CommandContext): Promise<void> {
-  const dir = ctx.args[0] ? resolve(ctx.args[0]) : process.cwd();
+  let dir = ctx.args[0] ? resolve(ctx.args[0]) : process.cwd();
 
   // Check if git repo
   if (!(await isGitRepo(dir))) {
@@ -96,17 +108,30 @@ export async function installHookHandler(ctx: CommandContext): Promise<void> {
     process.exitCode = 1;
     return;
   }
+  dir = await realpath(dir);
 
   // Check if .atlcli directory exists
   const atlcliDir = join(dir, ".atlcli");
   if (!existsSync(atlcliDir)) {
     console.error("Error: Directory not initialized for atlcli (missing .atlcli/)");
-    console.error("Run 'atlcli docs init' first");
+    console.error("Run 'atlcli wiki docs init' first");
     process.exitCode = 1;
     return;
   }
 
-  const hookPath = await getHookPath(dir);
+  const gitRoot = await getGitRoot(dir);
+  const relativeDocsDir = relative(gitRoot, dir);
+  if (
+    isAbsolute(relativeDocsDir) ||
+    relativeDocsDir === ".." ||
+    relativeDocsDir.startsWith(`..${sep}`)
+  ) {
+    console.error("Error: Docs directory must be inside the Git repository");
+    process.exitCode = 1;
+    return;
+  }
+  const portableDocsDir = relativeDocsDir ? relativeDocsDir.split(sep).join("/") : ".";
+  const hookPath = join(gitRoot, ".git", "hooks", "post-commit");
 
   // Check if our hook is already installed
   if (await isHookInstalled(hookPath)) {
@@ -135,7 +160,7 @@ export async function installHookHandler(ctx: CommandContext): Promise<void> {
   }
 
   // Write the hook
-  await writeFile(hookPath, HOOK_SCRIPT);
+  await writeFile(hookPath, buildHookScript(portableDocsDir));
   await chmod(hookPath, 0o755); // Make executable
 
   if (ctx.output.json) {

--- a/plugins/plugin-git/src/index.ts
+++ b/plugins/plugin-git/src/index.ts
@@ -6,7 +6,7 @@
  * 2. Git hooks: Install post-commit hook for auto-push to Confluence
  *
  * Usage:
- *   atlcli plugin install ./plugins/plugin-git
+ *   atlcli plugin enable git
  *   atlcli git hook install     # Enable auto-push on commit
  *   atlcli git hook status      # Check hook status
  *   atlcli git hook remove      # Disable auto-push
@@ -101,7 +101,7 @@ Options:
 
 /** Plugin definition */
 const plugin: AtlcliPlugin = {
-  name: "plugin-git",
+  name: "git",
   version: "1.0.0",
   description: "Git integration for Confluence sync - auto-commit on pull, auto-push on commit",
 

--- a/plugins/plugin-git/src/types.ts
+++ b/plugins/plugin-git/src/types.ts
@@ -8,11 +8,10 @@
 /** Output options passed to commands */
 export interface OutputOptions {
   json: boolean;
-  quiet: boolean;
 }
 
 /** Flag value types */
-export type FlagValue = string | number | boolean | undefined;
+export type FlagValue = string | boolean | string[];
 
 /** Context passed to command handlers and hooks */
 export interface CommandContext {
@@ -66,6 +65,8 @@ export interface CommandDefinition {
   name: string;
   description: string;
   subcommands?: Subcommand[];
+  /** Handler for a command without subcommands. */
+  handler?: (ctx: CommandContext) => Promise<void>;
 }
 
 /** Full plugin interface */

--- a/plugins/plugin-git/src/utils.test.ts
+++ b/plugins/plugin-git/src/utils.test.ts
@@ -134,6 +134,16 @@ describe("git utils", () => {
       expect(paths).toContain("staged.txt");
       expect(paths).toContain("unstaged.txt");
     });
+
+    test("limits changes to the supplied working directory", async () => {
+      const docsDir = join(tempDir, "docs");
+      await mkdir(docsDir);
+      await writeFile(join(docsDir, "inside.md"), "inside");
+      await writeFile(join(tempDir, "outside.md"), "outside");
+
+      const changes = await getAllGitChanges(docsDir);
+      expect(changes.map((change) => change.path)).toEqual(["docs/inside.md"]);
+    });
   });
 
   describe("gitAdd", () => {
@@ -158,6 +168,16 @@ describe("git utils", () => {
 
       const { stdout } = await gitExec(tempDir, ["diff", "--cached", "--name-only"]);
       expect(stdout.trim()).toBe("file.txt");
+    });
+
+    test("preserves file paths containing spaces", async () => {
+      const filename = "file with spaces.txt";
+      await writeFile(join(tempDir, filename), "content");
+
+      await gitAdd(tempDir, [filename]);
+
+      const { stdout } = await gitExec(tempDir, ["diff", "--cached", "--name-only"]);
+      expect(stdout.trim()).toBe(filename);
     });
   });
 
@@ -214,6 +234,16 @@ describe("git utils", () => {
       const { stdout } = await gitExec(tempDir, ["log", "-1", "--format=%B"]);
       expect(stdout.trim()).toContain("Subject line");
       expect(stdout.trim()).toContain("Body text here");
+    });
+
+    test("does not expand environment variables in messages", async () => {
+      await writeFile(join(tempDir, "file.txt"), "content");
+      await gitExec(tempDir, ["add", "."]);
+
+      await gitCommit(tempDir, "Keep $HOME literal");
+
+      const { stdout } = await gitExec(tempDir, ["log", "-1", "--format=%s"]);
+      expect(stdout.trim()).toBe("Keep $HOME literal");
     });
   });
 

--- a/plugins/plugin-git/src/utils.ts
+++ b/plugins/plugin-git/src/utils.ts
@@ -2,12 +2,12 @@
  * Git utilities for plugin-git.
  */
 
-import { exec } from "node:child_process";
+import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { stat } from "node:fs/promises";
 import { join } from "node:path";
 
-const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 
 /** File change from git status */
 export interface FileChange {
@@ -22,16 +22,52 @@ export async function gitExec(
   dir: string,
   args: string[]
 ): Promise<{ stdout: string; stderr: string }> {
-  const command = `git ${args.join(" ")}`;
+  const displayCommand = ["git", ...args].map((arg) => JSON.stringify(arg)).join(" ");
   try {
-    const result = await execAsync(command, { cwd: dir, maxBuffer: 10 * 1024 * 1024 });
-    return result;
+    const result = await execFileAsync("git", args, {
+      cwd: dir,
+      encoding: "utf-8",
+      maxBuffer: 10 * 1024 * 1024,
+    });
+    return { stdout: result.stdout, stderr: result.stderr };
   } catch (err: unknown) {
     const error = err as { stdout?: string; stderr?: string; message?: string };
     throw new Error(
-      `Git command failed: ${command}\n${error.stderr || error.message}`
+      `Git command failed: ${displayCommand}\n${error.stderr || error.message}`
     );
   }
+}
+
+interface PorcelainEntry {
+  indexStatus: string;
+  workTreeStatus: string;
+  path: string;
+}
+
+/** Parse NUL-delimited porcelain output without relying on shell quoting. */
+function parsePorcelain(output: string): PorcelainEntry[] {
+  const records = output.split("\0");
+  const entries: PorcelainEntry[] = [];
+
+  for (let i = 0; i < records.length; i++) {
+    const record = records[i];
+    if (!record || record.length < 4) continue;
+
+    const indexStatus = record.charAt(0);
+    const workTreeStatus = record.charAt(1);
+    entries.push({
+      indexStatus,
+      workTreeStatus,
+      path: record.substring(3),
+    });
+
+    // Rename/copy records contain a second NUL-delimited source path.
+    if (indexStatus === "R" || indexStatus === "C" || workTreeStatus === "R" || workTreeStatus === "C") {
+      i += 1;
+    }
+  }
+
+  return entries;
 }
 
 /**
@@ -66,28 +102,21 @@ export async function getGitRoot(dir: string): Promise<string> {
  * Returns only untracked and modified files (not staged).
  */
 export async function getGitChanges(dir: string): Promise<FileChange[]> {
-  const { stdout } = await gitExec(dir, ["status", "--porcelain"]);
+  const { stdout } = await gitExec(dir, [
+    "status",
+    "--porcelain=v1",
+    "-z",
+    "--untracked-files=all",
+    "--",
+    ".",
+  ]);
 
   if (!stdout.trim()) {
     return [];
   }
 
   const changes: FileChange[] = [];
-  // Don't use trim() on the full output - it removes leading spaces from status codes
-  const lines = stdout.replace(/\n$/, "").split("\n");
-
-  for (const line of lines) {
-    if (!line || line.length < 4) continue;
-
-    // Git status --porcelain format: XY filename
-    // X = index status, Y = work tree status
-    // Format is exactly: "XY " followed by filename (3 chars then filename)
-    const indexStatus = line.charAt(0);
-    const workTreeStatus = line.charAt(1);
-    const path = line.substring(3); // Skip "XY "
-
-    // We care about work tree changes (untracked, modified)
-    // ? = untracked, M = modified, A = added, D = deleted
+  for (const { indexStatus, workTreeStatus, path } of parsePorcelain(stdout)) {
     if (workTreeStatus === "?" || workTreeStatus === "M" || workTreeStatus === "D") {
       changes.push({
         path,
@@ -109,23 +138,21 @@ export async function getGitChanges(dir: string): Promise<FileChange[]> {
  * Get list of all uncommitted changes (staged + unstaged).
  */
 export async function getAllGitChanges(dir: string): Promise<FileChange[]> {
-  const { stdout } = await gitExec(dir, ["status", "--porcelain"]);
+  const { stdout } = await gitExec(dir, [
+    "status",
+    "--porcelain=v1",
+    "-z",
+    "--untracked-files=all",
+    "--",
+    ".",
+  ]);
 
   if (!stdout.trim()) {
     return [];
   }
 
   const changes: FileChange[] = [];
-  // Don't use trim() on the full output - it removes leading spaces from status codes
-  const lines = stdout.replace(/\n$/, "").split("\n");
-
-  for (const line of lines) {
-    if (!line || line.length < 4) continue;
-
-    const indexStatus = line.charAt(0);
-    const workTreeStatus = line.charAt(1);
-    const path = line.substring(3);
-
+  for (const { indexStatus, workTreeStatus, path } of parsePorcelain(stdout)) {
     // Include any file that has changes (staged or unstaged)
     if (indexStatus !== " " || workTreeStatus !== " ") {
       // Determine the most relevant status
@@ -163,17 +190,23 @@ export async function gitAdd(dir: string, files: string[] | FileChange[]): Promi
 /**
  * Stage all changes.
  */
-export async function gitAddAll(dir: string): Promise<void> {
-  await gitExec(dir, ["add", "-A"]);
+export async function gitAddAll(dir: string, pathspec = "."): Promise<void> {
+  await gitExec(dir, ["add", "-A", "--", pathspec]);
 }
 
 /**
  * Create a git commit.
  */
-export async function gitCommit(dir: string, message: string): Promise<string> {
-  // Quote the message to handle special characters like parentheses
-  const quotedMessage = `"${message.replace(/"/g, '\\"')}"`;
-  const { stdout } = await gitExec(dir, ["commit", "-m", quotedMessage]);
+export async function gitCommit(
+  dir: string,
+  message: string,
+  pathspecs: string[] = [],
+): Promise<string> {
+  const args = ["commit", "-m", message];
+  if (pathspecs.length > 0) {
+    args.push("--only", "--", ...pathspecs);
+  }
+  const { stdout } = await gitExec(dir, args);
   return stdout;
 }
 


### PR DESCRIPTION
## Summary

- compile the Git plugin into every atlcli release binary as a built-in plugin
- use `git` as the plugin's canonical name and persist built-in enable/disable state
- show the bundled plugin in `plugin list`, prevent duplicate installation/removal, and add end-to-end regression coverage

## Root cause

The release binary never imported or registered the Git plugin, while `plugin enable` only searched entries already present in `plugins.json`. The plugin also identified itself as `plugin-git`, although the documented command used `git`.

## User impact

Fresh binary installations can now run `atlcli plugin enable git` on every supported platform, including Windows, without separately installing plugin source files.

## Validation

- `bun test plugins/plugin-git apps/cli/src/commands/plugin.test.ts` — 51 passed, 0 failed
- `bun run typecheck`
- release-style macOS compiled-binary smoke test
- Windows x64 cross-compilation

The full suite reached 1,065 passing tests; 12 existing webhook-server tests could not bind localhost ports in the sandbox.

Fixes #20