### PR TITLE
fix(ci): eliminate webhook port collisions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,28 @@ jobs:
         run: bun run typecheck
 
       - name: Run tests
-        run: bun test
+        run: |
+          # Bun 1.3.5 can exit with code 1 on Linux even when every test passes.
+          # Preserve genuine failures while accepting an exact zero-failure summary.
+          set +e
+          bun test 2>&1 | tee "$RUNNER_TEMP/bun-test.log"
+          TEST_EXIT=${PIPESTATUS[0]}
+          set -e
+
+          if [ "$TEST_EXIT" -eq 0 ]; then
+            exit 0
+          fi
+
+          if grep -Eq '^[[:space:]]*[1-9][0-9]* errors?[[:space:]]*$' "$RUNNER_TEMP/bun-test.log"; then
+            exit "$TEST_EXIT"
+          fi
+
+          if grep -Eq '^[[:space:]]*0 fail[[:space:]]*$' "$RUNNER_TEMP/bun-test.log"; then
+            echo "::warning::Bun exited with code $TEST_EXIT despite reporting zero failed tests"
+            exit 0
+          fi
+
+          exit "$TEST_EXIT"
 
       - name: Build
         run: bun run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.5
 
       - name: Cache Turbo
         uses: actions/cache@v4
@@ -32,22 +32,7 @@ jobs:
         run: bun run typecheck
 
       - name: Run tests
-        run: |
-          # Bun test may exit with code 1 due to stderr output even when all tests pass
-          # Capture output and verify no failures
-          set +e
-          OUTPUT=$(bun test 2>&1)
-          EXIT_CODE=$?
-          echo "$OUTPUT"
-
-          # Check if all tests passed (look for "0 fail" in output)
-          if echo "$OUTPUT" | grep -q "0 fail"; then
-            echo "All tests passed!"
-            exit 0
-          else
-            echo "Tests failed!"
-            exit $EXIT_CODE
-          fi
+        run: bun test
 
       - name: Build
         run: bun run build

--- a/packages/confluence/src/webhook-server.test.ts
+++ b/packages/confluence/src/webhook-server.test.ts
@@ -1,13 +1,26 @@
-import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
+import { describe, test, expect, afterEach } from "bun:test";
 import {
   WebhookServer,
   createWebhookServer,
-  WebhookPayload,
+} from "./webhook-server.js";
+import type {
   WebhookHandler,
+  WebhookPayload,
+  WebhookServerOptions,
 } from "./webhook-server.js";
 
-// Use a random port for each test to avoid conflicts
-let testPort = 40000 + Math.floor(Math.random() * 10000);
+function createTestServer(
+  options: Omit<WebhookServerOptions, "port"> = {},
+): WebhookServer {
+  return new WebhookServer({ ...options, port: 0 });
+}
+
+function startServer(instance: WebhookServer): URL {
+  instance.start();
+  const url = instance.getUrl();
+  if (!url) throw new Error("Webhook server did not start");
+  return new URL(url);
+}
 
 describe("WebhookServer", () => {
   let server: WebhookServer | null = null;
@@ -21,7 +34,7 @@ describe("WebhookServer", () => {
 
   describe("lifecycle", () => {
     test("starts and stops correctly", () => {
-      server = new WebhookServer({ port: ++testPort });
+      server = createTestServer();
       expect(server.isRunning()).toBe(false);
 
       server.start();
@@ -32,34 +45,33 @@ describe("WebhookServer", () => {
     });
 
     test("getUrl returns correct URL when running", () => {
-      const port = ++testPort;
-      server = new WebhookServer({ port });
-      server.start();
+      server = createTestServer();
+      const url = startServer(server);
 
-      expect(server.getUrl()).toBe(`http://localhost:${port}/webhook`);
+      expect(url.hostname).toBe("localhost");
+      expect(Number(url.port)).toBeGreaterThan(0);
+      expect(url.pathname).toBe("/webhook");
     });
 
     test("getUrl returns null when not running", () => {
-      server = new WebhookServer({ port: ++testPort });
+      server = createTestServer();
       expect(server.getUrl()).toBe(null);
     });
 
     test("custom path is used", () => {
-      const port = ++testPort;
-      server = new WebhookServer({ port, path: "/custom-hook" });
-      server.start();
+      server = createTestServer({ path: "/custom-hook" });
+      const url = startServer(server);
 
-      expect(server.getUrl()).toBe(`http://localhost:${port}/custom-hook`);
+      expect(url.pathname).toBe("/custom-hook");
     });
   });
 
   describe("HTTP endpoints", () => {
     test("health endpoint returns ok", async () => {
-      const port = ++testPort;
-      server = new WebhookServer({ port });
-      server.start();
+      server = createTestServer();
+      const url = startServer(server);
 
-      const res = await fetch(`http://localhost:${port}/health`);
+      const res = await fetch(new URL("/health", url));
       expect(res.status).toBe(200);
 
       const data = await res.json();
@@ -67,9 +79,8 @@ describe("WebhookServer", () => {
     });
 
     test("webhook endpoint accepts POST", async () => {
-      const port = ++testPort;
-      server = new WebhookServer({ port });
-      server.start();
+      server = createTestServer();
+      const url = startServer(server);
 
       const payload: WebhookPayload = {
         eventType: "page_updated",
@@ -82,7 +93,7 @@ describe("WebhookServer", () => {
         },
       };
 
-      const res = await fetch(`http://localhost:${port}/webhook`, {
+      const res = await fetch(url, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(payload),
@@ -94,20 +105,18 @@ describe("WebhookServer", () => {
     });
 
     test("returns 404 for unknown paths", async () => {
-      const port = ++testPort;
-      server = new WebhookServer({ port });
-      server.start();
+      server = createTestServer();
+      const url = startServer(server);
 
-      const res = await fetch(`http://localhost:${port}/unknown`);
+      const res = await fetch(new URL("/unknown", url));
       expect(res.status).toBe(404);
     });
 
     test("returns 400 for invalid JSON", async () => {
-      const port = ++testPort;
-      server = new WebhookServer({ port });
-      server.start();
+      server = createTestServer();
+      const url = startServer(server);
 
-      const res = await fetch(`http://localhost:${port}/webhook`, {
+      const res = await fetch(url, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: "not valid json",
@@ -119,15 +128,14 @@ describe("WebhookServer", () => {
 
   describe("event handling", () => {
     test("calls registered handlers", async () => {
-      const port = ++testPort;
-      server = new WebhookServer({ port });
+      server = createTestServer();
 
       const receivedPayloads: WebhookPayload[] = [];
       server.on((payload) => {
         receivedPayloads.push(payload);
       });
 
-      server.start();
+      const url = startServer(server);
 
       const payload: WebhookPayload = {
         eventType: "page_created",
@@ -140,7 +148,7 @@ describe("WebhookServer", () => {
         },
       };
 
-      await fetch(`http://localhost:${port}/webhook`, {
+      await fetch(url, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(payload),
@@ -155,17 +163,16 @@ describe("WebhookServer", () => {
     });
 
     test("can remove handlers", async () => {
-      const port = ++testPort;
-      server = new WebhookServer({ port });
+      server = createTestServer();
 
       let callCount = 0;
       const handler: WebhookHandler = () => { callCount++; };
 
       server.on(handler);
       server.off(handler);
-      server.start();
+      const url = startServer(server);
 
-      await fetch(`http://localhost:${port}/webhook`, {
+      await fetch(url, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -179,8 +186,7 @@ describe("WebhookServer", () => {
     });
 
     test("async handlers are awaited", async () => {
-      const port = ++testPort;
-      server = new WebhookServer({ port });
+      server = createTestServer();
 
       let completed = false;
       server.on(async () => {
@@ -188,9 +194,9 @@ describe("WebhookServer", () => {
         completed = true;
       });
 
-      server.start();
+      const url = startServer(server);
 
-      await fetch(`http://localhost:${port}/webhook`, {
+      await fetch(url, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -206,18 +212,16 @@ describe("WebhookServer", () => {
 
   describe("filtering", () => {
     test("filters by page ID", async () => {
-      const port = ++testPort;
-      server = new WebhookServer({
-        port,
+      server = createTestServer({
         filterPageIds: new Set(["allowed"]),
       });
 
       const receivedPayloads: WebhookPayload[] = [];
       server.on((payload) => { receivedPayloads.push(payload); });
-      server.start();
+      const url = startServer(server);
 
       // Send allowed page
-      await fetch(`http://localhost:${port}/webhook`, {
+      await fetch(url, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -228,7 +232,7 @@ describe("WebhookServer", () => {
       });
 
       // Send filtered page
-      await fetch(`http://localhost:${port}/webhook`, {
+      await fetch(url, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -245,18 +249,16 @@ describe("WebhookServer", () => {
     });
 
     test("filters by space key", async () => {
-      const port = ++testPort;
-      server = new WebhookServer({
-        port,
+      server = createTestServer({
         filterSpaceKeys: new Set(["ALLOWED"]),
       });
 
       const receivedPayloads: WebhookPayload[] = [];
       server.on((payload) => { receivedPayloads.push(payload); });
-      server.start();
+      const url = startServer(server);
 
       // Send allowed space
-      await fetch(`http://localhost:${port}/webhook`, {
+      await fetch(url, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -267,7 +269,7 @@ describe("WebhookServer", () => {
       });
 
       // Send filtered space
-      await fetch(`http://localhost:${port}/webhook`, {
+      await fetch(url, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({

--- a/packages/confluence/src/webhook-server.ts
+++ b/packages/confluence/src/webhook-server.ts
@@ -107,7 +107,7 @@ export class WebhookServer {
   /** Get server URL */
   getUrl(): string | null {
     if (!this.server) return null;
-    return `http://localhost:${this.options.port}${this.options.path}`;
+    return `http://localhost:${this.server.port}${this.options.path}`;
   }
 
   /** Handle incoming webhook request */


### PR DESCRIPTION
## Summary

- let the OS allocate webhook test ports and use the server's actual bound port in generated URLs
- update webhook tests to derive request URLs from the running server instead of guessing ports
- pin CI to the repository's declared Bun 1.3.5
- narrow the Bun 1.3.5 Linux compatibility guard so it accepts only an exact zero-failure summary with no reported errors

## Root cause

The webhook suite selected ports from a random fixed range without reserving them. GitHub-hosted runners intermittently assigned one of those ports to another socket first, causing `Bun.serve()` to fail with `EADDRINUSE`. This produced unrelated failures in runs [29083971664](https://github.com/BjoernSchotte/atlcli/actions/runs/29083971664) and [29081346728](https://github.com/BjoernSchotte/atlcli/actions/runs/29081346728).

CI also used `bun-version: latest` even though the repository and release workflow declare Bun 1.3.5. On Linux, Bun 1.3.5 can report all tests passing and still exit with code 1; the first PR run confirmed 1,084 passed, 3 skipped, and 0 failed before that exit. The previous broad substring check could also mistake counts such as `10 fail` for success.

## Impact

Webhook tests no longer race for guessed ports, CI uses the same Bun version as releases, and the compatibility guard cannot hide nonzero failure or error summaries.

## Validation

- `bun test packages/confluence/src/webhook-server.test.ts --rerun-each 50` — 750 passed
- `bun test` — 1,087 passed
- `bun run typecheck`
- `bun run build`
- `uv run pytest tests/ -v` in `packages/export` — 17 passed
- `git diff --check`
