### PR TITLE
feat(docx): close gap G3 — logo placeholders embed the space logo

### DIFF
--- a/apps/cli/src/commands/export.ts
+++ b/apps/cli/src/commands/export.ts
@@ -763,6 +763,23 @@ async function exportWithTsEngine(args: TsEngineArgs): Promise<void> {
         getCurrentUser: () => client.getCurrentUser(),
         getPageOwner: (id: string) => client.getPageOwner(id),
         getSpaceHomepageStorage: (key: string) => client.getSpaceHomepageStorage(key),
+        // Spec 005 logo pass: the space icon path feeds $scroll.spacelogo /
+        // $scroll.globallogo; bytes then ride the asset fetcher below. A
+        // custom logo's icon.path is a cookie-only `/download/attachments/
+        // {contentId}/{filename}` URL that 401s under token auth (same Cloud
+        // behavior as page attachments), so the content id + filename are
+        // carried on the ref — the fetcher then resolves them through the
+        // REST attachment listing, which honors token auth.
+        getSpaceLogo: async (key: string) => {
+          const icon = await client.getSpaceIcon(key);
+          if (!icon) return null;
+          const m = icon.path.match(/^\/download\/attachments\/(\d+)\/([^/?]+)/);
+          return {
+            url: icon.path,
+            pageId: m?.[1],
+            filename: m ? decodeURIComponent(m[2]) : undefined,
+          };
+        },
       },
     },
     {

--- a/apps/extension/entrypoints/sidepanel/TemplateSection.tsx
+++ b/apps/extension/entrypoints/sidepanel/TemplateSection.tsx
@@ -202,6 +202,12 @@ export function TemplateSection({
                 getCurrentUser: () => client.getCurrentUser(),
                 getPageOwner: (id) => client.getPageOwner(id),
                 getSpaceHomepageStorage: (key) => client.getSpaceHomepageStorage(key),
+                // Spec 005 logo pass: icon path in, bytes via the session
+                // asset fetcher below ($scroll.spacelogo / $scroll.globallogo).
+                getSpaceLogo: async (key) => {
+                  const icon = await client.getSpaceIcon(key);
+                  return icon ? { url: icon.path } : null;
+                },
               }
             : {},
         },

--- a/apps/extension/tests/docx/scan-view.test.tsx
+++ b/apps/extension/tests/docx/scan-view.test.tsx
@@ -42,8 +42,8 @@ describe("ScanView — content insertion point (spec 004 finding)", () => {
 describe("ScanView — per-placeholder reasons (E2E finding)", () => {
   // The panel used to print one static "will be empty" per row and drop the
   // per-hit `reason` the scan already carries. That flattened causes which are
-  // in fact unrelated: a Cloud-impossible DC username vs. a gap waiting on the
-  // image module. Each row must state its OWN reason.
+  // in fact unrelated: a Cloud-impossible DC username vs. an unfetched content
+  // property. Each row must state its OWN reason.
   const scan: ScanResult = {
     supported: [{ base: "$scroll.title", status: "supported", count: 2, raw: ["$scroll.title"] }],
     unsupported: [
@@ -55,11 +55,11 @@ describe("ScanView — per-placeholder reasons (E2E finding)", () => {
         reason: "Confluence Cloud has no usernames — Data Center only (Gap G2)",
       },
       {
-        base: "$scroll.spacelogo",
+        base: "$scroll.jsoncontentproperty",
         status: "unsupported",
         count: 1,
-        raw: ["$scroll.spacelogo"],
-        reason: "the space logo is an image — needs the image module (spec 005, Gap G3)",
+        raw: ["$scroll.jsoncontentproperty.(key)"],
+        reason: "content properties are not fetched (Gap G5)",
       },
     ],
     never: [
@@ -78,7 +78,7 @@ describe("ScanView — per-placeholder reasons (E2E finding)", () => {
   it("renders each unsupported row's own reason, not one shared note", () => {
     const html = renderToStaticMarkup(<ScanView scan={scan} />);
     expect(html).toContain("Data Center only");
-    expect(html).toContain("needs the image module");
+    expect(html).toContain("content properties are not fetched");
     // The two causes are distinct — the old static note made them identical.
     expect(html).not.toContain("— will be empty");
   });

--- a/packages/confluence/src/client.test.ts
+++ b/packages/confluence/src/client.test.ts
@@ -1078,6 +1078,54 @@ describe("ConfluenceClient", () => {
     });
   });
 
+  describe("getSpaceIcon (spec 005 logo pass)", () => {
+    test("expands icon and returns the path with dimensions", async () => {
+      let capturedUrl = "";
+      globalThis.fetch = mock((url: string) => {
+        capturedUrl = url;
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              id: "1",
+              key: "DOCSY",
+              name: "Docs",
+              icon: {
+                path: "/download/attachments/623935492/DOCSY-default?version=1&api=v2",
+                width: 48,
+                height: 48,
+                isDefault: false,
+              },
+            }),
+            { status: 200 }
+          )
+        );
+      }) as unknown as typeof fetch;
+
+      const client = new ConfluenceClient(mockProfile);
+      const icon = await client.getSpaceIcon("DOCSY");
+
+      expect(capturedUrl).toContain("/rest/api/space/DOCSY");
+      expect(capturedUrl).toContain("expand=icon");
+      expect(icon).toEqual({
+        path: "/download/attachments/623935492/DOCSY-default?version=1&api=v2",
+        width: 48,
+        height: 48,
+        isDefault: false,
+      });
+    });
+
+    test("returns null when the space carries no icon", async () => {
+      globalThis.fetch = mock(() =>
+        Promise.resolve(
+          new Response(JSON.stringify({ id: "1", key: "X", name: "X" }), { status: 200 })
+        )
+      ) as unknown as typeof fetch;
+
+      const client = new ConfluenceClient(mockProfile);
+      expect(await client.getSpaceIcon("X")).toBeNull();
+    });
+  });
+
   describe("session auth mode (spec 001 task 5)", () => {
     const sessionProfile: Profile = {
       name: "session",

--- a/packages/confluence/src/client.ts
+++ b/packages/confluence/src/client.ts
@@ -45,6 +45,16 @@ export type ConfluenceSpace = {
   url?: string;
 };
 
+/** A space's logo, from `GET /space/{key}?expand=icon` (spec 005, gap G3). */
+export type SpaceIcon = {
+  /** Wiki-base-relative download path (e.g. `/download/attachments/…`). */
+  path: string;
+  width?: number;
+  height?: number;
+  /** True for the stock Confluence space logo (an SVG on Cloud). */
+  isDefault?: boolean;
+};
+
 export type ConfluenceSearchResult = {
   id: string;
   title: string;
@@ -1199,6 +1209,25 @@ export class ConfluenceClient {
       name: data.name,
       type: data.type ?? "global",
       url: data._links?.base ? `${data._links.base}${data._links.webui}` : undefined,
+    };
+  }
+
+  /**
+   * Get a space's logo icon (spec 005: drives `$scroll.spacelogo` /
+   * `$scroll.globallogo` embedding). Returns `null` when the space carries no
+   * icon — Cloud normally always has one (the default is an SVG).
+   */
+  async getSpaceIcon(key: string): Promise<SpaceIcon | null> {
+    const data = (await this.request(`/space/${key}`, {
+      query: { expand: "icon" },
+    })) as any;
+    const icon = data.icon;
+    if (!icon?.path) return null;
+    return {
+      path: icon.path,
+      width: icon.width,
+      height: icon.height,
+      isDefault: icon.isDefault,
     };
   }
 

--- a/packages/docx/src/export.test.ts
+++ b/packages/docx/src/export.test.ts
@@ -112,18 +112,20 @@ describe("exportDocx — full pipeline", () => {
     expect(doc).toContain("Heads up");
     expect(doc).toContain('<w:pStyle w:val="AtlcliCode"/>');
 
-    // Image skipped: no drawing, report lists it.
+    // Image + logo skipped (no asset fetcher): no drawing, report lists both.
     expect(doc).not.toContain("<w:drawing");
-    expect(report.skippedImages).toBe(1);
+    expect(report.skippedImages).toBe(2);
     expect(report.notes.some((n) => n.code === "image-skipped")).toBe(true);
+    expect(report.notes.some((n) => n.code === "logo-skipped")).toBe(true);
 
     // Report summary fields.
     expect(report.resolvedCount).toBeGreaterThan(0);
     // The owner resolves through the full pipeline (G1) — and is the OWNER,
     // not the creator.
     expect(doc).toContain("Olga Owner");
-    // The space logo stays unsupported (it is an image — spec 005).
-    expect(report.unsupportedNames).toContain("$scroll.spacelogo");
+    // The space logo is supported since spec 005 (G3) — it degrades to a
+    // logo-skipped note here (no asset fetcher), never to "unsupported".
+    expect(report.unsupportedNames).not.toContain("$scroll.spacelogo");
     expect(report.filename).toBe("Q3_ Architecture _ Overview.docx");
     expect(report.durationMs).toBeGreaterThanOrEqual(0);
   });
@@ -643,6 +645,213 @@ describe("exportDocx — image embedding (spec 005)", () => {
     expect(report.skippedImages).toBe(1);
     expect(report.notes.some((n) => n.code === "image-skipped")).toBe(true);
     expect(readPart(bytes, "word/document.xml")).not.toContain("<w:drawing");
+  });
+
+  // Logo tests run on an image-free page so drawings/notes are logo-only.
+  const logoDetails: ConfluencePageDetails = { ...details, storage: "<p>plain body</p>" };
+
+  it("embeds the space logo for $scroll.spacelogo AND $scroll.globallogo — body drawing, header drawing with its own rels, one shared media part", async () => {
+    const { refs, fetcher } = recordingFetcher(pngFixtureBytes(300, 100));
+    let logoCalls = 0;
+    const { bytes, report } = await exportDocx({
+      templateBytes: buildDocx({
+        body: para("$scroll.content") + para("$scroll.spacelogo"),
+        styles: stylesXml(headingStyle("Heading1", "Heading 1")),
+        header: para("$scroll.globallogo"),
+      }),
+      details: logoDetails,
+      template,
+      deps: {
+        ...deps,
+        getSpaceLogo: async (key: string) => {
+          logoCalls++;
+          expect(key).toBe("ENG");
+          return { url: "/download/attachments/999/space-logo.png" };
+        },
+      },
+      assets: fetcher,
+    });
+
+    // One icon-ref round-trip, one byte fetch — shared across both drawings.
+    expect(logoCalls).toBe(1);
+    expect(refs).toEqual([{ url: "/download/attachments/999/space-logo.png" }]);
+
+    const doc = readPart(bytes, "word/document.xml");
+    const header = readPart(bytes, "word/header1.xml");
+    for (const part of [doc, header]) {
+      expect(part).toContain("<w:drawing>");
+      expect(part).not.toContain("$scroll.");
+      assertBalancedXml(part);
+    }
+    expect(doc).toContain('descr="ENG space logo"');
+
+    // The header drawing's relationship lives in the HEADER's own rels part.
+    const headerRels = readPart(bytes, "word/_rels/header1.xml.rels");
+    const headerRelId = header.match(/r:embed="(rId\d+)"/)?.[1];
+    expect(headerRels).toContain(`Id="${headerRelId}"`);
+    expect(headerRels).toContain('Target="media/atlcli-image1.png"');
+    const docRels = readPart(bytes, "word/_rels/document.xml.rels");
+    expect(docRels).toContain('Target="media/atlcli-image1.png"');
+
+    // One media part serves both occurrences (byte-identical dedup).
+    const zip = new PizZip(bytes);
+    const media = Object.keys(zip.files).filter((p) => p.startsWith("word/media/"));
+    expect(media).toEqual(["word/media/atlcli-image1.png"]);
+
+    expect(report.embeddedImages).toBe(2);
+    expect(report.skippedImages).toBe(0);
+    expect(report.unsupportedNames).not.toContain("$scroll.spacelogo");
+    expect(report.unsupportedNames).not.toContain("$scroll.globallogo");
+    // The globallogo → space-logo substitution is said out loud, once.
+    const subs = report.notes.filter(
+      (n) => n.code === "placeholder-substituted" && n.message.includes("$scroll.globallogo")
+    );
+    expect(subs).toHaveLength(1);
+  });
+
+  it("honors the .(H,W) logo size args (height first, per the Scroll grammar)", async () => {
+    const { fetcher } = recordingFetcher(pngFixtureBytes(300, 100));
+    const { bytes } = await exportDocx({
+      templateBytes: buildDocx({
+        body: para("$scroll.content") + para("$scroll.spacelogo.(50,120)"),
+        styles: stylesXml(headingStyle("Heading1", "Heading 1")),
+      }),
+      details: logoDetails,
+      template,
+      deps: { ...deps, getSpaceLogo: async () => ({ url: "/download/attachments/999/logo.png" }) },
+      assets: fetcher,
+    });
+    const doc = readPart(bytes, "word/document.xml");
+    expect(doc).toContain(`<wp:extent cx="${120 * 9525}" cy="${50 * 9525}"/>`);
+  });
+
+  it("preserves the placeholder paragraph's pPr (alignment) on the drawing paragraph", async () => {
+    const { fetcher } = recordingFetcher(pngFixtureBytes(300, 100));
+    const centered =
+      `<w:p><w:pPr><w:jc w:val="center"/></w:pPr>` +
+      `<w:r><w:t xml:space="preserve">$scroll.spacelogo</w:t></w:r></w:p>`;
+    const { bytes } = await exportDocx({
+      templateBytes: buildDocx({
+        body: para("$scroll.content") + centered,
+        styles: stylesXml(headingStyle("Heading1", "Heading 1")),
+      }),
+      details: logoDetails,
+      template,
+      deps: { ...deps, getSpaceLogo: async () => ({ url: "/download/attachments/999/logo.png" }) },
+      assets: fetcher,
+    });
+    const doc = readPart(bytes, "word/document.xml");
+    const drawingPara = doc.slice(doc.indexOf("<w:p><w:pPr><w:jc"), doc.indexOf("</w:drawing>"));
+    expect(drawingPara).toContain('<w:jc w:val="center"/>');
+    expect(drawingPara).toContain("<w:drawing>");
+  });
+
+  it("degrades logos to a note + empty text when no getSpaceLogo dep is wired (F3 invariant)", async () => {
+    const { fetcher } = recordingFetcher();
+    const { bytes, report } = await exportDocx({
+      templateBytes: buildDocx({
+        body: para("$scroll.content") + para("$scroll.spacelogo"),
+        styles: stylesXml(headingStyle("Heading1", "Heading 1")),
+      }),
+      details: logoDetails,
+      template,
+      deps, // no getSpaceLogo
+      assets: fetcher,
+    });
+    const note = report.notes.find((n) => n.code === "logo-skipped");
+    expect(note?.level).toBe("warning");
+    expect(note?.message).toContain("$scroll.spacelogo");
+    expect(report.embeddedImages).toBe(0);
+    expect(report.skippedImages).toBe(1);
+    const doc = readPart(bytes, "word/document.xml");
+    expect(doc).not.toContain("$scroll.");
+    expect(doc).not.toContain("<w:drawing");
+    expect(readPart(bytes, "word/_rels/document.xml.rels")).not.toContain("relationships/image");
+  });
+
+  it("degrades an SVG space logo (the Cloud default) to a logo-embed-failed note", async () => {
+    const svg = new TextEncoder().encode('<svg xmlns="http://www.w3.org/2000/svg"/>');
+    const { bytes, report } = await exportDocx({
+      templateBytes: buildDocx({
+        body: para("$scroll.content") + para("$scroll.spacelogo"),
+        styles: stylesXml(headingStyle("Heading1", "Heading 1")),
+      }),
+      details: logoDetails,
+      template,
+      deps: { ...deps, getSpaceLogo: async () => ({ url: "/images/logo/default-space-logo.svg" }) },
+      assets: { fetch: async () => svg },
+    });
+    const note = report.notes.find((n) => n.code === "logo-embed-failed");
+    expect(note?.level).toBe("warning");
+    expect(note?.message).toContain("SVG");
+    expect(report.skippedImages).toBe(1);
+    const doc = readPart(bytes, "word/document.xml");
+    expect(doc).not.toContain("$scroll.");
+    expect(doc).not.toContain("<w:drawing");
+  });
+
+  it("degrades a failed logo fetch to a warning, token blanked", async () => {
+    const { bytes, report } = await exportDocx({
+      templateBytes: buildDocx({
+        body: para("$scroll.content") + para("$scroll.globallogo"),
+        styles: stylesXml(headingStyle("Heading1", "Heading 1")),
+      }),
+      details: logoDetails,
+      template,
+      deps: { ...deps, getSpaceLogo: async () => ({ url: "/download/attachments/999/logo.png" }) },
+      assets: {
+        async fetch() {
+          throw new Error("boom (403)");
+        },
+      },
+    });
+    const note = report.notes.find((n) => n.code === "logo-skipped");
+    expect(note?.level).toBe("warning");
+    expect(note?.message).toContain("boom (403)");
+    expect(readPart(bytes, "word/document.xml")).not.toContain("$scroll.");
+  });
+
+  it("never calls getSpaceLogo when the template uses no logo placeholder (lazy contract)", async () => {
+    const { fetcher } = recordingFetcher();
+    let logoCalls = 0;
+    await exportDocx({
+      templateBytes: imageTemplate(),
+      details,
+      template,
+      deps: {
+        ...deps,
+        getSpaceLogo: async () => {
+          logoCalls++;
+          return null;
+        },
+      },
+      assets: fetcher,
+    });
+    expect(logoCalls).toBe(0);
+  });
+
+  it("never calls getSpaceLogo when embedding is disabled (--no-images)", async () => {
+    let logoCalls = 0;
+    const { fetcher } = recordingFetcher();
+    const { report } = await exportDocx({
+      templateBytes: buildDocx({
+        body: para("$scroll.content") + para("$scroll.spacelogo"),
+        styles: stylesXml(headingStyle("Heading1", "Heading 1")),
+      }),
+      details: logoDetails,
+      template,
+      deps: {
+        ...deps,
+        getSpaceLogo: async () => {
+          logoCalls++;
+          return { url: "/x.png" };
+        },
+      },
+      assets: fetcher,
+      embedImages: false,
+    });
+    expect(logoCalls).toBe(0);
+    expect(report.notes.some((n) => n.code === "logo-skipped")).toBe(true);
   });
 
   it("embeds images inside table cells and honors ac:width scaling", async () => {

--- a/packages/docx/src/export.ts
+++ b/packages/docx/src/export.ts
@@ -45,7 +45,8 @@ import {
   type TemplateMeta,
 } from "./resolver.js";
 import { serializeBlocks, type ImageBlock, type ImageEmbedSeam } from "./serialize.js";
-import { ImageEmbedder } from "./image.js";
+import { ImageEmbedder, ImageEmbedError } from "./image.js";
+import { parseLogoArgs } from "./placeholder-map.js";
 import type { AssetFetcher, AssetRef } from "./env.js";
 import { CODE_STYLE_ID, codeStyleXml, parseStyleNames } from "./ooxml.js";
 import {
@@ -182,6 +183,20 @@ export async function exportDocx(input: ExportInput): Promise<ExportResult> {
   //    template has none, inject the tag before the body's final section break.
   const contentFound = injectContentTag(zip);
   const flowNotes: ExportNote[] = [];
+
+  // 3b. Logo pass (spec 005, gap G3): replace each $scroll.spacelogo /
+  //     $scroll.globallogo placeholder PARAGRAPH with an inline drawing of the
+  //     space logo. Runs before preprocessScrollText so a failed/skipped logo
+  //     still has its token blanked there (never a literal), and before render
+  //     so the drawing paragraphs pass through docxtemplater untouched.
+  await embedLogoPlaceholders(zip, {
+    embedder,
+    assets: input.assets,
+    getSpaceLogo: input.deps?.getSpaceLogo,
+    spaceKey: input.details.spaceKey,
+    notes: flowNotes,
+  });
+
   if (!contentFound) {
     injectContentTagAtEnd(zip);
     flowNotes.push({
@@ -298,7 +313,138 @@ const IMAGE_SKIP_CODES = new Set([
   "image-embed-failed",
   "image-unresolved",
   "inline-image-skipped",
+  "logo-skipped",
+  "logo-embed-failed",
 ]);
+
+// ---------------------------------------------------------------------------
+// Logo pass (spec 005, gap G3)
+// ---------------------------------------------------------------------------
+
+/** One logo token, matching the shared PLACEHOLDER_RE grammar for these bases. */
+const LOGO_TOKEN_RE = /\$scroll\.(spacelogo|globallogo)(?:\.?\([^)]*\))?/;
+
+interface LogoPassInput {
+  embedder?: ImageEmbedder;
+  assets?: AssetFetcher;
+  getSpaceLogo?: (spaceKey: string) => Promise<AssetRef | null>;
+  spaceKey?: string;
+  notes: ExportNote[];
+}
+
+interface LogoOccurrence {
+  part: string;
+  paragraph: string;
+  /** The raw token (carries the `.(H,W)` size args). */
+  raw: string;
+  base: string;
+}
+
+/**
+ * Replace each `$scroll.spacelogo` / `$scroll.globallogo` placeholder
+ * paragraph with an inline `<w:drawing>` of the space logo, across the main
+ * story and all header/footer parts (the embedder writes the `r:embed`
+ * relationship into each part's own rels).
+ *
+ * Both bases resolve to the SPACE logo (`GET /space/{key}?expand=icon`):
+ * Confluence Cloud exposes no separately fetchable global logo, so
+ * `$scroll.globallogo` degrades to the space logo with an info note rather
+ * than to nothing. The whole placeholder paragraph is replaced (mirroring the
+ * `$scroll.content` contract), preserving its `<w:pPr>` so alignment survives;
+ * any other text in that paragraph is dropped.
+ *
+ * Every failure branch — no fetcher, no dep, no space key, fetch error,
+ * undecodable bytes (the Cloud DEFAULT space logo is an SVG, which spec 005
+ * defers) — leaves the token in place for {@link preprocessScrollText} to
+ * blank, and adds a note whose code counts toward `skippedImages`. The
+ * embedder writes nothing on failure, so no dangling media part or
+ * relationship survives (the 004-F3 invariant).
+ */
+async function embedLogoPlaceholders(zip: PizZip, input: LogoPassInput): Promise<void> {
+  const { embedder, assets, getSpaceLogo, spaceKey, notes } = input;
+
+  // Collect occurrences first: the space-logo round-trip stays lazy (it fires
+  // only when a template actually uses a logo placeholder).
+  const occurrences: LogoOccurrence[] = [];
+  for (const part of documentPartNames(zip)) {
+    const xml = zip.file(part)?.asText() ?? "";
+    if (!xml.includes("$scroll.spacelogo") && !xml.includes("$scroll.globallogo")) continue;
+    for (const para of splitParagraphs(xml)) {
+      const m = paragraphText(para).match(LOGO_TOKEN_RE);
+      if (m) occurrences.push({ part, paragraph: para, raw: m[0], base: `$scroll.${m[1]}` });
+    }
+  }
+  if (occurrences.length === 0) return;
+
+  const bases = [...new Set(occurrences.map((o) => o.base))].sort();
+  const skipAll = (message: string, level: "info" | "warning" = "warning"): void => {
+    for (const base of bases) {
+      notes.push({ level, code: "logo-skipped", message: `${base} was not embedded: ${message}` });
+    }
+  };
+
+  if (!embedder || !assets) {
+    skipAll("image embedding is off or no asset fetcher is available; rendered empty.", "info");
+    return;
+  }
+  if (!getSpaceLogo) {
+    skipAll("no space-logo fetcher is available; rendered empty.");
+    return;
+  }
+  if (!spaceKey) {
+    skipAll("the page has no space key; rendered empty.");
+    return;
+  }
+
+  let bytes: Uint8Array;
+  try {
+    const ref = await getSpaceLogo(spaceKey);
+    if (!ref) {
+      skipAll(`space "${spaceKey}" has no logo; rendered empty.`, "info");
+      return;
+    }
+    bytes = await assets.fetch(ref);
+  } catch (err) {
+    skipAll(
+      `the space logo could not be fetched (${err instanceof Error ? err.message : String(err)}); rendered empty.`
+    );
+    return;
+  }
+
+  if (bases.includes("$scroll.globallogo")) {
+    notes.push({
+      level: "info",
+      code: "placeholder-substituted",
+      message:
+        "$scroll.globallogo resolved to the space logo — Confluence Cloud has no separately fetchable global logo.",
+    });
+  }
+
+  for (const occ of occurrences) {
+    const xml = zip.file(occ.part)?.asText() ?? "";
+    if (!xml.includes(occ.paragraph)) continue; // already replaced (identical paragraph)
+    const args = parseLogoArgs(occ.raw);
+    try {
+      const drawing = embedder.embed(bytes, {
+        name: occ.base === "$scroll.globallogo" ? "Global logo" : "Space logo",
+        alt: `${spaceKey} space logo`,
+        heightPx: args.heightPx,
+        widthPx: args.widthPx,
+        partPath: occ.part,
+        pPrXml: occ.paragraph.match(/<w:pPr>[\s\S]*?<\/w:pPr>/)?.[0],
+      });
+      zip.file(occ.part, xml.replace(occ.paragraph, drawing));
+    } catch (err) {
+      notes.push({
+        level: "warning",
+        code: "logo-embed-failed",
+        message:
+          `${occ.base} could not be embedded` +
+          `${err instanceof ImageEmbedError ? ` (${err.message})` : ""}; rendered empty.`,
+      });
+    }
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Image seam (spec 005)

--- a/packages/docx/src/golden-extension-export.json
+++ b/packages/docx/src/golden-extension-export.json
@@ -11,14 +11,12 @@
   },
   "report": {
     "resolvedCount": 5,
-    "unsupportedNames": [
-      "$scroll.spacelogo"
-    ],
-    "skippedImages": 1,
+    "unsupportedNames": [],
+    "skippedImages": 2,
     "filename": "DOCX Feature Zoo _ Golden.docx",
     "noteCodes": [
-      "placeholder-unsupported",
-      "image-skipped"
+      "image-skipped",
+      "logo-skipped"
     ]
   }
 }

--- a/packages/docx/src/golden.test.ts
+++ b/packages/docx/src/golden.test.ts
@@ -19,6 +19,12 @@
  * deterministic given the fixed export date. `durationMs` is excluded for the
  * same reason. Cross-host reuse (the same golden rendered under Node adapters)
  * is asserted in `node-consumer.test.ts`.
+ *
+ * REPORT fields recaptured 2026-07-16 for the spec-005 logo pass:
+ * `$scroll.spacelogo` moved unsupported→supported, so with no asset fetcher it
+ * now yields a `logo-skipped` note (counted in `skippedImages`) instead of a
+ * `placeholder-unsupported` entry. Every zip ENTRY was asserted byte-identical
+ * across the recapture — only the report block changed.
  */
 import { describe, expect, it } from "bun:test";
 import { readFileSync } from "node:fs";

--- a/packages/docx/src/image.test.ts
+++ b/packages/docx/src/image.test.ts
@@ -244,6 +244,46 @@ describe("ImageEmbedder", () => {
     expect(c.match(/r:embed="(rId\d+)"/)?.[1]).not.toBe(a.match(/r:embed="(rId\d+)"/)?.[1]!);
   });
 
+  it("writes the relationship into the referencing part's OWN rels (partPath)", () => {
+    const zip = new PizZip(
+      buildDocx({ body: para("x"), header: para("h"), footer: para("f") })
+    );
+    const embedder = new ImageEmbedder(zip);
+    const inHeader = embedder.embed(pngBytes(10, 10), { partPath: "word/header1.xml" });
+    const inBody = embedder.embed(pngBytes(10, 10), { partPath: "word/document.xml" });
+
+    // One shared media part; one relationship PER part, ids independent.
+    expect(zip.file("word/media/atlcli-image1.png")).not.toBeNull();
+    expect(zip.file("word/media/atlcli-image2.png")).toBeNull();
+
+    const headerRelId = inHeader.match(/r:embed="(rId\d+)"/)?.[1];
+    // The header had no rels part — it was created fresh.
+    const headerRels = zip.file("word/_rels/header1.xml.rels")!.asText();
+    expect(headerRels).toContain(`Id="${headerRelId}"`);
+    expect(headerRels).toContain('Target="media/atlcli-image1.png"');
+
+    const bodyRelId = inBody.match(/r:embed="(rId\d+)"/)?.[1];
+    const bodyRels = zip.file("word/_rels/document.xml.rels")!.asText();
+    expect(bodyRels).toContain(`Id="${bodyRelId}"`);
+    expect(bodyRels).toContain('Target="media/atlcli-image1.png"');
+    // The header's relationship never leaked into the document rels.
+    expect(bodyRels.match(/relationships\/image/g)).toHaveLength(1);
+
+    // A second embed into the same part reuses the part's relationship.
+    const again = embedder.embed(pngBytes(10, 10), { partPath: "word/header1.xml" });
+    expect(again.match(/r:embed="(rId\d+)"/)?.[1]).toBe(headerRelId!);
+    expect(zip.file("word/_rels/header1.xml.rels")!.asText().match(/relationships\/image/g)).toHaveLength(1);
+  });
+
+  it("carries the given pPr onto the drawing paragraph", () => {
+    const zip = templateZip();
+    const xml = new ImageEmbedder(zip).embed(pngBytes(10, 10), {
+      pPrXml: '<w:pPr><w:jc w:val="center"/></w:pPr>',
+    });
+    expect(xml.startsWith('<w:p><w:pPr><w:jc w:val="center"/></w:pPr><w:r><w:drawing>')).toBe(true);
+    assertBalancedXml(xml);
+  });
+
   it("caps oversized images to the content width", () => {
     const zip = templateZip();
     const xml = new ImageEmbedder(zip).embed(pngBytes(1200, 600));

--- a/packages/docx/src/image.ts
+++ b/packages/docx/src/image.ts
@@ -209,6 +209,11 @@ export interface DrawingParams {
   descr: string;
   cxEmu: number;
   cyEmu: number;
+  /**
+   * Optional `<w:pPr>…</w:pPr>` carried onto the emitted paragraph — used by
+   * the logo pass to preserve the replaced placeholder paragraph's alignment.
+   */
+  pPrXml?: string;
 }
 
 /**
@@ -223,7 +228,7 @@ export function inlineImageParagraph(p: DrawingParams): string {
   const name = escAttr(p.name);
   const descr = escAttr(p.descr);
   return (
-    `<w:p><w:r><w:drawing>` +
+    `<w:p>${p.pPrXml ?? ""}<w:r><w:drawing>` +
     `<wp:inline distT="0" distB="0" distL="0" distR="0" xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing">` +
     `<wp:extent cx="${p.cxEmu}" cy="${p.cyEmu}"/>` +
     `<wp:effectExtent l="0" t="0" r="0" b="0"/>` +
@@ -273,15 +278,28 @@ export interface EmbedImageOptions {
   widthPx?: number;
   /** Author-specified rendered height in px. */
   heightPx?: number;
+  /**
+   * The document part whose XML will carry the returned drawing (default
+   * `word/document.xml`). An `r:embed` relationship is only valid in the rels
+   * of the part that references it, so a logo drawn into a header/footer must
+   * name that part here — the relationship then lands in e.g.
+   * `word/_rels/header1.xml.rels` (spec 005 logo pass).
+   */
+  partPath?: string;
+  /** `<w:pPr>…</w:pPr>` to preserve on the emitted paragraph (see {@link DrawingParams.pPrXml}). */
+  pPrXml?: string;
 }
 
 interface MediaEntry {
-  relId: string;
+  /** Media-part filename (under `word/media/`), shared across parts. */
+  filename: string;
+  /** Relationship id PER RELS PART — the same media gets one rel per part. */
+  relIds: Map<string, string>;
   info: ImageInfo;
   bytes: Uint8Array;
 }
 
-const RELS_PATH = "word/_rels/document.xml.rels";
+const DOCUMENT_PART = "word/document.xml";
 const CT_PATH = "[Content_Types].xml";
 const EMPTY_RELS =
   `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>` +
@@ -331,16 +349,18 @@ export class ImageEmbedder {
     if (!info) throw new ImageEmbedError("unsupported image format (PNG, JPEG and GIF are supported)");
 
     const entry = this.findOrCreateMedia(bytes, info);
+    const relId = this.ensureRelationship(entry, opts.partPath ?? DOCUMENT_PART);
     const size = resolveTargetSize(info, { widthPx: opts.widthPx, heightPx: opts.heightPx }, this.maxWidthPx);
     const docPrId = this.nextDocPrId++;
     this.embedded += 1;
     return inlineImageParagraph({
-      relId: entry.relId,
+      relId,
       docPrId,
       name: opts.name || `Image ${docPrId}`,
       descr: opts.alt || opts.name || "image",
       cxEmu: pxToEmu(size.widthPx),
       cyEmu: pxToEmu(size.heightPx),
+      pPrXml: opts.pPrXml,
     });
   }
 
@@ -353,13 +373,13 @@ export class ImageEmbedder {
         if (sameBytes(candidate.bytes, bytes)) return candidate;
       }
     }
-    const entry: MediaEntry = { relId: this.writeMedia(bytes, info), info, bytes };
+    const entry: MediaEntry = { filename: this.writeMedia(bytes, info), relIds: new Map(), info, bytes };
     if (bucket) bucket.push(entry);
     else this.dedup.set(key, [entry]);
     return entry;
   }
 
-  /** The three archive edits: media part, content-type default, relationship. */
+  /** The two shared archive edits: media part + content-type default. */
   private writeMedia(bytes: Uint8Array, info: ImageInfo): string {
     let filename: string;
     do {
@@ -368,21 +388,41 @@ export class ImageEmbedder {
     } while (this.zip.file(`word/media/${filename}`));
 
     ensureContentTypeDefault(this.zip, info.ext, info.mime);
+    this.zip.file(`word/media/${filename}`, bytes);
+    return filename;
+  }
 
-    const rels = this.zip.file(RELS_PATH)?.asText() ?? EMPTY_RELS;
+  /**
+   * Ensure the media part is related from `partPath`'s rels (created on first
+   * use per part — the same media gets exactly one relationship per part).
+   */
+  private ensureRelationship(entry: MediaEntry, partPath: string): string {
+    const relsPath = relsPathFor(partPath);
+    const existing = entry.relIds.get(relsPath);
+    if (existing) return existing;
+
+    const rels = this.zip.file(relsPath)?.asText() ?? EMPTY_RELS;
     // Match both quote styles, like the settings-part surgery in export.ts.
     const ids = [...rels.matchAll(/Id=["']rId(\d+)["']/g)].map((m) => Number(m[1]));
     const relId = `rId${(ids.length ? Math.max(...ids) : 0) + 1}`;
     this.zip.file(
-      RELS_PATH,
+      relsPath,
       rels.replace(
         "</Relationships>",
-        `<Relationship Id="${relId}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="media/${filename}"/></Relationships>`
+        `<Relationship Id="${relId}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="media/${entry.filename}"/></Relationships>`
       )
     );
-    this.zip.file(`word/media/${filename}`, bytes);
+    entry.relIds.set(relsPath, relId);
     return relId;
   }
+}
+
+/** `word/header1.xml` → `word/_rels/header1.xml.rels` (OPC rels convention). */
+export function relsPathFor(partPath: string): string {
+  const slash = partPath.lastIndexOf("/");
+  const dir = slash === -1 ? "" : partPath.slice(0, slash + 1);
+  const base = slash === -1 ? partPath : partPath.slice(slash + 1);
+  return `${dir}_rels/${base}.rels`;
 }
 
 /** Add a `<Default Extension=…>` to `[Content_Types].xml` unless present. */

--- a/packages/docx/src/placeholder-map.test.ts
+++ b/packages/docx/src/placeholder-map.test.ts
@@ -9,7 +9,7 @@
  * ever contradicts real Scroll behaviour, these tests are where it surfaces.
  */
 import { describe, expect, it } from "bun:test";
-import { classifyPlaceholder, parsePagePropertyArgs } from "./placeholder-map.js";
+import { classifyPlaceholder, parseLogoArgs, parsePagePropertyArgs } from "./placeholder-map.js";
 
 describe("parsePagePropertyArgs — documented forms", () => {
   it("(key)", () => {
@@ -97,6 +97,35 @@ describe("classifyPlaceholder — .name is supported on Cloud (G2)", () => {
     const cls = classifyPlaceholder("$scroll.exporter.name");
     expect(cls.status).toBe("supported");
     expect(cls.dependency).toBe("currentUser");
+  });
+});
+
+describe("classifyPlaceholder — logo placeholders are supported (G3, spec 005)", () => {
+  it("spacelogo and globallogo classify as supported with the spaceLogo dependency", () => {
+    for (const raw of ["$scroll.spacelogo", "$scroll.globallogo", "$scroll.spacelogo.(50,120)"]) {
+      const cls = classifyPlaceholder(raw);
+      expect(cls.status).toBe("supported");
+      expect(cls.dependency).toBe("spaceLogo");
+    }
+  });
+});
+
+describe("parseLogoArgs — the .(H,W) size grammar (height first)", () => {
+  it("parses height-only and height+width forms", () => {
+    expect(parseLogoArgs("$scroll.spacelogo")).toEqual({ heightPx: undefined, widthPx: undefined });
+    expect(parseLogoArgs("$scroll.spacelogo.(50)")).toEqual({ heightPx: 50, widthPx: undefined });
+    expect(parseLogoArgs("$scroll.spacelogo.(50, 120)")).toEqual({ heightPx: 50, widthPx: 120 });
+  });
+
+  it("ignores non-numeric or non-positive arguments (intrinsic size wins)", () => {
+    expect(parseLogoArgs("$scroll.spacelogo.(auto,120)")).toEqual({
+      heightPx: undefined,
+      widthPx: 120,
+    });
+    expect(parseLogoArgs("$scroll.spacelogo.(0,-5)")).toEqual({
+      heightPx: undefined,
+      widthPx: undefined,
+    });
   });
 });
 

--- a/packages/docx/src/placeholder-map.ts
+++ b/packages/docx/src/placeholder-map.ts
@@ -10,22 +10,21 @@
  *    §2 `direct` and `derivable` rows the resolver ({@link resolvePlaceholders})
  *    can compute from `{ details, space?, currentUser?, template, exportDate }`.
  *  - **unsupported** — Confluence exposes it but atlcli does not model it yet
- *    (the §2 `unsupported (v1)` rows: DC usernames, space logo, page properties,
- *    JSON content properties) plus the derivable-but-out-of-v1-scope
- *    `$scroll.includepage.*` family (cross-page include is a Phase-2 non-goal,
- *    PLAN §Non-goals). Rendered ⚠ "will be empty"; resolves to `""` + report line.
- *  - **never** — depends on a third-party app or a system asset atlcli does not
- *    target (Comala `$adhocState`/`$scroll.metadata.*`, Scroll Documents
- *    `$scroll.custom.*`, `$scroll.globallogo`). Rendered ✗; resolves to `""`.
+ *    (the §2 `unsupported (v1)` rows: JSON content properties) plus the
+ *    derivable-but-out-of-v1-scope `$scroll.includepage.*` family (cross-page
+ *    include is a Phase-2 non-goal, PLAN §Non-goals). Rendered ⚠ "will be
+ *    empty"; resolves to `""` + report line.
+ *  - **never** — depends on a third-party app atlcli does not target (Comala
+ *    `$adhocState`/`$scroll.metadata.*`, Scroll Documents `$scroll.custom.*`).
+ *    Rendered ✗; resolves to `""`.
  *
  * Each `reason` is surfaced verbatim per row in the panel, so it must say WHY
  * this particular placeholder is empty — the causes differ sharply and a generic
- * "will be empty" would flatten them. Three distinct kinds live here: genuinely
- * impossible on Cloud (`.name` — Atlassian removed usernames), blocked on
- * another spec (the logos need 005's image module), and simply not modelled yet
- * (page properties). `$scroll.pageowner.fullName` used to sit in the first group
- * by implication; it does not — Cloud's v2 API exposes `ownerId`, so it is now
- * supported via {@link SUPPORTED_OWNER} (gap G1 closed).
+ * "will be empty" would flatten them. `$scroll.pageowner.fullName` used to sit
+ * in an "impossible on Cloud" group by implication; it does not — Cloud's v2
+ * API exposes `ownerId`, so it is supported via {@link SUPPORTED_OWNER} (gap G1
+ * closed). The logo placeholders were unblocked the same way once spec 005's
+ * image module landed (gap G3 closed, see {@link SUPPORTED_LOGO}).
  *
  * A placeholder's *base* is its dotted name with any `.("format")` argument and
  * `.(params)` stripped (e.g. `$scroll.exportdate.("dd.MM.yyyy")` → base
@@ -46,7 +45,8 @@ export type PlaceholderDependency =
   | "space"
   | "currentUser"
   | "owner"
-  | "spaceHomepage";
+  | "spaceHomepage"
+  | "spaceLogo";
 
 /**
  * Parsed argument list of `$scroll.pageproperty.(…)` (spec 001 gap **G4**).
@@ -93,6 +93,34 @@ export function parsePagePropertyArgs(raw: string): PagePropertyArgs {
     fallbackEnabled: parts[2] === "true",
     alternateText: parts[3] || undefined,
   };
+}
+
+/**
+ * Parsed size argument of a logo placeholder — Scroll documents
+ * `$scroll.spacelogo.(H,W)`: height first, then width, both px. A single
+ * argument is the height (the width scales by the logo's aspect ratio).
+ * Non-numeric arguments are ignored (intrinsic size wins).
+ */
+export interface LogoArgs {
+  heightPx?: number;
+  widthPx?: number;
+}
+
+/** Parse the raw `$scroll.spacelogo.(H,W)` / `$scroll.globallogo.(H,W)` size args. */
+export function parseLogoArgs(raw: string): LogoArgs {
+  const open = raw.indexOf("(");
+  const close = raw.lastIndexOf(")");
+  if (open === -1 || close <= open) return {};
+  const parts = raw
+    .slice(open + 1, close)
+    .split(",")
+    .map((p) => p.trim());
+  const num = (s: string | undefined): number | undefined => {
+    if (!s || !/^\d+$/.test(s)) return undefined;
+    const n = Number(s);
+    return n > 0 ? n : undefined;
+  };
+  return { heightPx: num(parts[0]), widthPx: num(parts[1]) };
 }
 
 export interface PlaceholderClass {
@@ -177,9 +205,17 @@ const SUPPORTED_OWNER = new Set<string>(["$scroll.pageowner.fullName"]);
  * `$scroll.includepage.*` and the parameterized `$scroll.pageproperty.*` /
  * `$scroll.jsoncontentproperty.*` families match by prefix (see classifier).
  */
-const UNSUPPORTED_EXACT: Record<string, string> = {
-  "$scroll.spacelogo": "the space logo is an image — needs the image module (spec 005, Gap G3)",
-};
+/**
+ * Logo placeholders (spec 005, Gap G3 closed): both resolve to an embedded
+ * image of the space logo (`GET /space/{key}?expand=icon`), handled by the
+ * export orchestrator's logo pass — NOT by the text resolver (a logo is a
+ * drawing, not a string). `$scroll.globallogo` also maps to the space logo:
+ * Confluence Cloud exposes no separately fetchable global logo, and the export
+ * report says so per occurrence.
+ */
+const SUPPORTED_LOGO = new Set<string>(["$scroll.spacelogo", "$scroll.globallogo"]);
+
+const UNSUPPORTED_EXACT: Record<string, string> = {};
 
 const UNSUPPORTED_PREFIXES: { prefix: string; reason: string }[] = [
   { prefix: "$scroll.includepage", reason: "cross-page include is out of scope in v1 (Phase 2)" },
@@ -199,9 +235,7 @@ const UNSUPPORTED_PREFIXES: { prefix: string; reason: string }[] = [
  * unrecognized→unsupported branch below: empty value + report line, just with a
  * generic reason instead of a Comala-specific one.
  */
-const NEVER_EXACT: Record<string, string> = {
-  "$scroll.globallogo": "the global logo is an image — needs the image module (spec 005)",
-};
+const NEVER_EXACT: Record<string, string> = {};
 
 const NEVER_PREFIXES: { prefix: string; reason: string }[] = [
   { prefix: "$scroll.custom", reason: "Scroll Documents app — not integrated" },
@@ -219,6 +253,7 @@ export function classifyPlaceholder(raw: string): PlaceholderClass {
   if (SUPPORTED_SPACE.has(base)) return { base, status: "supported", dependency: "space" };
   if (SUPPORTED_USER.has(base)) return { base, status: "supported", dependency: "currentUser" };
   if (SUPPORTED_OWNER.has(base)) return { base, status: "supported", dependency: "owner" };
+  if (SUPPORTED_LOGO.has(base)) return { base, status: "supported", dependency: "spaceLogo" };
 
   // Page Properties (G4). The dependency varies by ARGUMENT, not by base: only
   // the fallback form needs the space homepage. Classification sees the raw, and

--- a/packages/docx/src/resolver.test.ts
+++ b/packages/docx/src/resolver.test.ts
@@ -347,14 +347,15 @@ describe("$adhocState — dropped from the curated list, still blanked", () => {
 
 describe("resolvePlaceholders — pinning: never a literal", () => {
   it("maps unsupported and never placeholders to empty string + report entry", async () => {
-    // $scroll.spacelogo is genuinely unsupported (needs the image module);
-    // $scroll.pageowner.fullName is NOT used here — it became supported (G1).
+    // $scroll.jsoncontentproperty is genuinely unsupported (Gap G5);
+    // $scroll.pageowner.fullName and $scroll.spacelogo are NOT used here —
+    // they became supported (G1 / G3).
     const res = await resolvePlaceholders(
-      ["$scroll.spacelogo", "$adhocState", "$scroll.pageproperty.(status)"],
+      ["$scroll.jsoncontentproperty.(key)", "$adhocState", "$scroll.pageproperty.(status)"],
       ctx,
       {}
     );
-    expect(res.values.get("$scroll.spacelogo")).toBe("");
+    expect(res.values.get("$scroll.jsoncontentproperty.(key)")).toBe("");
     expect(res.values.get("$adhocState")).toBe("");
     expect(res.values.get("$scroll.pageproperty.(status)")).toBe("");
     // Every value is a string; none contains a literal $scroll./$adhoc.

--- a/packages/docx/src/resolver.ts
+++ b/packages/docx/src/resolver.ts
@@ -31,6 +31,7 @@ import {
 } from "@atlcli/confluence";
 import { classifyPlaceholder, parsePagePropertyArgs } from "./placeholder-map.js";
 import { formatDatePlaceholder } from "./dateformat.js";
+import type { AssetRef } from "./env.js";
 
 /** atlcli-side template metadata (G8): filename + upload timestamp. */
 export interface TemplateMeta {
@@ -59,13 +60,22 @@ export interface PageOwner {
   email?: string;
 }
 
-/** Lazily-invoked fetchers for the derivable round-trips (G1/G4/G6/G7). */
+/** Lazily-invoked fetchers for the derivable round-trips (G1/G3/G4/G6/G7). */
 export interface ResolveDeps {
   getSpace?: (spaceKey: string) => Promise<ConfluenceSpace>;
   getCurrentUser?: () => Promise<CurrentUser>;
   getPageOwner?: (pageId: string) => Promise<PageOwner | null>;
   /** Storage of the space homepage — only for the pageproperty fallback form. */
   getSpaceHomepageStorage?: (spaceKey: string) => Promise<string | null>;
+  /**
+   * Where the space logo lives (G3): the `icon.path` of
+   * `GET /space/{key}?expand=icon`, as an {@link AssetRef} for the host's
+   * asset fetcher — or `null` when the space has none. Consumed by the export
+   * orchestrator's LOGO pass (`$scroll.spacelogo` / `$scroll.globallogo`
+   * become embedded drawings), not by the text resolver — it lives here so
+   * hosts wire every per-site round-trip through one `deps` bag.
+   */
+  getSpaceLogo?: (spaceKey: string) => Promise<AssetRef | null>;
 }
 
 /**

--- a/packages/docx/src/scan.test.ts
+++ b/packages/docx/src/scan.test.ts
@@ -36,17 +36,18 @@ describe("scanTemplate", () => {
     const never = scan.never.map((h) => h.base).sort();
 
     // pageowner is SUPPORTED since G1 closed (Cloud v2 exposes `ownerId`); the
-    // space logo stays unsupported because it is an image (needs spec 005).
+    // space logo is SUPPORTED since spec 005's image module landed (G3).
     expect(supported).toEqual([
       "$scroll.pageowner.fullName",
       "$scroll.space.name",
+      "$scroll.spacelogo",
       "$scroll.title",
     ]);
     // $adhocState was dropped from the curated never-list ("bauen wir aus") but
     // is still DETECTED, so it lands on the generic unrecognized→unsupported
     // path and gets blanked. Were it dropped from detection instead, the raw
     // token would survive into the exported document.
-    expect(unsupported).toEqual(["$adhocState", "$scroll.spacelogo"]);
+    expect(unsupported).toEqual(["$adhocState"]);
     expect(never).toEqual(["$scroll.custom"]);
     expect(scan.hasContentPlaceholder).toBe(true);
     // $scroll.content is not listed as a placeholder hit.

--- a/specs/001-browser-ready-core/scroll-placeholder-mapping.md
+++ b/specs/001-browser-ready-core/scroll-placeholder-mapping.md
@@ -141,8 +141,8 @@ atlcli fields below are on `ConfluencePageDetails` unless prefixed with `Conflue
 | `$scroll.space.key` | `.spaceKey` / `ConfluenceSpace.key` | direct | Present on page details. |
 | `$scroll.space.name` | `ConfluenceSpace.name` | derivable | Needs a `getSpace(spaceKey)` call; page details carry only the key. |
 | `$scroll.space.url` | `ConfluenceSpace.url` | derivable | Same extra `getSpace` call. |
-| `$scroll.spacelogo` `.(H,W)` | — | unsupported (v1) | No space-logo fetch in atlcli. Gap G3. |
-| `$scroll.globallogo` | — | never | Confluence system-wide logo; not a per-content datum atlcli targets. |
+| `$scroll.spacelogo` `.(H,W)` | `getSpaceIcon(spaceKey).path` → embedded drawing | derivable | Gap G3 ✅ closed 2026-07-16: spec 005's image module embeds the space logo (`/space/{key}?expand=icon`). `.(H,W)` = height,width px. Cloud DEFAULT logos are SVG → degrade to a report note. |
+| `$scroll.globallogo` | same as `$scroll.spacelogo` | derivable | Cloud exposes no separately fetchable global logo — resolves to the SPACE logo with a `placeholder-substituted` report note. |
 
 ### 2.5 Export info
 
@@ -240,10 +240,17 @@ referenced from the mapping table.
     for a login and got a person's name. The value is useful; hiding the swap would not be.
   - Not a "closed" gap like G1/G4 — the data genuinely does not exist. This is a deliberate
     product decision to degrade usefully instead of emptily.
-- **G3 — Space & global logos.** The data exists — `GET /space/{key}?expand=icon` returns
-  `icon.path` — but a logo is an **image**, so both placeholders are blocked on the OOXML image
-  module (spec `005-docx-image-module`), not on a missing fetch. Blocks: `$scroll.spacelogo` (G3);
-  `$scroll.globallogo` is `never` (system asset).
+- **G3 — Space & global logos. ✅ CLOSED 2026-07-16.** Was blocked on the OOXML image module
+  (spec `005-docx-image-module`); once that landed, the export gained a logo pass: the
+  placeholder PARAGRAPH is replaced by an inline `<w:drawing>` of the space logo
+  (`GET /space/{key}?expand=icon` → `icon.path`, wired through `deps.getSpaceLogo` + the host's
+  `AssetFetcher`; relationships land in the referencing part's own rels, so header/footer logos
+  work). `$scroll.globallogo` resolves to the SPACE logo — Cloud has no separately fetchable
+  global logo — with a `placeholder-substituted` report note. Cloud DEFAULT space logos are SVG
+  and degrade to `logo-embed-failed` (SVG embedding stays deferred); custom PNG/JPEG/GIF logos
+  embed. Token hosts must resolve a custom logo's cookie-only `/download/attachments/…` path via
+  the REST attachment listing (the CLI's `getSpaceLogo` carries content id + filename on the ref
+  for exactly this).
 - **G4 — Page Properties macro extraction. ✅ CLOSED 2026-07-16.** Was a scope call, not a
   capability one: the macro (`ac:name="details"`) lives in the page's OWN storage, which the
   export already holds, so the common `(key)` form needs no round-trip at all. Implemented in
@@ -277,10 +284,10 @@ referenced from the mapping table.
   (the chosen `.docx` template file). No template registry/metadata model exists yet; Phase 1 must
   define where template name + mtime come from.
 
-**Out of scope (never, not gaps to close):** Comala metadata (`$scroll.metadata.*`), the entire
-Scroll Documents `$scroll.custom.*` family, and the system-wide `$scroll.globallogo`. These
-require third-party K15t/Comala apps or Confluence-instance assets that atlcli deliberately does
-not target.
+**Out of scope (never, not gaps to close):** Comala metadata (`$scroll.metadata.*`) and the
+entire Scroll Documents `$scroll.custom.*` family. These require third-party K15t/Comala apps
+that atlcli deliberately does not target. (`$scroll.globallogo` moved OUT of this list with G3:
+it now resolves to the space logo, see above.)
 
 **`$adhocState` — dropped from the curated list** (Björn, 2026-07-16: "bauen wir aus, das wollen
 wir aktuell nicht supporten"). It no longer carries a Comala-specific entry and falls through to

--- a/src/content/docs/confluence/export.md
+++ b/src/content/docs/confluence/export.md
@@ -224,7 +224,12 @@ atlcli supports templates created for Scroll Word Exporter. With the default `py
 Scroll placeholders (`$scroll.title`, `$scroll.content`, etc.) are automatically converted to the
 equivalent atlcli variables. With `--engine ts`, Scroll placeholders are resolved natively — the
 template is scanned, supported placeholders are filled, unsupported ones are emptied and listed in
-the export report, and the page body is injected at `$scroll.content`.
+the export report, and the page body is injected at `$scroll.content`. The logo placeholders
+`$scroll.spacelogo` and `$scroll.globallogo` embed the space logo as an image (optionally sized
+via `.(height,width)` in px); on Confluence Cloud the global logo is not separately fetchable, so
+`$scroll.globallogo` also resolves to the space logo (noted in the report). Default Cloud space
+logos are SVGs, which are not embedded yet — upload a custom PNG/JPEG logo to the space for logo
+embedding.
 
 ## Troubleshooting
 

--- a/src/content/docs/reference/docx-engine.md
+++ b/src/content/docs/reference/docx-engine.md
@@ -83,6 +83,28 @@ inline `<w:drawing>` with unique element ids and alt text. Details that matter t
 - Byte-identical images share one media part; the report counts `embeddedImages` and
   `skippedImages`.
 
+### Logo placeholders
+
+`$scroll.spacelogo` and `$scroll.globallogo` embed the **space logo** as an inline drawing
+through the same image module (the placeholder paragraph is replaced, its alignment preserved).
+The icon location comes from the optional `deps.getSpaceLogo(spaceKey)` round-trip — wire it to
+`GET /space/{key}?expand=icon` and return the `icon.path` as an `AssetRef` (the CLI and the
+extension both do). Details:
+
+- **`$scroll.globallogo` maps to the space logo:** Confluence Cloud exposes no separately
+  fetchable global logo; the report carries a `placeholder-substituted` info note per export.
+- **Size args:** `$scroll.spacelogo.(H,W)` — height first, then width, in px; a single argument
+  is the height (width scales by aspect ratio). Both are optional.
+- **Headers/footers work:** the `r:embed` relationship is written into the referencing part's
+  own rels (e.g. `word/_rels/header1.xml.rels`).
+- **Cloud default logos are SVG** and therefore degrade to a `logo-embed-failed` note (same SVG
+  deferral as page images). Custom logos (PNG/JPEG/GIF) embed. On a token host, a custom logo's
+  `icon.path` is a cookie-only `/download/attachments/{contentId}/{filename}` URL — carry the
+  content id + filename on the `AssetRef` so the fetcher resolves them via the REST attachment
+  listing (the CLI's `getSpaceLogo` does exactly this).
+- **Missing dep/fetcher, fetch errors, no space key** all degrade to `logo-skipped` notes; the
+  token is blanked, never left literal.
+
 ## Plugging in a new surface
 
 A new consumer (MCP server, Tauri Studio, Org-Server) implements the three interfaces and calls
@@ -100,6 +122,10 @@ const report = await runExport(
       getCurrentUser: () => client.getCurrentUser(),
       getPageOwner: (id) => client.getPageOwner(id),
       getSpaceHomepageStorage: (key) => client.getSpaceHomepageStorage(key),
+      getSpaceLogo: async (key) => {      // $scroll.spacelogo / $scroll.globallogo
+        const icon = await client.getSpaceIcon(key);
+        return icon ? { url: icon.path } : null;
+      },
     },
   },
   {


### PR DESCRIPTION
## What

`$scroll.spacelogo` and `$scroll.globallogo` move from unsupported/never to **supported**: a new logo pass in the export replaces each placeholder paragraph with an inline `<w:drawing>` of the space logo, fetched through the new `deps.getSpaceLogo` seam (`GET /space/{key}?expand=icon` → `icon.path`) plus the host's `AssetFetcher`. Both placeholders leave `report.unsupportedNames`.

## How

- **`export.ts` — logo pass** between content-tag injection and the `$scroll` preprocessor: placeholder paragraph → drawing paragraph (mirroring the `$scroll.content` contract), with the original `<w:pPr>` preserved so alignment survives. Every failure branch (no fetcher/dep/space key, fetch error, undecodable bytes) degrades to a `logo-skipped` / `logo-embed-failed` note counted in `skippedImages`; the token is blanked by the preprocessor — never a literal, never a dangling relationship (004-F3 invariant).
- **`image.ts` — per-part relationships:** `ImageEmbedder.embed` takes a `partPath`; the `r:embed` relationship lands in the referencing part's own rels (e.g. `word/_rels/header1.xml.rels`, created when missing), so header/footer logos work. The media part stays shared across parts (byte-identical dedup).
- **`placeholder-map.ts`:** both bases classify as supported with the new `spaceLogo` dependency; `parseLogoArgs` implements the documented `.(H,W)` size grammar (height first, single arg = height, width scales by aspect).
- **`@atlcli/confluence`:** `ConfluenceClient.getSpaceIcon(key)` + `SpaceIcon` type.
- **Hosts wired:** CLI (`--engine ts`) and extension side panel both pass `getSpaceLogo` in `deps`.

## Decisions a reviewer should know

1. **`$scroll.globallogo` resolves to the space logo.** Confluence Cloud exposes no separately fetchable global logo; the substitution is reported per export via a `placeholder-substituted` info note, never silent. Documented in the mapping spec (G3 closed) and the docs.
2. **Token-auth 401 workaround:** a custom logo's `icon.path` is the cookie-only `/download/attachments/{contentId}/{filename}` URL, which answers 401 to API tokens (verified live). The CLI's `getSpaceLogo` parses content id + filename onto the `AssetRef` so `tokenAssetFetcher` resolves them through the REST attachment listing — same pattern as page attachments.
3. **Cloud default space logos are SVG** and degrade to a `logo-embed-failed` note (SVG embedding stays deferred per spec 005). Custom PNG/JPEG/GIF logos embed.
4. **Golden file:** report fields recaptured (`unsupportedNames`, `noteCodes`, `skippedImages`); every zip entry was asserted **byte-identical** across the recapture (guard script), so the engine's output is unchanged — only the report classification moved.

## Testing

- **1623 tests pass**, typecheck clean (root `tsc` + extension via turbo).
- New coverage: 8 logo-pipeline tests in `export.test.ts` (body + header embedding with own rels, `.(H,W)` sizing, pPr preservation, no-dep/SVG/fetch-failure degradation, lazy contract incl. `--no-images`), `partPath`/pPr embedder tests in `image.test.ts`, `parseLogoArgs` + classification tests, `getSpaceIcon` client tests.
- **E2E** (profile `mayflower`, space `DOCSY`, page 1117356071, `--engine ts`): all 3 logo occurrences embedded — centered body logo (pPr preserved), `.(24)`-sized variant, header logo with its own rels file; one shared PNG media part; zero `$scroll.` literals in any part. No test resources left behind (fixture page stays per project convention).

Docs updated in the same PR: `docx-engine.md` (logo section + `getSpaceLogo` example), `export.md` (Scroll compatibility), and the normative placeholder mapping (`specs/001…/scroll-placeholder-mapping.md`, G3 ✅ closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)