### PR TITLE
feat(docx): spec 005 — self-built OOXML image module (images in DOCX export)

### DIFF
--- a/apps/cli/src/commands/export.ts
+++ b/apps/cli/src/commands/export.ts
@@ -116,6 +116,7 @@ export async function handleExport(
       resolvedTemplatePath,
       outputPath,
       includeChildren,
+      embedImages,
       opts,
     });
     return;
@@ -690,6 +691,7 @@ interface TsEngineArgs {
   resolvedTemplatePath: string;
   outputPath: string;
   includeChildren: boolean;
+  embedImages: boolean;
   opts: OutputOptions;
 }
 
@@ -697,17 +699,48 @@ interface TsEngineArgs {
  * Spec 006 Task 5: drive the isomorphic `@atlcli/docx` engine — the exact
  * code the Chrome extension runs — with Node-side env implementations:
  * template bytes from the filesystem, output to the filesystem, resolver
- * round-trips over the token-auth client. Feature scope matches the
- * extension's v1 export: single page, `$scroll.*` placeholder resolution,
- * images deferred (they become report notes, never OOXML — spec 005).
+ * round-trips over the token-auth client, and image bytes over the client's
+ * token-auth binary download (spec 005: attachment refs arrive as
+ * wiki-base-relative download URLs; external images as absolute URLs).
  * The engine is imported lazily so the common CLI paths never load
  * pizzip/docxtemplater.
  */
+/**
+ * Image bytes over the token-auth client (spec 005). The site's cookie-only
+ * `/download/attachments/{pageId}/{filename}` path 401s under API-token Basic
+ * auth (verified against Cloud), so attachment refs resolve through the REST
+ * attachment listing to the API's own `downloadUrl`
+ * (`/rest/api/content/{id}/child/attachment/{attId}/download`), which honors
+ * token auth. The listing is cached per page — one extra round-trip per page,
+ * not per image. External image URLs are absolute and fetched without auth.
+ */
+function tokenAssetFetcher(client: ConfluenceClient) {
+  const listings = new Map<string, Promise<{ filename: string; downloadUrl: string }[]>>();
+  return {
+    async fetch(ref: { url: string; pageId?: string; filename?: string }): Promise<Uint8Array> {
+      if (/^https?:\/\//i.test(ref.url)) {
+        const res = await fetch(ref.url);
+        if (!res.ok) throw new Error(`image download failed (${res.status}) for ${ref.url}`);
+        return new Uint8Array(await res.arrayBuffer());
+      }
+      if (ref.pageId && ref.filename) {
+        let listing = listings.get(ref.pageId);
+        if (!listing) {
+          listing = client.listAttachments(ref.pageId);
+          listings.set(ref.pageId, listing);
+        }
+        const attachment = (await listing).find((a) => a.filename === ref.filename);
+        if (!attachment) throw new Error(`attachment "${ref.filename}" not found on page ${ref.pageId}`);
+        return client.downloadAttachment(attachment);
+      }
+      return client.downloadAttachment({ downloadUrl: ref.url });
+    },
+  };
+}
+
 async function exportWithTsEngine(args: TsEngineArgs): Promise<void> {
-  const { client, page, resolvedTemplatePath, outputPath, includeChildren, opts } = args;
-  const { runExport, fileTemplateSource, fileOutputSink, unsupportedAssetFetcher } = await import(
-    "@atlcli/docx"
-  );
+  const { client, page, resolvedTemplatePath, outputPath, includeChildren, embedImages, opts } = args;
+  const { runExport, fileTemplateSource, fileOutputSink } = await import("@atlcli/docx");
   const { stat } = await import("node:fs/promises");
 
   const cliNotes: string[] = [];
@@ -724,6 +757,7 @@ async function exportWithTsEngine(args: TsEngineArgs): Promise<void> {
         name: basename(resolvedTemplatePath),
         modificationDate: templateStat.mtime,
       },
+      embedImages,
       deps: {
         getSpace: (key: string) => client.getSpace(key),
         getCurrentUser: () => client.getCurrentUser(),
@@ -733,7 +767,7 @@ async function exportWithTsEngine(args: TsEngineArgs): Promise<void> {
     },
     {
       templates: fileTemplateSource(resolvedTemplatePath),
-      assets: unsupportedAssetFetcher("image embedding is not yet available in the ts engine"),
+      assets: tokenAssetFetcher(client),
       output: fileOutputSink(resolvedOutputPath),
     }
   );
@@ -747,6 +781,7 @@ async function exportWithTsEngine(args: TsEngineArgs): Promise<void> {
       report: {
         resolvedCount: report.resolvedCount,
         unsupportedNames: report.unsupportedNames,
+        embeddedImages: report.embeddedImages,
         skippedImages: report.skippedImages,
         durationMs: report.durationMs,
         notes: [...cliNotes, ...report.notes.map((n) => `${n.level}: ${n.message}`)],

--- a/apps/extension/entrypoints/sidepanel/TemplateSection.tsx
+++ b/apps/extension/entrypoints/sidepanel/TemplateSection.tsx
@@ -11,6 +11,7 @@
  */
 import React, { useEffect, useRef, useState } from "react";
 import { ConfluenceClient } from "@atlcli/confluence/browser";
+import { getConfluenceBaseUrl } from "@atlcli/core";
 import { profileFromTabUrl } from "../../utils/profile.js";
 import type { LoadedPage } from "../../utils/read-path.js";
 import type { ScanResult, ExportReport } from "@atlcli/docx/browser";
@@ -206,7 +207,9 @@ export function TemplateSection({
         },
         {
           templates: idbTemplateSource(),
-          assets: sessionAssetFetcher(),
+          // Attachment refs are wiki-base-relative (spec 005); resolve them
+          // against the tab's Confluence root so the session cookies apply.
+          assets: sessionAssetFetcher(profile ? getConfluenceBaseUrl(profile) : undefined),
           output: downloadOutputSink(),
         }
       );
@@ -397,7 +400,12 @@ export function ReportView({ report }: { report: ExportReport }): React.JSX.Elem
             {report.unsupportedNames.length} unsupported: {report.unsupportedNames.join(", ")}
           </li>
         )}
-        {report.skippedImages > 0 && <li data-testid="report-skipped-images">{report.skippedImages} image(s) skipped (embedding not yet available)</li>}
+        {report.embeddedImages > 0 && (
+          <li data-testid="report-embedded-images">{report.embeddedImages} image(s) embedded</li>
+        )}
+        {report.skippedImages > 0 && (
+          <li data-testid="report-skipped-images">{report.skippedImages} image(s) skipped (see notes)</li>
+        )}
         <li>{report.durationMs} ms</li>
       </ul>
 

--- a/apps/extension/tests/docx/env.test.ts
+++ b/apps/extension/tests/docx/env.test.ts
@@ -36,15 +36,20 @@ describe("idbTemplateSource", () => {
 });
 
 describe("sessionAssetFetcher", () => {
-  it("fetches with session credentials and returns the bytes", async () => {
+  function recordingFetch(payload = new Uint8Array([1, 2, 3])) {
     const calls: Array<{ url: string; init: RequestInit | undefined }> = [];
-    const payload = new Uint8Array([1, 2, 3]);
     const fetchFn = (async (url: unknown, init?: RequestInit) => {
       calls.push({ url: String(url), init });
       return new Response(payload.slice());
     }) as typeof fetch;
+    return { calls, fetchFn };
+  }
 
-    const bytes = await sessionAssetFetcher(fetchFn).fetch({
+  it("fetches with session credentials and returns the bytes", async () => {
+    const payload = new Uint8Array([1, 2, 3]);
+    const { calls, fetchFn } = recordingFetch(payload);
+
+    const bytes = await sessionAssetFetcher(undefined, fetchFn).fetch({
       url: "https://x.atlassian.net/wiki/download/attachments/1/a.png",
       filename: "a.png",
     });
@@ -54,10 +59,28 @@ describe("sessionAssetFetcher", () => {
     expect(calls[0].init?.credentials).toBe("include");
   });
 
+  it("resolves wiki-base-relative attachment refs against the baseUrl (spec 005)", async () => {
+    const { calls, fetchFn } = recordingFetch();
+    await sessionAssetFetcher("https://x.atlassian.net/wiki", fetchFn).fetch({
+      url: "/download/attachments/123/diagram.png",
+      pageId: "123",
+      filename: "diagram.png",
+    });
+    expect(calls[0].url).toBe("https://x.atlassian.net/wiki/download/attachments/123/diagram.png");
+  });
+
+  it("passes absolute external URLs through untouched, ignoring the baseUrl", async () => {
+    const { calls, fetchFn } = recordingFetch();
+    await sessionAssetFetcher("https://x.atlassian.net/wiki", fetchFn).fetch({
+      url: "https://cdn.example.com/pic.png",
+    });
+    expect(calls[0].url).toBe("https://cdn.example.com/pic.png");
+  });
+
   it("throws with status + filename on a non-OK response", async () => {
     const fetchFn = (async () => new Response("nope", { status: 403 })) as unknown as typeof fetch;
     expect(
-      sessionAssetFetcher(fetchFn).fetch({ url: "https://x/att", filename: "a.png" })
+      sessionAssetFetcher(undefined, fetchFn).fetch({ url: "https://x/att", filename: "a.png" })
     ).rejects.toThrow("Asset fetch failed (403) for a.png");
   });
 });

--- a/apps/extension/tests/docx/report-view.test.tsx
+++ b/apps/extension/tests/docx/report-view.test.tsx
@@ -23,6 +23,7 @@ function makeReport(notes: ExportReport["notes"]): ExportReport {
     resolvedCount: 3,
     unsupportedNames: [],
     skippedImages: 0,
+    embeddedImages: 0,
     durationMs: 42,
     filename: "page.docx",
     notes,

--- a/apps/extension/tests/manifest.test.ts
+++ b/apps/extension/tests/manifest.test.ts
@@ -47,8 +47,14 @@ describe("built manifest.json", () => {
     );
   });
 
-  it("declares atlassian.net host permissions", () => {
-    expect(manifest.host_permissions).toEqual(["*://*.atlassian.net/*"]);
+  it("declares atlassian.net + media-CDN host permissions", () => {
+    // api.media.atlassian.com: attachment downloads 302 to the media CDN;
+    // without this host permission the redirect hop falls back to normal CORS
+    // and its wildcard ACAO rejects the credentialed session fetch (spec 005).
+    expect(manifest.host_permissions).toEqual([
+      "*://*.atlassian.net/*",
+      "https://api.media.atlassian.com/*",
+    ]);
   });
 
   it("uses a module service worker whose file exists in the output", () => {

--- a/apps/extension/utils/docx/env.ts
+++ b/apps/extension/utils/docx/env.ts
@@ -28,13 +28,19 @@ export function idbTemplateSource(factory?: IDBFactory): TemplateSource {
 /**
  * {@link AssetFetcher} over the page's own session: attachment downloads are
  * plain GETs that succeed because the browser attaches the Atlassian cookies
- * (`credentials: "include"`). Unused in v1 (image embedding is deferred to
- * spec 005) but wired now so the seam is real, not aspirational.
+ * (`credentials: "include"`). Drives image embedding (spec 005).
+ *
+ * The engine hands attachment refs as WIKI-BASE-RELATIVE download paths
+ * (`/download/attachments/…`); the panel runs on the extension origin, so a
+ * relative fetch would resolve against `chrome-extension://` — `baseUrl`
+ * (the site's Confluence root, e.g. `https://x.atlassian.net/wiki`) is
+ * prefixed to make them absolute. External image URLs pass through as-is.
  */
-export function sessionAssetFetcher(fetchFn: typeof fetch = fetch): AssetFetcher {
+export function sessionAssetFetcher(baseUrl?: string, fetchFn: typeof fetch = fetch): AssetFetcher {
   return {
     async fetch(ref: AssetRef): Promise<Uint8Array> {
-      const res = await fetchFn(ref.url, { credentials: "include" });
+      const url = /^https?:\/\//i.test(ref.url) ? ref.url : `${baseUrl ?? ""}${ref.url}`;
+      const res = await fetchFn(url, { credentials: "include" });
       if (!res.ok) {
         throw new Error(`Asset fetch failed (${res.status}) for ${ref.filename ?? ref.url}`);
       }

--- a/apps/extension/wxt.config.ts
+++ b/apps/extension/wxt.config.ts
@@ -27,7 +27,11 @@ export default defineConfig({
     // MV3 side panel + offscreen APIs baseline (PLAN §6 risk 1).
     minimum_chrome_version: "116",
     permissions: ["sidePanel", "offscreen", "storage", "tabs"],
-    host_permissions: ["*://*.atlassian.net/*"],
+    // api.media.atlassian.com: Cloud 302s attachment downloads to the media
+    // CDN, which answers `Access-Control-Allow-Origin: *` — incompatible with
+    // the session fetch's `credentials: "include"` unless the host permission
+    // exempts that hop from CORS too (spec 005 image embedding, E2E finding).
+    host_permissions: ["*://*.atlassian.net/*", "https://api.media.atlassian.com/*"],
     // WASM in extension pages requires 'wasm-unsafe-eval' (Chrome >= 103).
     // Deliberately NOT 'unsafe-eval' — asserted by the Task 2 test.
     content_security_policy: {

--- a/packages/docx/src/env.ts
+++ b/packages/docx/src/env.ts
@@ -18,9 +18,10 @@ export interface TemplateSource {
 }
 
 /**
- * A reference to a page asset (attachment) the engine may need to embed.
- * v1 defers image embedding, but the seam exists so the OOXML image-module
- * follow-up (spec 005) plugs in without changing the host contract.
+ * A reference to a page asset (attachment) the engine needs to embed.
+ * Attachment refs carry a wiki-base-relative `url` (the same shape as the
+ * Confluence API's own `downloadUrl`); external images carry their absolute
+ * URL. The OOXML image module (spec 005) drives this seam.
  */
 export interface AssetRef {
   /** Download URL of the asset (absolute, or site-relative for session hosts). */
@@ -44,7 +45,11 @@ export interface OutputSink {
 /** Everything a host must supply to run an export. */
 export interface ExportEnv {
   templates: TemplateSource;
-  assets: AssetFetcher;
+  /**
+   * How image bytes are fetched (spec 005). A host with no asset path simply
+   * omits it — images then degrade to report notes instead of embedding.
+   */
+  assets?: AssetFetcher;
   output: OutputSink;
 }
 
@@ -67,7 +72,9 @@ export interface RunExportInput extends Omit<ExportInput, "templateBytes"> {
 export async function runExport(input: RunExportInput, env: ExportEnv): Promise<ExportReport> {
   const { templateId, ...rest } = input;
   const templateBytes = await env.templates.getBytes(templateId ?? "current");
-  const { bytes, report } = await exportDocx({ ...rest, templateBytes });
+  // The env's asset fetcher drives image embedding (spec 005) unless the
+  // input overrides it; `embedImages: false` disables embedding entirely.
+  const { bytes, report } = await exportDocx({ ...rest, templateBytes, assets: rest.assets ?? env.assets });
   await env.output.emit(report.filename, bytes);
   return report;
 }

--- a/packages/docx/src/export.test.ts
+++ b/packages/docx/src/export.test.ts
@@ -13,6 +13,7 @@ import {
   fldSimpleResult,
   headingStyle,
   para,
+  pngFixtureBytes,
   readPart,
   runSplitPara,
   smartArtDataPart,
@@ -492,5 +493,178 @@ describe("exportDocx — full pipeline", () => {
     });
     expect(spaceCalls).toBe(0);
     expect(userCalls).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Image embedding through the full pipeline (spec 005)
+// ---------------------------------------------------------------------------
+
+describe("exportDocx — image embedding (spec 005)", () => {
+  const imageTemplate = () =>
+    buildDocx({
+      body: para("$scroll.content"),
+      styles: stylesXml(headingStyle("Heading1", "Heading 1")),
+    });
+
+  /** An AssetFetcher recording every ref, serving PNG fixture bytes. */
+  function recordingFetcher(bytes = pngFixtureBytes(200, 100)) {
+    const refs: { url: string; pageId?: string; filename?: string }[] = [];
+    return {
+      refs,
+      fetcher: {
+        async fetch(ref: { url: string; pageId?: string; filename?: string }) {
+          refs.push(ref);
+          return bytes;
+        },
+      },
+    };
+  }
+
+  it("embeds an attachment image: drawing + media + rel + content type, report counts it", async () => {
+    const { refs, fetcher } = recordingFetcher();
+    const { bytes, report } = await exportDocx({
+      templateBytes: imageTemplate(),
+      details: {
+        ...details,
+        storage: '<p>before</p><ac:image ac:alt="the diagram"><ri:attachment ri:filename="diagram.png"/></ac:image>',
+      },
+      template,
+      deps,
+      assets: fetcher,
+    });
+
+    // The fetch used the canonical wiki-base-relative download URL.
+    expect(refs).toEqual([
+      { url: "/download/attachments/123/diagram.png", pageId: "123", filename: "diagram.png" },
+    ]);
+
+    const doc = readPart(bytes, "word/document.xml");
+    expect(doc).toContain("<w:drawing>");
+    expect(doc).toContain('descr="the diagram"');
+    expect(doc).toContain(`<wp:extent cx="${200 * 9525}" cy="${100 * 9525}"/>`);
+    const relId = doc.match(/r:embed="(rId\d+)"/)?.[1];
+    expect(relId).toBeDefined();
+
+    const rels = readPart(bytes, "word/_rels/document.xml.rels");
+    expect(rels).toContain(`Id="${relId}"`);
+    expect(rels).toContain('Target="media/atlcli-image1.png"');
+    expect(readPart(bytes, "[Content_Types].xml")).toContain('Extension="png"');
+    // The media part survived the docxtemplater render byte-identically.
+    const zip = new PizZip(bytes);
+    expect([...zip.file("word/media/atlcli-image1.png")!.asUint8Array()]).toEqual([
+      ...pngFixtureBytes(200, 100),
+    ]);
+
+    expect(report.embeddedImages).toBe(1);
+    expect(report.skippedImages).toBe(0);
+    expect(report.notes.some((n) => n.code.startsWith("image"))).toBe(false);
+  });
+
+  it("passes external image URLs through to the fetcher unchanged", async () => {
+    const { refs, fetcher } = recordingFetcher();
+    const { report } = await exportDocx({
+      templateBytes: imageTemplate(),
+      details: {
+        ...details,
+        storage: '<ac:image><ri:url ri:value="https://cdn.example.com/pic.png"/></ac:image>',
+      },
+      template,
+      deps,
+      assets: fetcher,
+    });
+    expect(refs[0]?.url).toBe("https://cdn.example.com/pic.png");
+    expect(report.embeddedImages).toBe(1);
+  });
+
+  it("degrades a failed fetch to a warning note with NO dangling relationship (F3 invariant)", async () => {
+    const { bytes, report } = await exportDocx({
+      templateBytes: imageTemplate(),
+      details: {
+        ...details,
+        storage: '<p>t</p><ac:image><ri:attachment ri:filename="broken.png"/></ac:image>',
+      },
+      template,
+      deps,
+      assets: {
+        async fetch() {
+          throw new Error("boom (401)");
+        },
+      },
+    });
+
+    const note = report.notes.find((n) => n.code === "image-embed-failed");
+    expect(note?.level).toBe("warning");
+    expect(note?.message).toContain("broken.png");
+    expect(note?.message).toContain("boom (401)");
+    expect(report.embeddedImages).toBe(0);
+    expect(report.skippedImages).toBe(1);
+
+    const doc = readPart(bytes, "word/document.xml");
+    expect(doc).not.toContain("<w:drawing");
+    const rels = readPart(bytes, "word/_rels/document.xml.rels");
+    expect(rels).not.toContain("relationships/image");
+    const zip = new PizZip(bytes);
+    expect(Object.keys(zip.files).some((p) => p.startsWith("word/media/"))).toBe(false);
+  });
+
+  it("degrades undecodable bytes (SVG) to a report line, export still succeeds", async () => {
+    const svg = new TextEncoder().encode('<svg xmlns="http://www.w3.org/2000/svg"/>');
+    const { report } = await exportDocx({
+      templateBytes: imageTemplate(),
+      details: {
+        ...details,
+        storage: '<ac:image><ri:attachment ri:filename="logo.svg"/></ac:image>',
+      },
+      template,
+      deps,
+      assets: { fetch: async () => svg },
+    });
+    const note = report.notes.find((n) => n.code === "image-embed-failed");
+    expect(note?.message).toContain("SVG");
+    expect(report.skippedImages).toBe(1);
+  });
+
+  it("embedImages: false skips embedding without touching the fetcher", async () => {
+    const { refs, fetcher } = recordingFetcher();
+    const { bytes, report } = await exportDocx({
+      templateBytes: imageTemplate(),
+      details: {
+        ...details,
+        storage: '<ac:image><ri:attachment ri:filename="diagram.png"/></ac:image>',
+      },
+      template,
+      deps,
+      assets: fetcher,
+      embedImages: false,
+    });
+    expect(refs).toHaveLength(0);
+    expect(report.embeddedImages).toBe(0);
+    expect(report.skippedImages).toBe(1);
+    expect(report.notes.some((n) => n.code === "image-skipped")).toBe(true);
+    expect(readPart(bytes, "word/document.xml")).not.toContain("<w:drawing");
+  });
+
+  it("embeds images inside table cells and honors ac:width scaling", async () => {
+    const { fetcher } = recordingFetcher(pngFixtureBytes(800, 400));
+    const { bytes, report } = await exportDocx({
+      templateBytes: imageTemplate(),
+      details: {
+        ...details,
+        storage:
+          "<table><tbody><tr><td>" +
+          '<ac:image ac:width="250"><ri:attachment ri:filename="cell.png"/></ac:image>' +
+          "</td></tr></tbody></table>",
+      },
+      template,
+      deps,
+      assets: fetcher,
+    });
+    const doc = readPart(bytes, "word/document.xml");
+    expect(report.embeddedImages).toBe(1);
+    // Inside the table cell, scaled to 250×125 px.
+    const cellStart = doc.indexOf("<w:tc>");
+    expect(doc.indexOf("<w:drawing>")).toBeGreaterThan(cellStart);
+    expect(doc).toContain(`<wp:extent cx="${250 * 9525}" cy="${125 * 9525}"/>`);
   });
 });

--- a/packages/docx/src/export.ts
+++ b/packages/docx/src/export.ts
@@ -29,7 +29,10 @@
  * re-parsing, so page-authored `$scroll.*` / braces pass through verbatim
  * (finding #7). Non-content `$scroll.*` placeholders are resolved to text on the
  * template parts BEFORE render (engine-agnostic run-normalized preprocessor,
- * findings #8/#9). Images are deferred (F3): they add report lines, never OOXML.
+ * findings #8/#9). Images embed through the self-built OOXML image module
+ * (spec 005) when the host supplies an {@link AssetFetcher}; a missing fetcher
+ * or a failed fetch/decode degrades to a report line, never a dangling
+ * relationship (the 004-F3 skip-path invariant holds on every failure branch).
  */
 import PizZip from "pizzip";
 import Docxtemplater from "docxtemplater";
@@ -41,7 +44,9 @@ import {
   type ResolveDeps,
   type TemplateMeta,
 } from "./resolver.js";
-import { serializeBlocks } from "./serialize.js";
+import { serializeBlocks, type ImageBlock, type ImageEmbedSeam } from "./serialize.js";
+import { ImageEmbedder } from "./image.js";
+import type { AssetFetcher, AssetRef } from "./env.js";
 import { CODE_STYLE_ID, codeStyleXml, parseStyleNames } from "./ooxml.js";
 import {
   encodeXmlText,
@@ -55,8 +60,10 @@ export interface ExportReport {
   resolvedCount: number;
   /** Distinct unsupported/never placeholder bases (rendered empty). */
   unsupportedNames: string[];
-  /** Number of images skipped (deferred embedding). */
+  /** Number of images skipped (no fetcher, disabled, or embed failure). */
   skippedImages: number;
+  /** Number of images embedded into the document (spec 005). */
+  embeddedImages: number;
   /** Wall-clock export duration in milliseconds. */
   durationMs: number;
   /** Suggested download filename (`<page-title>.docx`). */
@@ -78,6 +85,16 @@ export interface ExportInput {
   template: TemplateMeta;
   exportDate?: Date;
   deps?: ResolveDeps;
+  /**
+   * How image bytes are fetched (spec 005). Absent → every image degrades to
+   * a report note, exactly the pre-005 behavior.
+   */
+  assets?: AssetFetcher;
+  /**
+   * Set `false` to skip image embedding even when `assets` is available
+   * (the CLI's `--no-images`). Defaults to `true`.
+   */
+  embedImages?: boolean;
 }
 
 /**
@@ -150,10 +167,16 @@ export async function exportDocx(input: ExportInput): Promise<ExportResult> {
   const usedRaw = [...scan.supported, ...scan.unsupported, ...scan.never].flatMap((h) => h.raw);
   const resolved = await resolvePlaceholders(usedRaw, { details: input.details, template: input.template, exportDate }, input.deps);
 
-  // 2. Storage → blocks → OOXML body.
+  // 2. Storage → blocks → OOXML body. When the host supplied an asset fetcher
+  //    (and images aren't disabled), the serializer's image seam embeds each
+  //    image into THIS zip (media + rel + content type) before render — the
+  //    rendered rawxml body then references relationships that already exist.
   const { blocks, notes: walkNotes } = storageToBlocks(input.details.storage ?? "");
   const styleNames = parseStyleNames(zip.file("word/styles.xml")?.asText() ?? "");
-  const body = await serializeBlocks(blocks, { styleNames });
+  const embedder =
+    input.assets && input.embedImages !== false ? new ImageEmbedder(zip) : undefined;
+  const images = embedder ? imageSeam(embedder, input.assets!, input.details.id) : undefined;
+  const body = await serializeBlocks(blocks, { styleNames, images });
 
   // 3. Swap the $scroll.content paragraph for the rawxml tag paragraph. If the
   //    template has none, inject the tag before the body's final section break.
@@ -188,7 +211,8 @@ export async function exportDocx(input: ExportInput): Promise<ExportResult> {
 
   const notes = [...resolved.notes, ...walkNotes, ...body.notes, ...flowNotes];
   // Every image-skip note kind counts toward the report's skipped-image total:
-  // serializer `image-skipped`, walker `image-unresolved` and `inline-image-skipped`.
+  // serializer `image-skipped`/`image-embed-failed`, walker `image-unresolved`
+  // and `inline-image-skipped`.
   const skippedImages = notes.filter((n) => IMAGE_SKIP_CODES.has(n.code)).length;
 
   return {
@@ -197,6 +221,7 @@ export async function exportDocx(input: ExportInput): Promise<ExportResult> {
       resolvedCount: resolved.resolvedCount,
       unsupportedNames: resolved.unsupportedNames,
       skippedImages,
+      embeddedImages: embedder?.embeddedCount ?? 0,
       durationMs: Date.now() - start,
       filename: toDownloadFilename(input.details.title),
       notes,
@@ -268,7 +293,63 @@ function explainDocxError(err: unknown): string[] {
 // ---------------------------------------------------------------------------
 
 /** Note kinds that mean "an image was not embedded" (for the report tally). */
-const IMAGE_SKIP_CODES = new Set(["image-skipped", "image-unresolved", "inline-image-skipped"]);
+const IMAGE_SKIP_CODES = new Set([
+  "image-skipped",
+  "image-embed-failed",
+  "image-unresolved",
+  "inline-image-skipped",
+]);
+
+// ---------------------------------------------------------------------------
+// Image seam (spec 005)
+// ---------------------------------------------------------------------------
+
+/**
+ * Bridge the serializer's {@link ImageEmbedSeam} to the host's
+ * {@link AssetFetcher} + the OOXML {@link ImageEmbedder}: resolve the block's
+ * source to an {@link AssetRef}, fetch the bytes, embed. EVERY throw —
+ * fetch, decode, oversized — funnels into `{ok:false}` so the serializer
+ * writes a report line and the export always succeeds; the embedder writes
+ * nothing to the archive unless it returns a fragment, so a failure never
+ * leaves a dangling media part or relationship.
+ */
+function imageSeam(embedder: ImageEmbedder, assets: AssetFetcher, pageId: string): ImageEmbedSeam {
+  return {
+    async embed(block: ImageBlock) {
+      try {
+        const bytes = await assets.fetch(assetRefFor(block, pageId));
+        const name = block.source.kind === "attachment" ? block.source.filename : undefined;
+        const xml = embedder.embed(bytes, {
+          alt: block.alt,
+          name,
+          widthPx: block.width,
+          heightPx: block.height,
+        });
+        return { ok: true as const, xml };
+      } catch (err) {
+        return { ok: false as const, reason: err instanceof Error ? err.message : String(err) };
+      }
+    },
+  };
+}
+
+/**
+ * The {@link AssetRef} for an image block. Attachments use Confluence's
+ * canonical download path, RELATIVE to the wiki base (`/wiki` on Cloud) —
+ * exactly the shape the API's own `downloadUrl` uses, so a token host can
+ * feed it straight to its binary-request helper and a session host prefixes
+ * its wiki base. External images pass their absolute URL through.
+ */
+function assetRefFor(block: ImageBlock, pageId: string): AssetRef {
+  if (block.source.kind === "attachment") {
+    return {
+      url: `/download/attachments/${encodeURIComponent(pageId)}/${encodeURIComponent(block.source.filename)}`,
+      pageId,
+      filename: block.source.filename,
+    };
+  }
+  return { url: block.source.url, pageId };
+}
 
 /** Replace the paragraph containing `$scroll.content` with the rawxml tag. */
 function injectContentTag(zip: PizZip): boolean {

--- a/packages/docx/src/fixtures.ts
+++ b/packages/docx/src/fixtures.ts
@@ -339,3 +339,21 @@ export function readPart(bytes: Uint8Array, part: string): string {
   const zip = new PizZip(bytes);
   return zip.file(part)?.asText() ?? "";
 }
+
+/**
+ * A structurally valid PNG header (signature + IHDR) with the given pixel
+ * size — real bytes for the image-module decoder, no image library needed.
+ * `pad` appends zero bytes so two fixtures can share a size yet differ.
+ */
+export function pngFixtureBytes(width: number, height: number, pad = 0): Uint8Array {
+  const b = new Uint8Array(33 + pad);
+  b.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a], 0);
+  const view = new DataView(b.buffer);
+  view.setUint32(8, 13); // IHDR length
+  b.set([0x49, 0x48, 0x44, 0x52], 12); // "IHDR"
+  view.setUint32(16, width);
+  view.setUint32(20, height);
+  b[24] = 8; // bit depth
+  b[25] = 6; // color type RGBA
+  return b;
+}

--- a/packages/docx/src/image.test.ts
+++ b/packages/docx/src/image.test.ts
@@ -1,0 +1,325 @@
+/**
+ * OOXML image module tests (spec 005): the dimension decoder against real
+ * header bytes, sizing/EMU math, and the embedder's archive surgery on a real
+ * PizZip package (media part, relationship, content-type, unique ids, dedup)
+ * — no stubs, per the repo's real-infra directive.
+ */
+import { describe, expect, it } from "bun:test";
+import PizZip from "pizzip";
+import {
+  ImageEmbedder,
+  ImageEmbedError,
+  MAX_CONTENT_WIDTH_PX,
+  decodeImageInfo,
+  ensureContentTypeDefault,
+  inlineImageParagraph,
+  isSvg,
+  pxToEmu,
+  resolveTargetSize,
+} from "./image.js";
+import { assertBalancedXml, buildDocx, para, pngFixtureBytes as pngBytes } from "./fixtures.js";
+
+// ---------------------------------------------------------------------------
+// Fixture bytes — real, minimal image headers (PNG builder lives in fixtures)
+// ---------------------------------------------------------------------------
+
+/** A JPEG: SOI, a COM segment (exercises segment skipping), then SOF0. */
+function jpegBytes(width: number, height: number): Uint8Array {
+  const b = new Uint8Array(2 + 8 + 13 + 2);
+  const view = new DataView(b.buffer);
+  let i = 0;
+  b.set([0xff, 0xd8], i); // SOI
+  i += 2;
+  b.set([0xff, 0xfe], i); // COM marker
+  view.setUint16(i + 2, 6); // segment length (incl. the 2 length bytes)
+  i += 2 + 6;
+  b.set([0xff, 0xc0], i); // SOF0
+  view.setUint16(i + 2, 11);
+  b[i + 4] = 8; // precision
+  view.setUint16(i + 5, height);
+  view.setUint16(i + 7, width);
+  b[i + 9] = 3; // components
+  i += 2 + 11;
+  b.set([0xff, 0xd9], i); // EOI
+  return b;
+}
+
+/** A GIF89a logical-screen header with the given size. */
+function gifBytes(width: number, height: number): Uint8Array {
+  const b = new Uint8Array(13);
+  b.set([0x47, 0x49, 0x46, 0x38, 0x39, 0x61], 0); // "GIF89a"
+  const view = new DataView(b.buffer);
+  view.setUint16(6, width, true);
+  view.setUint16(8, height, true);
+  return b;
+}
+
+function svgBytes(): Uint8Array {
+  const text = `<?xml version="1.0" encoding="UTF-8"?>\n<!-- logo -->\n<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10"/>`;
+  return new TextEncoder().encode(text);
+}
+
+function templateZip(body = para("hello")): PizZip {
+  return new PizZip(buildDocx({ body }));
+}
+
+// ---------------------------------------------------------------------------
+// Decoder
+// ---------------------------------------------------------------------------
+
+describe("decodeImageInfo", () => {
+  it("decodes PNG IHDR dimensions", () => {
+    expect(decodeImageInfo(pngBytes(640, 480))).toEqual({
+      format: "png",
+      ext: "png",
+      mime: "image/png",
+      width: 640,
+      height: 480,
+    });
+  });
+
+  it("decodes JPEG SOF dimensions past skippable segments", () => {
+    expect(decodeImageInfo(jpegBytes(1024, 768))).toMatchObject({
+      format: "jpeg",
+      mime: "image/jpeg",
+      width: 1024,
+      height: 768,
+    });
+  });
+
+  it("decodes GIF logical-screen dimensions (little-endian)", () => {
+    expect(decodeImageInfo(gifBytes(300, 200))).toMatchObject({
+      format: "gif",
+      width: 300,
+      height: 200,
+    });
+  });
+
+  it("decodes a real 1×1 PNG (base64 fixture)", () => {
+    const onePx = Uint8Array.from(
+      atob("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="),
+      (c) => c.charCodeAt(0)
+    );
+    expect(decodeImageInfo(onePx)).toMatchObject({ format: "png", width: 1, height: 1 });
+  });
+
+  it("rejects garbage, truncated and SVG bytes", () => {
+    expect(decodeImageInfo(new Uint8Array([1, 2, 3, 4]))).toBeNull();
+    expect(decodeImageInfo(pngBytes(10, 10).slice(0, 20))).toBeNull();
+    expect(decodeImageInfo(svgBytes())).toBeNull();
+  });
+
+  it("decodes from a non-zero-offset subarray view", () => {
+    // The engine hands out views over fetched buffers; the DataView math must
+    // respect byteOffset, not assume the view starts at the buffer's origin.
+    const buf = new Uint8Array(10 + 33);
+    buf.set(pngBytes(20, 30), 10);
+    expect(decodeImageInfo(buf.subarray(10))).toMatchObject({ width: 20, height: 30 });
+  });
+});
+
+describe("isSvg", () => {
+  it("detects an SVG behind XML declaration and comments", () => {
+    expect(isSvg(svgBytes())).toBe(true);
+  });
+  it("does not flag PNG or HTML-ish text", () => {
+    expect(isSvg(pngBytes(1, 1))).toBe(false);
+    expect(isSvg(new TextEncoder().encode("<p>svg is mentioned</p>"))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Sizing
+// ---------------------------------------------------------------------------
+
+describe("resolveTargetSize / pxToEmu", () => {
+  const intrinsic = { width: 800, height: 400 };
+
+  it("uses intrinsic size when nothing is specified", () => {
+    expect(resolveTargetSize(intrinsic, {}, 1000)).toEqual({ widthPx: 800, heightPx: 400 });
+  });
+
+  it("scales the missing axis from a width-only override", () => {
+    expect(resolveTargetSize(intrinsic, { widthPx: 400 }, 1000)).toEqual({ widthPx: 400, heightPx: 200 });
+  });
+
+  it("scales the missing axis from a height-only override", () => {
+    expect(resolveTargetSize(intrinsic, { heightPx: 100 }, 1000)).toEqual({ widthPx: 200, heightPx: 100 });
+  });
+
+  it("caps to the content width preserving aspect ratio", () => {
+    expect(resolveTargetSize(intrinsic, {}, MAX_CONTENT_WIDTH_PX)).toEqual({ widthPx: 600, heightPx: 300 });
+    expect(resolveTargetSize(intrinsic, { widthPx: 1200, heightPx: 300 }, 600)).toEqual({
+      widthPx: 600,
+      heightPx: 150,
+    });
+  });
+
+  it("converts px to EMU with rounding", () => {
+    expect(pxToEmu(1)).toBe(9525);
+    expect(pxToEmu(0.5)).toBe(4763);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Embedder — archive surgery on a real package
+// ---------------------------------------------------------------------------
+
+describe("ImageEmbedder", () => {
+  it("writes media part + relationship + content type and returns the drawing", () => {
+    const zip = templateZip();
+    const embedder = new ImageEmbedder(zip);
+    const xml = embedder.embed(pngBytes(100, 50), { name: "diagram.png", alt: "the diagram" });
+
+    assertBalancedXml(xml);
+    // Drawing landmarks: extent in EMU, alt text on docPr, blip → rel id.
+    expect(xml).toContain(`<wp:extent cx="${100 * 9525}" cy="${50 * 9525}"/>`);
+    expect(xml).toContain('descr="the diagram"');
+    const relId = xml.match(/r:embed="(rId\d+)"/)?.[1];
+    expect(relId).toBeDefined();
+
+    // Media part holds the exact bytes.
+    const media = zip.file("word/media/atlcli-image1.png");
+    expect(media).not.toBeNull();
+    expect([...media!.asUint8Array()]).toEqual([...pngBytes(100, 50)]);
+
+    // Relationship targets the media part.
+    const rels = zip.file("word/_rels/document.xml.rels")!.asText();
+    expect(rels).toContain(`Id="${relId}"`);
+    expect(rels).toContain('Target="media/atlcli-image1.png"');
+    expect(rels).toContain("relationships/image");
+
+    // Content-type default registered exactly once.
+    const ct = zip.file("[Content_Types].xml")!.asText();
+    expect(ct.match(/Extension="png"/g)).toHaveLength(1);
+    expect(embedder.embeddedCount).toBe(1);
+  });
+
+  it("allocates unique docPr ids and rIds across multiple images", () => {
+    const zip = templateZip();
+    const embedder = new ImageEmbedder(zip);
+    const a = embedder.embed(pngBytes(10, 10));
+    const b = embedder.embed(gifBytes(20, 20));
+
+    const idsA = [...a.matchAll(/(?:wp:docPr|pic:cNvPr) id="(\d+)"/g)].map((m) => m[1]);
+    const idsB = [...b.matchAll(/(?:wp:docPr|pic:cNvPr) id="(\d+)"/g)].map((m) => m[1]);
+    // Within one drawing, docPr and cNvPr share the id; across drawings they differ.
+    expect(new Set(idsA).size).toBe(1);
+    expect(new Set(idsB).size).toBe(1);
+    expect(idsA[0]).not.toBe(idsB[0]);
+
+    const relA = a.match(/r:embed="(rId\d+)"/)?.[1];
+    const relB = b.match(/r:embed="(rId\d+)"/)?.[1];
+    expect(relA).not.toBe(relB);
+    // Both formats registered generically (not PNG-only).
+    const ct = zip.file("[Content_Types].xml")!.asText();
+    expect(ct).toContain('Extension="png"');
+    expect(ct).toContain('Extension="gif"');
+  });
+
+  it("seeds docPr ids above drawings the template already contains", () => {
+    const body =
+      para("x") +
+      `<w:p><w:r><w:drawing><wp:docPr id="41" name="Existing"/></w:drawing></w:r></w:p>`;
+    const zip = templateZip(body);
+    const xml = new ImageEmbedder(zip).embed(pngBytes(5, 5));
+    const id = Number(xml.match(/wp:docPr id="(\d+)"/)?.[1]);
+    expect(id).toBeGreaterThan(41);
+  });
+
+  it("dedupes byte-identical images into one media part with distinct docPr ids", () => {
+    const zip = templateZip();
+    const embedder = new ImageEmbedder(zip);
+    const a = embedder.embed(pngBytes(10, 10), { alt: "first" });
+    const b = embedder.embed(pngBytes(10, 10), { alt: "second" });
+
+    expect(a.match(/r:embed="(rId\d+)"/)?.[1]).toBe(b.match(/r:embed="(rId\d+)"/)?.[1]!);
+    expect(a.match(/wp:docPr id="(\d+)"/)?.[1]).not.toBe(b.match(/wp:docPr id="(\d+)"/)?.[1]!);
+    expect(zip.file("word/media/atlcli-image1.png")).not.toBeNull();
+    expect(zip.file("word/media/atlcli-image2.png")).toBeNull();
+    expect(embedder.embeddedCount).toBe(2);
+
+    // Same-size but different bytes must NOT dedupe (hash bucket verified).
+    const c = embedder.embed(pngBytes(10, 10, /* pad */ 0).map((v, i) => (i === 32 ? 99 : v)) as Uint8Array);
+    expect(c.match(/r:embed="(rId\d+)"/)?.[1]).not.toBe(a.match(/r:embed="(rId\d+)"/)?.[1]!);
+  });
+
+  it("caps oversized images to the content width", () => {
+    const zip = templateZip();
+    const xml = new ImageEmbedder(zip).embed(pngBytes(1200, 600));
+    expect(xml).toContain(`<wp:extent cx="${600 * 9525}" cy="${300 * 9525}"/>`);
+  });
+
+  it("honors author width/height overrides", () => {
+    const zip = templateZip();
+    const xml = new ImageEmbedder(zip).embed(pngBytes(800, 400), { widthPx: 250 });
+    expect(xml).toContain(`<wp:extent cx="${250 * 9525}" cy="${125 * 9525}"/>`);
+  });
+
+  it("escapes alt text and names for XML attributes", () => {
+    const zip = templateZip();
+    const xml = new ImageEmbedder(zip).embed(pngBytes(5, 5), { name: 'a"<b>&.png', alt: 'says "hi" & <bye>' });
+    assertBalancedXml(xml);
+    expect(xml).toContain('descr="says &quot;hi&quot; &amp; &lt;bye&gt;"');
+    expect(xml).toContain('name="a&quot;&lt;b&gt;&amp;.png"');
+  });
+
+  it("throws ImageEmbedError and leaves the archive untouched on bad input", () => {
+    const zip = templateZip();
+    const relsBefore = zip.file("word/_rels/document.xml.rels")!.asText();
+    const ctBefore = zip.file("[Content_Types].xml")!.asText();
+    const embedder = new ImageEmbedder(zip);
+
+    expect(() => embedder.embed(new Uint8Array(0))).toThrow(ImageEmbedError);
+    expect(() => embedder.embed(new TextEncoder().encode("not an image"))).toThrow(ImageEmbedError);
+    expect(() => embedder.embed(svgBytes())).toThrow(/SVG/);
+
+    expect(zip.file("word/_rels/document.xml.rels")!.asText()).toBe(relsBefore);
+    expect(zip.file("[Content_Types].xml")!.asText()).toBe(ctBefore);
+    expect(Object.keys(zip.files).some((p) => p.startsWith("word/media/"))).toBe(false);
+    expect(embedder.embeddedCount).toBe(0);
+  });
+
+  it("avoids media filename collisions with existing parts", () => {
+    const zip = templateZip();
+    zip.file("word/media/atlcli-image1.png", pngBytes(1, 1));
+    const xml = new ImageEmbedder(zip).embed(pngBytes(9, 9));
+    expect(xml).toContain("r:embed=");
+    const rels = zip.file("word/_rels/document.xml.rels")!.asText();
+    expect(rels).toContain('Target="media/atlcli-image2.png"');
+  });
+});
+
+describe("ensureContentTypeDefault", () => {
+  it("is idempotent and case-insensitive on the extension", () => {
+    const zip = templateZip();
+    ensureContentTypeDefault(zip, "jpeg", "image/jpeg");
+    ensureContentTypeDefault(zip, "jpeg", "image/jpeg");
+    const ct = zip.file("[Content_Types].xml")!.asText();
+    expect(ct.match(/Extension="jpeg"/g)).toHaveLength(1);
+  });
+});
+
+describe("inlineImageParagraph", () => {
+  it("emits the full Word-blessed fragment (aspect locks, effectExtent, useLocalDpi)", () => {
+    const xml = inlineImageParagraph({
+      relId: "rId9",
+      docPrId: 3,
+      name: "pic",
+      descr: "alt",
+      cxEmu: 100,
+      cyEmu: 200,
+    });
+    assertBalancedXml(xml);
+    for (const landmark of [
+      '<wp:effectExtent l="0" t="0" r="0" b="0"/>',
+      'noChangeAspect="1"',
+      "<a:picLocks",
+      "a14:useLocalDpi",
+      '<a:blip r:embed="rId9"',
+      "<a:noFill/>",
+    ]) {
+      expect(xml).toContain(landmark);
+    }
+  });
+});

--- a/packages/docx/src/image.ts
+++ b/packages/docx/src/image.ts
@@ -1,0 +1,427 @@
+/**
+ * Self-built OOXML image module (spec 005).
+ *
+ * The engine decision (spec 004 F1, docxtemplater free) leaves no library
+ * image support, so embedding is hand-built zip surgery on the template's
+ * PizZip archive — the four coordinated edits OOXML needs per image
+ * (research §2): a media part (`word/media/…`), a `document.xml.rels`
+ * relationship, a `[Content_Types].xml` default, and an inline
+ * `<w:drawing>` fragment referencing the relationship with EMU sizing.
+ *
+ * Isomorphic by construction: dimensions come from an in-house header
+ * decoder over a `DataView` (no node `Buffer`/`image-size`), bytes are
+ * `Uint8Array`, and the rels/content-type edits are string splices (no
+ * `xmldom`). SVG is detected but deferred (research §5: svgBlip needs a
+ * rasterized PNG fallback, which requires a canvas — not isomorphic); an
+ * SVG asset degrades to the caller's report line.
+ *
+ * The failure invariant callers rely on: {@link ImageEmbedder.embed} writes
+ * NOTHING to the archive unless it returns a drawing fragment — a thrown
+ * {@link ImageEmbedError} leaves no dangling media part or relationship.
+ */
+import type PizZip from "pizzip";
+
+/** 914400 EMU/inch ÷ 96 dpi (research §2.5; matches Scroll/Word defaults). */
+export const EMU_PER_PX = 9525;
+
+/**
+ * Content-width cap in pixels: ~6.25" of usable A4/Letter width at 96 dpi,
+ * matching the 9000 dxa table width the serializer already targets.
+ */
+export const MAX_CONTENT_WIDTH_PX = 600;
+
+/** Refuse to embed assets above this size (spec 005 risk 2: docx bloat). */
+export const MAX_IMAGE_BYTES = 25 * 1024 * 1024;
+
+export type ImageFormat = "png" | "jpeg" | "gif";
+
+export interface ImageInfo {
+  format: ImageFormat;
+  /** Media-part filename extension. */
+  ext: string;
+  /** MIME type for the `[Content_Types].xml` default. */
+  mime: string;
+  /** Intrinsic pixel dimensions from the header. */
+  width: number;
+  height: number;
+}
+
+/** A non-fatal embed failure: the export continues with a report line. */
+export class ImageEmbedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ImageEmbedError";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Format sniffing + dimension decoding (research §4: in-browser, DataView)
+// ---------------------------------------------------------------------------
+
+/**
+ * Decode format + intrinsic dimensions from the image header. Returns `null`
+ * for anything that is not a well-formed PNG/JPEG/GIF.
+ */
+export function decodeImageInfo(bytes: Uint8Array): ImageInfo | null {
+  return decodePng(bytes) ?? decodeJpeg(bytes) ?? decodeGif(bytes);
+}
+
+/** PNG: 8-byte signature, IHDR width/height at offsets 16/20 (big-endian). */
+function decodePng(bytes: Uint8Array): ImageInfo | null {
+  const SIG = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+  if (bytes.length < 24 || SIG.some((b, i) => bytes[i] !== b)) return null;
+  // Bytes 12–15 must name the IHDR chunk (always first in a valid PNG).
+  if (bytes[12] !== 0x49 || bytes[13] !== 0x48 || bytes[14] !== 0x44 || bytes[15] !== 0x52) return null;
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const width = view.getUint32(16);
+  const height = view.getUint32(20);
+  if (!width || !height) return null;
+  return { format: "png", ext: "png", mime: "image/png", width, height };
+}
+
+/** GIF: `GIF87a`/`GIF89a`, logical-screen width/height at 6/8 (little-endian). */
+function decodeGif(bytes: Uint8Array): ImageInfo | null {
+  if (bytes.length < 10) return null;
+  const head = String.fromCharCode(...bytes.subarray(0, 6));
+  if (head !== "GIF87a" && head !== "GIF89a") return null;
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const width = view.getUint16(6, true);
+  const height = view.getUint16(8, true);
+  if (!width || !height) return null;
+  return { format: "gif", ext: "gif", mime: "image/gif", width, height };
+}
+
+/**
+ * JPEG: walk the marker segments from SOI until a start-of-frame (SOF0–SOF15,
+ * excluding the non-frame C4/C8/CC markers) yields height/width, or the scan
+ * data (SOS) begins.
+ */
+function decodeJpeg(bytes: Uint8Array): ImageInfo | null {
+  if (bytes.length < 4 || bytes[0] !== 0xff || bytes[1] !== 0xd8) return null;
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  let i = 2;
+  while (i + 3 < bytes.length) {
+    if (bytes[i] !== 0xff) return null; // desynced — not a marker
+    const marker = bytes[i + 1];
+    if (marker === 0xff) {
+      i += 1; // fill byte
+      continue;
+    }
+    // Standalone markers without a length (RSTn, SOI, EOI, TEM).
+    if ((marker >= 0xd0 && marker <= 0xd9) || marker === 0x01) {
+      i += 2;
+      continue;
+    }
+    if (i + 4 > bytes.length) return null;
+    const length = view.getUint16(i + 2);
+    if (length < 2) return null;
+    const isSof = marker >= 0xc0 && marker <= 0xcf && marker !== 0xc4 && marker !== 0xc8 && marker !== 0xcc;
+    if (isSof) {
+      if (i + 9 > bytes.length) return null;
+      const height = view.getUint16(i + 5);
+      const width = view.getUint16(i + 7);
+      if (!width || !height) return null;
+      return { format: "jpeg", ext: "jpeg", mime: "image/jpeg", width, height };
+    }
+    if (marker === 0xda) return null; // scan data reached without a SOF
+    i += 2 + length;
+  }
+  return null;
+}
+
+/**
+ * True when the bytes look like an SVG document (optionally behind a BOM /
+ * XML declaration / comments). Only the first 512 bytes are inspected.
+ */
+export function isSvg(bytes: Uint8Array): boolean {
+  let head = "";
+  const limit = Math.min(bytes.length, 512);
+  for (let i = 0; i < limit; i++) head += String.fromCharCode(bytes[i]);
+  head = head.replace(/^(?:\uFEFF|\xEF\xBB\xBF)/, "").trimStart();
+  if (!head.startsWith("<")) return false;
+  return /<svg[\s>]/i.test(head);
+}
+
+// ---------------------------------------------------------------------------
+// Sizing
+// ---------------------------------------------------------------------------
+
+export interface TargetSize {
+  widthPx: number;
+  heightPx: number;
+}
+
+/**
+ * Resolve the rendered size: author-specified px override the intrinsic size
+ * (one missing axis scales by the intrinsic aspect ratio), then the result is
+ * capped to `maxWidthPx` preserving aspect (spec 005: width-capping).
+ */
+export function resolveTargetSize(
+  intrinsic: { width: number; height: number },
+  wanted: { widthPx?: number; heightPx?: number },
+  maxWidthPx: number
+): TargetSize {
+  let w = intrinsic.width;
+  let h = intrinsic.height;
+  if (wanted.widthPx && wanted.heightPx) {
+    w = wanted.widthPx;
+    h = wanted.heightPx;
+  } else if (wanted.widthPx) {
+    h = Math.round((intrinsic.height * wanted.widthPx) / intrinsic.width);
+    w = wanted.widthPx;
+  } else if (wanted.heightPx) {
+    w = Math.round((intrinsic.width * wanted.heightPx) / intrinsic.height);
+    h = wanted.heightPx;
+  }
+  if (w > maxWidthPx) {
+    h = Math.round((h * maxWidthPx) / w);
+    w = maxWidthPx;
+  }
+  return { widthPx: Math.max(1, w), heightPx: Math.max(1, h) };
+}
+
+/** px → EMU with rounding (research §2.5). */
+export function pxToEmu(px: number): number {
+  return Math.round(px * EMU_PER_PX);
+}
+
+// ---------------------------------------------------------------------------
+// Drawing fragment
+// ---------------------------------------------------------------------------
+
+/** Escape a string for an XML attribute value (quotes included). */
+function escAttr(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+export interface DrawingParams {
+  /** Full relationship id, e.g. `rId7` (never a bare number — research §2.1). */
+  relId: string;
+  /** Unique per image across the whole document (research §5: id collisions). */
+  docPrId: number;
+  /** Element name shown in Word's selection pane. */
+  name: string;
+  /** Alt text carried onto `wp:docPr`/`pic:cNvPr` `descr` (accessibility). */
+  descr: string;
+  cxEmu: number;
+  cyEmu: number;
+}
+
+/**
+ * The inline `<w:p><w:drawing>` fragment for one embedded image — the fuller,
+ * Word-blessed shape from the reference module (research §2.1): effectExtent,
+ * aspect-ratio locks (`graphicFrameLocks`/`picLocks`), `a14:useLocalDpi`,
+ * `noFill` shape properties. All namespaces are declared inline (the spike's
+ * robustness improvement), so the fragment is self-contained wherever the
+ * serializer splices it.
+ */
+export function inlineImageParagraph(p: DrawingParams): string {
+  const name = escAttr(p.name);
+  const descr = escAttr(p.descr);
+  return (
+    `<w:p><w:r><w:drawing>` +
+    `<wp:inline distT="0" distB="0" distL="0" distR="0" xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing">` +
+    `<wp:extent cx="${p.cxEmu}" cy="${p.cyEmu}"/>` +
+    `<wp:effectExtent l="0" t="0" r="0" b="0"/>` +
+    `<wp:docPr id="${p.docPrId}" name="${name}" descr="${descr}"/>` +
+    `<wp:cNvGraphicFramePr>` +
+    `<a:graphicFrameLocks xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" noChangeAspect="1"/>` +
+    `</wp:cNvGraphicFramePr>` +
+    `<a:graphic xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main">` +
+    `<a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/picture">` +
+    `<pic:pic xmlns:pic="http://schemas.openxmlformats.org/drawingml/2006/picture">` +
+    `<pic:nvPicPr>` +
+    `<pic:cNvPr id="${p.docPrId}" name="${name}" descr="${descr}"/>` +
+    `<pic:cNvPicPr><a:picLocks noChangeAspect="1" noChangeArrowheads="1"/></pic:cNvPicPr>` +
+    `</pic:nvPicPr>` +
+    `<pic:blipFill>` +
+    `<a:blip r:embed="${p.relId}" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">` +
+    `<a:extLst><a:ext uri="{28A0092B-C50C-407E-A947-70E740481C1C}">` +
+    `<a14:useLocalDpi xmlns:a14="http://schemas.microsoft.com/office/drawing/2010/main" val="0"/>` +
+    `</a:ext></a:extLst>` +
+    `</a:blip>` +
+    `<a:srcRect/><a:stretch><a:fillRect/></a:stretch>` +
+    `</pic:blipFill>` +
+    `<pic:spPr bwMode="auto">` +
+    `<a:xfrm><a:off x="0" y="0"/><a:ext cx="${p.cxEmu}" cy="${p.cyEmu}"/></a:xfrm>` +
+    `<a:prstGeom prst="rect"><a:avLst/></a:prstGeom>` +
+    `<a:noFill/><a:ln><a:noFill/></a:ln>` +
+    `</pic:spPr>` +
+    `</pic:pic></a:graphicData></a:graphic></wp:inline></w:drawing></w:r></w:p>`
+  );
+}
+
+// ---------------------------------------------------------------------------
+// The embedder: media part + relationship + content type on a PizZip archive
+// ---------------------------------------------------------------------------
+
+export interface ImageEmbedderOptions {
+  /** Content-width cap in px; defaults to {@link MAX_CONTENT_WIDTH_PX}. */
+  maxWidthPx?: number;
+}
+
+export interface EmbedImageOptions {
+  /** Alt text for `descr` (accessibility). */
+  alt?: string;
+  /** Human-facing name (e.g. the attachment filename). */
+  name?: string;
+  /** Author-specified rendered width in px (Confluence `ac:width`). */
+  widthPx?: number;
+  /** Author-specified rendered height in px. */
+  heightPx?: number;
+}
+
+interface MediaEntry {
+  relId: string;
+  info: ImageInfo;
+  bytes: Uint8Array;
+}
+
+const RELS_PATH = "word/_rels/document.xml.rels";
+const CT_PATH = "[Content_Types].xml";
+const EMPTY_RELS =
+  `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
+  `<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"></Relationships>`;
+
+/**
+ * Embeds images into one document's PizZip archive. Construct once per export:
+ * the instance owns the unique-id counters (docPr ids seeded above anything
+ * the template already contains; rIds above the existing rels) and the
+ * byte-identical dedup map (identical images share one media part +
+ * relationship, each occurrence still getting its own unique docPr id).
+ */
+export class ImageEmbedder {
+  private readonly zip: PizZip;
+  private readonly maxWidthPx: number;
+  private nextDocPrId: number;
+  private mediaIndex = 0;
+  private embedded = 0;
+  /** FNV-1a+length key → entries with those bytes (hash collisions chained). */
+  private readonly dedup = new Map<string, MediaEntry[]>();
+
+  constructor(zip: PizZip, opts: ImageEmbedderOptions = {}) {
+    this.zip = zip;
+    this.maxWidthPx = opts.maxWidthPx ?? MAX_CONTENT_WIDTH_PX;
+    this.nextDocPrId = maxExistingDrawingId(zip) + 1;
+  }
+
+  /** Number of image occurrences successfully embedded so far. */
+  get embeddedCount(): number {
+    return this.embedded;
+  }
+
+  /**
+   * Embed one image occurrence and return its `<w:p><w:drawing>` fragment.
+   * Throws {@link ImageEmbedError} on unsupported/oversized/undecodable input
+   * — in that case the archive is untouched (no dangling media part or rel).
+   */
+  embed(bytes: Uint8Array, opts: EmbedImageOptions = {}): string {
+    if (bytes.length === 0) throw new ImageEmbedError("the fetched image was empty");
+    if (bytes.length > MAX_IMAGE_BYTES) {
+      throw new ImageEmbedError(
+        `the image is too large to embed (${Math.round(bytes.length / (1024 * 1024))} MB > 25 MB)`
+      );
+    }
+    if (isSvg(bytes)) throw new ImageEmbedError("SVG images are not embedded yet (spec 005 deferral)");
+    const info = decodeImageInfo(bytes);
+    if (!info) throw new ImageEmbedError("unsupported image format (PNG, JPEG and GIF are supported)");
+
+    const entry = this.findOrCreateMedia(bytes, info);
+    const size = resolveTargetSize(info, { widthPx: opts.widthPx, heightPx: opts.heightPx }, this.maxWidthPx);
+    const docPrId = this.nextDocPrId++;
+    this.embedded += 1;
+    return inlineImageParagraph({
+      relId: entry.relId,
+      docPrId,
+      name: opts.name || `Image ${docPrId}`,
+      descr: opts.alt || opts.name || "image",
+      cxEmu: pxToEmu(size.widthPx),
+      cyEmu: pxToEmu(size.heightPx),
+    });
+  }
+
+  /** Reuse the media part for byte-identical images, else write a new one. */
+  private findOrCreateMedia(bytes: Uint8Array, info: ImageInfo): MediaEntry {
+    const key = `${fnv1a(bytes)}:${bytes.length}`;
+    const bucket = this.dedup.get(key);
+    if (bucket) {
+      for (const candidate of bucket) {
+        if (sameBytes(candidate.bytes, bytes)) return candidate;
+      }
+    }
+    const entry: MediaEntry = { relId: this.writeMedia(bytes, info), info, bytes };
+    if (bucket) bucket.push(entry);
+    else this.dedup.set(key, [entry]);
+    return entry;
+  }
+
+  /** The three archive edits: media part, content-type default, relationship. */
+  private writeMedia(bytes: Uint8Array, info: ImageInfo): string {
+    let filename: string;
+    do {
+      this.mediaIndex += 1;
+      filename = `atlcli-image${this.mediaIndex}.${info.ext}`;
+    } while (this.zip.file(`word/media/${filename}`));
+
+    ensureContentTypeDefault(this.zip, info.ext, info.mime);
+
+    const rels = this.zip.file(RELS_PATH)?.asText() ?? EMPTY_RELS;
+    // Match both quote styles, like the settings-part surgery in export.ts.
+    const ids = [...rels.matchAll(/Id=["']rId(\d+)["']/g)].map((m) => Number(m[1]));
+    const relId = `rId${(ids.length ? Math.max(...ids) : 0) + 1}`;
+    this.zip.file(
+      RELS_PATH,
+      rels.replace(
+        "</Relationships>",
+        `<Relationship Id="${relId}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="media/${filename}"/></Relationships>`
+      )
+    );
+    this.zip.file(`word/media/${filename}`, bytes);
+    return relId;
+  }
+}
+
+/** Add a `<Default Extension=…>` to `[Content_Types].xml` unless present. */
+export function ensureContentTypeDefault(zip: PizZip, ext: string, mime: string): void {
+  const ct = zip.file(CT_PATH)?.asText();
+  if (!ct) return; // not a Word package — unzipDocx would have rejected it
+  if (new RegExp(`<Default[^>]+Extension="${ext}"`, "i").test(ct)) return;
+  zip.file(CT_PATH, ct.replace("</Types>", `<Default Extension="${ext}" ContentType="${mime}"/></Types>`));
+}
+
+/**
+ * Highest `wp:docPr`/`pic:cNvPr` id anywhere in the template's XML parts, so
+ * our ids never collide with drawings the template already carries.
+ */
+function maxExistingDrawingId(zip: PizZip): number {
+  let max = 0;
+  for (const [path, entry] of Object.entries(zip.files)) {
+    if (entry.dir || !path.endsWith(".xml")) continue;
+    const xml = entry.asText();
+    for (const m of xml.matchAll(/<(?:wp:docPr|pic:cNvPr)\b[^>]*\bid="(\d+)"/g)) {
+      const id = Number(m[1]);
+      if (id > max) max = id;
+    }
+  }
+  return max;
+}
+
+/** 32-bit FNV-1a over the bytes (dedup bucket key; equality is verified). */
+function fnv1a(bytes: Uint8Array): number {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < bytes.length; i++) {
+    hash ^= bytes[i];
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return hash >>> 0;
+}
+
+function sameBytes(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+  return true;
+}

--- a/packages/docx/src/index.browser.ts
+++ b/packages/docx/src/index.browser.ts
@@ -16,4 +16,5 @@ export * from "./resolver.js";
 export * from "./serialize.js";
 export * from "./export.js";
 export * from "./env.js";
+export * from "./image.js";
 export { CODE_STYLE_ID, resolveHeadingStyleId, parseStyleNames, normalizeColor } from "./ooxml.js";

--- a/packages/docx/src/node-adapters.ts
+++ b/packages/docx/src/node-adapters.ts
@@ -36,10 +36,11 @@ export function fileOutputSink(path: string): OutputSink {
 }
 
 /**
- * An {@link AssetFetcher} that fails on first use. v1 never fetches assets
- * (image embedding is deferred to spec 005), so hosts without an asset path
- * can inject this instead of inventing a fake — if the engine ever calls it,
- * that is a real wiring gap and should surface loudly.
+ * An {@link AssetFetcher} that fails on first use. Since spec 005 landed,
+ * hosts without an asset path should simply OMIT `assets` from their
+ * {@link ExportEnv} (images then degrade to `image-skipped` report notes);
+ * inject this only where an asset fetch indicates a real wiring gap that
+ * should surface loudly (as an `image-embed-failed` warning note).
  */
 export function unsupportedAssetFetcher(reason = "asset fetching is not wired for this host"): AssetFetcher {
   return {

--- a/packages/docx/src/node-consumer.test.ts
+++ b/packages/docx/src/node-consumer.test.ts
@@ -39,7 +39,8 @@ describe("Node consumer (spec 006 Task 5)", () => {
       },
       {
         templates: fileTemplateSource(templatePath),
-        assets: unsupportedAssetFetcher(),
+        // No asset fetcher: images degrade to `image-skipped` notes — the
+        // pre-005 behavior the golden capture pins.
         output: fileOutputSink(outPath),
       }
     );

--- a/packages/docx/src/serialize.ts
+++ b/packages/docx/src/serialize.ts
@@ -6,9 +6,11 @@
  * code blocks are colored via lazily-loaded Shiki ({@link highlightCode}); every
  * other block builds synchronously.
  *
- * Image handling is **deferred (v1)**: an `image` block emits NO OOXML and adds
- * a report note ("image skipped — embedding not yet available"), so the output
- * never carries a dangling relationship (PLAN Task 5 / Decision F3).
+ * Image handling goes through the optional {@link SerializeContext.images}
+ * seam (spec 005): when a host wires an embedder, an `image` block becomes an
+ * inline `<w:drawing>`; when the seam is absent or an embed fails, the block
+ * emits NO OOXML and adds a report note instead — so the output never carries
+ * a dangling relationship (the spec-004 skip-path invariant).
  */
 import type {
   ExportBlock,
@@ -33,9 +35,27 @@ import {
   type RunStyle,
 } from "./ooxml.js";
 
+/** The `image` variant of {@link ExportBlock}. */
+export type ImageBlock = Extract<ExportBlock, { type: "image" }>;
+
+/** Result of one image-embed attempt (spec 005). */
+export type ImageEmbedOutcome = { ok: true; xml: string } | { ok: false; reason: string };
+
+/**
+ * The serializer's image seam (spec 005): turns an `image` block into an
+ * inline-drawing fragment, or reports why it could not. The implementation
+ * (asset fetch + zip surgery) lives with the export orchestrator — the
+ * serializer stays free of IO and zip state.
+ */
+export interface ImageEmbedSeam {
+  embed(block: ImageBlock): Promise<ImageEmbedOutcome>;
+}
+
 export interface SerializeContext {
   /** Lower-cased style-name → styleId map from the template's styles.xml. */
   styleNames: Map<string, string>;
+  /** Image embedding seam; absent → images degrade to report notes. */
+  images?: ImageEmbedSeam;
 }
 
 /** {@link SerializeContext} plus the document-wide heading promotion offset. */
@@ -285,13 +305,26 @@ async function serializeBlock(
     case "divider":
       return dividerParagraph();
 
-    case "image":
+    case "image": {
+      if (!ctx.images) {
+        notes.push({
+          level: "info",
+          code: "image-skipped",
+          message: `Image ${describeImage(block)} skipped — image embedding is unavailable in this export.`,
+        });
+        return "";
+      }
+      const outcome = await ctx.images.embed(block);
+      if (outcome.ok) return outcome.xml;
+      // Failure branch: no OOXML, so no dangling relationship — the export
+      // still succeeds with a report line (spec 005 / 004-F3 invariant).
       notes.push({
-        level: "info",
-        code: "image-skipped",
-        message: `Image ${describeImage(block)} skipped — embedding not yet available.`,
+        level: "warning",
+        code: "image-embed-failed",
+        message: `Image ${describeImage(block)} could not be embedded (${outcome.reason}).`,
       });
       return "";
+    }
 
     case "unknown":
       return paragraph(run(`[${block.macroName} macro not rendered]`, { italic: true, color: "97A0AF" }));

--- a/specs/005-docx-image-module/PLAN.md
+++ b/specs/005-docx-image-module/PLAN.md
@@ -1,6 +1,8 @@
 # DOCX Image Module — self-built OOXML image embedding for the DOCX export
 
-Status: **Planned** (deferred from spec 004; images were explicitly out of scope for the DOCX PoC)
+Status: **Implemented** (2026-07-16 — module in `packages/docx/src/image.ts`, seam through
+serializer/export/env, hosts wired: extension session fetch + CLI token fetcher; E2E passed
+against DOCSY. SVG deferred per §Non-goals: rasterized PNG fallback needs a canvas, not isomorphic.)
 
 Spec ID: `005-docx-image-module`
 Depends on: `004-docx-export` (the export flow this extends — docxtemplater free engine, `ExportBlock` model, session-auth asset fetch seam)
@@ -68,16 +70,25 @@ not vendor. All-permissive.
 
 ## 3. Task breakdown (outline — detail on pickup)
 
-- [ ] Promote `image-module-prototype.ts` into the real module (unique ids, generic
+- [x] Promote `image-module-prototype.ts` into the real module (unique ids, generic
       content-types, richer drawing fragment); unit tests on the produced OOXML (unzip + assert
       media part, relationship, content-type, blip r:embed, EMU sizing).
-- [ ] In-browser dimension decoder (PNG/JPEG/GIF via DataView) + tests with real fixture bytes.
-- [ ] Wire into the 004 export flow: `image` block → session-auth fetch (mock-fetch test asserts
+      → `packages/docx/src/image.ts` + `image.test.ts` (24 tests). Bonus: byte-identical dedup
+      (one media part per distinct image), docPr ids seeded above the template's existing drawings.
+- [x] In-browser dimension decoder (PNG/JPEG/GIF via DataView) + tests with real fixture bytes.
+- [x] Wire into the 004 export flow: `image` block → session-auth fetch (mock-fetch test asserts
       `credentials: "include"`) → embed; failure → report line, no dangling rel (pinning test).
-- [ ] Width-capping + alt text on `docPr descr`.
-- [ ] svgBlip + PNG@2x fallback (only if the spike proves it cheap; else report line + defer).
-- [ ] E2E with Björn: a real page with images exports with images embedded; compare against the
-      Scroll reference (which embeds images) — close the last v1-vs-Scroll gap.
+      → `SerializeContext.images` seam; `ExportInput.assets`/`embedImages`; `image-embed-failed`
+      warning note; report gains `embeddedImages`. Extension resolves wiki-relative refs against
+      the tab's Confluence root; CLI resolves via REST attachment listing (`tokenAssetFetcher`),
+      because `/download/attachments/…` answers 401 to API-token Basic auth (E2E finding).
+- [x] Width-capping + alt text on `docPr descr`.
+- [x] svgBlip + PNG@2x fallback — **deferred** (spike verdict: not cheap; the mandatory PNG
+      fallback needs rasterization, i.e. a canvas — not isomorphic). SVG degrades to a report line.
+- [x] E2E: DOCSY test page with a real PNG attachment + a missing-attachment image, exported via
+      `--engine ts` — PNG embedded (media part byte-identical, drawing scaled by `ac:width`,
+      alt text carried), missing image → warning note, no dangling rel. Page cleaned up.
+      Scroll-reference visual comparison remains open for Björn's next manual pass.
 
 ## 4. Test plan
 

--- a/specs/005-docx-image-module/PLAN.md
+++ b/specs/005-docx-image-module/PLAN.md
@@ -89,6 +89,13 @@ not vendor. All-permissive.
       `--engine ts` — PNG embedded (media part byte-identical, drawing scaled by `ac:width`,
       alt text carried), missing image → warning note, no dangling rel. Page cleaned up.
       Scroll-reference visual comparison remains open for Björn's next manual pass.
+- [x] E2E extension (2026-07-16, Björn, real Mayflower Prüfvorlage): panel export embedded both
+      test PNGs (intrinsic 400×200; `ac:width="150"` scaled 300×300 → 150×150), alt texts carried,
+      our rIds/docPr ids coexist with the template's own logo image (ids seeded above the
+      template's max), missing attachment degraded, no `$scroll` literals left. **Finding:** Cloud
+      302s `/wiki/download/attachments/…` to `api.media.atlassian.com`; that origin had to be
+      added to `host_permissions` — outside it the redirect hop falls back to plain CORS, whose
+      wildcard ACAO rejects `credentials:"include"` (fix `b95572c`).
 
 ## 4. Test plan
 

--- a/src/content/docs/confluence/export.md
+++ b/src/content/docs/confluence/export.md
@@ -51,7 +51,7 @@ atlcli wiki export "DOCS:Architecture Overview" -t report -o ./arch.docx
 | Engine | Templates | Requirements | Feature scope |
 |--------|-----------|--------------|---------------|
 | `python` (default) | Jinja2 variables (`{{ title }}`, …) | Python 3.12+ with `atlcli-export` | Images, children, content-by-label |
-| `ts` | Scroll placeholders (`$scroll.title`, `$scroll.content`, …) | None (runs in-process) | Single page; image embedding not yet available |
+| `ts` | Scroll placeholders (`$scroll.title`, `$scroll.content`, …) | None (runs in-process) | Single page; embeds PNG/JPEG/GIF images (SVG not yet) |
 
 The `ts` engine is the isomorphic [`@atlcli/docx` export engine](/reference/docx-engine/) — the exact
 same code the atlcli browser extension uses for its "Export to Word" button, driven here with
@@ -63,7 +63,10 @@ atlcli wiki export 12345678 --template scroll-corporate.docx --output out.docx -
 ```
 
 The JSON result includes an export report: how many placeholders resolved, which are unsupported
-(rendered empty), and which images were skipped.
+(rendered empty), and how many images were embedded or skipped. Attachment and external images
+embed inline at their intrinsic size (or the page-set width), capped to the content width; an
+image that cannot be fetched or decoded becomes a warning note instead of failing the export.
+`--no-images` disables embedding for this engine too.
 
 ## Templates
 

--- a/src/content/docs/reference/docx-engine.md
+++ b/src/content/docs/reference/docx-engine.md
@@ -74,7 +74,9 @@ inline `<w:drawing>` with unique element ids and alt text. Details that matter t
 - **`AssetRef` shape:** attachment refs carry a wiki-base-relative `url`
   (`/download/attachments/{pageId}/{filename}`) plus `pageId`/`filename`; external images carry
   their absolute URL. A session host (the extension) prefixes its Confluence root and rides the
-  ambient cookies. A **token host must not** fetch the cookie-only `/download/attachments/…`
+  ambient cookies — note Cloud 302s these downloads to `api.media.atlassian.com`, so an MV3 host
+  needs that origin in its `host_permissions` (the media CDN's wildcard CORS header rejects
+  credentialed fetches otherwise). A **token host must not** fetch the cookie-only `/download/attachments/…`
   path (it answers 401 to API tokens) — resolve `pageId`+`filename` through the REST attachment
   listing and fetch the API's own `downloadUrl` instead, as the CLI's fetcher does
   (`tokenAssetFetcher` in `apps/cli/src/commands/export.ts`).

--- a/src/content/docs/reference/docx-engine.md
+++ b/src/content/docs/reference/docx-engine.md
@@ -15,6 +15,7 @@ inject.
 
 - [Architecture](#architecture)
 - [The three injected interfaces](#the-three-injected-interfaces)
+- [Image embedding](#image-embedding)
 - [Plugging in a new surface](#plugging-in-a-new-surface)
 - [Guarantees and gates](#guarantees-and-gates)
 - [Related topics](#related-topics)
@@ -51,11 +52,34 @@ interface AssetFetcher {
 interface OutputSink {
   emit(name: string, bytes: Uint8Array): Promise<void>; // extension: download · CLI: writeFile
 }
-interface ExportEnv { templates: TemplateSource; assets: AssetFetcher; output: OutputSink; }
+interface ExportEnv { templates: TemplateSource; assets?: AssetFetcher; output: OutputSink; }
 ```
 
-`AssetFetcher` is reserved for image embedding (spec 005) — v1 never calls it, and hosts without
-an asset path can inject `unsupportedAssetFetcher()`.
+`AssetFetcher` drives image embedding (spec 005). It is optional: a host that omits it gets the
+pre-005 behavior — every image degrades to an `image-skipped` report note instead of embedding.
+
+## Image embedding
+
+Images embed through a self-built OOXML image module (`packages/docx/src/image.ts` — the
+docxtemplater free tier has no image support): per image the engine writes a
+`word/media/…` part, a `document.xml.rels` relationship, a `[Content_Types].xml` default, and an
+inline `<w:drawing>` with unique element ids and alt text. Details that matter to hosts:
+
+- **Formats:** PNG, JPEG, GIF (dimensions decoded from the header bytes, no image library).
+  SVG is detected but deferred — it degrades to a report note.
+- **Sizing:** page-set width/height (`ac:width`) wins over the intrinsic size; everything is
+  capped to the content width (600 px at 96 dpi) preserving aspect ratio.
+- **Failure is never fatal:** a failed fetch/decode/oversized image produces an
+  `image-embed-failed` warning note and no OOXML — never a dangling relationship.
+- **`AssetRef` shape:** attachment refs carry a wiki-base-relative `url`
+  (`/download/attachments/{pageId}/{filename}`) plus `pageId`/`filename`; external images carry
+  their absolute URL. A session host (the extension) prefixes its Confluence root and rides the
+  ambient cookies. A **token host must not** fetch the cookie-only `/download/attachments/…`
+  path (it answers 401 to API tokens) — resolve `pageId`+`filename` through the REST attachment
+  listing and fetch the API's own `downloadUrl` instead, as the CLI's fetcher does
+  (`tokenAssetFetcher` in `apps/cli/src/commands/export.ts`).
+- Byte-identical images share one media part; the report counts `embeddedImages` and
+  `skippedImages`.
 
 ## Plugging in a new surface
 
@@ -63,7 +87,7 @@ A new consumer (MCP server, Tauri Studio, Org-Server) implements the three inter
 `runExport`. Minimal Node example:
 
 ```ts
-import { runExport, fileTemplateSource, fileOutputSink, unsupportedAssetFetcher } from "@atlcli/docx";
+import { runExport, fileTemplateSource, fileOutputSink } from "@atlcli/docx";
 
 const report = await runExport(
   {
@@ -78,7 +102,8 @@ const report = await runExport(
   },
   {
     templates: fileTemplateSource("./corporate.docx"),
-    assets: unsupportedAssetFetcher(),
+    // assets: { fetch } — supply an AssetFetcher to embed images (see above);
+    // omitted, images become report notes instead.
     output: fileOutputSink("./out.docx"),
   }
 );


### PR DESCRIPTION
## Summary

Closes spec 005: page images now embed into the exported `.docx` on **both hosts** (extension panel + `atlcli wiki export --engine ts`). The docxtemplater free tier has no image support, so this is a hand-built OOXML module doing the four coordinated zip edits per image — media part, `document.xml.rels` relationship, `[Content_Types].xml` default, inline `<w:drawing>`.

## What's in

- **`packages/docx/src/image.ts`** — isomorphic image module:
  - PNG/JPEG/GIF dimension decoder over a `DataView` (no `Buffer`/`image-size`); SVG detected but deferred to a report line (the mandatory PNG fallback needs a canvas — not isomorphic)
  - unique `docPr`/`cNvPr` ids seeded **above the template's existing drawings**, generic content-type dedup, aspect locks + `effectExtent` + `a14:useLocalDpi` (the Word-blessed fragment from the research), alt text on `descr`
  - sizing: page-set `ac:width`/height wins, capped to content width (600 px) preserving aspect; byte-identical images share one media part
- **Seam:** `SerializeContext.images`; `ExportInput.assets`/`embedImages`; `ExportEnv.assets` now **optional** (omit → pre-005 `image-skipped` behavior, golden capture unchanged). Report gains `embeddedImages`.
- **Failure invariant (004-F3):** fetch/decode/oversize failures become an `image-embed-failed` warning note and write **nothing** — never a dangling relationship; the export always succeeds.
- **Hosts:**
  - extension: `sessionAssetFetcher(baseUrl)` resolves wiki-relative attachment refs against the tab's Confluence root; panel report shows embedded/skipped counts
  - CLI: `tokenAssetFetcher` resolves attachments through the REST listing to the API `downloadUrl` (honors `--no-images`)

## E2E findings baked in

1. **Token hosts:** `/download/attachments/{pageId}/{filename}` answers **401 to API-token Basic auth** (cookie-only route) — the CLI fetcher resolves via the REST attachment listing instead.
2. **MV3/CORS:** Cloud 302s attachment downloads to `api.media.atlassian.com`; that origin is outside `*.atlassian.net`, so the redirect hop fell back to plain CORS whose wildcard ACAO rejects `credentials:"include"`. Fixed by adding the media origin to `host_permissions`.

## Testing

- 24 new module tests (real PizZip surgery, real header bytes) + 6 pipeline integration tests; repo-wide: **1604 pass**, typecheck, build, `check:browser`, `check:extension-output` all green; golden capture byte-identical (pre-005 behavior pinned for hosts without assets)
- **E2E CLI** (DOCSY): PNG embedded byte-identically, `ac:width` scaling + alt text verified, missing attachment degraded to warning; test page deleted
- **E2E extension** (Björn, real Mayflower Prüfvorlage): both test PNGs embedded (intrinsic + scaled 150×150), coexists with the template's own logo image (fresh rIds, ids above template max), 29 placeholders resolved, no `$scroll` literals left

Docs (`confluence/export.md`, `reference/docx-engine.md`) and spec 005 PLAN updated.

Follow-ups spawned separately: `$scroll.spacelogo`/`$scroll.globallogo` via this module; quarter tokens (`QQQ`) in date formats.

🤖 Generated with [Claude Code](https://claude.com/claude-code)