### PR TITLE
fix(markdown): convert regular code blocks to Confluence macros

### DIFF
--- a/packages/confluence/src/markdown.test.ts
+++ b/packages/confluence/src/markdown.test.ts
@@ -20,9 +20,32 @@ describe("markdownToStorage", () => {
   test("converts code blocks with language", () => {
     const md = "```typescript\nconst x = 1;\n```";
     const html = markdownToStorage(md);
-    expect(html).toContain("<pre>");
-    expect(html).toContain("<code");
-    expect(html).toContain("language-typescript");
+    expect(html).toContain('<ac:structured-macro ac:name="code">');
+    expect(html).toContain('<ac:parameter ac:name="language">typescript</ac:parameter>');
+    expect(html).toContain("<![CDATA[const x = 1;");
+    expect(html).toContain("</ac:plain-text-body>");
+    expect(html).toContain("</ac:structured-macro>");
+  });
+
+  test("converts code blocks without language to code macro (regression: no <pre><code>)", () => {
+    const md = "```\n# Default Code Owners\n* @Schneider.Felix.SE @Karpic.Jelenko\n```";
+    const html = markdownToStorage(md);
+    expect(html).toContain('<ac:structured-macro ac:name="code">');
+    expect(html).toContain("<![CDATA[# Default Code Owners");
+    expect(html).toContain("@Schneider.Felix.SE @Karpic.Jelenko");
+    expect(html).toContain("</ac:plain-text-body>");
+    expect(html).not.toContain('ac:name="language"');
+    expect(html).not.toContain('<pre><code');
+    expect(html).not.toContain('class=""');
+  });
+
+  test("converts code blocks with 'text' language to code macro (regression: round-trip)", () => {
+    const md = "```text\nplain text content\n```";
+    const html = markdownToStorage(md);
+    expect(html).toContain('<ac:structured-macro ac:name="code">');
+    expect(html).toContain('<ac:parameter ac:name="language">text</ac:parameter>');
+    expect(html).toContain("<![CDATA[plain text content");
+    expect(html).not.toContain('<pre><code');
   });
 
   test("converts task lists to Confluence format", () => {
@@ -556,6 +579,22 @@ describe("round-trip conversion", () => {
     const result = storageToMarkdown(html);
     expect(result).toContain("```");
     expect(result).toContain("const x = 1;");
+  });
+
+  test("code macro without language survives storage → markdown → storage (regression)", () => {
+    const originalStorage =
+      '<ac:structured-macro ac:name="code" ac:schema-version="1">' +
+      '<ac:parameter ac:name="language">text</ac:parameter>' +
+      '<ac:plain-text-body><![CDATA[# Default Code Owners\n* @Schneider.Felix.SE @Karpic.Jelenko\n]]></ac:plain-text-body>' +
+      '</ac:structured-macro>';
+    const md = storageToMarkdown(originalStorage);
+    const roundtrip = markdownToStorage(md);
+    expect(roundtrip).toContain('<ac:structured-macro ac:name="code">');
+    expect(roundtrip).toContain('<ac:parameter ac:name="language">text</ac:parameter>');
+    expect(roundtrip).toContain("# Default Code Owners");
+    expect(roundtrip).toContain("@Schneider.Felix.SE @Karpic.Jelenko");
+    expect(roundtrip).not.toContain('<pre><code');
+    expect(roundtrip).not.toContain('class=""');
   });
 
   test("list survives round-trip", () => {

--- a/packages/confluence/src/markdown.test.ts
+++ b/packages/confluence/src/markdown.test.ts
@@ -48,6 +48,13 @@ describe("markdownToStorage", () => {
     expect(html).not.toContain('<pre><code');
   });
 
+  test("splits CDATA terminators inside code blocks", () => {
+    const md = '```xml\nconst terminator = "]]>";\n```';
+    const html = markdownToStorage(md);
+    expect(html).toContain('<![CDATA[const terminator = "]]]]><![CDATA[>";');
+    expect(storageToMarkdown(html)).toContain('const terminator = "]]>";');
+  });
+
   test("converts task lists to Confluence format", () => {
     const md = "- [ ] Unchecked\n- [x] Checked";
     const html = markdownToStorage(md);
@@ -584,17 +591,25 @@ describe("round-trip conversion", () => {
   test("code macro without language survives storage → markdown → storage (regression)", () => {
     const originalStorage =
       '<ac:structured-macro ac:name="code" ac:schema-version="1">' +
-      '<ac:parameter ac:name="language">text</ac:parameter>' +
       '<ac:plain-text-body><![CDATA[# Default Code Owners\n* @Schneider.Felix.SE @Karpic.Jelenko\n]]></ac:plain-text-body>' +
       '</ac:structured-macro>';
     const md = storageToMarkdown(originalStorage);
     const roundtrip = markdownToStorage(md);
     expect(roundtrip).toContain('<ac:structured-macro ac:name="code">');
-    expect(roundtrip).toContain('<ac:parameter ac:name="language">text</ac:parameter>');
+    expect(roundtrip).not.toContain('ac:name="language"');
     expect(roundtrip).toContain("# Default Code Owners");
     expect(roundtrip).toContain("@Schneider.Felix.SE @Karpic.Jelenko");
     expect(roundtrip).not.toContain('<pre><code');
     expect(roundtrip).not.toContain('class=""');
+  });
+
+  test("split CDATA terminators survive storage → markdown → storage", () => {
+    const original = '```xml\nconst terminator = "]]>";\n```\n';
+    const storage = markdownToStorage(original);
+    const md = storageToMarkdown(storage);
+    const roundtrip = markdownToStorage(md);
+    expect(md).toContain('const terminator = "]]>";');
+    expect(roundtrip).toContain('<![CDATA[const terminator = "]]]]><![CDATA[>";');
   });
 
   test("list survives round-trip", () => {

--- a/packages/confluence/src/markdown.ts
+++ b/packages/confluence/src/markdown.ts
@@ -108,9 +108,12 @@ md.renderer.rules.fence = (tokens, idx) => {
   }
 
   // Regular code block
-  const lang = info ? ` language-${escapeHtml(info)}` : "";
-  const escapedContent = escapeHtml(content);
-  return `<pre><code class="${lang.trim()}">${escapedContent}</code></pre>`;
+  let macroHtml = `<ac:structured-macro ac:name="code">`;
+  if (info) {
+    macroHtml += `\n<ac:parameter ac:name="language">${escapeHtml(info)}</ac:parameter>`;
+  }
+  macroHtml += `\n<ac:plain-text-body><![CDATA[${content}]]></ac:plain-text-body>\n</ac:structured-macro>`;
+  return macroHtml;
 };
 
 /**

--- a/packages/confluence/src/markdown.ts
+++ b/packages/confluence/src/markdown.ts
@@ -76,7 +76,7 @@ md.renderer.rules.fence = (tokens, idx) => {
 
   // Handle noformat blocks: ```noformat
   if (info.toLowerCase() === "noformat") {
-    return `<ac:structured-macro ac:name="noformat">\n<ac:plain-text-body><![CDATA[${content}]]></ac:plain-text-body>\n</ac:structured-macro>`;
+    return `<ac:structured-macro ac:name="noformat">\n${serializePlainTextBody(content)}\n</ac:structured-macro>`;
   }
 
   // Parse extended syntax: ```lang{title="..." collapse}
@@ -102,7 +102,7 @@ md.renderer.rules.fence = (tokens, idx) => {
     if (hasCollapse) {
       macroHtml += `\n<ac:parameter ac:name="collapse">true</ac:parameter>`;
     }
-    macroHtml += `\n<ac:plain-text-body><![CDATA[${content}]]></ac:plain-text-body>\n</ac:structured-macro>`;
+    macroHtml += `\n${serializePlainTextBody(content)}\n</ac:structured-macro>`;
 
     return macroHtml;
   }
@@ -112,7 +112,7 @@ md.renderer.rules.fence = (tokens, idx) => {
   if (info) {
     macroHtml += `\n<ac:parameter ac:name="language">${escapeHtml(info)}</ac:parameter>`;
   }
-  macroHtml += `\n<ac:plain-text-body><![CDATA[${content}]]></ac:plain-text-body>\n</ac:structured-macro>`;
+  macroHtml += `\n${serializePlainTextBody(content)}\n</ac:structured-macro>`;
   return macroHtml;
 };
 
@@ -1689,13 +1689,10 @@ function preprocessStorageMacros(storage: string, options?: ConversionOptions): 
       const langMatch = inner.match(/<ac:parameter\s+ac:name="language"[^>]*>([^<]*)<\/ac:parameter>/i);
       const titleMatch = inner.match(/<ac:parameter\s+ac:name="title"[^>]*>([^<]*)<\/ac:parameter>/i);
       const collapseMatch = inner.match(/<ac:parameter\s+ac:name="collapse"[^>]*>([^<]*)<\/ac:parameter>/i);
-      // Code is in plain-text-body, possibly wrapped in CDATA
-      const bodyMatch = inner.match(/<ac:plain-text-body>(?:<!\[CDATA\[)?([\s\S]*?)(?:\]\]>)?<\/ac:plain-text-body>/i);
-
       const lang = langMatch ? langMatch[1] : "";
       const title = titleMatch ? titleMatch[1] : "";
       const collapse = collapseMatch ? collapseMatch[1] : "";
-      const code = bodyMatch ? bodyMatch[1] : "";
+      const code = extractPlainTextBody(inner);
 
       return `<pre data-macro="code" data-lang="${escapeHtml(lang)}" data-title="${escapeHtml(title)}" data-collapse="${escapeHtml(collapse)}"><code>${escapeHtml(code)}</code></pre>`;
     }
@@ -1705,8 +1702,7 @@ function preprocessStorageMacros(storage: string, options?: ConversionOptions): 
   storage = storage.replace(
     /<ac:structured-macro\s+ac:name="noformat"[^>]*>([\s\S]*?)<\/ac:structured-macro>/gi,
     (_, inner) => {
-      const bodyMatch = inner.match(/<ac:plain-text-body>(?:<!\[CDATA\[)?([\s\S]*?)(?:\]\]>)?<\/ac:plain-text-body>/i);
-      const content = bodyMatch ? bodyMatch[1] : "";
+      const content = extractPlainTextBody(inner);
       return `<pre data-macro="noformat"><code>${escapeHtml(content)}</code></pre>`;
     }
   );
@@ -3059,6 +3055,30 @@ export function storageToMarkdown(storage: string, options?: ConversionOptions):
 
   const markdown = service.turndown(preprocessed);
   return markdown.trim() + "\n";
+}
+
+/**
+ * Wrap text in CDATA while preserving literal CDATA terminators.
+ * XML represents `]]>` by closing and reopening the CDATA section.
+ */
+function serializePlainTextBody(content: string): string {
+  const safeContent = content.replaceAll("]]>", "]]]]><![CDATA[>");
+  return `<ac:plain-text-body><![CDATA[${safeContent}]]></ac:plain-text-body>`;
+}
+
+/** Extract a Confluence plain-text body and reassemble split CDATA sections. */
+function extractPlainTextBody(input: string): string {
+  const bodyMatch = input.match(/<ac:plain-text-body>([\s\S]*?)<\/ac:plain-text-body>/i);
+  if (!bodyMatch) return "";
+
+  const body = bodyMatch[1];
+  if (!body.startsWith("<![CDATA[") || !body.endsWith("]]>")) {
+    return body;
+  }
+
+  return body
+    .slice("<![CDATA[".length, -"]]>".length)
+    .replaceAll("]]]]><![CDATA[>", "]]>");
 }
 
 function escapeHtml(input: string): string {


### PR DESCRIPTION
#### Description

I noticed that regular code blocks (``` fences without a language specifier), do not result in Confluence macros when pushing back.
This creates a divergence between pull and push logic, which leads to content being unintentionally overridden.

This PR fixes this by rendering regular code blocks to Confluence macros as well, like they were when the pull happened.