### PR TITLE
fix(path): resolve path correctly on Windows

### DIFF
--- a/apps/cli/src/commands/docs.test.ts
+++ b/apps/cli/src/commands/docs.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Tests for docs command path resolution helpers.
+ *
+ * These regression tests cover the fixes for confusing "path duplication"
+ * and stale-state errors on `atlcli wiki docs push --page-id <id>`:
+ *
+ * - The command must find the file when the recorded state path is valid.
+ * - The command must find the file when it was renamed/moved locally by
+ *   scanning frontmatter IDs, and it must heal state on the fly.
+ * - State paths must round-trip as POSIX so lookups work across Windows/Unix.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import type { AtlcliState } from "@atlcli/confluence";
+
+const { resolvePageFile, findMarkdownFileByFrontmatterId } = await import("./docs.js");
+
+function buildState(overrides: Partial<AtlcliState> = {}): AtlcliState {
+  return {
+    schemaVersion: 1,
+    lastSync: null,
+    pages: {},
+    pathIndex: {},
+    ...overrides,
+  };
+}
+
+function frontmatter(id: string, title = "Test"): string {
+  return `---\natlcli:\n  id: "${id}"\n  title: "${title}"\n---\n\n# ${title}\n`;
+}
+
+describe("docs path resolution helpers", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "atlcli-docs-test-"));
+    await mkdir(join(tempDir, ".atlcli"), { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  describe("resolvePageFile", () => {
+    test("returns the state path when the file exists there", async () => {
+      const rel = "guides/install.md";
+      await mkdir(join(tempDir, "guides"), { recursive: true });
+      await writeFile(join(tempDir, rel), frontmatter("42", "Install"));
+
+      const state = buildState({
+        pages: {
+          "42": {
+            path: rel,
+            title: "Install",
+            spaceKey: "TEAM",
+            version: 1,
+            lastSyncedAt: "",
+            localHash: "",
+            remoteHash: "",
+            baseHash: "",
+            syncState: "synced",
+            parentId: null,
+            ancestors: [],
+          },
+        },
+        pathIndex: { [rel]: "42" },
+      });
+
+      const resolved = await resolvePageFile(tempDir, "42", state);
+
+      expect(resolved).not.toBeNull();
+      expect(resolved!.relativePath).toBe(rel);
+      expect(resolved!.absolutePath).toBe(join(tempDir, "guides", "install.md"));
+    });
+
+    test("scans the tree by frontmatter ID when the recorded path is stale", async () => {
+      const oldRel = "guides/install.md";
+      const newRel = "getting-started/install.md";
+      await mkdir(join(tempDir, "getting-started"), { recursive: true });
+      await writeFile(join(tempDir, newRel), frontmatter("42", "Install"));
+
+      const state = buildState({
+        pages: {
+          "42": {
+            path: oldRel,
+            title: "Install",
+            spaceKey: "TEAM",
+            version: 1,
+            lastSyncedAt: "",
+            localHash: "",
+            remoteHash: "",
+            baseHash: "",
+            syncState: "synced",
+            parentId: null,
+            ancestors: [],
+          },
+        },
+        pathIndex: { [oldRel]: "42" },
+      });
+
+      const resolved = await resolvePageFile(tempDir, "42", state);
+
+      expect(resolved).not.toBeNull();
+      expect(resolved!.relativePath).toBe(newRel);
+      // State should have healed: index refreshed, old entry removed.
+      expect(state.pages["42"].path).toBe(newRel);
+      expect(state.pathIndex[newRel]).toBe("42");
+      expect(state.pathIndex[oldRel]).toBeUndefined();
+    });
+
+    test("finds files whose page ID is not yet in state at all", async () => {
+      const rel = "orphans/loose-page.md";
+      await mkdir(join(tempDir, "orphans"), { recursive: true });
+      await writeFile(join(tempDir, rel), frontmatter("999", "Loose"));
+
+      const state = buildState();
+
+      const resolved = await resolvePageFile(tempDir, "999", state);
+
+      expect(resolved).not.toBeNull();
+      expect(resolved!.relativePath).toBe(rel);
+      // No page state to heal, so state stays empty.
+      expect(state.pages["999"]).toBeUndefined();
+    });
+
+    test("returns null when the page cannot be located anywhere", async () => {
+      const state = buildState();
+      const resolved = await resolvePageFile(tempDir, "does-not-exist", state);
+      expect(resolved).toBeNull();
+    });
+  });
+
+  describe("findMarkdownFileByFrontmatterId", () => {
+    test("locates a matching file and skips non-matches", async () => {
+      await mkdir(join(tempDir, "a"), { recursive: true });
+      await mkdir(join(tempDir, "b"), { recursive: true });
+      await writeFile(join(tempDir, "a", "other.md"), frontmatter("111", "Other"));
+      await writeFile(join(tempDir, "b", "target.md"), frontmatter("222", "Target"));
+
+      const found = await findMarkdownFileByFrontmatterId(tempDir, "222");
+
+      expect(found).toBe(join(tempDir, "b", "target.md"));
+    });
+
+    test("returns null when nothing matches", async () => {
+      await writeFile(join(tempDir, "x.md"), frontmatter("111"));
+      const found = await findMarkdownFileByFrontmatterId(tempDir, "nope");
+      expect(found).toBeNull();
+    });
+  });
+});

--- a/apps/cli/src/commands/docs.ts
+++ b/apps/cli/src/commands/docs.ts
@@ -1,6 +1,6 @@
 import { readdir, writeFile, readFile, mkdir, stat, unlink, rename, rm } from "node:fs/promises";
 import { FSWatcher, watch, existsSync } from "node:fs";
-import { join, basename, extname, dirname, relative, resolve } from "node:path";
+import { join, basename, extname, dirname, relative, resolve, sep } from "node:path";
 import {
   ERROR_CODES,
   OutputOptions,
@@ -211,6 +211,88 @@ function findAtlcliDirWithWarning(
   }
   return atlcliDir;
 }
+
+/** Normalize a stored state path to the platform separator for filesystem ops. */
+function toPlatformPath(p: string): string {
+  return sep === "\\" ? p.split("/").join(sep) : p;
+}
+
+/** Normalize any path to POSIX (forward slashes) for state storage. */
+function toPosixPath(p: string): string {
+  return sep === "\\" ? p.split(sep).join("/") : p;
+}
+
+/**
+ * @internal
+ * Locate the markdown file for a tracked page inside an atlcli directory.
+ *
+ * Prefers the path recorded in state. If the file has moved or the state is
+ * stale, falls back to scanning the tree for a file whose frontmatter matches
+ * the page ID. When a match is found via scan, the state is healed so future
+ * lookups are cheap.
+ *
+ * Returns null when nothing matches; the caller decides how to report that.
+ */
+export async function resolvePageFile(
+  atlcliDir: string,
+  pageId: string,
+  state: AtlcliState
+): Promise<{ absolutePath: string; relativePath: string } | null> {
+  const pageState = state.pages[pageId];
+
+  if (pageState?.path) {
+    const abs = join(atlcliDir, toPlatformPath(pageState.path));
+    if (existsSync(abs)) {
+      return { absolutePath: abs, relativePath: pageState.path };
+    }
+  }
+
+  const scanned = await findMarkdownFileByFrontmatterId(atlcliDir, pageId);
+  if (!scanned) return null;
+
+  const newRelativePath = toPosixPath(relative(atlcliDir, scanned));
+
+  if (pageState) {
+    if (pageState.path && pageState.path !== newRelativePath) {
+      delete state.pathIndex[pageState.path];
+    }
+    pageState.path = newRelativePath;
+    state.pathIndex[newRelativePath] = pageId;
+  }
+
+  return { absolutePath: scanned, relativePath: newRelativePath };
+}
+
+/**
+ * @internal
+ * Scan an atlcli tree for a markdown file whose frontmatter ID matches.
+ * Respects .atlcliignore/.gitignore so stray files (build output, drafts)
+ * don't get mistakenly returned.
+ */
+export async function findMarkdownFileByFrontmatterId(
+  atlcliDir: string,
+  pageId: string
+): Promise<string | null> {
+  const ignoreResult = await loadIgnorePatterns(atlcliDir);
+  const files = await collectMarkdownFiles(atlcliDir, {
+    ignore: ignoreResult.ignore,
+    rootDir: atlcliDir,
+  });
+
+  for (const file of files) {
+    try {
+      const content = await readTextFile(file);
+      const { frontmatter } = parseFrontmatter(content);
+      if (frontmatter?.id === pageId) {
+        return file;
+      }
+    } catch {
+      // Ignore unreadable files
+    }
+  }
+  return null;
+}
+
 
 export async function handleDocs(args: string[], flags: Record<string, string | boolean | string[]>, opts: OutputOptions): Promise<void> {
   // Show help if --help or -h flag is set
@@ -1457,19 +1539,38 @@ async function handlePush(args: string[], flags: Record<string, string | boolean
   let files: string[];
   let atlcliDir: string | null;
   let isSingleFile = false;
+  // State may be loaded during --page-id resolution; reuse it later to avoid a re-read.
+  let state: AtlcliState | undefined;
 
   if (pageIdFlag) {
-    // Push by page ID - find the file in state
     atlcliDir = findAtlcliDirWithWarning(pathArg, opts);
     if (!atlcliDir) {
-      fail(opts, 1, ERROR_CODES.USAGE, "Not in an initialized directory. Run 'docs init' first.");
+      const searchedFrom = resolve(pathArg);
+      fail(
+        opts,
+        1,
+        ERROR_CODES.USAGE,
+        `Not in an initialized directory (searched from ${searchedFrom}). Run 'atlcli wiki docs init' first, or cd into an initialized directory.`
+      );
     }
-    const state = await readState(atlcliDir);
-    const pageState = state.pages[pageIdFlag];
-    if (!pageState) {
-      fail(opts, 1, ERROR_CODES.USAGE, `Page ${pageIdFlag} not found in state. Pull it first or use file path.`);
+    state = await readState(atlcliDir);
+    const priorPath = state.pages[pageIdFlag]?.path;
+    const resolved = await resolvePageFile(atlcliDir, pageIdFlag, state);
+    if (!resolved) {
+      fail(
+        opts,
+        1,
+        ERROR_CODES.USAGE,
+        `Page ${pageIdFlag} not found under ${atlcliDir}. Pull it first with 'atlcli wiki docs pull --page-id ${pageIdFlag}', or push the file directly by path.`
+      );
     }
-    files = [join(atlcliDir, pageState.path)];
+    if (priorPath && priorPath !== resolved.relativePath && !opts.json) {
+      output(
+        `Note: page ${pageIdFlag} moved locally (${priorPath} -> ${resolved.relativePath}); updating state.`,
+        opts
+      );
+    }
+    files = [resolved.absolutePath];
     isSingleFile = true;
   } else if (pathArg.endsWith(".md")) {
     // Single file push
@@ -1488,16 +1589,18 @@ async function handlePush(args: string[], flags: Record<string, string | boolean
 
   const globalConfig = await loadConfig();
   let space = getFlag(flags, "space");
-  let state: AtlcliState | undefined;
   let dirConfig: AtlcliConfig | null = null;
 
   if (atlcliDir) {
     dirConfig = await readConfig(atlcliDir);
     space = space || dirConfig.space || globalConfig.global?.space;
-    state = await readState(atlcliDir);
+    if (!state) {
+      state = await readState(atlcliDir);
+    }
   } else {
     space = space || globalConfig.global?.space;
   }
+
 
   // Run validation if --validate flag is set
   if (hasFlag(flags, "validate") && atlcliDir) {
@@ -3290,6 +3393,10 @@ async function handleDocsConvert(
 function docsHelp(): string {
   return `atlcli wiki docs <command>
 
+Directory argument is optional for most commands - defaults to the current directory
+and walks up to find the nearest .atlcli/. Run commands from inside the initialized
+tree, or pass an explicit path/--dir when running from elsewhere.
+
 Commands:
   init <dir> [scope options]                        Initialize directory for sync
   pull [dir] [scope options] [--limit <n>] [--force] [--label <l>] [--comments]
@@ -3347,13 +3454,15 @@ Examples:
   atlcli wiki docs init ./docs --space TEAM              Initialize for entire space
   atlcli wiki docs init ./docs --ancestor 12345          Initialize for page tree
   atlcli wiki docs init ./docs --page-id 67890           Initialize for single page
-  atlcli wiki docs pull ./docs                           Pull using saved scope
+  atlcli wiki docs pull                                  Pull into the current directory
+  atlcli wiki docs pull ./docs                           Pull into ./docs
   atlcli wiki docs pull ./docs --ancestor 99999          Override scope for this pull
   atlcli wiki docs pull ./docs --label architecture      Pull only pages with label
   atlcli wiki docs pull ./docs --comments                Pull pages with comments
+  atlcli wiki docs push                                  Push everything in current directory
   atlcli wiki docs push ./docs                           Push all tracked files
   atlcli wiki docs push ./docs/page.md                   Push single file
-  atlcli wiki docs push --page-id 12345                  Push by page ID
+  atlcli wiki docs push --page-id 12345                  Push by page ID (from anywhere in the tree)
   atlcli wiki docs push --validate                       Validate before pushing
   atlcli wiki docs push --validate --strict              Fail on warnings too
   atlcli wiki docs diff ./docs/page.md                   Show local vs remote diff

--- a/packages/confluence/src/atlcli-dir.test.ts
+++ b/packages/confluence/src/atlcli-dir.test.ts
@@ -14,6 +14,7 @@ import {
   isInitialized,
   findAtlcliDir,
   getAtlcliPath,
+  getRelativePath,
   AtlcliConfigV1,
   AtlcliConfigV2,
   ConfigScope,
@@ -370,6 +371,35 @@ describe("atlcli-dir", () => {
 
       // Cleanup
       await rm(noDbDir, { recursive: true, force: true });
+    });
+  });
+
+  describe("getRelativePath", () => {
+    /**
+     * Regression test: state paths must stay POSIX so lookups work the same
+     * on Windows and Unix. Previously, add/push on Windows stored paths with
+     * backslashes while pull stored them with forward slashes, breaking
+     * pathIndex lookups and move detection.
+     */
+    test("returns a POSIX-style path regardless of platform", () => {
+      const root = process.platform === "win32" ? "C:\\repo\\docs" : "/repo/docs";
+      const file = process.platform === "win32"
+        ? "C:\\repo\\docs\\guides\\install.md"
+        : "/repo/docs/guides/install.md";
+
+      const result = getRelativePath(root, file);
+
+      expect(result).toBe("guides/install.md");
+      expect(result).not.toContain("\\");
+    });
+
+    test("returns a bare filename when the file sits at the root", () => {
+      const root = process.platform === "win32" ? "C:\\repo\\docs" : "/repo/docs";
+      const file = process.platform === "win32"
+        ? "C:\\repo\\docs\\index.md"
+        : "/repo/docs/index.md";
+
+      expect(getRelativePath(root, file)).toBe("index.md");
     });
   });
 });

--- a/packages/confluence/src/atlcli-dir.ts
+++ b/packages/confluence/src/atlcli-dir.ts
@@ -8,7 +8,7 @@
  * └── cache/         # Base versions for 3-way merge
  */
 
-import { join, dirname, relative, resolve } from "path";
+import { join, dirname, relative, resolve, sep } from "path";
 import { existsSync } from "fs";
 import { mkdir, readFile, writeFile, unlink } from "fs/promises";
 import { createSyncDb, hasSyncDb, getStorageType } from "./sync-db/index.js";
@@ -767,9 +767,13 @@ export function generateUniqueFilename(
 
 /**
  * Get relative path from root directory.
+ *
+ * Always returns a POSIX-style path (forward slashes) so that stored
+ * state paths remain stable and comparable across Windows and Unix.
  */
 export function getRelativePath(rootDir: string, filePath: string): string {
-  return relative(rootDir, filePath);
+  const rel = relative(rootDir, filePath);
+  return sep === "\\" ? rel.split(sep).join("/") : rel;
 }
 
 // ============ Attachment State Functions ============

--- a/src/content/docs/confluence/sync.md
+++ b/src/content/docs/confluence/sync.md
@@ -38,6 +38,10 @@ Options:
 | `--page-id` | Sync single page by ID |
 | `--ancestor` | Sync tree under specific page |
 
+:::note[Where to run subsequent commands]
+`init` creates the `.atlcli/` folder inside the directory you pass. Every later command (`pull`, `push`, `status`, `sync`, ...) then either takes that same path or walks up from your current directory to find the nearest `.atlcli/`. In practice: pass the same path you used for `init`, or `cd` into it and drop the path argument.
+:::
+
 ### Scope Options
 
 ```bash
@@ -260,6 +264,8 @@ Download pages from Confluence to local markdown files:
 atlcli wiki docs pull ./docs
 ```
 
+The path argument is optional and defaults to the current directory. Pass the same path you used for `init` (or `cd` into it and omit the path) so files land where the state expects them.
+
 Options:
 
 | Flag | Description |
@@ -313,6 +319,8 @@ Upload local changes to Confluence:
 atlcli wiki docs push ./docs
 ```
 
+The path argument is optional. When omitted, push walks up from the current directory to find the nearest `.atlcli/` — so from inside your synced tree `atlcli wiki docs push` and `atlcli wiki docs push --page-id 12345` both work without any path.
+
 Options:
 
 | Flag | Description |
@@ -331,7 +339,7 @@ atlcli wiki docs push ./docs
 # Push single file
 atlcli wiki docs push ./docs/page.md
 
-# Push by page ID
+# Push by page ID (from anywhere inside the synced tree)
 atlcli wiki docs push --page-id 12345
 
 # Validate before pushing
@@ -340,6 +348,10 @@ atlcli wiki docs push ./docs --validate
 # Strict validation (fail on warnings)
 atlcli wiki docs push ./docs --validate --strict
 ```
+
+:::note[Pushing by page ID]
+`--page-id` looks the file up from `.atlcli/state.json`. If you renamed or moved the file locally, push scans the tree for the matching frontmatter ID and heals the state automatically — you don't have to re-pull.
+:::
 
 :::caution[Permission errors on push?]
 If you see "You don't have permission to edit page", verify your Confluence space/page permissions. You need Edit permission for push operations.


### PR DESCRIPTION
#### Description

I noticed that on Windows, some operations with `<dir>` option do not work as expected because the resulting paths were not resolved correctly.

Therefore, this PR fixes it and also makes it more convenient to work with the commands by falling back to the current directory.