### PR TITLE
fix(docx): support quarter tokens Q/QQ/QQQ/QQQQ in date placeholders

### DIFF
--- a/packages/docx/src/dateformat.test.ts
+++ b/packages/docx/src/dateformat.test.ts
@@ -17,6 +17,35 @@ describe("formatSimpleDate (SimpleDateFormat subset)", () => {
     expect(formatSimpleDate(D, "dd''MM").text).toBe("14'07");
   });
 
+  it("formats quarter tokens (Q/QQ/QQQ/QQQQ)", () => {
+    // D is in July → Q3.
+    expect(formatSimpleDate(D, "Q").text).toBe("3");
+    expect(formatSimpleDate(D, "QQ").text).toBe("03");
+    expect(formatSimpleDate(D, "QQQ").text).toBe("Q3");
+    expect(formatSimpleDate(D, "QQQQ").text).toBe("3rd quarter");
+    expect(formatSimpleDate(D, "QQQ yyyy").text).toBe("Q3 2026");
+  });
+
+  it("covers all four quarters and their ordinals", () => {
+    const quarters: Array<[number, string, string]> = [
+      [0, "1", "1st quarter"], // January
+      [3, "2", "2nd quarter"], // April
+      [6, "3", "3rd quarter"], // July
+      [9, "4", "4th quarter"], // October
+    ];
+    for (const [month, q, full] of quarters) {
+      const d = new Date(2026, month, 15);
+      expect(formatSimpleDate(d, "Q").text).toBe(q);
+      expect(formatSimpleDate(d, "QQQQ").text).toBe(full);
+    }
+  });
+
+  it("still falls back to ISO on an over-long quarter run", () => {
+    const res = formatSimpleDate(D, "QQQQQ");
+    expect(res.unknownToken).toBe("QQQQQ");
+    expect(res.text).toBe("2026-07-14");
+  });
+
   it("falls back to ISO on an unknown token, reporting it", () => {
     const res = formatSimpleDate(D, "yyyy-MM-dd EEEE");
     expect(res.unknownToken).toBe("EEEE");

--- a/packages/docx/src/dateformat.ts
+++ b/packages/docx/src/dateformat.ts
@@ -4,7 +4,9 @@
  * Scroll date placeholders accept a Java `SimpleDateFormat` argument, e.g.
  * `$scroll.exportdate.("dd.MM.yyyy")`. We implement the common numeric-pattern
  * tokens only (PLAN §2.2): `yyyy`, `MM`, `dd`, `HH`, `mm` (plus `yy`, `M`, `d`,
- * `H`, `m` single/short forms and literal quoting). Any token we don't recognize
+ * `H`, `m` single/short forms and literal quoting), and the quarter tokens
+ * `Q`/`QQ`/`QQQ`/`QQQQ` with `java.time.DateTimeFormatter` semantics
+ * (`3`, `03`, `Q3`, `3rd quarter`). Any token we don't recognize
  * makes the whole format fall back to ISO (`toISOString`) and records a report
  * note so the export surface stays honest (PLAN §2.2: "unknown format tokens
  * fall back to ISO + report line").
@@ -15,7 +17,26 @@
  */
 
 /** Tokens we support, longest-first so `yyyy` matches before `yy`. */
-const SUPPORTED_TOKENS = ["yyyy", "yy", "MM", "M", "dd", "d", "HH", "H", "mm", "m", "ss", "s"];
+const SUPPORTED_TOKENS = [
+  "yyyy",
+  "yy",
+  "MM",
+  "M",
+  "dd",
+  "d",
+  "HH",
+  "H",
+  "mm",
+  "m",
+  "ss",
+  "s",
+  "QQQQ",
+  "QQQ",
+  "QQ",
+  "Q",
+];
+
+const QUARTER_ORDINALS = ["1st", "2nd", "3rd", "4th"];
 
 export interface DateFormatResult {
   text: string;
@@ -35,6 +56,7 @@ function pad2(n: number): string {
  * (`'...'`) is emitted verbatim; `''` is a literal apostrophe.
  */
 export function formatSimpleDate(date: Date, pattern: string): DateFormatResult {
+  const quarter = Math.floor(date.getMonth() / 3) + 1;
   const values: Record<string, string> = {
     yyyy: String(date.getFullYear()),
     yy: pad2(date.getFullYear() % 100),
@@ -48,6 +70,10 @@ export function formatSimpleDate(date: Date, pattern: string): DateFormatResult 
     m: String(date.getMinutes()),
     ss: pad2(date.getSeconds()),
     s: String(date.getSeconds()),
+    Q: String(quarter),
+    QQ: pad2(quarter),
+    QQQ: `Q${quarter}`,
+    QQQQ: `${QUARTER_ORDINALS[quarter - 1]} quarter`,
   };
 
   let out = "";

--- a/packages/docx/src/resolver.test.ts
+++ b/packages/docx/src/resolver.test.ts
@@ -99,9 +99,16 @@ describe("resolveOne — every direct + derivable mapping row", () => {
     expect(notes.some((n) => n.code === "placeholder-empty")).toBe(true);
   });
 
+  it("exportdate with a quarter token formats without a note", () => {
+    const notes: import("@atlcli/confluence").ExportNote[] = [];
+    const out = resolveOne('$scroll.exportdate.("QQQ")', ctx, { space, currentUser, owner }, notes);
+    expect(out).toBe("Q3");
+    expect(notes.some((n) => n.code === "date-format-unknown")).toBe(false);
+  });
+
   it("exportdate with an unknown format token falls back to ISO + a note (#10)", () => {
     const notes: import("@atlcli/confluence").ExportNote[] = [];
-    const out = resolveOne('$scroll.exportdate.("yyyy-QQ")', ctx, { space, currentUser, owner }, notes);
+    const out = resolveOne('$scroll.exportdate.("yyyy-EEEE")', ctx, { space, currentUser, owner }, notes);
     expect(out).toBe("2026-07-14"); // ISO fallback for the export date
     expect(notes.some((n) => n.code === "date-format-unknown")).toBe(true);
   });


### PR DESCRIPTION
## What

Adds quarter tokens to the SimpleDateFormat subset in `packages/docx/src/dateformat.ts`, following `java.time.DateTimeFormatter` semantics:

| Token | Output (July) |
|-------|---------------|
| `Q`   | `3` |
| `QQ`  | `03` |
| `QQQ` | `Q3` |
| `QQQQ`| `3rd quarter` |

Runs longer than `QQQQ` (and all other unknown tokens) still take the ISO fallback with a `date-format-unknown` report note — the warning path is unchanged.

## Why

The real Scroll template `Mayflower_E2E_Platzhalter-Pruefung.docx` uses `$scroll.exportdate.("QQQ")`, which previously triggered `Unknown date token "QQQ" ... fell back to ISO date` instead of rendering the quarter.

## Notes for reviewers

- The existing resolver test for the unknown-token fallback used `yyyy-QQ` as its example pattern; since `QQ` is now a valid token, that test was switched to `yyyy-EEEE`.
- New tests cover all four token forms, all four quarters incl. ordinals (`1st`–`4th`), the over-long `QQQQQ` fallback, and a resolver-level regression test for the exact real-world case `$scroll.exportdate.("QQQ")`.
- E2E-verified against DOCSY page 1117356071 with the real template (`--engine ts`): the cell renders `Q3` and the warning note is gone. All 157 docx tests pass, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)