### PR TITLE
ci: update actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22.12.0'
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22.12.0'
 
@@ -51,7 +51,7 @@ jobs:
         run: bun run docs:build
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: dist/
 

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -29,7 +29,7 @@ jobs:
           bun-version: latest
 
       - name: Setup Node.js (for npm publish)
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/release-core.yml
+++ b/.github/workflows/release-core.yml
@@ -29,7 +29,7 @@ jobs:
           bun-version: latest
 
       - name: Setup Node.js (for npm publish)
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
## Summary

- update `actions/setup-node` from v4 to v6 in CI, documentation, and release workflows
- update `actions/upload-pages-artifact` from v3 to v4
- retain the existing project Node versions and `actions/deploy-pages@v4`

## Why

GitHub Actions runners now warn when JavaScript actions still target the deprecated Node.js 20 runtime. Using the current supported major versions removes the direct `setup-node` warning and keeps the Pages upload action current.

The Pages upload action still transitively references `actions/upload-artifact@v4.6.2`, so GitHub may continue to emit that upstream warning until `actions/upload-pages-artifact` updates its dependency.

## Impact

Application and documentation output are unchanged. This only updates the JavaScript runtimes used internally by GitHub-hosted actions.

## Validation

- parsed every workflow with Ruby's YAML parser
- `git diff --check`
- confirmed no `actions/setup-node@v4` or `actions/upload-pages-artifact@v3` references remain