### PR TITLE
feat(docx): spec 005a — mermaid diagrams render as vector drawings (svgBlip + PNG fallback)

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -8,3 +8,13 @@ made prior to the relicensing were originally licensed under the MIT License by
 their respective authors; those authors retain their copyright, and their
 contributions are included here under the Apache License, Version 2.0, with the
 original attribution preserved.
+
+Third-party notices:
+
+- beautiful-mermaid (https://github.com/lukilabs/beautiful-mermaid),
+  Copyright Craft Docs / Luki Labs, licensed under the MIT License.
+- elkjs (https://github.com/kieler/elkjs), a JavaScript build of the Eclipse
+  Layout Kernel (https://projects.eclipse.org/projects/modeling.elk), licensed
+  under the Eclipse Public License 2.0 (EPL-2.0). elkjs is distributed in
+  object-code form inside atlcli's bundled artifacts; its source code is
+  available at the URL above.

--- a/apps/cli/src/commands/export.ts
+++ b/apps/cli/src/commands/export.ts
@@ -799,6 +799,7 @@ async function exportWithTsEngine(args: TsEngineArgs): Promise<void> {
         resolvedCount: report.resolvedCount,
         unsupportedNames: report.unsupportedNames,
         embeddedImages: report.embeddedImages,
+        renderedDiagrams: report.renderedDiagrams,
         skippedImages: report.skippedImages,
         durationMs: report.durationMs,
         notes: [...cliNotes, ...report.notes.map((n) => `${n.level}: ${n.message}`)],
@@ -918,8 +919,10 @@ Options:
   --no-toc-prompt     Disable TOC dirty flag (Word won't prompt to update fields)
   --engine <name>     Rendering engine: "python" (default, docxtpl) or "ts"
                       (isomorphic @atlcli/docx engine — same as the browser
-                      extension; $scroll.* placeholders, no Python needed;
-                      images/children not yet supported)
+                      extension; $scroll.* placeholders + image embedding, no
+                      Python needed; children not yet supported. Mermaid
+                      diagrams export as readable source blocks — rendering
+                      them needs the extension's rasterizer)
   --profile <name>    Use a specific auth profile
 
 Page Reference Formats:

--- a/apps/extension/entrypoints/sidepanel/TemplateSection.tsx
+++ b/apps/extension/entrypoints/sidepanel/TemplateSection.tsx
@@ -189,7 +189,8 @@ export function TemplateSection({
     setBusy("export");
     try {
       const { runExport } = await loadExport();
-      const { idbTemplateSource, sessionAssetFetcher, downloadOutputSink } = await loadEnv();
+      const { idbTemplateSource, sessionAssetFetcher, downloadOutputSink, canvasSvgRasterizer } =
+        await loadEnv();
       const profile = profileFromTabUrl(pageUrl);
       const client = profile ? new ConfluenceClient(profile) : null;
       const rep = await runExport(
@@ -216,6 +217,9 @@ export function TemplateSection({
           // Attachment refs are wiki-base-relative (spec 005); resolve them
           // against the tab's Confluence root so the session cookies apply.
           assets: sessionAssetFetcher(profile ? getConfluenceBaseUrl(profile) : undefined),
+          // Mermaid diagrams (spec 005a): the panel document supplies the
+          // SVG → PNG raster fallback via a real <canvas>.
+          rasterizer: canvasSvgRasterizer(),
           output: downloadOutputSink(),
         }
       );
@@ -408,6 +412,9 @@ export function ReportView({ report }: { report: ExportReport }): React.JSX.Elem
         )}
         {report.embeddedImages > 0 && (
           <li data-testid="report-embedded-images">{report.embeddedImages} image(s) embedded</li>
+        )}
+        {report.renderedDiagrams > 0 && (
+          <li data-testid="report-rendered-diagrams">{report.renderedDiagrams} diagram(s) rendered</li>
         )}
         {report.skippedImages > 0 && (
           <li data-testid="report-skipped-images">{report.skippedImages} image(s) skipped (see notes)</li>

--- a/apps/extension/tests/docx/env.test.ts
+++ b/apps/extension/tests/docx/env.test.ts
@@ -10,6 +10,7 @@ import { IDBFactory } from "fake-indexeddb";
 import { Window } from "happy-dom";
 import { buildDocx, para } from "@atlcli/docx/fixtures";
 import {
+  canvasSvgRasterizer,
   downloadOutputSink,
   idbTemplateSource,
   sessionAssetFetcher,
@@ -82,6 +83,26 @@ describe("sessionAssetFetcher", () => {
     expect(
       sessionAssetFetcher(undefined, fetchFn).fetch({ url: "https://x/att", filename: "a.png" })
     ).rejects.toThrow("Asset fetch failed (403) for a.png");
+  });
+});
+
+describe("canvasSvgRasterizer", () => {
+  // happy-dom has no rendering engine: an <img> never fires load/error for a
+  // blob SVG, and canvas.getContext("2d") is null — so the REAL rasterization
+  // is covered by the manual extension E2E (spec 005a Task 6). What IS
+  // testable against a real happy-dom document is the freeze guard: a decode
+  // that never settles must reject (→ the engine's code-block fallback route)
+  // instead of hanging the whole export.
+  it("rejects instead of hanging when the SVG never decodes", async () => {
+    const window = new Window();
+    const doc = window.document as unknown as Document;
+    const rasterizer = canvasSvgRasterizer(doc, 50);
+    expect(
+      rasterizer.rasterize('<svg xmlns="http://www.w3.org/2000/svg" width="2" height="2"/>', {
+        widthPx: 4,
+        heightPx: 4,
+      })
+    ).rejects.toThrow("did not decode within 50 ms");
   });
 });
 

--- a/apps/extension/tests/docx/report-view.test.tsx
+++ b/apps/extension/tests/docx/report-view.test.tsx
@@ -24,6 +24,7 @@ function makeReport(notes: ExportReport["notes"]): ExportReport {
     unsupportedNames: [],
     skippedImages: 0,
     embeddedImages: 0,
+    renderedDiagrams: 0,
     durationMs: 42,
     filename: "page.docx",
     notes,

--- a/apps/extension/utils/docx/env.ts
+++ b/apps/extension/utils/docx/env.ts
@@ -6,7 +6,13 @@
  * document leaves through a browser download. No engine code touches
  * `chrome.*` / DOM — it all lives here, next to the host that owns it.
  */
-import type { AssetFetcher, AssetRef, OutputSink, TemplateSource } from "@atlcli/docx/browser";
+import type {
+  AssetFetcher,
+  AssetRef,
+  OutputSink,
+  SvgRasterizer,
+  TemplateSource,
+} from "@atlcli/docx/browser";
 import { getTemplate } from "./template-store.js";
 
 /**
@@ -45,6 +51,57 @@ export function sessionAssetFetcher(baseUrl?: string, fetchFn: typeof fetch = fe
         throw new Error(`Asset fetch failed (${res.status}) for ${ref.filename ?? ref.url}`);
       }
       return new Uint8Array(await res.arrayBuffer());
+    },
+  };
+}
+
+/**
+ * {@link SvgRasterizer} over the panel's real document (spec 005a §2.4,
+ * option 1): the rendered diagram SVG becomes an `<img src="blob:…">`, is
+ * drawn onto a `<canvas>` at the requested target size (the engine asks for
+ * 2× the intrinsic size), and encoded to PNG via `canvas.toBlob`. The SVG is
+ * self-contained (beautiful-mermaid output, external font import stripped by
+ * the engine), so the blob image decodes without network and the canvas
+ * stays untainted. Any failure throws — the engine then routes the diagram
+ * to the readable code-block fallback; a decode that never settles is cut off
+ * by `decodeTimeoutMs` so one broken diagram can't freeze the whole export.
+ */
+export function canvasSvgRasterizer(doc: Document = document, decodeTimeoutMs = 10_000): SvgRasterizer {
+  return {
+    async rasterize(svg, { widthPx, heightPx }): Promise<Uint8Array> {
+      // Image/Blob/URL come from the document's own window so the rasterizer
+      // works against any real DOM handed in (panel window, happy-dom tests).
+      const view = (doc.defaultView ?? globalThis) as Window & typeof globalThis;
+      const url = view.URL.createObjectURL(new view.Blob([svg], { type: "image/svg+xml" }));
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      try {
+        const img = new view.Image();
+        await new Promise<void>((resolve, reject) => {
+          timer = setTimeout(
+            () => reject(new Error(`the diagram SVG did not decode within ${decodeTimeoutMs} ms`)),
+            decodeTimeoutMs
+          );
+          img.onload = () => resolve();
+          img.onerror = () => reject(new Error("the diagram SVG could not be decoded"));
+          img.src = url;
+        });
+        const canvas = doc.createElement("canvas");
+        canvas.width = widthPx;
+        canvas.height = heightPx;
+        const ctx = canvas.getContext("2d");
+        if (!ctx) throw new Error("no 2d canvas context available");
+        ctx.drawImage(img, 0, 0, widthPx, heightPx);
+        const blob = await new Promise<Blob>((resolve, reject) =>
+          canvas.toBlob(
+            (b) => (b ? resolve(b) : reject(new Error("PNG encoding failed"))),
+            "image/png"
+          )
+        );
+        return new Uint8Array(await blob.arrayBuffer());
+      } finally {
+        clearTimeout(timer);
+        view.URL.revokeObjectURL(url);
+      }
     },
   };
 }

--- a/bun.lock
+++ b/bun.lock
@@ -82,13 +82,20 @@
         "yaml": "^2.7.0",
       },
     },
+    "packages/diagram": {
+      "name": "@atlcli/diagram",
+      "version": "0.6.0",
+      "dependencies": {
+        "beautiful-mermaid": "1.1.3",
+      },
+    },
     "packages/docx": {
       "name": "@atlcli/docx",
       "version": "0.6.0",
       "dependencies": {
         "@atlcli/confluence": "workspace:*",
         "@atlcli/core": "workspace:*",
-        "beautiful-mermaid": "1.1.3",
+        "@atlcli/diagram": "workspace:*",
         "docxtemplater": "^3.69.0",
         "pizzip": "^3.2.0",
         "shiki": "^4.3.1",
@@ -162,6 +169,8 @@
     "@atlcli/confluence": ["@atlcli/confluence@workspace:packages/confluence"],
 
     "@atlcli/core": ["@atlcli/core@workspace:packages/core"],
+
+    "@atlcli/diagram": ["@atlcli/diagram@workspace:packages/diagram"],
 
     "@atlcli/docx": ["@atlcli/docx@workspace:packages/docx"],
 

--- a/bun.lock
+++ b/bun.lock
@@ -88,6 +88,7 @@
       "dependencies": {
         "@atlcli/confluence": "workspace:*",
         "@atlcli/core": "workspace:*",
+        "beautiful-mermaid": "1.1.3",
         "docxtemplater": "^3.69.0",
         "pizzip": "^3.2.0",
         "shiki": "^4.3.1",
@@ -638,6 +639,8 @@
 
     "bcp-47-match": ["bcp-47-match@2.0.3", "", {}, "sha512-JtTezzbAibu8G0R9op9zb3vcWZd9JF6M0xOYGPn0fNCd7wOpRB1mU2mH9T8gaBGbAAyIIVgB2G7xG0GP98zMAQ=="],
 
+    "beautiful-mermaid": ["beautiful-mermaid@1.1.3", "", { "dependencies": { "elkjs": "^0.11.0", "entities": "^7.0.1" } }, "sha512-TItrtrAyHp1vwFfFVYauWGrquouk/6SS21Aq3RsxindSYZODcN4xYrPZD6BiZRU+o5mKJzDPz9MUSMvELdylyg=="],
+
     "bluebird": ["bluebird@3.7.2", "", {}, "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="],
 
     "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
@@ -789,6 +792,8 @@
     "dset": ["dset@3.1.4", "", {}, "sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA=="],
 
     "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
+
+    "elkjs": ["elkjs@0.11.1", "", {}, "sha512-zxxR9k+rx5ktMwT/FwyLdPCrq7xN6e4VGGHH8hA01vVYKjTFik7nHOxBnAYtrgYUB1RpAiLvA1/U2YraWxyKKg=="],
 
     "emmet": ["emmet@2.4.11", "", { "dependencies": { "@emmetio/abbreviation": "^2.3.3", "@emmetio/css-abbreviation": "^2.1.8" } }, "sha512-23QPJB3moh/U9sT4rQzGgeyyGIrcM+GH5uVYg2C6wZIxAIJq7Ng3QLT79tl8FUwDXhyq9SusfknOrofAKqvgyQ=="],
 
@@ -1789,6 +1794,8 @@
     "@wxt-dev/storage/@wxt-dev/browser": ["@wxt-dev/browser@0.1.43", "", { "dependencies": { "@types/filesystem": "*", "@types/har-format": "*" } }, "sha512-RMB0zgfe7uuiTp18s9taLeKXoOCLBV418797dnEggiMWmM1JDJekiLtlvrNc6QeZg+amDBy2/KKYuQB2kh/K9A=="],
 
     "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
+
+    "beautiful-mermaid/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
     "boxen/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 

--- a/packages/diagram/package.json
+++ b/packages/diagram/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@atlcli/diagram",
+  "version": "0.6.0",
+  "license": "Apache-2.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "dependencies": {
+    "beautiful-mermaid": "1.1.3"
+  }
+}

--- a/packages/diagram/src/index.test.ts
+++ b/packages/diagram/src/index.test.ts
@@ -6,7 +6,7 @@
  * mocks (repo directive: real test infra).
  */
 import { describe, expect, it } from "bun:test";
-import { DEFAULT_DIAGRAM_THEME, renderDiagram, type DiagramRenderResult } from "./diagram.js";
+import { DEFAULT_DIAGRAM_THEME, renderDiagram, type DiagramRenderResult } from "./index.js";
 
 function expectSvg(result: DiagramRenderResult): Extract<DiagramRenderResult, { kind: "svg" }> {
   expect(result.kind).toBe("svg");

--- a/packages/diagram/src/index.ts
+++ b/packages/diagram/src/index.ts
@@ -135,6 +135,12 @@ function headerToken(body: string): string | null {
   return null;
 }
 
+import { flattenSvgStyles } from "./svg-flatten.js";
+
+// Exported for consumers that bring their own SVG (the PDF path can flatten
+// any diagram SVG to the portable subset) and for direct unit testing.
+export { flattenSvgStyles } from "./svg-flatten.js";
+
 type BeautifulMermaid = typeof import("beautiful-mermaid");
 
 let rendererPromise: Promise<BeautifulMermaid> | null = null;
@@ -143,16 +149,6 @@ let rendererPromise: Promise<BeautifulMermaid> | null = null;
 function loadRenderer(): Promise<BeautifulMermaid> {
   if (!rendererPromise) rendererPromise = import("beautiful-mermaid");
   return rendererPromise;
-}
-
-/**
- * beautiful-mermaid embeds a Google-Fonts `@import` in the SVG `<style>`.
- * Neither Word nor an `<img>`-context rasterizer loads external resources, so
- * the import is dead weight at best and an external call at worst — strip it;
- * the `font-family` stack's system fallbacks take over deterministically.
- */
-function stripExternalFontImport(svg: string): string {
-  return svg.replace(/@import url\([^)]*\);?/g, "");
 }
 
 /** Intrinsic pixel size from the SVG root's width/height attributes. */
@@ -195,7 +191,11 @@ export async function renderDiagram(
 
   try {
     const { renderMermaidSVG } = await loadRenderer();
-    const svg = stripExternalFontImport(renderMermaidSVG(input, { ...theme }));
+    // Flattening resolves the CSS custom properties / color-mix() /
+    // class rules into literal attributes — Word's svgBlip renderer (and
+    // the PDF path's SVG consumers) don't support them, and dropping the
+    // <style> blocks also removes the external Google-Fonts @import.
+    const svg = flattenSvgStyles(renderMermaidSVG(input, { ...theme }));
     const size = intrinsicSize(svg);
     if (!size) return { kind: "failed", reason: "the rendered SVG has no usable intrinsic size" };
     return { kind: "svg", svg, ...size };

--- a/packages/diagram/src/index.ts
+++ b/packages/diagram/src/index.ts
@@ -1,20 +1,28 @@
 /**
- * Mermaid diagram rendering (spec 005a Task 2).
+ * `@atlcli/diagram` — mermaid → SVG rendering (spec 005a Task 2).
  *
- * `renderDiagram` turns mermaid source into an SVG string via
+ * A deliberately **format-agnostic adapter**: this package knows nothing
+ * about DOCX, PDF or any export container. It turns mermaid source into a
+ * themed SVG string; each export path then embeds that SVG its own way —
+ * DOCX as svgBlip + rasterized PNG fallback (`@atlcli/docx`, spec 005a),
+ * PDF natively as vector (spec 007). Keep it that way: no OOXML, no zip,
+ * no rasterization in here.
+ *
+ * `renderDiagram` renders via
  * [`beautiful-mermaid`](https://github.com/lukilabs/beautiful-mermaid) — a
  * self-contained renderer (own parser/layout/text metrics, **not** mermaid.js)
  * that is synchronous, DOM-free and MV3-CSP-clean (no `eval`/`new Function`;
  * its elkjs layout runs the in-process FakeWorker, never a real `Worker`).
  *
- * The module is isomorphic and follows the `highlight.ts` lazy pattern:
+ * The module is isomorphic and follows the docx `highlight.ts` lazy pattern:
  * beautiful-mermaid (+ its ~1.5 MB elkjs dependency) is only reached through a
  * dynamic `import()`, so hosts that never see a mermaid block never load the
  * chunk. Diagram-type detection runs BEFORE that import — a page with only
  * unsupported diagram types (Gantt, Pie, …) also skips the chunk entirely.
  *
  * Nothing here throws: every outcome is a {@link DiagramRenderResult}, and the
- * caller routes non-`svg` results to the spec-004 pinned code-block fallback.
+ * caller routes non-`svg` results to its own fallback (the DOCX path uses the
+ * spec-004 pinned code block).
  */
 
 /**

--- a/packages/diagram/src/svg-flatten.test.ts
+++ b/packages/diagram/src/svg-flatten.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Regression tests for the Word E2E finding (spec 005a): beautiful-mermaid
+ * SVGs style everything through CSS custom properties + color-mix() + class
+ * rules, which Word's svgBlip renderer cannot resolve — diagrams rendered
+ * all-black with missing arrowheads. Flattening must leave ONLY the portable
+ * SVG subset: literal presentation attributes, no <style>, no var(), no
+ * color-mix(). Runs against the REAL renderer output (no fixtures-only).
+ */
+import { describe, expect, it } from "bun:test";
+import { flattenSvgStyles } from "./svg-flatten.js";
+import { renderDiagram, type DiagramRenderResult } from "./index.js";
+
+function svgOf(result: DiagramRenderResult): string {
+  expect(result.kind).toBe("svg");
+  return (result as Extract<DiagramRenderResult, { kind: "svg" }>).svg;
+}
+
+/** Every construct Word cannot resolve must be gone. */
+function expectPortable(svg: string): void {
+  expect(svg).not.toContain("var(");
+  expect(svg).not.toContain("color-mix(");
+  expect(svg).not.toContain("<style>");
+  expect(svg).not.toContain("@import");
+  expect(svg).not.toContain("--bg:");
+}
+
+describe("flattenSvgStyles — unit", () => {
+  it("resolves var() chains, fallbacks and color-mix() into literal attributes", () => {
+    const input =
+      `<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" style="--bg:#ffffff;--fg:#000000;background:var(--bg)">` +
+      `<style>svg { --_line: var(--line, color-mix(in srgb, var(--fg) 50%, var(--bg))); }</style>` +
+      `<line x1="0" y1="0" x2="9" y2="9" stroke="var(--_line)"/>` +
+      `<rect fill="var(--fg)" width="4" height="4"/>` +
+      `</svg>`;
+    const out = flattenSvgStyles(input);
+    expectPortable(out);
+    expect(out).toContain('stroke="#808080"'); // 50% mix of black on white
+    expect(out).toContain('fill="#000000"');
+    // Background painted as a real rect (Word ignores CSS background).
+    expect(out).toContain('<rect x="0" y="0" width="100%" height="100%" fill="#ffffff"/>');
+  });
+
+  it("inlines class rules with CSS-over-attribute precedence and multi-class selectors", () => {
+    const input =
+      `<svg xmlns="http://www.w3.org/2000/svg" style="--bg:#ffffff;--fg:#000000">` +
+      `<style>.bar { stroke-width: 1.5; } .bar.c0 { fill: var(--fg); } rect.c0 { opacity: 0.5; }</style>` +
+      `<rect class="bar c0" fill="#123456" width="4" height="4"/>` +
+      `<rect class="bar" fill="#123456" width="4" height="4"/>` +
+      `</svg>`;
+    const out = flattenSvgStyles(input);
+    // The .bar.c0 rule REPLACES the fill attribute (CSS beats presentation attrs)…
+    expect(out).toContain('fill="#000000"');
+    expect(out).toContain('stroke-width="1.5"');
+    expect(out).toContain('opacity="0.5"');
+    // …but the rule-less second rect keeps its own fill.
+    expect(out).toContain('fill="#123456"');
+  });
+
+  it("leaves non-CSS style attributes (style=\"solid\") untouched", () => {
+    const input =
+      `<svg xmlns="http://www.w3.org/2000/svg"><polyline style="solid" points="0,0 1,1"/></svg>`;
+    expect(flattenSvgStyles(input)).toContain('style="solid"');
+  });
+});
+
+describe("flattenSvgStyles — real renderer output (Word regression)", () => {
+  it("flowchart: literal node fill / arrowhead colors, background rect, no <style>", async () => {
+    const svg = svgOf(await renderDiagram("graph TD\n  A[Start] --> B[Done]"));
+    expectPortable(svg);
+    // Default theme (bg #FFFFFF, fg #27272A): node fill = 3% mix, arrow = 85% mix.
+    expect(svg).toContain('fill="#f9f9f9"');
+    expect(svg).toContain('fill="#47474a"'); // arrowhead marker — "keine Pfeile" fix
+    expect(svg).toContain('fill="#FFFFFF"'); // background rect
+    // Text carries the font stack as a literal attribute now.
+    expect(svg).toMatch(/<text[^>]*font-family="/);
+  });
+
+  it("xychart: class-based series colors become literal stroke/fill", async () => {
+    const svg = svgOf(
+      await renderDiagram('xychart-beta\n  title "S"\n  x-axis [a, b]\n  bar [1, 2]')
+    );
+    expectPortable(svg);
+    expect(svg).toContain('stroke="#3b82f6"'); // series 0 (accent fallback)
+    expect(svg).toContain('fill="#cee0fd"'); // bar fill: 25% series color on white
+  });
+
+  it("every supported type flattens portable", async () => {
+    const sources = [
+      "stateDiagram-v2\n  [*] --> A\n  A --> [*]",
+      "sequenceDiagram\n  A->>B: hi",
+      "classDiagram\n  X <|-- Y",
+      "erDiagram\n  A ||--o{ B : has",
+    ];
+    for (const source of sources) {
+      expectPortable(svgOf(await renderDiagram(source)));
+    }
+  });
+
+  it("theme overrides survive flattening as literals", async () => {
+    const svg = svgOf(
+      await renderDiagram("graph TD\n  A --> B", { bg: "#101820", fg: "#FEE715", accent: "#FF0000" })
+    );
+    expectPortable(svg);
+    expect(svg).toContain('fill="#101820"'); // background rect
+    expect(svg).toContain("#FEE715"); // text fill
+    expect(svg).toContain('fill="#FF0000"'); // accent drives the arrowheads
+  });
+});

--- a/packages/diagram/src/svg-flatten.ts
+++ b/packages/diagram/src/svg-flatten.ts
@@ -1,0 +1,226 @@
+/**
+ * SVG portability flattening (spec 005a, Word E2E finding).
+ *
+ * beautiful-mermaid styles its SVG through CSS custom properties,
+ * `color-mix()` derivations and class rules inside `<style>` elements. That
+ * is fine in a browser, but the consumers this adapter exists for have a
+ * much smaller SVG subset: **Word's svgBlip renderer** supports neither CSS
+ * variables nor `color-mix()` (observed: every var()-styled shape renders
+ * black, arrowhead markers vanish), and the PDF path's SVG consumers
+ * (resvg/Typst) share those limits.
+ *
+ * `flattenSvgStyles` therefore rewrites the SVG to the portable subset:
+ *
+ *  1. resolve every custom property (root `style` attribute + `svg { … }`
+ *     rules), evaluating `var(--x, fallback)` and `color-mix(in srgb, …)`
+ *     numerically;
+ *  2. inline every class/tag rule from the `<style>` blocks into literal
+ *     presentation attributes on the matching elements (CSS rules override
+ *     presentation attributes, so inlined declarations replace existing
+ *     attributes of the same name);
+ *  3. drop the `<style>` blocks entirely (this also removes the external
+ *     Google-Fonts `@import`) and paint the background as a real `<rect>`.
+ *
+ * The rewrite is conservative: values that cannot be resolved are left
+ * untouched, and non-CSS `style` attributes beautiful-mermaid emits (e.g.
+ * `style="solid"` on edges) are ignored rather than mangled.
+ */
+
+interface Rule {
+  selectors: SimpleSelector[];
+  decls: Map<string, string>;
+}
+
+interface SimpleSelector {
+  tag?: string;
+  classes: string[];
+}
+
+/** Parse `#rgb` / `#rrggbb` into channels; null for anything else. */
+function parseHexColor(value: string): [number, number, number] | null {
+  const v = value.trim();
+  const short = v.match(/^#([0-9a-f])([0-9a-f])([0-9a-f])$/i);
+  if (short) return [short[1], short[2], short[3]].map((c) => parseInt(c + c, 16)) as [number, number, number];
+  const long = v.match(/^#([0-9a-f]{2})([0-9a-f]{2})([0-9a-f]{2})$/i);
+  if (long) return [long[1], long[2], long[3]].map((c) => parseInt(c, 16)) as [number, number, number];
+  return null;
+}
+
+function toHex(rgb: [number, number, number]): string {
+  return `#${rgb.map((c) => Math.max(0, Math.min(255, Math.round(c))).toString(16).padStart(2, "0")).join("")}`;
+}
+
+/**
+ * Evaluate every `color-mix(in srgb, A p%, B [q%])` in `value` (innermost
+ * first) over hex colors — the sRGB channel interpolation Word can't do.
+ * Unresolvable mixes are left as-is.
+ */
+function evaluateColorMix(value: string): string {
+  const MIX_RE = /color-mix\(in srgb,\s*([^,()]+?)\s+([\d.]+)%\s*,\s*([^,()]+?)(?:\s+([\d.]+)%)?\s*\)/;
+  let out = value;
+  for (let guard = 0; guard < 10; guard++) {
+    const m = out.match(MIX_RE);
+    if (!m) break;
+    const c1 = parseHexColor(m[1]);
+    const c2 = parseHexColor(m[3]);
+    if (!c1 || !c2) break;
+    const p1 = Number(m[2]);
+    const p2 = m[4] !== undefined ? Number(m[4]) : 100 - p1;
+    const total = p1 + p2 || 100;
+    const mixed = toHex([
+      (c1[0] * p1 + c2[0] * p2) / total,
+      (c1[1] * p1 + c2[1] * p2) / total,
+      (c1[2] * p1 + c2[2] * p2) / total,
+    ]);
+    out = out.slice(0, m.index!) + mixed + out.slice(m.index! + m[0].length);
+  }
+  return out;
+}
+
+/** Substitute `var(--name[, fallback])` from `props`, innermost first. */
+function substituteVars(value: string, props: Map<string, string>, depth = 0): string {
+  if (depth > 10) return value;
+  // Innermost var(): its argument list contains no further `var(`.
+  const VAR_RE = /var\(\s*(--[\w-]+)\s*(?:,\s*((?:[^()]|\([^()]*\))*?))?\s*\)/;
+  let out = value;
+  for (let guard = 0; guard < 20; guard++) {
+    const m = out.match(VAR_RE);
+    if (!m) break;
+    const replacement = props.get(m[1]) ?? m[2];
+    if (replacement === undefined) break; // unknown var, no fallback — leave it
+    out = out.slice(0, m.index!) + replacement + out.slice(m.index! + m[0].length);
+  }
+  return out;
+}
+
+/** Fully resolve a CSS value: vars substituted, color-mix evaluated. */
+function resolveValue(value: string, props: Map<string, string>): string {
+  return evaluateColorMix(substituteVars(value, props)).trim();
+}
+
+/** Parse `prop: value; …` declarations (CSS comments already stripped). */
+function parseDecls(block: string): Map<string, string> {
+  const decls = new Map<string, string>();
+  for (const part of block.split(";")) {
+    const idx = part.indexOf(":");
+    if (idx === -1) continue;
+    const prop = part.slice(0, idx).trim();
+    const value = part.slice(idx + 1).trim();
+    if (prop && value) decls.set(prop, value);
+  }
+  return decls;
+}
+
+function parseSelector(selector: string): SimpleSelector | null {
+  // Supported grammar (all beautiful-mermaid emits): `tag`, `.class`,
+  // `tag.class`, `.class.class`. Anything else (descendants, pseudo, @media)
+  // fails the whole rule — safer to leave that rule un-inlined.
+  const m = selector.trim().match(/^([a-zA-Z][\w-]*)?((?:\.[\w-]+)*)$/);
+  if (!m || (!m[1] && !m[2])) return null;
+  return { tag: m[1] || undefined, classes: m[2] ? m[2].split(".").filter(Boolean) : [] };
+}
+
+function selectorMatches(sel: SimpleSelector, tag: string, classes: Set<string>): boolean {
+  if (sel.tag && sel.tag !== tag) return false;
+  return sel.classes.every((c) => classes.has(c));
+}
+
+/**
+ * Flatten CSS custom properties, `color-mix()` and `<style>` class rules
+ * into literal presentation attributes — the SVG subset Word's svgBlip
+ * renderer (and resvg/Typst on the PDF path) actually supports.
+ */
+export function flattenSvgStyles(svg: string): string {
+  // ---- 1. Collect stylesheet text and custom properties -------------------
+  // NB: the Google-Fonts @import URL contains semicolons (`wght@400;500;…`),
+  // so the strip must consume the full url(…) rather than stop at the first `;`.
+  const styleBlocks = [...svg.matchAll(/<style>([\s\S]*?)<\/style>/g)].map((m) =>
+    m[1].replace(/\/\*[\s\S]*?\*\//g, "").replace(/@import\s+url\([^)]*\)\s*;?/g, "")
+  );
+
+  const props = new Map<string, string>();
+  // Root <svg style="--bg:…;--fg:…;…"> — the theme's base values.
+  const rootTag = svg.match(/<svg[^>]*>/)?.[0] ?? "";
+  const rootStyle = rootTag.match(/style="([^"]*)"/)?.[1] ?? "";
+  for (const [prop, value] of parseDecls(rootStyle)) {
+    if (prop.startsWith("--")) props.set(prop, value);
+  }
+
+  const rules: Rule[] = [];
+  for (const block of styleBlocks) {
+    for (const m of block.matchAll(/([^{}]+)\{([^{}]*)\}/g)) {
+      const selectorList = m[1].trim();
+      const decls = parseDecls(m[2]);
+      // `svg { --_x: … }` rules define the derived palette.
+      const selectors: SimpleSelector[] = [];
+      let allParsed = true;
+      for (const sel of selectorList.split(",")) {
+        const parsed = parseSelector(sel);
+        if (!parsed) {
+          allParsed = false;
+          break;
+        }
+        selectors.push(parsed);
+      }
+      if (!allParsed) continue;
+      if (selectors.some((s) => s.tag === "svg" && s.classes.length === 0)) {
+        for (const [prop, value] of decls) {
+          if (prop.startsWith("--")) props.set(prop, value);
+        }
+      }
+      const attrDecls = new Map([...decls].filter(([p]) => !p.startsWith("--")));
+      if (attrDecls.size > 0) rules.push({ selectors, decls: attrDecls });
+    }
+  }
+
+  // Resolve prop definitions against each other (e.g. --xychart-bar-fill-0
+  // mixes --xychart-color-0, which itself falls back through --accent).
+  for (const [name, value] of props) props.set(name, resolveValue(value, props));
+
+  // ---- 2. Rewrite every element open tag ----------------------------------
+  let out = svg.replace(/<([a-zA-Z][\w:-]*)((?:\s+[\w:-]+="[^"]*")*)\s*(\/?)>/g, (whole, tag: string, attrText: string, selfClose: string) => {
+    if (tag === "style") return whole;
+
+    const attrs = new Map<string, string>();
+    for (const a of attrText.matchAll(/([\w:-]+)="([^"]*)"/g)) attrs.set(a[1], a[2]);
+
+    // Matching class/tag rules, in stylesheet order (later rules win); their
+    // declarations REPLACE same-name attributes (CSS beats presentation attrs).
+    const classes = new Set((attrs.get("class") ?? "").split(/\s+/).filter(Boolean));
+    for (const rule of rules) {
+      if (!rule.selectors.some((s) => selectorMatches(s, tag, classes))) continue;
+      for (const [prop, value] of rule.decls) attrs.set(prop, resolveValue(value, props));
+    }
+
+    // Resolve var()/color-mix() left in literal attributes (fill="var(--_text)").
+    for (const [name, value] of attrs) {
+      if (value.includes("var(") || value.includes("color-mix(")) {
+        attrs.set(name, resolveValue(value, props));
+      }
+    }
+
+    // The style attribute: drop custom-prop declarations, resolve the rest in
+    // place. Non-CSS values (`style="solid"`) pass through untouched.
+    const styleAttr = attrs.get("style");
+    if (styleAttr && styleAttr.includes(":")) {
+      const kept: string[] = [];
+      for (const [prop, value] of parseDecls(styleAttr)) {
+        if (prop.startsWith("--")) continue;
+        kept.push(`${prop}:${resolveValue(value, props)}`);
+      }
+      if (kept.length > 0) attrs.set("style", kept.join(";"));
+      else attrs.delete("style");
+    }
+
+    const rebuilt = [...attrs].map(([k, v]) => `${k}="${v}"`).join(" ");
+    return `<${tag}${rebuilt ? " " + rebuilt : ""}${selfClose ? "/" : ""}>`;
+  });
+
+  // ---- 3. Drop <style> blocks, paint the background as a real rect --------
+  out = out.replace(/<style>[\s\S]*?<\/style>/g, "");
+  const bg = props.get("--bg") ? resolveValue(props.get("--bg")!, props) : undefined;
+  if (bg && parseHexColor(bg)) {
+    out = out.replace(/(<svg[^>]*>)/, `$1<rect x="0" y="0" width="100%" height="100%" fill="${bg}"/>`);
+  }
+  return out;
+}

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@atlcli/confluence": "workspace:*",
     "@atlcli/core": "workspace:*",
-    "beautiful-mermaid": "1.1.3",
+    "@atlcli/diagram": "workspace:*",
     "docxtemplater": "^3.69.0",
     "pizzip": "^3.2.0",
     "shiki": "^4.3.1"

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@atlcli/confluence": "workspace:*",
     "@atlcli/core": "workspace:*",
+    "beautiful-mermaid": "1.1.3",
     "docxtemplater": "^3.69.0",
     "pizzip": "^3.2.0",
     "shiki": "^4.3.1"

--- a/packages/docx/src/diagram.test.ts
+++ b/packages/docx/src/diagram.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Renderer tests (spec 005a Task 2 + Task 4): the six supported types produce
+ * real SVG with content landmarks, known-unsupported types are reported by
+ * name, malformed source becomes `failed` (never an escaping throw), and the
+ * theme flows into the SVG. Runs the REAL beautiful-mermaid renderer — no
+ * mocks (repo directive: real test infra).
+ */
+import { describe, expect, it } from "bun:test";
+import { DEFAULT_DIAGRAM_THEME, renderDiagram, type DiagramRenderResult } from "./diagram.js";
+
+function expectSvg(result: DiagramRenderResult): Extract<DiagramRenderResult, { kind: "svg" }> {
+  expect(result.kind).toBe("svg");
+  return result as Extract<DiagramRenderResult, { kind: "svg" }>;
+}
+
+describe("renderDiagram — supported types", () => {
+  it("renders a flowchart", async () => {
+    const r = expectSvg(await renderDiagram("graph TD\n  A[Start] --> B{OK?}\n  B -->|yes| C[Done]"));
+    expect(r.svg).toStartWith("<svg");
+    expect(r.svg).toContain("Start");
+    expect(r.svg).toContain("Done");
+    expect(r.widthPx).toBeGreaterThan(0);
+    expect(r.heightPx).toBeGreaterThan(0);
+  });
+
+  it("renders a state diagram", async () => {
+    const r = expectSvg(await renderDiagram("stateDiagram-v2\n  [*] --> Idle\n  Idle --> Busy: work\n  Busy --> [*]"));
+    expect(r.svg).toContain("Idle");
+    expect(r.svg).toContain("Busy");
+  });
+
+  it("renders a sequence diagram", async () => {
+    const r = expectSvg(await renderDiagram("sequenceDiagram\n  Alice->>Bob: Hello\n  Bob-->>Alice: Hi"));
+    expect(r.svg).toContain("Alice");
+    expect(r.svg).toContain("Bob");
+  });
+
+  it("renders a class diagram", async () => {
+    const r = expectSvg(
+      await renderDiagram("classDiagram\n  class Animal {\n    +name: string\n  }\n  Animal <|-- Dog")
+    );
+    expect(r.svg).toContain("Animal");
+    expect(r.svg).toContain("Dog");
+  });
+
+  it("renders the classDiagram-v2 alias through the normalized header", async () => {
+    const r = expectSvg(await renderDiagram("classDiagram-v2\n  Animal <|-- Dog"));
+    expect(r.svg).toContain("Dog");
+  });
+
+  it("renders an ER diagram", async () => {
+    const r = expectSvg(
+      await renderDiagram("erDiagram\n  CUSTOMER ||--o{ ORDER : places\n  ORDER ||--|{ LINE-ITEM : contains")
+    );
+    expect(r.svg).toContain("CUSTOMER");
+    expect(r.svg).toContain("ORDER");
+  });
+
+  it("renders an XY chart", async () => {
+    const r = expectSvg(
+      await renderDiagram('xychart-beta\n  title "Sales"\n  x-axis [jan, feb, mar]\n  y-axis "Rev" 0 --> 100\n  bar [20, 50, 80]')
+    );
+    expect(r.svg).toContain("Sales");
+  });
+
+  it("skips YAML frontmatter and %% comments before the header", async () => {
+    const r = expectSvg(
+      await renderDiagram("---\ntitle: Fancy\n---\n%% a comment\ngraph LR\n  A --> B")
+    );
+    expect(r.svg).toStartWith("<svg");
+  });
+
+  it("strips the external Google-Fonts @import from the SVG", async () => {
+    const r = expectSvg(await renderDiagram("graph TD\n  A --> B"));
+    expect(r.svg).not.toContain("fonts.googleapis.com");
+    expect(r.svg).not.toContain("@import");
+  });
+});
+
+describe("renderDiagram — theme (Task 4)", () => {
+  it("applies the default theme when none is given", async () => {
+    const r = expectSvg(await renderDiagram("graph TD\n  A --> B"));
+    expect(r.svg).toContain(DEFAULT_DIAGRAM_THEME.bg);
+    expect(r.svg).toContain(DEFAULT_DIAGRAM_THEME.fg);
+  });
+
+  it("applies configured brand colors", async () => {
+    const r = expectSvg(
+      await renderDiagram("graph TD\n  A --> B", { bg: "#112233", fg: "#EEDDCC", accent: "#FF0000" })
+    );
+    expect(r.svg).toContain("#112233");
+    expect(r.svg).toContain("#EEDDCC");
+    expect(r.svg).not.toContain(DEFAULT_DIAGRAM_THEME.fg);
+  });
+});
+
+describe("renderDiagram — unsupported types are named", () => {
+  const cases: Array<[string, string]> = [
+    ["gantt\n  title A\n  section S\n  T :a1, 2026-01-01, 30d", "Gantt"],
+    ['pie title Pets\n  "Dogs" : 50', "Pie"],
+    ["mindmap\n  root((m))\n    A", "Mindmap"],
+    ["timeline\n  title H\n  2020 : E", "Timeline"],
+    ["gitGraph\n  commit", "Git graph"],
+    ["journey\n  title J", "User journey"],
+    ["quadrantChart\n  title Q", "Quadrant chart"],
+    ["C4Context\n  title C", "C4"],
+    ["sankey-beta\nA,B,10", "Sankey"],
+  ];
+
+  for (const [source, name] of cases) {
+    it(`reports ${name} by name`, async () => {
+      expect(await renderDiagram(source)).toEqual({ kind: "unsupported", diagramType: name });
+    });
+  }
+});
+
+describe("renderDiagram — failure routes (never throws)", () => {
+  it("fails on empty source", async () => {
+    const r = await renderDiagram("");
+    expect(r.kind).toBe("failed");
+  });
+
+  it("fails on comment-only source", async () => {
+    const r = await renderDiagram("%% nothing here\n%% still nothing");
+    expect(r.kind).toBe("failed");
+  });
+
+  it("fails on an unrecognized header with the token in the reason", async () => {
+    const r = await renderDiagram("bogusDiagram\n  A --> B");
+    expect(r.kind).toBe("failed");
+    expect((r as { reason: string }).reason).toContain("bogusDiagram");
+  });
+
+  it("fails on prose that is not mermaid at all", async () => {
+    const r = await renderDiagram("this is not mermaid at all");
+    expect(r.kind).toBe("failed");
+  });
+});

--- a/packages/docx/src/diagram.ts
+++ b/packages/docx/src/diagram.ts
@@ -1,0 +1,197 @@
+/**
+ * Mermaid diagram rendering (spec 005a Task 2).
+ *
+ * `renderDiagram` turns mermaid source into an SVG string via
+ * [`beautiful-mermaid`](https://github.com/lukilabs/beautiful-mermaid) — a
+ * self-contained renderer (own parser/layout/text metrics, **not** mermaid.js)
+ * that is synchronous, DOM-free and MV3-CSP-clean (no `eval`/`new Function`;
+ * its elkjs layout runs the in-process FakeWorker, never a real `Worker`).
+ *
+ * The module is isomorphic and follows the `highlight.ts` lazy pattern:
+ * beautiful-mermaid (+ its ~1.5 MB elkjs dependency) is only reached through a
+ * dynamic `import()`, so hosts that never see a mermaid block never load the
+ * chunk. Diagram-type detection runs BEFORE that import — a page with only
+ * unsupported diagram types (Gantt, Pie, …) also skips the chunk entirely.
+ *
+ * Nothing here throws: every outcome is a {@link DiagramRenderResult}, and the
+ * caller routes non-`svg` results to the spec-004 pinned code-block fallback.
+ */
+
+/**
+ * Diagram color theme (spec 005a Task 4). `bg` + `fg` are the two base
+ * values; beautiful-mermaid derives the full scheme from them via
+ * `color-mix()`. The optional roles override single derivations so the
+ * diagram can match the export's brand colors exactly.
+ */
+export interface DiagramTheme {
+  /** Background color (CSS color, e.g. `#FFFFFF`). */
+  bg: string;
+  /** Foreground / primary text color. */
+  fg: string;
+  /** Edge/connector color. */
+  line?: string;
+  /** Arrow heads, highlights. */
+  accent?: string;
+  /** Secondary text, edge labels. */
+  muted?: string;
+  /** Node/box fill tint. */
+  surface?: string;
+  /** Node/group stroke color. */
+  border?: string;
+  /** Font family for all diagram text. */
+  font?: string;
+}
+
+/**
+ * The default theme when no brand colors are configured: beautiful-mermaid's
+ * zinc-light palette (white background, near-black text), which matches the
+ * export's github-light code blocks and neutral body text.
+ */
+export const DEFAULT_DIAGRAM_THEME: DiagramTheme = { bg: "#FFFFFF", fg: "#27272A" };
+
+export type DiagramRenderResult =
+  | {
+      kind: "svg";
+      svg: string;
+      /** Intrinsic pixel size from the SVG root (layout-computed, rounded up). */
+      widthPx: number;
+      heightPx: number;
+    }
+  | { kind: "unsupported"; diagramType: string }
+  | { kind: "failed"; reason: string };
+
+/**
+ * Diagram types beautiful-mermaid renders, keyed by the first token of the
+ * mermaid header line. Values are normalized headers: `classDiagram-v2` is
+ * mermaid's alias for the same class-diagram grammar, but beautiful-mermaid
+ * only accepts the unsuffixed header, so the token is rewritten.
+ */
+const SUPPORTED_HEADERS: Record<string, string | null> = {
+  graph: null,
+  flowchart: null,
+  stateDiagram: null,
+  "stateDiagram-v2": null,
+  sequenceDiagram: null,
+  classDiagram: null,
+  "classDiagram-v2": "classDiagram",
+  erDiagram: null,
+  xychart: null,
+  "xychart-beta": null,
+};
+
+/** Human-readable names for known-but-unsupported mermaid diagram types. */
+const UNSUPPORTED_TYPES: Record<string, string> = {
+  gantt: "Gantt",
+  pie: "Pie",
+  mindmap: "Mindmap",
+  timeline: "Timeline",
+  gitGraph: "Git graph",
+  journey: "User journey",
+  quadrantChart: "Quadrant chart",
+  requirementDiagram: "Requirement",
+  C4Context: "C4",
+  C4Container: "C4",
+  C4Component: "C4",
+  C4Dynamic: "C4",
+  C4Deployment: "C4",
+  "sankey-beta": "Sankey",
+  "block-beta": "Block",
+  "packet-beta": "Packet",
+  kanban: "Kanban",
+  "architecture-beta": "Architecture",
+  zenuml: "ZenUML",
+  radar: "Radar",
+};
+
+/**
+ * Split mermaid source into (optional YAML frontmatter, body): mermaid allows
+ * a leading `---\ntitle: …\n---` block, which beautiful-mermaid's header check
+ * rejects — the body is what gets type-detected and rendered.
+ */
+function stripFrontmatter(source: string): string {
+  const m = source.match(/^\s*---\r?\n[\s\S]*?\r?\n\s*---\s*\r?\n/);
+  return m ? source.slice(m[0].length) : source;
+}
+
+/**
+ * The first meaningful line's leading token — skipping blank lines and `%%`
+ * comment/directive lines — or `null` for effectively-empty source.
+ */
+function headerToken(body: string): string | null {
+  for (const raw of body.split("\n")) {
+    const line = raw.trim();
+    if (!line || line.startsWith("%%")) continue;
+    const m = line.match(/^([A-Za-z][A-Za-z0-9-]*)/);
+    return m ? m[1] : line;
+  }
+  return null;
+}
+
+type BeautifulMermaid = typeof import("beautiful-mermaid");
+
+let rendererPromise: Promise<BeautifulMermaid> | null = null;
+
+/** Lazy-load beautiful-mermaid exactly once (the `highlight.ts` pattern). */
+function loadRenderer(): Promise<BeautifulMermaid> {
+  if (!rendererPromise) rendererPromise = import("beautiful-mermaid");
+  return rendererPromise;
+}
+
+/**
+ * beautiful-mermaid embeds a Google-Fonts `@import` in the SVG `<style>`.
+ * Neither Word nor an `<img>`-context rasterizer loads external resources, so
+ * the import is dead weight at best and an external call at worst — strip it;
+ * the `font-family` stack's system fallbacks take over deterministically.
+ */
+function stripExternalFontImport(svg: string): string {
+  return svg.replace(/@import url\([^)]*\);?/g, "");
+}
+
+/** Intrinsic pixel size from the SVG root's width/height attributes. */
+function intrinsicSize(svg: string): { widthPx: number; heightPx: number } | null {
+  const w = svg.match(/<svg[^>]*\bwidth="([\d.]+)"/)?.[1];
+  const h = svg.match(/<svg[^>]*\bheight="([\d.]+)"/)?.[1];
+  const widthPx = Math.ceil(Number(w));
+  const heightPx = Math.ceil(Number(h));
+  if (!w || !h || !widthPx || !heightPx || !Number.isFinite(widthPx) || !Number.isFinite(heightPx)) {
+    return null;
+  }
+  return { widthPx, heightPx };
+}
+
+/**
+ * Render mermaid `source` to a themed SVG string, or say why it can't be:
+ * a known-unsupported diagram type is reported **by name** (`unsupported`,
+ * without ever loading the renderer chunk); a parse/layout error is `failed`.
+ * Never throws.
+ */
+export async function renderDiagram(
+  source: string,
+  theme: DiagramTheme = DEFAULT_DIAGRAM_THEME
+): Promise<DiagramRenderResult> {
+  const body = stripFrontmatter(source);
+  const token = headerToken(body);
+  if (!token) return { kind: "failed", reason: "the diagram source is empty" };
+
+  const unsupported = UNSUPPORTED_TYPES[token];
+  if (unsupported) return { kind: "unsupported", diagramType: unsupported };
+
+  if (!(token in SUPPORTED_HEADERS)) {
+    return { kind: "failed", reason: `unrecognized diagram type "${token}"` };
+  }
+
+  const normalizedHeader = SUPPORTED_HEADERS[token];
+  const input = normalizedHeader
+    ? body.replace(new RegExp(`^(\\s*)${token}`, "m"), `$1${normalizedHeader}`)
+    : body;
+
+  try {
+    const { renderMermaidSVG } = await loadRenderer();
+    const svg = stripExternalFontImport(renderMermaidSVG(input, { ...theme }));
+    const size = intrinsicSize(svg);
+    if (!size) return { kind: "failed", reason: "the rendered SVG has no usable intrinsic size" };
+    return { kind: "svg", svg, ...size };
+  } catch (err) {
+    return { kind: "failed", reason: err instanceof Error ? err.message : String(err) };
+  }
+}

--- a/packages/docx/src/env.ts
+++ b/packages/docx/src/env.ts
@@ -42,6 +42,19 @@ export interface OutputSink {
   emit(name: string, bytes: Uint8Array): Promise<void>;
 }
 
+/**
+ * How an SVG becomes PNG bytes (spec 005a §2.4). Rasterization is inherently
+ * a host capability — the engine has no canvas — so it is injected like the
+ * other seams: the extension panel supplies a `<canvas>` implementation, a
+ * Node/server host can plug in resvg or similar later. Callers pass the
+ * TARGET pixel size (the engine asks for 2× the diagram's intrinsic size);
+ * the returned bytes MUST be a well-formed PNG. A host with no rasterizer
+ * omits it — mermaid diagrams then stay readable source code blocks.
+ */
+export interface SvgRasterizer {
+  rasterize(svg: string, target: { widthPx: number; heightPx: number }): Promise<Uint8Array>;
+}
+
 /** Everything a host must supply to run an export. */
 export interface ExportEnv {
   templates: TemplateSource;
@@ -50,6 +63,11 @@ export interface ExportEnv {
    * omits it — images then degrade to report notes instead of embedding.
    */
   assets?: AssetFetcher;
+  /**
+   * SVG → PNG rasterization (spec 005a). Omit it and mermaid diagrams
+   * degrade to source code blocks with a report note.
+   */
+  rasterizer?: SvgRasterizer;
   output: OutputSink;
 }
 
@@ -72,9 +90,15 @@ export interface RunExportInput extends Omit<ExportInput, "templateBytes"> {
 export async function runExport(input: RunExportInput, env: ExportEnv): Promise<ExportReport> {
   const { templateId, ...rest } = input;
   const templateBytes = await env.templates.getBytes(templateId ?? "current");
-  // The env's asset fetcher drives image embedding (spec 005) unless the
-  // input overrides it; `embedImages: false` disables embedding entirely.
-  const { bytes, report } = await exportDocx({ ...rest, templateBytes, assets: rest.assets ?? env.assets });
+  // The env's asset fetcher drives image embedding (spec 005) and its
+  // rasterizer drives diagram embedding (spec 005a) unless the input
+  // overrides them; `embedImages: false` disables image embedding entirely.
+  const { bytes, report } = await exportDocx({
+    ...rest,
+    templateBytes,
+    assets: rest.assets ?? env.assets,
+    rasterizer: rest.rasterizer ?? env.rasterizer,
+  });
   await env.output.emit(report.filename, bytes);
   return report;
 }

--- a/packages/docx/src/export.test.ts
+++ b/packages/docx/src/export.test.ts
@@ -877,3 +877,179 @@ describe("exportDocx — image embedding (spec 005)", () => {
     expect(doc).toContain(`<wp:extent cx="${250 * 9525}" cy="${125 * 9525}"/>`);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Mermaid diagram embedding through the full pipeline (spec 005a)
+// ---------------------------------------------------------------------------
+
+describe("exportDocx — mermaid diagrams (spec 005a)", () => {
+  const diagramTemplate = () =>
+    buildDocx({
+      body: para("$scroll.content"),
+      styles: stylesXml(headingStyle("Heading1", "Heading 1")),
+    });
+
+  const mermaidStorage = (source: string) =>
+    `<p>before</p><ac:structured-macro ac:name="code"><ac:parameter ac:name="language">mermaid</ac:parameter>` +
+    `<ac:plain-text-body><![CDATA[${source}]]></ac:plain-text-body></ac:structured-macro>`;
+
+  /** A rasterizer recording every call, serving real PNG fixture bytes. */
+  function recordingRasterizer() {
+    const calls: { svg: string; widthPx: number; heightPx: number }[] = [];
+    return {
+      calls,
+      rasterizer: {
+        async rasterize(svg: string, target: { widthPx: number; heightPx: number }) {
+          calls.push({ svg, ...target });
+          return pngFixtureBytes(target.widthPx, target.heightPx);
+        },
+      },
+    };
+  }
+
+  it("embeds a flowchart as svgBlip + PNG@2x with the source as alt text (no asset fetcher needed)", async () => {
+    const { calls, rasterizer } = recordingRasterizer();
+    const source = "graph TD\n  A[Start] --> B[Done]";
+    const { bytes, report } = await exportDocx({
+      templateBytes: diagramTemplate(),
+      details: { ...details, storage: mermaidStorage(source) },
+      template,
+      deps,
+      rasterizer,
+    });
+
+    // Rendered through the REAL renderer, rasterized at 2× the intrinsic size.
+    expect(calls).toHaveLength(1);
+    expect(calls[0].svg).toStartWith("<svg");
+    const intrinsicW = calls[0].widthPx / 2;
+    const intrinsicH = calls[0].heightPx / 2;
+
+    const doc = readPart(bytes, "word/document.xml");
+    expect(doc).toContain("<w:drawing>");
+    // svgBlip extension + raster blip, two distinct relationships.
+    const pngRel = doc.match(/<a:blip r:embed="(rId\d+)"/)?.[1];
+    const svgRel = doc.match(/<asvg:svgBlip[^>]*r:embed="(rId\d+)"/)?.[1];
+    expect(pngRel).toBeDefined();
+    expect(svgRel).toBeDefined();
+    expect(pngRel).not.toBe(svgRel);
+    // Display size = intrinsic px (small diagram, uncapped).
+    expect(doc).toContain(`<wp:extent cx="${intrinsicW * 9525}" cy="${intrinsicH * 9525}"/>`);
+    // Accessibility: the diagram SOURCE is the description (XML-escaped).
+    expect(doc).toContain('descr="graph TD\n  A[Start] --&gt; B[Done]"');
+
+    const rels = readPart(bytes, "word/_rels/document.xml.rels");
+    expect(rels).toContain('Target="media/atlcli-image1.svg"');
+    expect(rels).toContain('Target="media/atlcli-image2.png"');
+    const ct = readPart(bytes, "[Content_Types].xml");
+    expect(ct).toContain('Extension="svg" ContentType="image/svg+xml"');
+    expect(ct).toContain('Extension="png"');
+
+    // The SVG media part is the rendered diagram (theme default, font import stripped).
+    const zip = new PizZip(bytes);
+    const svgPart = zip.file("word/media/atlcli-image1.svg")!.asText();
+    expect(svgPart).toContain("Start");
+    expect(svgPart).not.toContain("fonts.googleapis.com");
+
+    expect(report.renderedDiagrams).toBe(1);
+    expect(report.embeddedImages).toBe(0);
+    expect(report.skippedImages).toBe(0);
+    expect(report.notes.some((n) => n.code.startsWith("diagram"))).toBe(false);
+  });
+
+  it("routes an unsupported type (Gantt) to the pinned code block — no drawing, note names the type, rasterizer untouched", async () => {
+    const { calls, rasterizer } = recordingRasterizer();
+    const { bytes, report } = await exportDocx({
+      templateBytes: diagramTemplate(),
+      details: { ...details, storage: mermaidStorage("gantt\n  title T\n  section S\n  A :a1, 2026-01-01, 3d") },
+      template,
+      deps,
+      rasterizer,
+    });
+    expect(calls).toHaveLength(0);
+    const doc = readPart(bytes, "word/document.xml");
+    expect(doc).not.toContain("<w:drawing");
+    expect(doc).toContain('<w:pStyle w:val="AtlcliCode"/>');
+    expect(doc).toContain("gantt");
+    const rels = readPart(bytes, "word/_rels/document.xml.rels");
+    expect(rels).not.toContain("relationships/image");
+    const note = report.notes.find((n) => n.code === "diagram-unsupported");
+    expect(note?.message).toContain("Gantt");
+    expect(report.renderedDiagrams).toBe(0);
+  });
+
+  it("degrades a rasterizer failure to a warning with NO dangling relationship (F3 invariant)", async () => {
+    const { bytes, report } = await exportDocx({
+      templateBytes: diagramTemplate(),
+      details: { ...details, storage: mermaidStorage("graph TD\n  A --> B") },
+      template,
+      deps,
+      rasterizer: {
+        async rasterize() {
+          throw new Error("canvas exploded");
+        },
+      },
+    });
+    const note = report.notes.find((n) => n.code === "diagram-render-failed");
+    expect(note?.level).toBe("warning");
+    expect(note?.message).toContain("canvas exploded");
+    const doc = readPart(bytes, "word/document.xml");
+    expect(doc).not.toContain("<w:drawing");
+    expect(doc).toContain("A --&gt; B");
+    expect(readPart(bytes, "word/_rels/document.xml.rels")).not.toContain("relationships/image");
+    const zip = new PizZip(bytes);
+    expect(Object.keys(zip.files).some((p) => p.startsWith("word/media/"))).toBe(false);
+    expect(report.renderedDiagrams).toBe(0);
+  });
+
+  it("keeps mermaid a code block when no rasterizer is supplied (pre-005a behavior + note)", async () => {
+    const { bytes, report } = await exportDocx({
+      templateBytes: diagramTemplate(),
+      details: { ...details, storage: mermaidStorage("graph TD\n  A --> B") },
+      template,
+      deps,
+    });
+    const doc = readPart(bytes, "word/document.xml");
+    expect(doc).not.toContain("<w:drawing");
+    expect(doc).toContain('<w:pStyle w:val="AtlcliCode"/>');
+    expect(report.notes.some((n) => n.code === "diagram-skipped")).toBe(true);
+    expect(report.renderedDiagrams).toBe(0);
+  });
+
+  it("applies the configured diagram theme to the embedded SVG (Task 4)", async () => {
+    const { rasterizer } = recordingRasterizer();
+    const { bytes } = await exportDocx({
+      templateBytes: diagramTemplate(),
+      details: { ...details, storage: mermaidStorage("graph TD\n  A --> B") },
+      template,
+      deps,
+      rasterizer,
+      diagramTheme: { bg: "#101820", fg: "#FEE715" },
+    });
+    const zip = new PizZip(bytes);
+    const svgPart = zip.file("word/media/atlcli-image1.svg")!.asText();
+    expect(svgPart).toContain("#101820");
+    expect(svgPart).toContain("#FEE715");
+  });
+
+  it("diagram embedding coexists with attachment images — shared id space, separate counts", async () => {
+    const { rasterizer } = recordingRasterizer();
+    const { bytes, report } = await exportDocx({
+      templateBytes: diagramTemplate(),
+      details: {
+        ...details,
+        storage:
+          '<ac:image><ri:attachment ri:filename="pic.png"/></ac:image>' +
+          mermaidStorage("graph TD\n  A --> B"),
+      },
+      template,
+      deps,
+      assets: { fetch: async () => pngFixtureBytes(100, 50) },
+      rasterizer,
+    });
+    expect(report.embeddedImages).toBe(1);
+    expect(report.renderedDiagrams).toBe(1);
+    const doc = readPart(bytes, "word/document.xml");
+    const ids = [...doc.matchAll(/wp:docPr id="(\d+)"/g)].map((m) => m[1]);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});

--- a/packages/docx/src/export.ts
+++ b/packages/docx/src/export.ts
@@ -44,10 +44,17 @@ import {
   type ResolveDeps,
   type TemplateMeta,
 } from "./resolver.js";
-import { serializeBlocks, type ImageBlock, type ImageEmbedSeam } from "./serialize.js";
+import {
+  serializeBlocks,
+  type CodeBlock,
+  type DiagramEmbedSeam,
+  type ImageBlock,
+  type ImageEmbedSeam,
+} from "./serialize.js";
 import { ImageEmbedder, ImageEmbedError } from "./image.js";
+import { renderDiagram, type DiagramTheme } from "./diagram.js";
 import { parseLogoArgs } from "./placeholder-map.js";
-import type { AssetFetcher, AssetRef } from "./env.js";
+import type { AssetFetcher, AssetRef, SvgRasterizer } from "./env.js";
 import { CODE_STYLE_ID, codeStyleXml, parseStyleNames } from "./ooxml.js";
 import {
   encodeXmlText,
@@ -65,6 +72,8 @@ export interface ExportReport {
   skippedImages: number;
   /** Number of images embedded into the document (spec 005). */
   embeddedImages: number;
+  /** Number of mermaid diagrams rendered + embedded as svgBlip/PNG (spec 005a). */
+  renderedDiagrams: number;
   /** Wall-clock export duration in milliseconds. */
   durationMs: number;
   /** Suggested download filename (`<page-title>.docx`). */
@@ -96,6 +105,18 @@ export interface ExportInput {
    * (the CLI's `--no-images`). Defaults to `true`.
    */
   embedImages?: boolean;
+  /**
+   * SVG → PNG rasterization (spec 005a). When present, mermaid code blocks
+   * render to svgBlip + PNG@2x drawings; absent → they stay source code
+   * blocks with a report note. Independent of `embedImages`, which governs
+   * page ATTACHMENT images.
+   */
+  rasterizer?: SvgRasterizer;
+  /**
+   * Diagram brand colors (spec 005a Task 4). Defaults to the neutral
+   * zinc-light theme matching the export's code blocks and body text.
+   */
+  diagramTheme?: DiagramTheme;
 }
 
 /**
@@ -174,10 +195,18 @@ export async function exportDocx(input: ExportInput): Promise<ExportResult> {
   //    rendered rawxml body then references relationships that already exist.
   const { blocks, notes: walkNotes } = storageToBlocks(input.details.storage ?? "");
   const styleNames = parseStyleNames(zip.file("word/styles.xml")?.asText() ?? "");
-  const embedder =
-    input.assets && input.embedImages !== false ? new ImageEmbedder(zip) : undefined;
-  const images = embedder ? imageSeam(embedder, input.assets!, input.details.id) : undefined;
-  const body = await serializeBlocks(blocks, { styleNames, images });
+  // One embedder per export owns the unique-id counters for images AND
+  // diagrams (spec 005a: "unique element ids reused from 005 — no collisions
+  // with page images"). Attachment images additionally need an asset fetcher;
+  // diagrams additionally need a rasterizer — each seam exists independently.
+  const wantImages = Boolean(input.assets) && input.embedImages !== false;
+  const embedder = wantImages || input.rasterizer ? new ImageEmbedder(zip) : undefined;
+  const images = embedder && wantImages ? imageSeam(embedder, input.assets!, input.details.id) : undefined;
+  const diagrams =
+    embedder && input.rasterizer
+      ? diagramSeam(embedder, input.rasterizer, input.diagramTheme)
+      : undefined;
+  const body = await serializeBlocks(blocks, { styleNames, images, diagrams });
 
   // 3. Swap the $scroll.content paragraph for the rawxml tag paragraph. If the
   //    template has none, inject the tag before the body's final section break.
@@ -237,6 +266,7 @@ export async function exportDocx(input: ExportInput): Promise<ExportResult> {
       unsupportedNames: resolved.unsupportedNames,
       skippedImages,
       embeddedImages: embedder?.embeddedCount ?? 0,
+      renderedDiagrams: embedder?.diagramCount ?? 0,
       durationMs: Date.now() - start,
       filename: toDownloadFilename(input.details.title),
       notes,
@@ -474,6 +504,61 @@ function imageSeam(embedder: ImageEmbedder, assets: AssetFetcher, pageId: string
         return { ok: true as const, xml };
       } catch (err) {
         return { ok: false as const, reason: err instanceof Error ? err.message : String(err) };
+      }
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Diagram seam (spec 005a)
+// ---------------------------------------------------------------------------
+
+/**
+ * Bridge the serializer's {@link DiagramEmbedSeam} to the mermaid renderer,
+ * the host's {@link SvgRasterizer} and the OOXML embedder: render the source
+ * to a themed SVG, rasterize the mandatory PNG fallback at 2× the intrinsic
+ * size, embed both through one `<a:blip>` (svgBlip + raster). Failure on ANY
+ * leg — render, rasterize, embed — funnels into a non-ok outcome so the
+ * serializer takes the pinned code-block route; the embedder writes nothing
+ * to the archive unless it returns a fragment, so no failure leaves a
+ * dangling media part or relationship (the 004-F3 invariant).
+ */
+function diagramSeam(
+  embedder: ImageEmbedder,
+  rasterizer: SvgRasterizer,
+  theme: DiagramTheme | undefined
+): DiagramEmbedSeam {
+  let count = 0;
+  return {
+    async embed(block: CodeBlock) {
+      const rendered = await renderDiagram(block.code, theme);
+      if (rendered.kind === "unsupported") {
+        return { ok: false as const, route: "unsupported" as const, diagramType: rendered.diagramType };
+      }
+      if (rendered.kind === "failed") {
+        return { ok: false as const, route: "failed" as const, reason: rendered.reason };
+      }
+      try {
+        const png = await rasterizer.rasterize(rendered.svg, {
+          widthPx: rendered.widthPx * 2,
+          heightPx: rendered.heightPx * 2,
+        });
+        count += 1;
+        const xml = embedder.embedSvg(rendered.svg, png, {
+          name: `Mermaid diagram ${count}`,
+          // Accessibility (spec 005a Task 3): the diagram SOURCE is the
+          // best available description of the drawing.
+          alt: block.code,
+          widthPx: rendered.widthPx,
+          heightPx: rendered.heightPx,
+        });
+        return { ok: true as const, xml };
+      } catch (err) {
+        return {
+          ok: false as const,
+          route: "failed" as const,
+          reason: err instanceof Error ? err.message : String(err),
+        };
       }
     },
   };

--- a/packages/docx/src/export.ts
+++ b/packages/docx/src/export.ts
@@ -52,7 +52,7 @@ import {
   type ImageEmbedSeam,
 } from "./serialize.js";
 import { ImageEmbedder, ImageEmbedError } from "./image.js";
-import { renderDiagram, type DiagramTheme } from "./diagram.js";
+import { renderDiagram, type DiagramTheme } from "@atlcli/diagram";
 import { parseLogoArgs } from "./placeholder-map.js";
 import type { AssetFetcher, AssetRef, SvgRasterizer } from "./env.js";
 import { CODE_STYLE_ID, codeStyleXml, parseStyleNames } from "./ooxml.js";

--- a/packages/docx/src/image.test.ts
+++ b/packages/docx/src/image.test.ts
@@ -363,3 +363,121 @@ describe("inlineImageParagraph", () => {
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// embedSvg — svgBlip + mandatory PNG fallback (spec 005a)
+// ---------------------------------------------------------------------------
+
+/** A real (header-valid) SVG diagram string with intrinsic size markers. */
+const DIAGRAM_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 100" width="200" height="100"><rect width="200" height="100"/><text>Start</text></svg>`;
+
+describe("ImageEmbedder.embedSvg", () => {
+  it("writes BOTH media parts, relationships and content types; blip carries svgBlip + raster", () => {
+    const zip = templateZip();
+    const embedder = new ImageEmbedder(zip);
+    const xml = embedder.embedSvg(DIAGRAM_SVG, pngBytes(400, 200), {
+      name: "Mermaid diagram 1",
+      alt: "graph TD",
+      widthPx: 200,
+      heightPx: 100,
+    });
+
+    assertBalancedXml(xml);
+    // Display size = SVG intrinsic px in EMU.
+    expect(xml).toContain(`<wp:extent cx="${200 * 9525}" cy="${100 * 9525}"/>`);
+    expect(xml).toContain('descr="graph TD"');
+
+    // The blip: raster r:embed + svgBlip extension with its own rel.
+    const pngRel = xml.match(/<a:blip r:embed="(rId\d+)"/)?.[1];
+    const svgRel = xml.match(/<asvg:svgBlip[^>]*r:embed="(rId\d+)"/)?.[1];
+    expect(pngRel).toBeDefined();
+    expect(svgRel).toBeDefined();
+    expect(pngRel).not.toBe(svgRel);
+    expect(xml).toContain('uri="{96DAC541-7B7A-43D3-8B79-37D633B846F1}"');
+    expect(xml).toContain("a14:useLocalDpi");
+
+    // Media parts hold the exact bytes.
+    const svgPart = zip.file("word/media/atlcli-image1.svg");
+    const pngPart = zip.file("word/media/atlcli-image2.png");
+    expect(svgPart).not.toBeNull();
+    expect(pngPart).not.toBeNull();
+    expect(svgPart!.asText()).toBe(DIAGRAM_SVG);
+
+    // Both relationships target their parts.
+    const rels = zip.file("word/_rels/document.xml.rels")!.asText();
+    expect(rels).toContain(`Id="${pngRel}"`);
+    expect(rels).toContain(`Id="${svgRel}"`);
+    expect(rels).toContain('Target="media/atlcli-image1.svg"');
+    expect(rels).toContain('Target="media/atlcli-image2.png"');
+
+    // Content types for both extensions.
+    const ct = zip.file("[Content_Types].xml")!.asText();
+    expect(ct).toContain('Extension="svg" ContentType="image/svg+xml"');
+    expect(ct).toContain('Extension="png"');
+
+    // Counted as a diagram, not an image.
+    expect(embedder.diagramCount).toBe(1);
+    expect(embedder.embeddedCount).toBe(0);
+  });
+
+  it("caps oversized diagrams to the content width preserving aspect", () => {
+    const zip = templateZip();
+    const xml = new ImageEmbedder(zip).embedSvg(DIAGRAM_SVG, pngBytes(2400, 1200), {
+      widthPx: 1200,
+      heightPx: 600,
+    });
+    expect(xml).toContain(`<wp:extent cx="${600 * 9525}" cy="${300 * 9525}"/>`);
+  });
+
+  it("dedupes byte-identical diagrams into shared media parts", () => {
+    const zip = templateZip();
+    const embedder = new ImageEmbedder(zip);
+    const a = embedder.embedSvg(DIAGRAM_SVG, pngBytes(400, 200), { widthPx: 200, heightPx: 100 });
+    const b = embedder.embedSvg(DIAGRAM_SVG, pngBytes(400, 200), { widthPx: 200, heightPx: 100 });
+    expect(a.match(/<asvg:svgBlip[^>]*r:embed="(rId\d+)"/)?.[1]).toBe(
+      b.match(/<asvg:svgBlip[^>]*r:embed="(rId\d+)"/)?.[1]!
+    );
+    expect(a.match(/wp:docPr id="(\d+)"/)?.[1]).not.toBe(b.match(/wp:docPr id="(\d+)"/)?.[1]!);
+    expect(zip.file("word/media/atlcli-image3.svg")).toBeNull();
+    expect(embedder.diagramCount).toBe(2);
+  });
+
+  it("shares the id space with page images (no docPr collisions)", () => {
+    const zip = templateZip();
+    const embedder = new ImageEmbedder(zip);
+    const img = embedder.embed(pngBytes(10, 10));
+    const diag = embedder.embedSvg(DIAGRAM_SVG, pngBytes(20, 10), { widthPx: 20, heightPx: 10 });
+    expect(img.match(/wp:docPr id="(\d+)"/)?.[1]).not.toBe(diag.match(/wp:docPr id="(\d+)"/)?.[1]!);
+  });
+
+  it("throws ImageEmbedError and leaves the archive untouched on every bad leg", () => {
+    const zip = templateZip();
+    const relsBefore = zip.file("word/_rels/document.xml.rels")!.asText();
+    const ctBefore = zip.file("[Content_Types].xml")!.asText();
+    const embedder = new ImageEmbedder(zip);
+
+    // Not-an-SVG vector leg.
+    expect(() => embedder.embedSvg("plain text", pngBytes(4, 2), { widthPx: 2, heightPx: 1 })).toThrow(
+      ImageEmbedError
+    );
+    // Fallback that is not a PNG (a GIF header) — the raster leg is mandatory PNG.
+    const gif = new Uint8Array(13);
+    gif.set([0x47, 0x49, 0x46, 0x38, 0x39, 0x61], 0);
+    expect(() => embedder.embedSvg(DIAGRAM_SVG, gif, { widthPx: 2, heightPx: 1 })).toThrow(/PNG/);
+    // Empty legs.
+    expect(() => embedder.embedSvg("", pngBytes(4, 2), { widthPx: 2, heightPx: 1 })).toThrow(ImageEmbedError);
+    expect(() => embedder.embedSvg(DIAGRAM_SVG, new Uint8Array(0), { widthPx: 2, heightPx: 1 })).toThrow(
+      ImageEmbedError
+    );
+    // Missing intrinsic size.
+    expect(() => embedder.embedSvg(DIAGRAM_SVG, pngBytes(4, 2), { widthPx: 0, heightPx: 0 })).toThrow(
+      ImageEmbedError
+    );
+
+    // The 004-F3 invariant: nothing was written on any failure.
+    expect(zip.file("word/_rels/document.xml.rels")!.asText()).toBe(relsBefore);
+    expect(zip.file("[Content_Types].xml")!.asText()).toBe(ctBefore);
+    expect(Object.keys(zip.files).some((p) => p.startsWith("word/media/"))).toBe(false);
+    expect(embedder.diagramCount).toBe(0);
+  });
+});

--- a/packages/docx/src/image.ts
+++ b/packages/docx/src/image.ts
@@ -33,7 +33,7 @@ export const MAX_CONTENT_WIDTH_PX = 600;
 /** Refuse to embed assets above this size (spec 005 risk 2: docx bloat). */
 export const MAX_IMAGE_BYTES = 25 * 1024 * 1024;
 
-export type ImageFormat = "png" | "jpeg" | "gif";
+export type ImageFormat = "png" | "jpeg" | "gif" | "svg";
 
 export interface ImageInfo {
   format: ImageFormat;
@@ -214,6 +214,12 @@ export interface DrawingParams {
    * the logo pass to preserve the replaced placeholder paragraph's alignment.
    */
   pPrXml?: string;
+  /**
+   * Relationship id of an SVG media part (spec 005a). When set, the blip
+   * gains the `asvg:svgBlip` extension: modern Word renders the vector SVG,
+   * older Word falls back to the raster `relId` (the mandatory PNG).
+   */
+  svgRelId?: string;
 }
 
 /**
@@ -247,7 +253,13 @@ export function inlineImageParagraph(p: DrawingParams): string {
     `<a:blip r:embed="${p.relId}" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">` +
     `<a:extLst><a:ext uri="{28A0092B-C50C-407E-A947-70E740481C1C}">` +
     `<a14:useLocalDpi xmlns:a14="http://schemas.microsoft.com/office/drawing/2010/main" val="0"/>` +
-    `</a:ext></a:extLst>` +
+    `</a:ext>` +
+    (p.svgRelId
+      ? `<a:ext uri="{96DAC541-7B7A-43D3-8B79-37D633B846F1}">` +
+        `<asvg:svgBlip xmlns:asvg="http://schemas.microsoft.com/office/drawing/2016/SVG/main" r:embed="${p.svgRelId}"/>` +
+        `</a:ext>`
+      : "") +
+    `</a:extLst>` +
     `</a:blip>` +
     `<a:srcRect/><a:stretch><a:fillRect/></a:stretch>` +
     `</pic:blipFill>` +
@@ -290,6 +302,21 @@ export interface EmbedImageOptions {
   pPrXml?: string;
 }
 
+export interface EmbedSvgOptions {
+  /** Alt text for `descr` (spec 005a: the diagram SOURCE is the description). */
+  alt?: string;
+  /** Human-facing name (shown in Word's selection pane). */
+  name?: string;
+  /** Intrinsic pixel width of the SVG (drives the width-capped display size). */
+  widthPx: number;
+  /** Intrinsic pixel height of the SVG. */
+  heightPx: number;
+  /** Document part whose rels carry the relationships (default `word/document.xml`). */
+  partPath?: string;
+  /** `<w:pPr>…</w:pPr>` to preserve on the emitted paragraph. */
+  pPrXml?: string;
+}
+
 interface MediaEntry {
   /** Media-part filename (under `word/media/`), shared across parts. */
   filename: string;
@@ -318,6 +345,7 @@ export class ImageEmbedder {
   private nextDocPrId: number;
   private mediaIndex = 0;
   private embedded = 0;
+  private diagramsEmbedded = 0;
   /** FNV-1a+length key → entries with those bytes (hash collisions chained). */
   private readonly dedup = new Map<string, MediaEntry[]>();
 
@@ -327,9 +355,14 @@ export class ImageEmbedder {
     this.nextDocPrId = maxExistingDrawingId(zip) + 1;
   }
 
-  /** Number of image occurrences successfully embedded so far. */
+  /** Number of image occurrences successfully embedded so far (not diagrams). */
   get embeddedCount(): number {
     return this.embedded;
+  }
+
+  /** Number of diagram occurrences successfully embedded so far (spec 005a). */
+  get diagramCount(): number {
+    return this.diagramsEmbedded;
   }
 
   /**
@@ -358,6 +391,62 @@ export class ImageEmbedder {
       docPrId,
       name: opts.name || `Image ${docPrId}`,
       descr: opts.alt || opts.name || "image",
+      cxEmu: pxToEmu(size.widthPx),
+      cyEmu: pxToEmu(size.heightPx),
+      pPrXml: opts.pPrXml,
+    });
+  }
+
+  /**
+   * Embed a vector diagram: an SVG media part PLUS its mandatory PNG raster
+   * fallback in the same `<a:blip>` (spec 005a §2.4 — Word's `svgBlip` support
+   * is version-dependent, so the raster copy always rides along). Returns the
+   * `<w:p><w:drawing>` fragment sized to the SVG's intrinsic `widthPx` ×
+   * `heightPx`, width-capped like any other image.
+   *
+   * Throws {@link ImageEmbedError} when either leg is invalid (empty/oversized
+   * bytes, a fallback that is not a well-formed PNG, bytes that are not SVG) —
+   * all validation happens BEFORE the first archive write, so a throw leaves
+   * no dangling media part or relationship (the 004-F3 invariant).
+   */
+  embedSvg(svg: string | Uint8Array, pngFallback: Uint8Array, opts: EmbedSvgOptions): string {
+    const svgBytes = typeof svg === "string" ? new TextEncoder().encode(svg) : svg;
+    if (svgBytes.length === 0) throw new ImageEmbedError("the rendered SVG was empty");
+    if (svgBytes.length > MAX_IMAGE_BYTES) throw new ImageEmbedError("the rendered SVG is too large to embed");
+    if (!isSvg(svgBytes)) throw new ImageEmbedError("the diagram did not render to a well-formed SVG");
+    if (pngFallback.length === 0) throw new ImageEmbedError("the rasterized PNG fallback was empty");
+    if (pngFallback.length > MAX_IMAGE_BYTES) throw new ImageEmbedError("the rasterized PNG fallback is too large to embed");
+    const pngInfo = decodeImageInfo(pngFallback);
+    if (!pngInfo || pngInfo.format !== "png") {
+      throw new ImageEmbedError("the rasterizer did not produce a well-formed PNG fallback");
+    }
+    if (!opts.widthPx || !opts.heightPx) throw new ImageEmbedError("the diagram has no usable intrinsic size");
+
+    const svgInfo: ImageInfo = {
+      format: "svg",
+      ext: "svg",
+      mime: "image/svg+xml",
+      width: opts.widthPx,
+      height: opts.heightPx,
+    };
+    const partPath = opts.partPath ?? DOCUMENT_PART;
+    const svgEntry = this.findOrCreateMedia(svgBytes, svgInfo);
+    const pngEntry = this.findOrCreateMedia(pngFallback, pngInfo);
+    const svgRelId = this.ensureRelationship(svgEntry, partPath);
+    const pngRelId = this.ensureRelationship(pngEntry, partPath);
+    const size = resolveTargetSize(
+      { width: opts.widthPx, height: opts.heightPx },
+      {},
+      this.maxWidthPx
+    );
+    const docPrId = this.nextDocPrId++;
+    this.diagramsEmbedded += 1;
+    return inlineImageParagraph({
+      relId: pngRelId,
+      svgRelId,
+      docPrId,
+      name: opts.name || `Diagram ${docPrId}`,
+      descr: opts.alt || opts.name || "diagram",
       cxEmu: pxToEmu(size.widthPx),
       cyEmu: pxToEmu(size.heightPx),
       pPrXml: opts.pPrXml,

--- a/packages/docx/src/index.browser.ts
+++ b/packages/docx/src/index.browser.ts
@@ -14,6 +14,7 @@ export * from "./dateformat.js";
 export * from "./scan.js";
 export * from "./resolver.js";
 export * from "./serialize.js";
+export * from "./diagram.js";
 export * from "./export.js";
 export * from "./env.js";
 export * from "./image.js";

--- a/packages/docx/src/index.browser.ts
+++ b/packages/docx/src/index.browser.ts
@@ -14,7 +14,10 @@ export * from "./dateformat.js";
 export * from "./scan.js";
 export * from "./resolver.js";
 export * from "./serialize.js";
-export * from "./diagram.js";
+// The mermaid renderer is the format-agnostic `@atlcli/diagram` adapter
+// (shared with the PDF path, spec 007); re-exported here so DOCX consumers
+// get `DiagramTheme`/`renderDiagram` from one barrel.
+export * from "@atlcli/diagram";
 export * from "./export.js";
 export * from "./env.js";
 export * from "./image.js";

--- a/packages/docx/src/serialize.test.ts
+++ b/packages/docx/src/serialize.test.ts
@@ -1,10 +1,24 @@
 import { describe, expect, it } from "bun:test";
 import { storageToBlocks, type ExportBlock, type InlineNode } from "@atlcli/confluence";
-import { serializeBlocks, serializeInline } from "./serialize.js";
+import {
+  serializeBlocks,
+  serializeInline,
+  type CodeBlock,
+  type DiagramEmbedOutcome,
+  type DiagramEmbedSeam,
+} from "./serialize.js";
+import { renderDiagram } from "./diagram.js";
 import { parseStyleNames } from "./ooxml.js";
 import { headingStyle, stylesXml } from "./fixtures.js";
 
 const noStyles = new Map<string, string>();
+
+/** A diagram seam over an inline embed function (test double for the wiring). */
+function diagramSeamOver(
+  embed: (block: CodeBlock) => Promise<DiagramEmbedOutcome>
+): DiagramEmbedSeam {
+  return { embed };
+}
 
 describe("serializeInline", () => {
   it("emits marks and colors as run properties", () => {
@@ -350,26 +364,81 @@ describe("serializeBlocks — callouts, code, tables, images", () => {
     expect(note!.message).toContain("brainfuck");
   });
 
-  // Spec 004 Task 6 / F2 descope pin: mermaid rendering needs the image module (spec 005),
-  // so a mermaid block must degrade to a readable code block — PLAN §2.3: "never a broken
-  // image". This fails the moment a half-wired diagram path emits a drawing.
-  it("renders a mermaid block as a code block, never a broken image (F2 deferred)", async () => {
+  // The spec-004 F2 pin, retargeted per spec 005a Task 5: supported mermaid types
+  // now RENDER, so the "never a broken image" invariant is guarded through an
+  // UNSUPPORTED diagram type (Gantt) — it must degrade to a readable code block
+  // with no image plumbing whatsoever, and the report must name the type.
+  it("renders an unsupported diagram type as a code block, never a broken image (004 pin)", async () => {
     const blocks: ExportBlock[] = [
-      { type: "codeBlock", language: "mermaid", code: "graph TD;\n  A-->B;" },
+      { type: "codeBlock", language: "mermaid", code: "gantt\n  title T\n  section S\n  A :a1, 2026-01-01, 3d" },
     ];
-    const { xml, notes } = await serializeBlocks(blocks, { styleNames: noStyles });
+    const seam = diagramSeamOver(async (block) => {
+      const rendered = await renderDiagram(block.code);
+      if (rendered.kind === "unsupported") return { ok: false, route: "unsupported", diagramType: rendered.diagramType };
+      throw new Error("gantt must be unsupported");
+    });
+    const { xml, notes } = await serializeBlocks(blocks, { styleNames: noStyles, diagrams: seam });
     // Readable code block carrying the diagram source...
     expect(xml).toContain('<w:pStyle w:val="AtlcliCode"/>');
-    expect(xml).toContain("graph TD;");
-    expect(xml).toContain("A--&gt;B;");
+    expect(xml).toContain("gantt");
     // ...and no image plumbing whatsoever (no dangling relationship).
     expect(xml).not.toContain("<w:drawing");
     expect(xml).not.toContain("blip");
     expect(xml).not.toContain("r:embed");
-    // The user is told why it stayed source (mermaid is not a curated grammar).
-    const note = notes.find((n) => n.code === "code-highlight-skipped");
+    // The report names the diagram type (spec 005a Task 2).
+    const note = notes.find((n) => n.code === "diagram-unsupported");
     expect(note).toBeDefined();
-    expect(note!.message).toContain("mermaid");
+    expect(note!.message).toContain("Gantt");
+  });
+
+  // Hosts without a rasterizer (no diagram seam) keep the 004 behavior: source
+  // as a code block, plus a note saying diagram rendering was unavailable.
+  it("renders mermaid as a code block when no diagram seam is wired", async () => {
+    const blocks: ExportBlock[] = [
+      { type: "codeBlock", language: "mermaid", code: "graph TD;\n  A-->B;" },
+    ];
+    const { xml, notes } = await serializeBlocks(blocks, { styleNames: noStyles });
+    expect(xml).toContain('<w:pStyle w:val="AtlcliCode"/>');
+    expect(xml).toContain("graph TD;");
+    expect(xml).toContain("A--&gt;B;");
+    expect(xml).not.toContain("<w:drawing");
+    expect(xml).not.toContain("r:embed");
+    const note = notes.find((n) => n.code === "diagram-skipped");
+    expect(note).toBeDefined();
+  });
+
+  it("routes a supported mermaid block through the diagram seam (spec 005a)", async () => {
+    const blocks: ExportBlock[] = [
+      { type: "codeBlock", language: "MERMAID", code: "graph TD\n  A --> B" },
+    ];
+    const seen: string[] = [];
+    const seam = diagramSeamOver(async (block) => {
+      seen.push(block.code);
+      return { ok: true, xml: "<w:p><w:r><w:drawing>DIAGRAM</w:drawing></w:r></w:p>" };
+    });
+    const { xml, notes } = await serializeBlocks(blocks, { styleNames: noStyles, diagrams: seam });
+    expect(seen).toEqual(["graph TD\n  A --> B"]);
+    expect(xml).toContain("DIAGRAM");
+    // The rendered route emits no note — the report counts it instead.
+    expect(notes).toEqual([]);
+    // Non-mermaid code blocks never touch the seam.
+    await serializeBlocks([{ type: "codeBlock", language: "ts", code: "1;" }], { styleNames: noStyles, diagrams: seam });
+    expect(seen).toHaveLength(1);
+  });
+
+  it("degrades to the code block with a warning when the diagram path fails", async () => {
+    const blocks: ExportBlock[] = [
+      { type: "codeBlock", language: "mermaid", code: "graph TD\n  A --> B" },
+    ];
+    const seam = diagramSeamOver(async () => ({ ok: false, route: "failed", reason: "raster exploded" }));
+    const { xml, notes } = await serializeBlocks(blocks, { styleNames: noStyles, diagrams: seam });
+    expect(xml).toContain('<w:pStyle w:val="AtlcliCode"/>');
+    expect(xml).toContain("graph TD");
+    expect(xml).not.toContain("<w:drawing");
+    const note = notes.find((n) => n.code === "diagram-render-failed");
+    expect(note).toBeDefined();
+    expect(note!.level).toBe("warning");
+    expect(note!.message).toContain("raster exploded");
   });
 
   it("renders nested lists with markers", async () => {

--- a/packages/docx/src/serialize.test.ts
+++ b/packages/docx/src/serialize.test.ts
@@ -7,7 +7,7 @@ import {
   type DiagramEmbedOutcome,
   type DiagramEmbedSeam,
 } from "./serialize.js";
-import { renderDiagram } from "./diagram.js";
+import { renderDiagram } from "@atlcli/diagram";
 import { parseStyleNames } from "./ooxml.js";
 import { headingStyle, stylesXml } from "./fixtures.js";
 

--- a/packages/docx/src/serialize.ts
+++ b/packages/docx/src/serialize.ts
@@ -38,6 +38,9 @@ import {
 /** The `image` variant of {@link ExportBlock}. */
 export type ImageBlock = Extract<ExportBlock, { type: "image" }>;
 
+/** The `codeBlock` variant of {@link ExportBlock} (carries mermaid source). */
+export type CodeBlock = Extract<ExportBlock, { type: "codeBlock" }>;
+
 /** Result of one image-embed attempt (spec 005). */
 export type ImageEmbedOutcome = { ok: true; xml: string } | { ok: false; reason: string };
 
@@ -51,11 +54,32 @@ export interface ImageEmbedSeam {
   embed(block: ImageBlock): Promise<ImageEmbedOutcome>;
 }
 
+/**
+ * Result of one diagram-embed attempt (spec 005a). The two non-ok routes are
+ * distinguished so the report can name an unsupported diagram TYPE (info)
+ * separately from a genuine render/raster/embed failure (warning).
+ */
+export type DiagramEmbedOutcome =
+  | { ok: true; xml: string }
+  | { ok: false; route: "unsupported"; diagramType: string }
+  | { ok: false; route: "failed"; reason: string };
+
+/**
+ * The serializer's diagram seam (spec 005a): turns a mermaid `codeBlock` into
+ * an inline-drawing fragment (svgBlip + PNG fallback), or says why it could
+ * not. Render + rasterize + zip surgery live with the export orchestrator.
+ */
+export interface DiagramEmbedSeam {
+  embed(block: CodeBlock): Promise<DiagramEmbedOutcome>;
+}
+
 export interface SerializeContext {
   /** Lower-cased style-name → styleId map from the template's styles.xml. */
   styleNames: Map<string, string>;
   /** Image embedding seam; absent → images degrade to report notes. */
   images?: ImageEmbedSeam;
+  /** Diagram embedding seam; absent → mermaid stays a source code block. */
+  diagrams?: DiagramEmbedSeam;
 }
 
 /** {@link SerializeContext} plus the document-wide heading promotion offset. */
@@ -270,6 +294,11 @@ async function serializeBlock(
       return paragraph(serializeInline(block.content));
 
     case "codeBlock": {
+      // A ```mermaid block takes the diagram path (spec 005a); every other
+      // language is untouched by this branch.
+      if ((block.language ?? "").trim().toLowerCase() === "mermaid") {
+        return serializeMermaid(block, ctx, notes);
+      }
       const { lines, skipped } = await highlightCode(block.code, block.language);
       if (skipped) {
         notes.push({
@@ -338,6 +367,51 @@ async function serializeBlock(
 
 function describeImage(block: Extract<ExportBlock, { type: "image" }>): string {
   return block.source.kind === "attachment" ? `"${block.source.filename}"` : `"${block.source.url}"`;
+}
+
+/**
+ * A mermaid code block: try the diagram path (spec 005a); every non-ok route
+ * degrades to the spec-004 pinned fallback — the source as plain monospace
+ * code paragraphs, NO `<w:drawing>` ("the reader sees readable diagram
+ * source, never a broken image") — plus a report note naming the route.
+ */
+async function serializeMermaid(
+  block: CodeBlock,
+  ctx: InternalContext,
+  notes: ExportNote[]
+): Promise<string> {
+  if (!ctx.diagrams) {
+    notes.push({
+      level: "info",
+      code: "diagram-skipped",
+      message: "A mermaid diagram was rendered as source — diagram rendering is unavailable in this export.",
+    });
+    return plainCodeParagraphs(block.code);
+  }
+  const outcome = await ctx.diagrams.embed(block);
+  if (outcome.ok) return outcome.xml;
+  if (outcome.route === "unsupported") {
+    notes.push({
+      level: "info",
+      code: "diagram-unsupported",
+      message: `${outcome.diagramType} diagrams are not supported; the diagram was rendered as source.`,
+    });
+  } else {
+    notes.push({
+      level: "warning",
+      code: "diagram-render-failed",
+      message: `A mermaid diagram could not be rendered (${outcome.reason}); it was rendered as source.`,
+    });
+  }
+  return plainCodeParagraphs(block.code);
+}
+
+/** The diagram fallback: source lines as uncolored monospace code paragraphs. */
+function plainCodeParagraphs(code: string): string {
+  return code
+    .split("\n")
+    .map((line) => codeLineParagraph([{ text: line }]))
+    .join("");
 }
 
 /** Serialize child blocks, joining their fragments. */

--- a/scripts/check-browser-build.test.ts
+++ b/scripts/check-browser-build.test.ts
@@ -27,7 +27,7 @@ function fixtureDir(): string {
 }
 
 describe("browser-build gate (spec 001 task 6)", () => {
-  test("the gate's entrypoint set is exactly the six browser entrypoints", () => {
+  test("the gate's entrypoint set is exactly the seven browser entrypoints", () => {
     expect(BROWSER_ENTRYPOINTS).toEqual([
       "packages/confluence/src/markdown.ts",
       "packages/confluence/src/client.ts",
@@ -35,6 +35,7 @@ describe("browser-build gate (spec 001 task 6)", () => {
       "packages/core/src/index.browser.ts",
       "packages/confluence/src/index.browser.ts",
       "packages/docx/src/index.browser.ts",
+      "packages/diagram/src/index.ts",
     ]);
   });
 

--- a/scripts/check-browser-build.ts
+++ b/scripts/check-browser-build.ts
@@ -11,7 +11,7 @@
  * A stray `node:`/`bun:` import anywhere in an entrypoint's transitive graph
  * turns this red, naming both the entrypoint and the offending specifier(s).
  */
-/** The four entrypoints that MUST build for the browser (spec 001 §6). */
+/** The entrypoints that MUST build for the browser (spec 001 §6). */
 export const BROWSER_ENTRYPOINTS = [
   "packages/confluence/src/markdown.ts",
   "packages/confluence/src/client.ts",
@@ -19,6 +19,7 @@ export const BROWSER_ENTRYPOINTS = [
   "packages/core/src/index.browser.ts",
   "packages/confluence/src/index.browser.ts",
   "packages/docx/src/index.browser.ts",
+  "packages/diagram/src/index.ts",
 ];
 
 /**

--- a/specs/005a-mermaid-diagrams/PLAN.md
+++ b/specs/005a-mermaid-diagrams/PLAN.md
@@ -1,6 +1,7 @@
 # Mermaid Diagrams — beautiful-mermaid → SVG for the DOCX and PDF export paths
 
-Status: **Planned**
+Status: **Implemented** (2026-07-16 — engine + extension host; CLI exports mermaid as source
+blocks until a Node rasterizer host lands. Manual Word E2E = Task 6, pending Björn.)
 
 Spec ID: `005a-mermaid-diagrams`
 Depends on: `005-docx-image-module` (**must be merged** — this spec embeds SVG through the media-part/relationship/EMU plumbing 005 builds), `004-docx-export` Task 2 (the `ExportBlock` model whose `codeBlock` carries the diagram source), `004-docx-export` Task 5 (the pinned descope path this spec replaces)
@@ -188,39 +189,39 @@ belongs to 006, not to this spec.
 
 ### Task 1 — License + bundling gate **[decision gate]**
 
-- [ ] **M1 ratified by Björn**: EPL-2.0 (elkjs) accepted, or mermaid stays permanently
+- [x] **M1 ratified by Björn**: EPL-2.0 (elkjs) accepted, or mermaid stays permanently
       descoped. Recorded in the Decisions log with the reasoning (§2.2).
-- [ ] Bundling hazard (§2.3) proven or solved in a throwaway spike: beautiful-mermaid
+- [x] Bundling hazard (§2.3) proven or solved in a throwaway spike: beautiful-mermaid
       imports and renders inside the built MV3 panel with the `web-worker` require resolved
       (alias/stub/external), `check:extension-output` still clean, CSP not relaxed.
-- [ ] Real emitted chunk size + panel load delta recorded; confirmed lazy (a mermaid-free
+- [x] Real emitted chunk size + panel load delta recorded; confirmed lazy (a mermaid-free
       page loads no diagram chunk).
-- [ ] Rasterization approach (§2.4) picked with evidence, not from docs.
+- [x] Rasterization approach (§2.4) picked with evidence, not from docs.
 
 ### Task 2 — Renderer module (pure)
 
-- [ ] `renderDiagram(source, theme): { kind: "svg"; svg: string } | { kind: "unsupported"; diagramType?: string } | { kind: "failed"; reason: string }` — synchronous, DOM-free, no host globals.
-- [ ] Diagram-type detection so an unsupported type is reported **by name** ("Gantt diagrams are not supported") rather than as a generic failure.
-- [ ] Unit tests per supported type (Flowchart, State, Sequence, Class, ER, XY-Chart) asserting real SVG landmarks; per unsupported type asserting the `unsupported` route; malformed source asserting `failed` (never a throw escaping the module).
-- [ ] `bun run check:browser` covers the module — it must stay isomorphic.
+- [x] `renderDiagram(source, theme): { kind: "svg"; svg: string } | { kind: "unsupported"; diagramType?: string } | { kind: "failed"; reason: string }` — synchronous, DOM-free, no host globals.
+- [x] Diagram-type detection so an unsupported type is reported **by name** ("Gantt diagrams are not supported") rather than as a generic failure.
+- [x] Unit tests per supported type (Flowchart, State, Sequence, Class, ER, XY-Chart) asserting real SVG landmarks; per unsupported type asserting the `unsupported` route; malformed source asserting `failed` (never a throw escaping the module).
+- [x] `bun run check:browser` covers the module — it must stay isomorphic.
 
 ### Task 3 — DOCX embed path
 
-- [ ] SVG → svgBlip + PNG@2x fallback embedded via 005's media-part/relationship/content-type/EMU plumbing; unique element ids reused from 005 (no collisions with page images).
-- [ ] Injected rasterizer interface (§2.4); the panel supplies the browser implementation.
-- [ ] Width-capped to the content width like any other image; diagram source text carried as `<wp:docPr descr=…>` alt text (accessibility — the source *is* the description).
-- [ ] Failure on any leg (render, raster, embed) → pinned code-block path + report line, **no dangling relationship** (the 004/005 skip invariant, pinning test).
+- [x] SVG → svgBlip + PNG@2x fallback embedded via 005's media-part/relationship/content-type/EMU plumbing; unique element ids reused from 005 (no collisions with page images).
+- [x] Injected rasterizer interface (§2.4); the panel supplies the browser implementation.
+- [x] Width-capped to the content width like any other image; diagram source text carried as `<wp:docPr descr=…>` alt text (accessibility — the source *is* the description).
+- [x] Failure on any leg (render, raster, embed) → pinned code-block path + report line, **no dangling relationship** (the 004/005 skip invariant, pinning test).
 
 ### Task 4 — Theme coupling
 
-- [ ] Diagram theme derived from the export's brand colors (beautiful-mermaid derives its scheme from two base values via `color-mix()` — EXPORT-QUALITY §4), so diagrams match callouts/body.
-- [ ] Default theme when no brand colors are configured; test both.
+- [x] Diagram theme derived from the export's brand colors (beautiful-mermaid derives its scheme from two base values via `color-mix()` — EXPORT-QUALITY §4), so diagrams match callouts/body.
+- [x] Default theme when no brand colors are configured; test both.
 
 ### Task 5 — Replace the descope, keep the fallback honest
 
-- [ ] Serializer routes `codeBlock{language:"mermaid"}` to the diagram path; **all other** code blocks unchanged.
-- [ ] The 004 pin tests are **updated, not deleted**: `packages/confluence/src/export-blocks.test.ts` (walker still models mermaid as a `codeBlock` carrying source — unchanged) stays as-is; `apps/extension/tests/docx/serialize.test.ts`'s "renders a mermaid block as a code block, never a broken image" is **retargeted to an unsupported type** (e.g. a Gantt diagram), so the "never a broken image" invariant keeps a live guard instead of being silently dropped when the supported path starts emitting drawings.
-- [ ] Report lines distinguish the three routes: rendered / unsupported-type / render-failed.
+- [x] Serializer routes `codeBlock{language:"mermaid"}` to the diagram path; **all other** code blocks unchanged.
+- [x] The 004 pin tests are **updated, not deleted**: `packages/confluence/src/export-blocks.test.ts` (walker still models mermaid as a `codeBlock` carrying source — unchanged) stays as-is; `apps/extension/tests/docx/serialize.test.ts`'s "renders a mermaid block as a code block, never a broken image" is **retargeted to an unsupported type** (e.g. a Gantt diagram), so the "never a broken image" invariant keeps a live guard instead of being silently dropped when the supported path starts emitting drawings.
+- [x] Report lines distinguish the three routes: rendered / unsupported-type / render-failed.
 
 ### Task 6 — Manual E2E **[E2E: user]**
 
@@ -274,5 +275,21 @@ belongs to 006, not to this spec.
 
 - **Numbering `005a`** (Björn, 2026-07-16) — mermaid runs directly after the image module
   rather than at the end of the queue, because it is the same embed path.
-- **M1 — elkjs EPL-2.0**: ❓ open — Task 1 gate (§2.2). Recommendation: accept.
-- **M2 — renderer placement**: ❓ open — depends on the unresolved 005/006 ordering (§2.5).
+- **M1 — elkjs EPL-2.0**: ✅ **accepted** (2026-07-16) — Björn ordered the implementation with
+  the spec's "accept" recommendation on the table; EPL-2.0 is weak copyleft, does not reach our
+  code, and the source-availability obligation is satisfied by attribution + pointing at elkjs's
+  public source. Attribution added to the repository `NOTICE` file and noted in
+  `reference/docx-engine.md`.
+- **M2 — renderer placement**: ✅ resolved by sequencing — 006 merged first (PR #35), so the
+  renderer lives in the isomorphic engine (`packages/docx/src/diagram.ts`). The `packages/docx`
+  naming tension (§2.5) remains flagged for 007.
+- **Task-1 spike results** (2026-07-16): the `web-worker` require hazard (§2.3) did NOT
+  materialize — Vite's CJS transform removes the guarded requires (0 `require(` in the emitted
+  chunk) and `bun build --target=browser` bundles clean (no node:/bun: specifiers). Emitted
+  diagram chunk: **1.5 MB raw / ~472 KB gzip**, loaded via dynamic import behind the existing
+  lazy engine chunk — the panel's initial bundle is unchanged, and diagram-type detection runs
+  BEFORE the chunk import, so unsupported-only pages never load it. Total extension output
+  4.68 MB (well under store limits). Rasterization (§2.4): option 1 (panel `<canvas>`), with a
+  decode timeout so a hung decode degrades to the code-block route instead of freezing the
+  export. beautiful-mermaid emits a Google-Fonts `@import` in its SVG `<style>` — the engine
+  strips it (offline determinism; Word/rasterizers don't load external resources anyway).

--- a/specs/005a-mermaid-diagrams/PLAN.md
+++ b/specs/005a-mermaid-diagrams/PLAN.md
@@ -296,3 +296,10 @@ belongs to 006, not to this spec.
   decode timeout so a hung decode degrades to the code-block route instead of freezing the
   export. beautiful-mermaid emits a Google-Fonts `@import` in its SVG `<style>` — the engine
   strips it (offline determinism; Word/rasterizers don't load external resources anyway).
+- **Task-6 Word E2E finding #1** (Björn, 2026-07-16): first Word export rendered every diagram
+  black with missing arrowheads — Word's svgBlip renderer supports neither CSS custom
+  properties nor `color-mix()` nor (reliably) `<style>` class rules, which is ALL of
+  beautiful-mermaid's styling; the PNG fallback in the same blip was pixel-perfect. Fixed by
+  `flattenSvgStyles` in `@atlcli/diagram` (`3b1fb63`): the full custom-property/color-mix/class
+  cascade is resolved into literal presentation attributes and the `<style>` blocks dropped.
+  Also the portability prerequisite for 007's SVG consumers (resvg/Typst, same limits).

--- a/specs/005a-mermaid-diagrams/PLAN.md
+++ b/specs/005a-mermaid-diagrams/PLAN.md
@@ -2,7 +2,7 @@
 
 Status: **Done** (2026-07-16 — engine + extension host; Word E2E passed after finding #1
 (svgBlip flattening). CLI exports mermaid as source blocks until a Node rasterizer host lands.
-Open: the two spec-008 benchmark items in Task 6.)
+Task 6 fully done incl. Scroll comparison (0/7 vs. atlcli 6/7) and duration numbers.)
 
 Spec ID: `005a-mermaid-diagrams`
 Depends on: `005-docx-image-module` (**must be merged** — this spec embeds SVG through the media-part/relationship/EMU plumbing 005 builds), `004-docx-export` Task 2 (the `ExportBlock` model whose `codeBlock` carries the diagram source), `004-docx-export` Task 5 (the pinned descope path this spec replaces)
@@ -229,7 +229,7 @@ belongs to 006, not to this spec.
 - [x] A DOCSY test page with one diagram of each supported type + one exotic (Gantt) exports; open in Word: diagrams crisp, correctly sized, exotic shows as readable source. (Björn, 2026-07-16, page 1119158277, real Mayflower Prüfvorlage — after finding #1 was fixed.)
 - [x] Zoom to 400% in a modern Word → vector (svgBlip active, not the raster fallback). (Proven via Björn's Word print-PDF: the 6 diagrams appear as vector paths; the PDF's only raster XObjects are the template logos/footer.)
 - [x] Compare against Scroll's output on the same page (Scroll has no mermaid rendering — this is a **differentiator** shot for spec 008's benchmark row 9). *(Done 2026-07-16, Scroll Office export of page 1119158277: **0 of 7 mermaid blocks rendered** — all seven stay `scroll-codecontentdivline` source-text blocks, 0 `<w:drawing>` for diagrams, 0 svgBlip; atlcli renders 6 of 7 as vector drawings with a named report note for the 7th. Benchmark row 9 input recorded.)*
-- [ ] Export duration delta recorded vs. the 004 baseline (spec 008 input). *(open — spec 008 input)*
+- [x] Export duration delta recorded (spec 008 input). *(2026-07-16 — Björn's panel export of page 1119158277 with the real Mayflower Prüfvorlage: **661 ms total** for 29 placeholders + 2 images + 6 rendered diagrams. Engine-side isolation on the same live storage (5 runs, median): diagram path OFF 3 ms vs. ON 31 ms → **~28 ms for all 6 diagrams** (render + flatten + embed, excl. panel canvas rasterization — the remainder of the 661 ms is placeholder round-trips, image fetches and rasterization). Diagram cost is negligible against the 004-shape baseline.)*
 - [ ] Test page deleted afterwards. *(page 1119158277 kept for now — also useful for the Scroll comparison; delete after 008 row 9)*
 
 ---

--- a/specs/005a-mermaid-diagrams/PLAN.md
+++ b/specs/005a-mermaid-diagrams/PLAN.md
@@ -228,7 +228,7 @@ belongs to 006, not to this spec.
 
 - [x] A DOCSY test page with one diagram of each supported type + one exotic (Gantt) exports; open in Word: diagrams crisp, correctly sized, exotic shows as readable source. (Björn, 2026-07-16, page 1119158277, real Mayflower Prüfvorlage — after finding #1 was fixed.)
 - [x] Zoom to 400% in a modern Word → vector (svgBlip active, not the raster fallback). (Proven via Björn's Word print-PDF: the 6 diagrams appear as vector paths; the PDF's only raster XObjects are the template logos/footer.)
-- [ ] Compare against Scroll's output on the same page (Scroll has no mermaid rendering — this is a **differentiator** shot for spec 008's benchmark row 9). *(open — spec 008 input)*
+- [x] Compare against Scroll's output on the same page (Scroll has no mermaid rendering — this is a **differentiator** shot for spec 008's benchmark row 9). *(Done 2026-07-16, Scroll Office export of page 1119158277: **0 of 7 mermaid blocks rendered** — all seven stay `scroll-codecontentdivline` source-text blocks, 0 `<w:drawing>` for diagrams, 0 svgBlip; atlcli renders 6 of 7 as vector drawings with a named report note for the 7th. Benchmark row 9 input recorded.)*
 - [ ] Export duration delta recorded vs. the 004 baseline (spec 008 input). *(open — spec 008 input)*
 - [ ] Test page deleted afterwards. *(page 1119158277 kept for now — also useful for the Scroll comparison; delete after 008 row 9)*
 

--- a/specs/005a-mermaid-diagrams/PLAN.md
+++ b/specs/005a-mermaid-diagrams/PLAN.md
@@ -280,9 +280,12 @@ belongs to 006, not to this spec.
   code, and the source-availability obligation is satisfied by attribution + pointing at elkjs's
   public source. Attribution added to the repository `NOTICE` file and noted in
   `reference/docx-engine.md`.
-- **M2 — renderer placement**: ✅ resolved by sequencing — 006 merged first (PR #35), so the
-  renderer lives in the isomorphic engine (`packages/docx/src/diagram.ts`). The `packages/docx`
-  naming tension (§2.5) remains flagged for 007.
+- **M2 — renderer placement**: ✅ resolved (Björn, 2026-07-16) — the renderer is its own
+  **format-agnostic adapter package `@atlcli/diagram`** (`packages/diagram/src/index.ts`),
+  NOT part of `@atlcli/docx`: "das soll adapter sein, da wir das später auch für pdf export
+  brauchen, also nicht eng an docx binden". `@atlcli/docx` consumes it for the svgBlip+PNG
+  embed; spec 007 consumes the same SVG natively. This also dissolves the §2.5 naming
+  tension: the DOCX package no longer holds cross-format code.
 - **Task-1 spike results** (2026-07-16): the `web-worker` require hazard (§2.3) did NOT
   materialize — Vite's CJS transform removes the guarded requires (0 `require(` in the emitted
   chunk) and `bun build --target=browser` bundles clean (no node:/bun: specifiers). Emitted

--- a/specs/005a-mermaid-diagrams/PLAN.md
+++ b/specs/005a-mermaid-diagrams/PLAN.md
@@ -1,7 +1,8 @@
 # Mermaid Diagrams — beautiful-mermaid → SVG for the DOCX and PDF export paths
 
-Status: **Implemented** (2026-07-16 — engine + extension host; CLI exports mermaid as source
-blocks until a Node rasterizer host lands. Manual Word E2E = Task 6, pending Björn.)
+Status: **Done** (2026-07-16 — engine + extension host; Word E2E passed after finding #1
+(svgBlip flattening). CLI exports mermaid as source blocks until a Node rasterizer host lands.
+Open: the two spec-008 benchmark items in Task 6.)
 
 Spec ID: `005a-mermaid-diagrams`
 Depends on: `005-docx-image-module` (**must be merged** — this spec embeds SVG through the media-part/relationship/EMU plumbing 005 builds), `004-docx-export` Task 2 (the `ExportBlock` model whose `codeBlock` carries the diagram source), `004-docx-export` Task 5 (the pinned descope path this spec replaces)
@@ -225,11 +226,11 @@ belongs to 006, not to this spec.
 
 ### Task 6 — Manual E2E **[E2E: user]**
 
-- [ ] A DOCSY test page with one diagram of each supported type + one exotic (Gantt) exports; open in Word: diagrams crisp, correctly sized, exotic shows as readable source.
-- [ ] Zoom to 400% in a modern Word → vector (svgBlip active, not the raster fallback).
-- [ ] Compare against Scroll's output on the same page (Scroll has no mermaid rendering — this is a **differentiator** shot for spec 008's benchmark row 9).
-- [ ] Export duration delta recorded vs. the 004 baseline (spec 008 input).
-- [ ] Test page deleted afterwards.
+- [x] A DOCSY test page with one diagram of each supported type + one exotic (Gantt) exports; open in Word: diagrams crisp, correctly sized, exotic shows as readable source. (Björn, 2026-07-16, page 1119158277, real Mayflower Prüfvorlage — after finding #1 was fixed.)
+- [x] Zoom to 400% in a modern Word → vector (svgBlip active, not the raster fallback). (Proven via Björn's Word print-PDF: the 6 diagrams appear as vector paths; the PDF's only raster XObjects are the template logos/footer.)
+- [ ] Compare against Scroll's output on the same page (Scroll has no mermaid rendering — this is a **differentiator** shot for spec 008's benchmark row 9). *(open — spec 008 input)*
+- [ ] Export duration delta recorded vs. the 004 baseline (spec 008 input). *(open — spec 008 input)*
+- [ ] Test page deleted afterwards. *(page 1119158277 kept for now — also useful for the Scroll comparison; delete after 008 row 9)*
 
 ---
 

--- a/src/content/docs/confluence/export.md
+++ b/src/content/docs/confluence/export.md
@@ -68,6 +68,19 @@ embed inline at their intrinsic size (or the page-set width), capped to the cont
 image that cannot be fetched or decoded becomes a warning note instead of failing the export.
 `--no-images` disables embedding for this engine too.
 
+### Mermaid diagrams
+
+The browser extension renders fenced ```` ```mermaid ```` code blocks into real vector drawings
+(SVG with an automatic PNG fallback for older Word versions). Six diagram types are supported:
+**flowchart, state, sequence, class, ER, and XY chart**. Any other type (Gantt, Pie, Mindmap, …)
+and any diagram that fails to render exports as a readable source code block with a report note
+naming the reason — never a broken image. The diagram source is carried as the drawing's alt text.
+
+Rendering the PNG fallback needs a browser canvas, so the **CLI `ts` engine exports mermaid
+blocks as source code blocks** (with a `diagram-skipped` report note). Diagram theming follows
+the export's brand colors when configured; the default is a neutral light theme matching the
+code-block styling.
+
 ## Templates
 
 ### Template Resolution

--- a/src/content/docs/reference/docx-engine.md
+++ b/src/content/docs/reference/docx-engine.md
@@ -100,9 +100,11 @@ inline `<w:drawing>` with unique element ids and alt text. Details that matter t
 
 Fenced ```` ```mermaid ```` code blocks render into inline vector drawings (spec 005a) through
 [`beautiful-mermaid`](https://github.com/lukilabs/beautiful-mermaid) — a self-contained,
-DOM-free renderer (not mermaid.js). The renderer lives in the engine
-(`packages/docx/src/diagram.ts`, lazy-loaded so diagram-free exports never pay for its ~1.5 MB
-elkjs layout chunk); the SVG → PNG rasterization is the host's injected `SvgRasterizer`.
+DOM-free renderer (not mermaid.js). The renderer is the **format-agnostic adapter package
+`@atlcli/diagram`** (`packages/diagram`): it knows nothing about DOCX, so the PDF export path
+can consume the same SVG natively later. It is lazy-loaded, so diagram-free exports never pay
+for its ~1.5 MB elkjs layout chunk; the SVG → PNG rasterization is the host's injected
+`SvgRasterizer` (a DOCX-side concern — Word needs the raster fallback, PDF will not).
 
 - **Supported types:** flowchart (`graph`/`flowchart`), state, sequence, class, ER, XY chart.
 - **Word compatibility:** each diagram embeds as `asvg:svgBlip` (vector, modern Word) **plus** a

--- a/src/content/docs/reference/docx-engine.md
+++ b/src/content/docs/reference/docx-engine.md
@@ -16,6 +16,7 @@ inject.
 - [Architecture](#architecture)
 - [The three injected interfaces](#the-three-injected-interfaces)
 - [Image embedding](#image-embedding)
+- [Mermaid diagrams](#mermaid-diagrams)
 - [Plugging in a new surface](#plugging-in-a-new-surface)
 - [Guarantees and gates](#guarantees-and-gates)
 - [Related topics](#related-topics)
@@ -52,11 +53,23 @@ interface AssetFetcher {
 interface OutputSink {
   emit(name: string, bytes: Uint8Array): Promise<void>; // extension: download · CLI: writeFile
 }
-interface ExportEnv { templates: TemplateSource; assets?: AssetFetcher; output: OutputSink; }
+interface SvgRasterizer {
+  rasterize(svg: string, target: { widthPx: number; heightPx: number }): Promise<Uint8Array>;
+} // extension: <canvas> · Node hosts: resvg or similar (optional)
+interface ExportEnv {
+  templates: TemplateSource;
+  assets?: AssetFetcher;
+  rasterizer?: SvgRasterizer;
+  output: OutputSink;
+}
 ```
 
 `AssetFetcher` drives image embedding (spec 005). It is optional: a host that omits it gets the
 pre-005 behavior — every image degrades to an `image-skipped` report note instead of embedding.
+
+`SvgRasterizer` drives mermaid diagram embedding (spec 005a) — it supplies the mandatory PNG
+fallback Word needs next to the vector SVG. Also optional: a host that omits it exports mermaid
+blocks as readable source code blocks with a `diagram-skipped` report note.
 
 ## Image embedding
 
@@ -82,6 +95,31 @@ inline `<w:drawing>` with unique element ids and alt text. Details that matter t
   (`tokenAssetFetcher` in `apps/cli/src/commands/export.ts`).
 - Byte-identical images share one media part; the report counts `embeddedImages` and
   `skippedImages`.
+
+## Mermaid diagrams
+
+Fenced ```` ```mermaid ```` code blocks render into inline vector drawings (spec 005a) through
+[`beautiful-mermaid`](https://github.com/lukilabs/beautiful-mermaid) — a self-contained,
+DOM-free renderer (not mermaid.js). The renderer lives in the engine
+(`packages/docx/src/diagram.ts`, lazy-loaded so diagram-free exports never pay for its ~1.5 MB
+elkjs layout chunk); the SVG → PNG rasterization is the host's injected `SvgRasterizer`.
+
+- **Supported types:** flowchart (`graph`/`flowchart`), state, sequence, class, ER, XY chart.
+- **Word compatibility:** each diagram embeds as `asvg:svgBlip` (vector, modern Word) **plus** a
+  PNG rendered at 2× the intrinsic size in the same blip (older Word). Both media parts,
+  relationships and content types are written by the image module — shared id space with page
+  images, width-capped, and the diagram **source** carried as the drawing's alt text.
+- **Everything else degrades honestly:** an unsupported type (Gantt, Pie, Mindmap, Timeline,
+  Git graph, C4, …) yields a `diagram-unsupported` info note naming the type; a render, raster
+  or embed failure yields a `diagram-render-failed` warning; no rasterizer yields
+  `diagram-skipped`. In every non-rendered route the block exports as a readable monospace
+  source block — never a broken image, never a dangling relationship. The report counts
+  `renderedDiagrams`.
+- **Theming:** `ExportInput.diagramTheme` takes two base colors (`bg`, `fg`) plus optional role
+  overrides (`line`, `accent`, `muted`, `surface`, `border`, `font`); the full scheme is derived
+  from the base pair. Default is a neutral zinc-light palette matching the export's code blocks.
+- **Licensing note:** beautiful-mermaid is MIT; its layout dependency `elkjs` is **EPL-2.0**
+  (weak copyleft, satisfied by attribution — see the repository `NOTICE` file).
 
 ### Logo placeholders
 

--- a/turbo.json
+++ b/turbo.json
@@ -15,7 +15,8 @@
         "packages/confluence/src/**/*.ts",
         "packages/jira/src/**/*.ts",
         "packages/core/src/**/*.ts",
-        "packages/docx/src/**/*.ts"
+        "packages/docx/src/**/*.ts",
+        "packages/diagram/src/**/*.ts"
       ]
     }
   }


### PR DESCRIPTION
## Summary

Implements `specs/005a-mermaid-diagrams/PLAN.md`: fenced ```` ```mermaid ```` code blocks now export as real **vector drawings** (svgBlip + mandatory PNG@2x fallback) instead of source code blocks. Six diagram types are supported (flowchart, state, sequence, class, ER, XY-chart); everything else keeps the 004-pinned fallback — readable source, never a broken image.

### What's in

- **New format-agnostic adapter `@atlcli/diagram`** (`packages/diagram`, per Björn: "nicht eng an docx binden" — spec 007's PDF path consumes the same SVG natively):
  - `renderDiagram(source, theme)` over **beautiful-mermaid@1.1.3** (own renderer, MV3-CSP-clean, not mermaid.js), lazy-loaded like `highlight.ts`. Diagram-type detection runs BEFORE the chunk import, so unsupported types (Gantt, Pie, Mindmap, …) are reported **by name** without ever loading the ~1.5 MB elkjs chunk. Never throws.
  - `flattenSvgStyles` (Word E2E finding #1): beautiful-mermaid styles everything via CSS custom properties + `color-mix()` + `<style>` class rules — Word's svgBlip renderer supports none of those (first E2E rendered every diagram black with no arrowheads). The flattener resolves the full cascade into literal presentation attributes and drops the `<style>` blocks (which also removes the Google-Fonts `@import`). Same prerequisite for 007's SVG consumers (resvg/Typst).
- **`@atlcli/docx`:** `ImageEmbedder.embedSvg` — SVG media part + PNG@2x raster in one `<a:blip>` (`asvg:svgBlip` ext), shared docPr-id space with page images, dedup, width-capped, diagram **source as alt text**; all validation before the first archive write (004-F3: no dangling relationship on any failure leg). New `SvgRasterizer` seam on `ExportEnv`/`ExportInput` (host capability, like `AssetFetcher`); serializer routes mermaid through a `DiagramEmbedSeam`; report gains `renderedDiagrams` and distinguishes rendered / `diagram-unsupported` / `diagram-render-failed` / `diagram-skipped`. `DiagramTheme` (bg/fg + role overrides) with a neutral zinc-light default.
- **Hosts:** extension supplies `canvasSvgRasterizer` (panel `<canvas>`, decode timeout so a hung SVG degrades instead of freezing the export); panel report shows the diagram count. **CLI has no rasterizer yet** — mermaid stays a readable source block with a report note (follow-up session for a Node/resvg rasterizer is running separately).
- **Decisions ratified:** M1 — elkjs **EPL-2.0 accepted**, attribution added to `NOTICE`; M2 — renderer placement resolved via the adapter package (dissolves the §2.5 naming tension). 004 pin test retargeted to Gantt, not deleted.

### Bundle (Task-1 gate)

Diagram chunk **1.5 MB raw / ~472 KB gzip**, double-lazy (panel → engine chunk → diagram chunk); sidepanel entry unchanged. The feared elkjs `web-worker` require hazard did not materialize — Vite and bun both build clean. `check:browser` now gates 7 entrypoints (new: `packages/diagram/src/index.ts`).

## Test plan

- [x] 1669 tests pass (`bun test`): 24 renderer tests, svg-flatten unit + real-renderer regressions, `embedSvg` archive surgery, serializer routing, 6 pipeline integration tests incl. failure injection on every leg; golden capture unchanged (hosts without a rasterizer behave exactly as before)
- [x] `bun run typecheck`, `build`, `check:browser` (7 entrypoints), `check:extension-output`, `docs:check` all green
- [x] E2E CLI (profile `mayflower`, DOCSY): degradation path verified on a live page; rendered path byte-verified on the same live storage (svgBlip + PNG + rels, named Gantt note); temp page deleted
- [x] **E2E extension (Björn, real Mayflower Prüfvorlage, page 1119158277):** all 6 types render correctly in Word; Gantt stays source; vector confirmed via Word print-PDF analysis (diagrams are vector paths — the PDF's only raster images are the template logos/footer)
- [ ] Scroll comparison + export-duration delta → spec 008 benchmark inputs (test page 1119158277 kept for that)

Docs: `confluence/export.md` (Mermaid section), `reference/docx-engine.md` (SvgRasterizer seam, `@atlcli/diagram` adapter, licensing note); spec PLAN updated with decisions + findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)