### PR TITLE
fix(confluence): preserve users when checks are skipped

### DIFF
--- a/apps/cli/src/commands/docs.ts
+++ b/apps/cli/src/commands/docs.ts
@@ -113,13 +113,15 @@ import {
   formatValidationReport,
   ValidationResult,
   // Link storage
-  storePageLinksBatch,
+  extractLinksFromStorage,
   // Link change detection
   detectLinkChangesBatch,
   type LinkChangeResult,
   // User and contributor handling
   checkUsersFromPull,
   createContributorRecords,
+  ensureUserPlaceholders,
+  extractUserIdsFromContributorResults,
   fetchAllContributorsForPages,
   type UserCheckOptions,
   // Sync database
@@ -1240,13 +1242,7 @@ async function handlePull(args: string[], flags: Record<string, string | boolean
     state.lastSync = new Date().toISOString();
     await writeState(atlcliDir, state);
 
-    // Extract and store links from all pulled pages (Phase 1 link graph population)
-    // Uses batch operation for efficiency - only runs if sync.db exists
-    const linksData = pageDetails.map((p) => ({ pageId: p.id, storage: p.storage }));
-    await storePageLinksBatch(atlcliDir, linksData);
-
-    // Phase 2: User and contributor handling
-    // Open adapter once for all Phase 2 operations
+    // Populate sync.db after all content has been written.
     const { createSyncDb } = await import("@atlcli/confluence");
     const adapter = await createSyncDb(getAtlcliPath(atlcliDir), { autoMigrate: false });
     try {
@@ -1318,6 +1314,12 @@ async function handlePull(args: string[], flags: Record<string, string | boolean
         await adapter.upsertPage(folderRecord);
       }
 
+      // Store links only after their source page rows exist.
+      for (const detail of pageDetails) {
+        const links = extractLinksFromStorage(detail.storage, detail.id);
+        await adapter.setPageLinks(detail.id, links);
+      }
+
       // Store editor versions for pulled pages (after pages exist in DB)
       for (const detail of pageDetails) {
         // Use editorVersion from page details if available (fetched in same request)
@@ -1379,6 +1381,14 @@ async function handlePull(args: string[], flags: Record<string, string | boolean
           pageDetails.map((p) => p.id),
           client,
           { concurrency: 3 }
+        );
+
+        // Version history may contain users absent from creator/modifier metadata.
+        // Ensure those foreign-key targets exist without additional API requests.
+        const contributorUserIds = extractUserIdsFromContributorResults(contributorResults);
+        await ensureUserPlaceholders(
+          contributorUserIds.map((userId) => ({ userId })),
+          adapter
         );
 
         // Store full contributor data in database

--- a/packages/confluence/src/user-fetcher.test.ts
+++ b/packages/confluence/src/user-fetcher.test.ts
@@ -1,18 +1,27 @@
 import { describe, test, expect, beforeEach, mock } from "bun:test";
+import { Database } from "bun:sqlite";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   extractUserIdsFromPage,
   extractUserIdsFromPages,
   isUserCacheExpired,
   filterUsersNeedingCheck,
+  checkUsersFromPull,
   createContributorRecords,
+  ensureUserPlaceholders,
   userInfoToRecord,
   getUserStats,
   extractUserIdsFromContributorResults,
   DEFAULT_USER_CACHE_TTL_MS,
   type FetchContributorsResult,
 } from "./user-fetcher.js";
-import type { ConfluencePageDetails, UserInfo } from "./client.js";
+import type { ConfluenceClient, ConfluencePageDetails, UserInfo } from "./client.js";
 import type { SyncDbAdapter, UserRecord } from "./sync-db/types.js";
+import { createPageRecord } from "./sync-db/types.js";
+import { SqliteAdapter } from "./sync-db/sqlite-adapter.js";
+import { extractLinksFromStorage } from "./link-extractor-storage.js";
 
 /**
  * Create a mock page with user data.
@@ -219,6 +228,154 @@ describe("filterUsersNeedingCheck", () => {
     );
 
     expect(result).toEqual(["user-1"]);
+  });
+});
+
+describe("checkUsersFromPull", () => {
+  test("creates placeholder users before contributor and link persistence when checks are skipped", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "atlcli-user-pull-"));
+    const dbPath = join(tempDir, "sync.db");
+    const adapter = new SqliteAdapter({ dbPath });
+    let adapterClosed = false;
+
+    try {
+      await adapter.init();
+      const page = createMockPage({
+        storage: '<p><a href="https://example.com">External</a></p>',
+        createdBy: {
+          accountId: "user-creator",
+          displayName: "Creator User",
+          email: "creator@example.com",
+        },
+      });
+      await adapter.upsertPage(createPageRecord({
+        pageId: page.id,
+        path: "test-page.md",
+        title: page.title,
+        spaceKey: "TEST",
+      }));
+
+      const getUsersBulk = mock(() => Promise.resolve(new Map()));
+      const client = { getUsersBulk } as unknown as ConfluenceClient;
+      const result = await checkUsersFromPull(
+        [page],
+        client,
+        adapter,
+        { skipUserCheck: true }
+      );
+
+      await adapter.setPageLinks(page.id, extractLinksFromStorage(page.storage, page.id));
+      const contributors = [
+        ...createContributorRecords(page, page.id),
+        {
+          pageId: page.id,
+          userId: "user-historical",
+          contributionCount: 3,
+          lastContributedAt: "2023-12-01T00:00:00.000Z",
+        },
+      ];
+      const contributorResults = new Map<string, FetchContributorsResult>([[page.id, {
+        pageId: page.id,
+        contributors,
+        versionCount: 5,
+        userIds: contributors.map((contributor) => contributor.userId),
+      }]]);
+      await ensureUserPlaceholders(
+        extractUserIdsFromContributorResults(contributorResults)
+          .map((userId) => ({ userId })),
+        adapter
+      );
+      await adapter.setPageContributors(page.id, contributors);
+
+      expect(result.checked).toBe(0);
+      expect(getUsersBulk).not.toHaveBeenCalled();
+      expect(await adapter.getUser("user-creator")).toEqual({
+        userId: "user-creator",
+        displayName: "Creator User",
+        email: "creator@example.com",
+        isActive: null,
+        lastCheckedAt: null,
+      });
+      expect((await adapter.getPageContributors(page.id)).map((c) => c.userId).sort())
+        .toEqual(["user-creator", "user-historical", "user-modifier"]);
+      expect(await adapter.getUser("user-historical")).toEqual({
+        userId: "user-historical",
+        displayName: null,
+        email: null,
+        isActive: null,
+        lastCheckedAt: null,
+      });
+      expect(await adapter.getOutgoingLinks(page.id)).toHaveLength(1);
+
+      await adapter.close();
+      adapterClosed = true;
+
+      const db = new Database(dbPath, { readonly: true });
+      try {
+        expect(db.query("PRAGMA foreign_key_check").all()).toEqual([]);
+      } finally {
+        db.close();
+      }
+    } finally {
+      if (!adapterClosed) await adapter.close();
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test("still enriches placeholder users when remote checks are enabled", async () => {
+    const storedUsers = new Map<string, UserRecord>();
+    const adapter = {
+      getUser: mock((userId: string) => Promise.resolve(storedUsers.get(userId) ?? null)),
+      upsertUser: mock((user: UserRecord) => {
+        storedUsers.set(user.userId, user);
+        return Promise.resolve();
+      }),
+    } as unknown as SyncDbAdapter;
+    const getUsersBulk = mock((userIds: string[]) => Promise.resolve(new Map(
+      userIds.map((userId) => [userId, {
+        accountId: userId,
+        displayName: `Checked ${userId}`,
+        email: null,
+        isActive: true,
+        profilePicture: null,
+      } satisfies UserInfo])
+    )));
+    const client = { getUsersBulk } as unknown as ConfluenceClient;
+
+    const result = await checkUsersFromPull([createMockPage()], client, adapter);
+
+    expect(result.checked).toBe(2);
+    expect(getUsersBulk).toHaveBeenCalledTimes(1);
+    expect(storedUsers.get("user-creator")?.displayName).toBe("Checked user-creator");
+    expect(storedUsers.get("user-creator")?.isActive).toBe(true);
+    expect(storedUsers.get("user-creator")?.lastCheckedAt).not.toBeNull();
+  });
+
+  test("preserves cached status when filling missing placeholder metadata", async () => {
+    const cached = createMockUserRecord({
+      userId: "user-1",
+      displayName: null,
+      email: null,
+      isActive: true,
+    });
+    const storedUsers = new Map([[cached.userId, cached]]);
+    const adapter = {
+      getUser: mock((userId: string) => Promise.resolve(storedUsers.get(userId) ?? null)),
+      upsertUser: mock((user: UserRecord) => {
+        storedUsers.set(user.userId, user);
+        return Promise.resolve();
+      }),
+    } as unknown as SyncDbAdapter;
+
+    await ensureUserPlaceholders(
+      [{ userId: "user-1", displayName: "Page Display Name" }],
+      adapter
+    );
+
+    expect(storedUsers.get("user-1")).toEqual({
+      ...cached,
+      displayName: "Page Display Name",
+    });
   });
 });
 

--- a/packages/confluence/src/user-fetcher.ts
+++ b/packages/confluence/src/user-fetcher.ts
@@ -74,6 +74,81 @@ export function extractUserIdsFromPages(pages: ConfluencePageDetails[]): string[
 }
 
 /**
+ * Minimal user data that can be persisted without a remote status lookup.
+ */
+export interface UserPlaceholder {
+  userId: string;
+  displayName?: string | null;
+  email?: string | null;
+}
+
+/**
+ * Ensure user rows exist before records with user foreign keys are inserted.
+ *
+ * Existing status/cache data is preserved. Page metadata only fills missing
+ * display names or email addresses.
+ */
+export async function ensureUserPlaceholders(
+  users: UserPlaceholder[],
+  adapter: SyncDbAdapter
+): Promise<void> {
+  const uniqueUsers = new Map<string, UserPlaceholder>();
+
+  for (const user of users) {
+    const existing = uniqueUsers.get(user.userId);
+    uniqueUsers.set(user.userId, {
+      userId: user.userId,
+      displayName: existing?.displayName ?? user.displayName ?? null,
+      email: existing?.email ?? user.email ?? null,
+    });
+  }
+
+  for (const user of uniqueUsers.values()) {
+    const existing = await adapter.getUser(user.userId);
+    if (!existing) {
+      await adapter.upsertUser({
+        userId: user.userId,
+        displayName: user.displayName ?? null,
+        email: user.email ?? null,
+        isActive: null,
+        lastCheckedAt: null,
+      });
+      continue;
+    }
+
+    const displayName = existing.displayName ?? user.displayName ?? null;
+    const email = existing.email ?? user.email ?? null;
+    if (displayName !== existing.displayName || email !== existing.email) {
+      await adapter.upsertUser({ ...existing, displayName, email });
+    }
+  }
+}
+
+/**
+ * Ensure creator and last-modifier rows exist using metadata already returned
+ * with pulled pages.
+ */
+export async function ensureUsersFromPages(
+  pages: ConfluencePageDetails[],
+  adapter: SyncDbAdapter
+): Promise<void> {
+  const users: UserPlaceholder[] = [];
+
+  for (const page of pages) {
+    for (const user of [page.createdBy, page.modifiedBy]) {
+      if (!user?.accountId) continue;
+      users.push({
+        userId: user.accountId,
+        displayName: user.displayName,
+        email: user.email ?? null,
+      });
+    }
+  }
+
+  await ensureUserPlaceholders(users, adapter);
+}
+
+/**
  * Check if a user's cached status is expired.
  */
 export function isUserCacheExpired(
@@ -204,6 +279,9 @@ export async function checkUsersFromPull(
   adapter: SyncDbAdapter,
   options: UserCheckOptions = {}
 ): Promise<UserCheckResult> {
+  // Contributor rows reference users even when remote status checks are skipped.
+  await ensureUsersFromPages(pages, adapter);
+
   // Extract all user IDs from pages
   const allUserIds = extractUserIdsFromPages(pages);
 


### PR DESCRIPTION
## Summary

- persist placeholder user rows from pulled page metadata before filtering remote status checks
- preserve cached user status and timestamps while filling missing metadata
- ensure history-only contributor IDs exist before contributor persistence
- store extracted links after their source page rows are upserted

## Root cause

`--skip-user-check` returned before any rows were inserted into `users`, but the pull still inserted creator and modifier records into `contributors`. Because `contributors.user_id` references `users.user_id`, a fresh sync database failed with `FOREIGN KEY constraint failed` after writing the Markdown file.

## Impact

Pulls using `--skip-user-check` now complete normally without making remote user-status requests. Contributor and link metadata remain referentially valid, while normal and cached user-check paths retain their existing behavior.

## Validation

- `bun test`: 1,090 passed
- `bun run typecheck`
- `bun run build`
- fresh file-backed SQLite regression with `PRAGMA foreign_key_check`
- live `mayflower` / `DOCSY` E2E pull with `--skip-user-check`; temporary page and local resources removed afterward

Fixes #16