### PR TITLE
perf(docx): blazing-fast exports — parallel round-trips, wasm shiki, asset caches

### DIFF
--- a/apps/cli/src/commands/export-internals.test.ts
+++ b/apps/cli/src/commands/export-internals.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { chmod, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  createAssetByteCache,
+  mightContainMermaid,
+  prestartPageDependentDeps,
+  tokenAssetFetcher,
+} from "./export-internals.js";
+
+const tempDirs: string[] = [];
+
+async function testCache() {
+  const root = await mkdtemp(join(tmpdir(), "atlcli-export-cache-"));
+  tempDirs.push(root);
+  const cacheDir = join(root, "assets");
+  return { cache: createAssetByteCache("https://example.atlassian.net/wiki", cacheDir), cacheDir };
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe("export asset cache", () => {
+  test("writes a verified envelope and serves a later hit with private permissions", async () => {
+    const { cache, cacheDir } = await testCache();
+    const bytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
+    const load = mock(async () => bytes);
+
+    expect(await cache.getOrLoad("attachment:1:v2", load)).toEqual(bytes);
+    expect(await cache.getOrLoad("attachment:1:v2", load)).toEqual(bytes);
+
+    expect(load).toHaveBeenCalledTimes(1);
+    const encoded = new Uint8Array(await readFile(cache.pathFor("attachment:1:v2")));
+    expect(new TextDecoder().decode(encoded.subarray(0, encoded.indexOf(0x0a)))).toMatch(
+      /^atlcli-asset-v1 [0-9a-f]{64} 4$/
+    );
+    expect((await stat(cacheDir)).mode & 0o777).toBe(0o700);
+    expect((await stat(cache.pathFor("attachment:1:v2"))).mode & 0o777).toBe(0o600);
+  });
+
+  test("treats a non-zero checksum mismatch as a miss and self-heals it", async () => {
+    const { cache, cacheDir } = await testCache();
+    const original = new Uint8Array([1, 2, 3, 4]);
+    await cache.getOrLoad("url:/download/logo?version=1", async () => original);
+
+    const path = cache.pathFor("url:/download/logo?version=1");
+    const damaged = new Uint8Array(await readFile(path));
+    damaged[damaged.length - 1] ^= 0xff;
+    await writeFile(path, damaged);
+    await chmod(cacheDir, 0o755);
+    await chmod(path, 0o644);
+
+    const replacement = new Uint8Array([9, 8, 7, 6]);
+    const reload = mock(async () => replacement);
+    expect(await cache.getOrLoad("url:/download/logo?version=1", reload)).toEqual(replacement);
+    expect(await cache.getOrLoad("url:/download/logo?version=1", reload)).toEqual(replacement);
+
+    expect(reload).toHaveBeenCalledTimes(1);
+    expect((await stat(cacheDir)).mode & 0o777).toBe(0o700);
+    expect((await stat(path)).mode & 0o777).toBe(0o600);
+  });
+
+  test("stores a versioned custom logo under only the immutable URL key", async () => {
+    const cacheKeys: string[] = [];
+    const cache = {
+      async getOrLoad(key: string, load: () => Promise<Uint8Array>) {
+        cacheKeys.push(key);
+        return load();
+      },
+    };
+    const attachment = {
+      id: "77",
+      filename: "logo.png",
+      mediaType: "image/png",
+      fileSize: 4,
+      version: 3,
+      pageId: "42",
+      downloadUrl: "/rest/api/content/77/download",
+    };
+    const client = {
+      listAttachments: mock(async () => [attachment]),
+      downloadAttachment: mock(async () => new Uint8Array([1, 2, 3, 4])),
+    };
+
+    const assets = tokenAssetFetcher(client, cache);
+    await assets.fetch({
+      url: "/download/attachments/42/logo.png?version=3",
+      pageId: "42",
+      filename: "logo.png",
+    });
+
+    expect(cacheKeys).toEqual(["url:/download/attachments/42/logo.png?version=3"]);
+    expect(client.listAttachments).toHaveBeenCalledTimes(1);
+    expect(client.downloadAttachment).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("export host prefetch", () => {
+  test("starts scanned space and homepage deps only after the page yields its key", async () => {
+    let resolvePage!: (page: { spaceKey?: string }) => void;
+    const pagePromise = new Promise<{ spaceKey?: string }>((resolve) => {
+      resolvePage = resolve;
+    });
+    const getSpaceWithIcon = mock(async () => ({ space: {}, icon: null }));
+    const getSpaceHomepageStorage = mock(async () => "");
+
+    prestartPageDependentDeps({
+      pagePromise,
+      templateDeps: new Set(["space", "spaceLogo", "spaceHomepage"]),
+      embedImages: true,
+      getSpaceWithIcon,
+      getSpaceHomepageStorage,
+    });
+    expect(getSpaceWithIcon).not.toHaveBeenCalled();
+    expect(getSpaceHomepageStorage).not.toHaveBeenCalled();
+
+    resolvePage({ spaceKey: "DOCSY" });
+    await pagePromise;
+    await Promise.resolve();
+
+    expect(getSpaceWithIcon).toHaveBeenCalledTimes(1);
+    expect(getSpaceWithIcon).toHaveBeenCalledWith("DOCSY");
+    expect(getSpaceHomepageStorage).toHaveBeenCalledTimes(1);
+    expect(getSpaceHomepageStorage).toHaveBeenCalledWith("DOCSY");
+  });
+
+  test("does not start a logo-only dependency when image embedding is disabled", async () => {
+    const getSpaceWithIcon = mock(async () => ({ space: {}, icon: null }));
+    const getSpaceHomepageStorage = mock(async () => "");
+    prestartPageDependentDeps({
+      pagePromise: Promise.resolve({ spaceKey: "DOCSY" }),
+      templateDeps: new Set(["spaceLogo"]),
+      embedImages: false,
+      getSpaceWithIcon,
+      getSpaceHomepageStorage,
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(getSpaceWithIcon).not.toHaveBeenCalled();
+    expect(getSpaceHomepageStorage).not.toHaveBeenCalled();
+  });
+});
+
+describe("Mermaid rasterizer gate", () => {
+  test("recognizes a Confluence code macro whose language is Mermaid", () => {
+    expect(
+      mightContainMermaid(
+        '<ac:structured-macro ac:name="code"><ac:parameter ac:name="language">Mermaid</ac:parameter></ac:structured-macro>'
+      )
+    ).toBe(true);
+  });
+
+  test("does not load the rasterizer for ordinary code or prose mentioning Mermaid", () => {
+    expect(
+      mightContainMermaid(
+        '<ac:structured-macro ac:name="code"><ac:parameter ac:name="language">typescript</ac:parameter><ac:plain-text-body>mermaid</ac:plain-text-body></ac:structured-macro>'
+      )
+    ).toBe(false);
+    expect(mightContainMermaid("<p>Mermaid diagrams are useful.</p>")).toBe(false);
+  });
+});

--- a/apps/cli/src/commands/export-internals.ts
+++ b/apps/cli/src/commands/export-internals.ts
@@ -1,0 +1,192 @@
+import { createHash } from "node:crypto";
+import { chmod, mkdir, readFile, readdir, rename, stat, unlink, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import type { AttachmentInfo } from "@atlcli/confluence";
+
+const ASSET_CACHE_MAGIC = "atlcli-asset-v1";
+const ASSET_CACHE_HEADER_RE = /^atlcli-asset-v1 ([0-9a-f]{64}) (\d+)$/;
+const ASSET_CACHE_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
+
+let cachePruned = false;
+
+function encodeAssetCacheEntry(bytes: Uint8Array): Uint8Array {
+  const checksum = createHash("sha256").update(bytes).digest("hex");
+  const header = new TextEncoder().encode(`${ASSET_CACHE_MAGIC} ${checksum} ${bytes.byteLength}\n`);
+  const encoded = new Uint8Array(header.byteLength + bytes.byteLength);
+  encoded.set(header);
+  encoded.set(bytes, header.byteLength);
+  return encoded;
+}
+
+function decodeAssetCacheEntry(encoded: Uint8Array): Uint8Array | null {
+  const newline = encoded.indexOf(0x0a);
+  // The fixed-format header is 84 bytes today. Keep a small upper bound so a
+  // corrupt binary file never gets decoded into an unbounded string.
+  if (newline < 0 || newline > 128) return null;
+  const header = new TextDecoder().decode(encoded.subarray(0, newline));
+  const match = header.match(ASSET_CACHE_HEADER_RE);
+  if (!match) return null;
+  const payload = encoded.subarray(newline + 1);
+  if (payload.byteLength === 0 || payload.byteLength !== Number(match[2])) return null;
+  const checksum = createHash("sha256").update(payload).digest("hex");
+  return checksum === match[1] ? payload : null;
+}
+
+function assetCachePath(baseUrl: string, key: string, cacheDir: string): string {
+  const hash = createHash("sha256").update(`${baseUrl}\n${key}`).digest("hex").slice(0, 32);
+  return join(cacheDir, `${hash}.bin`);
+}
+
+function pruneAssetCacheOnce(dir: string): void {
+  if (cachePruned) return;
+  cachePruned = true;
+  void (async () => {
+    try {
+      const now = Date.now();
+      for (const name of await readdir(dir)) {
+        try {
+          const path = join(dir, name);
+          const s = await stat(path);
+          // Orphaned temp files are only reaped after a grace period so a
+          // concurrent export's in-flight write is never yanked away.
+          const maxAge = name.endsWith(".tmp") ? 60_000 : ASSET_CACHE_MAX_AGE_MS;
+          if (now - s.mtimeMs > maxAge) await unlink(path);
+        } catch {
+          // Ignore individual entries.
+        }
+      }
+    } catch {
+      // Best-effort eviction.
+    }
+  })();
+}
+
+/** Internal disk cache for immutable export assets. Not exported from the CLI package barrel. */
+export function createAssetByteCache(
+  baseUrl: string,
+  cacheDir = join(homedir(), ".atlcli", "cache", "assets")
+): {
+  pathFor(key: string): string;
+  getOrLoad(key: string, load: () => Promise<Uint8Array>): Promise<Uint8Array>;
+} {
+  const pathFor = (key: string): string => assetCachePath(baseUrl, key, cacheDir);
+  return {
+    pathFor,
+    async getOrLoad(key, load) {
+      const cachePath = pathFor(key);
+      try {
+        // Cache contents can be private Confluence attachments. Repair legacy
+        // permissions opportunistically on every hit.
+        await chmod(dirname(cachePath), 0o700).catch(() => {});
+        const cached = new Uint8Array(await readFile(cachePath));
+        await chmod(cachePath, 0o600).catch(() => {});
+        const decoded = decodeAssetCacheEntry(cached);
+        if (decoded) return decoded;
+      } catch {
+        // Cache miss; fall through to the authoritative loader.
+      }
+
+      const bytes = await load();
+      try {
+        const dir = dirname(cachePath);
+        await mkdir(dir, { recursive: true, mode: 0o700 });
+        await chmod(dir, 0o700);
+        const tmp = `${cachePath}.${process.pid.toString(36)}${Math.random().toString(36).slice(2)}.tmp`;
+        await writeFile(tmp, encodeAssetCacheEntry(bytes), { mode: 0o600 });
+        await chmod(tmp, 0o600);
+        await rename(tmp, cachePath);
+        await chmod(cachePath, 0o600);
+        pruneAssetCacheOnce(dir);
+      } catch {
+        // Cache writes are best-effort and never fail an export.
+      }
+      return bytes;
+    },
+  };
+}
+
+interface AssetByteCache {
+  getOrLoad(key: string, load: () => Promise<Uint8Array>): Promise<Uint8Array>;
+}
+
+interface AssetClient {
+  listAttachments(pageId: string): Promise<AttachmentInfo[]>;
+  downloadAttachment(attachment: AttachmentInfo | { downloadUrl: string }): Promise<Uint8Array>;
+}
+
+/** Token-auth asset adapter, kept here so its two immutable cache-key paths are regression-testable. */
+export function tokenAssetFetcher(client: AssetClient, cache: AssetByteCache): {
+  fetch(ref: { url: string; pageId?: string; filename?: string }): Promise<Uint8Array>;
+} {
+  const listings = new Map<string, Promise<AttachmentInfo[]>>();
+  const download = async (
+    ref: { url: string; pageId?: string; filename?: string },
+    cacheAttachment = true
+  ): Promise<Uint8Array> => {
+    if (/^https?:\/\//i.test(ref.url)) {
+      const res = await fetch(ref.url);
+      if (!res.ok) throw new Error(`image download failed (${res.status}) for ${ref.url}`);
+      return new Uint8Array(await res.arrayBuffer());
+    }
+    if (ref.pageId && ref.filename) {
+      let listing = listings.get(ref.pageId);
+      if (!listing) {
+        listing = client.listAttachments(ref.pageId);
+        listings.set(ref.pageId, listing);
+      }
+      const attachment = (await listing).find((a) => a.filename === ref.filename);
+      if (!attachment) throw new Error(`attachment "${ref.filename}" not found on page ${ref.pageId}`);
+      if (!cacheAttachment) return client.downloadAttachment(attachment);
+      return cache.getOrLoad(`attachment:${attachment.id}:v${attachment.version}`, () =>
+        client.downloadAttachment(attachment)
+      );
+    }
+    return client.downloadAttachment({ downloadUrl: ref.url });
+  };
+
+  return {
+    async fetch(ref) {
+      if (ref.url.startsWith("/download/") && /[?&](version|modificationDate)=/.test(ref.url)) {
+        // The immutable URL entry provides the repeat-export no-listing win.
+        // Bypass the inner id+version cache on a miss to avoid storing the same
+        // custom-logo bytes under two hashes.
+        return cache.getOrLoad(`url:${ref.url}`, () => download(ref, false));
+      }
+      return download(ref);
+    },
+  };
+}
+
+/** Cheap, conservative gate before loading the resvg wasm and bundled fonts. */
+export function mightContainMermaid(storage: string): boolean {
+  return /<ac:parameter\b[^>]*\bac:name\s*=\s*["']language["'][^>]*>\s*mermaid\s*<\/ac:parameter\s*>/i.test(
+    storage
+  );
+}
+
+/** Start only the page-key-dependent requests named by the local template scan. */
+export function prestartPageDependentDeps(input: {
+  pagePromise: Promise<{ spaceKey?: string }>;
+  templateDeps: ReadonlySet<string>;
+  embedImages: boolean;
+  getSpaceWithIcon: (spaceKey: string) => Promise<unknown>;
+  getSpaceHomepageStorage: (spaceKey: string) => Promise<unknown>;
+}): void {
+  const prefetch = input.pagePromise.then((details) => {
+    const key = details.spaceKey;
+    if (!key) return;
+    if (
+      input.templateDeps.has("space") ||
+      (input.embedImages && input.templateDeps.has("spaceLogo"))
+    ) {
+      input.getSpaceWithIcon(key).catch(() => {});
+    }
+    if (input.templateDeps.has("spaceHomepage")) {
+      input.getSpaceHomepageStorage(key).catch(() => {});
+    }
+  });
+  // The engine still awaits the original page promise and reports that error.
+  // This derived optimization branch must never become an unhandled rejection.
+  prefetch.catch(() => {});
+}

--- a/apps/cli/src/commands/export.ts
+++ b/apps/cli/src/commands/export.ts
@@ -109,10 +109,15 @@ export async function handleExport(
   if (engine === "ts") {
     // The page fetch is NOT awaited here: exportWithTsEngine overlaps it
     // with template read/scan + rasterizer setup + pre-started resolver
-    // round-trips (perf).
+    // round-trips (perf). The consumed catch branch keeps a FAST rejection
+    // (bad page id) from surfacing as an unhandled rejection while local
+    // setup is still running — the engine awaits the original promise and
+    // reports the real error.
+    const pagePromise = client.getPageDetails(pageId);
+    pagePromise.catch(() => {});
     await exportWithTsEngine({
       client,
-      pagePromise: client.getPageDetails(pageId),
+      pagePromise,
       pageId,
       baseUrl,
       resolvedTemplatePath,
@@ -752,15 +757,24 @@ function tokenAssetFetcher(client: ConfluenceClient, baseUrl: string) {
     const cachePath = assetCachePath(baseUrl, key);
     try {
       const { readFile } = await import("node:fs/promises");
-      return new Uint8Array(await readFile(cachePath));
+      const cached = new Uint8Array(await readFile(cachePath));
+      // Zero bytes can only be a damaged entry (no Confluence asset is
+      // empty) — treat as a miss and refetch.
+      if (cached.byteLength > 0) return cached;
     } catch {
       // cache miss — fall through to the network
     }
     const bytes = await load();
     try {
-      const { mkdir, writeFile } = await import("node:fs/promises");
+      const { mkdir, rename, writeFile } = await import("node:fs/promises");
       await mkdir(dirname(cachePath), { recursive: true });
-      await writeFile(cachePath, bytes);
+      // Write-then-rename keeps the cache atomic: a concurrent export or a
+      // crash mid-write must never leave partial bytes under the final
+      // name (they would be served as a permanent hit).
+      const tmp = `${cachePath}.${process.pid.toString(36)}${Math.random().toString(36).slice(2)}.tmp`;
+      await writeFile(tmp, bytes);
+      await rename(tmp, cachePath);
+      pruneAssetCacheOnce(dirname(cachePath));
     } catch {
       // best-effort cache write
     }
@@ -789,6 +803,40 @@ function tokenAssetFetcher(client: ConfluenceClient, baseUrl: string) {
 function assetCachePath(baseUrl: string, key: string): string {
   const hash = createHash("sha256").update(`${baseUrl}\n${key}`).digest("hex").slice(0, 32);
   return join(homedir(), ".atlcli", "cache", "assets", `${hash}.bin`);
+}
+
+/** Entries older than this are evicted opportunistically (immutable keys never go stale — this only bounds disk growth). */
+const ASSET_CACHE_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
+
+let cachePruned = false;
+
+/**
+ * Best-effort, once-per-process, fire-and-forget eviction of stale cache
+ * entries (and orphaned `.tmp` files). Never throws, never blocks the export.
+ */
+function pruneAssetCacheOnce(dir: string): void {
+  if (cachePruned) return;
+  cachePruned = true;
+  void (async () => {
+    try {
+      const { readdir, stat, unlink } = await import("node:fs/promises");
+      const now = Date.now();
+      for (const name of await readdir(dir)) {
+        try {
+          const path = join(dir, name);
+          const s = await stat(path);
+          // Orphaned temp files are only reaped after a grace period so a
+          // CONCURRENT export's in-flight write is never yanked away.
+          const maxAge = name.endsWith(".tmp") ? 60_000 : ASSET_CACHE_MAX_AGE_MS;
+          if (now - s.mtimeMs > maxAge) await unlink(path);
+        } catch {
+          // ignore individual entries
+        }
+      }
+    } catch {
+      // best-effort
+    }
+  })();
 }
 
 async function exportWithTsEngine(args: TsEngineArgs): Promise<void> {

--- a/apps/cli/src/commands/export.ts
+++ b/apps/cli/src/commands/export.ts
@@ -1,7 +1,6 @@
 import { spawn } from "node:child_process";
 import { assertCliAuthSupported } from "./session-guard.js";
 import { existsSync } from "node:fs";
-import { createHash } from "node:crypto";
 import { basename, dirname, join, resolve } from "node:path";
 import { homedir } from "node:os";
 import { fileURLToPath } from "node:url";
@@ -708,7 +707,6 @@ interface TsEngineArgs {
   opts: OutputOptions;
 }
 
-
 /**
  * Spec 006 Task 5: drive the isomorphic `@atlcli/docx` engine — the exact
  * code the Chrome extension runs — with Node-side env implementations:
@@ -718,9 +716,8 @@ interface TsEngineArgs {
  * wiki-base-relative download URLs; external images as absolute URLs).
  * The engine is imported lazily so the common CLI paths never load
  * pizzip/docxtemplater.
- */
-/**
- * Image bytes over the token-auth client (spec 005). The site's cookie-only
+ *
+ * The site's cookie-only
  * `/download/attachments/{pageId}/{filename}` path 401s under API-token Basic
  * auth (verified against Cloud), so attachment refs resolve through the REST
  * attachment listing to the API's own `downloadUrl`
@@ -728,117 +725,6 @@ interface TsEngineArgs {
  * token auth. The listing is cached per page — one extra round-trip per page,
  * not per image. External image URLs are absolute and fetched without auth.
  */
-function tokenAssetFetcher(client: ConfluenceClient, baseUrl: string) {
-  const listings = new Map<string, Promise<AttachmentInfo[]>>();
-  const download = async (ref: { url: string; pageId?: string; filename?: string }): Promise<Uint8Array> => {
-    if (/^https?:\/\//i.test(ref.url)) {
-      const res = await fetch(ref.url);
-      if (!res.ok) throw new Error(`image download failed (${res.status}) for ${ref.url}`);
-      return new Uint8Array(await res.arrayBuffer());
-    }
-    if (ref.pageId && ref.filename) {
-      let listing = listings.get(ref.pageId);
-      if (!listing) {
-        listing = client.listAttachments(ref.pageId);
-        listings.set(ref.pageId, listing);
-      }
-      const attachment = (await listing).find((a) => a.filename === ref.filename);
-      if (!attachment) throw new Error(`attachment "${ref.filename}" not found on page ${ref.pageId}`);
-      // An attachment's bytes are immutable per (id, version) — a re-upload
-      // bumps the version — so they cache under that key. The listing above
-      // stays live, so a replaced image is picked up on the next export.
-      return cachedBytes(`attachment:${attachment.id}:v${attachment.version}`, () =>
-        client.downloadAttachment(attachment)
-      );
-    }
-    return client.downloadAttachment({ downloadUrl: ref.url });
-  };
-  const cachedBytes = async (key: string, load: () => Promise<Uint8Array>): Promise<Uint8Array> => {
-    const cachePath = assetCachePath(baseUrl, key);
-    try {
-      const { readFile } = await import("node:fs/promises");
-      const cached = new Uint8Array(await readFile(cachePath));
-      // Zero bytes can only be a damaged entry (no Confluence asset is
-      // empty) — treat as a miss and refetch.
-      if (cached.byteLength > 0) return cached;
-    } catch {
-      // cache miss — fall through to the network
-    }
-    const bytes = await load();
-    try {
-      const { mkdir, rename, writeFile } = await import("node:fs/promises");
-      await mkdir(dirname(cachePath), { recursive: true });
-      // Write-then-rename keeps the cache atomic: a concurrent export or a
-      // crash mid-write must never leave partial bytes under the final
-      // name (they would be served as a permanent hit).
-      const tmp = `${cachePath}.${process.pid.toString(36)}${Math.random().toString(36).slice(2)}.tmp`;
-      await writeFile(tmp, bytes);
-      await rename(tmp, cachePath);
-      pruneAssetCacheOnce(dirname(cachePath));
-    } catch {
-      // best-effort cache write
-    }
-    return bytes;
-  };
-  return {
-    async fetch(ref: { url: string; pageId?: string; filename?: string }): Promise<Uint8Array> {
-      // Version-stamped `/download/attachments/...` URLs (the space logo's
-      // icon path carries `version=…&modificationDate=…`) are immutable per
-      // key, so their bytes are cached on disk — a repeat export skips the
-      // logo's attachment-listing + download round-trips (~450ms measured).
-      // Cache errors never fail an export.
-      if (ref.url.startsWith("/download/") && /[?&](version|modificationDate)=/.test(ref.url)) {
-        return cachedBytes(`url:${ref.url}`, () => download(ref));
-      }
-      return download(ref);
-    },
-  };
-}
-
-/**
- * Disk-cache location for an immutable asset key (a version-stamped download
- * URL, or an attachment id + version). Keyed by site + key, so a replaced
- * logo/attachment (new version stamp) is a new entry.
- */
-function assetCachePath(baseUrl: string, key: string): string {
-  const hash = createHash("sha256").update(`${baseUrl}\n${key}`).digest("hex").slice(0, 32);
-  return join(homedir(), ".atlcli", "cache", "assets", `${hash}.bin`);
-}
-
-/** Entries older than this are evicted opportunistically (immutable keys never go stale — this only bounds disk growth). */
-const ASSET_CACHE_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
-
-let cachePruned = false;
-
-/**
- * Best-effort, once-per-process, fire-and-forget eviction of stale cache
- * entries (and orphaned `.tmp` files). Never throws, never blocks the export.
- */
-function pruneAssetCacheOnce(dir: string): void {
-  if (cachePruned) return;
-  cachePruned = true;
-  void (async () => {
-    try {
-      const { readdir, stat, unlink } = await import("node:fs/promises");
-      const now = Date.now();
-      for (const name of await readdir(dir)) {
-        try {
-          const path = join(dir, name);
-          const s = await stat(path);
-          // Orphaned temp files are only reaped after a grace period so a
-          // CONCURRENT export's in-flight write is never yanked away.
-          const maxAge = name.endsWith(".tmp") ? 60_000 : ASSET_CACHE_MAX_AGE_MS;
-          if (now - s.mtimeMs > maxAge) await unlink(path);
-        } catch {
-          // ignore individual entries
-        }
-      }
-    } catch {
-      // best-effort
-    }
-  })();
-}
-
 async function exportWithTsEngine(args: TsEngineArgs): Promise<void> {
   const {
     client,
@@ -851,17 +737,23 @@ async function exportWithTsEngine(args: TsEngineArgs): Promise<void> {
     embedImages,
     opts,
   } = args;
-  // Everything local (engine import, rasterizer assets, template bytes) loads
-  // WHILE the page round-trip is in flight (perf).
+  // Everything local (engine import + template bytes) loads WHILE the page
+  // round-trip is in flight. The much larger rasterizer wasm/fonts are gated
+  // on the page storage below.
   const { readFile, stat } = await import("node:fs/promises");
-  const [{ runExport, fileOutputSink }, { buildDiagramRasterizer }, templateBytesRaw, templateStat] =
-    await Promise.all([
-      import("@atlcli/docx"),
-      import("./export-rasterizer.js"),
-      readFile(resolvedTemplatePath),
-      stat(resolvedTemplatePath),
-    ]);
+  const [
+    { runExport, fileOutputSink },
+    { createAssetByteCache, mightContainMermaid, prestartPageDependentDeps, tokenAssetFetcher },
+    templateBytesRaw,
+    templateStat,
+  ] = await Promise.all([
+    import("@atlcli/docx"),
+    import("./export-internals.js"),
+    readFile(resolvedTemplatePath),
+    stat(resolvedTemplatePath),
+  ]);
   const templateBytes = new Uint8Array(templateBytesRaw);
+  const assetCache = createAssetByteCache(baseUrl);
 
   const cliNotes: string[] = [];
   if (includeChildren) {
@@ -878,6 +770,9 @@ async function exportWithTsEngine(args: TsEngineArgs): Promise<void> {
   const currentUser = (): NonNullable<typeof currentUserP> => (currentUserP ??= client.getCurrentUser());
   let ownerP: ReturnType<ConfluenceClient["getPageOwner"]> | undefined;
   const pageOwner = (id: string): NonNullable<typeof ownerP> => (ownerP ??= client.getPageOwner(id));
+  let homepageP: ReturnType<ConfluenceClient["getSpaceHomepageStorage"]> | undefined;
+  const spaceHomepage = (key: string): NonNullable<typeof homepageP> =>
+    (homepageP ??= client.getSpaceHomepageStorage(key));
 
   // Pre-start the round-trips this TEMPLATE will need (a quick local scan
   // names them) so they run concurrently with the page fetch instead of
@@ -885,25 +780,52 @@ async function exportWithTsEngine(args: TsEngineArgs): Promise<void> {
   // dep when a placeholder uses it, and these memoized promises are exactly
   // what it receives. The `.catch` branches only prevent unhandled-rejection
   // noise; the resolver observes and reports the original error.
+  const templateDeps = new Set<string>();
   try {
     const { scanZip, unzipDocx } = await import("@atlcli/docx/scan");
     const { classifyPlaceholder } = await import("@atlcli/docx");
     const scan = scanZip(unzipDocx(templateBytes));
-    const deps = new Set(
-      scan.supported.flatMap((h) => h.raw).map((raw) => classifyPlaceholder(raw).dependency)
-    );
-    if (deps.has("currentUser")) currentUser().catch(() => {});
-    if (deps.has("owner")) pageOwner(pageId).catch(() => {});
+    for (const dependency of scan.supported
+      .flatMap((h) => h.raw)
+      .map((raw) => classifyPlaceholder(raw).dependency)) {
+      templateDeps.add(dependency);
+    }
+    if (templateDeps.has("currentUser")) currentUser().catch(() => {});
+    if (templateDeps.has("owner")) pageOwner(pageId).catch(() => {});
   } catch {
     // Pre-scan is a pure optimization; a scan failure surfaces properly
     // inside runExport.
   }
 
+  // Space-key-dependent work can only start after page details arrive. Hook
+  // the already-running page promise now so these exact memoized promises
+  // overlap rasterizer setup rather than waiting for runExport's resolver.
+  prestartPageDependentDeps({
+    pagePromise,
+    templateDeps,
+    embedImages,
+    getSpaceWithIcon: spaceInfo,
+    getSpaceHomepageStorage: spaceHomepage,
+  });
+
   // Mermaid diagrams render via resvg-wasm (spec 005a). A missing rasterizer
   // is not an error: the engine degrades those blocks to readable source
   // code and reports each one — the note here names the reason once.
-  const [page, rasterizer] = await Promise.all([pagePromise, buildDiagramRasterizer()]);
-  if (!rasterizer) {
+  const rasterizerPromise = pagePromise.then(async (details) => {
+    if (!mightContainMermaid(details.storage ?? "")) {
+      return { needed: false as const, rasterizer: null };
+    }
+    try {
+      const { buildDiagramRasterizer } = await import("./export-rasterizer.js");
+      return { needed: true as const, rasterizer: await buildDiagramRasterizer() };
+    } catch {
+      return { needed: true as const, rasterizer: null };
+    }
+  });
+  rasterizerPromise.catch(() => {});
+  const [page, rasterizerState] = await Promise.all([pagePromise, rasterizerPromise]);
+  const rasterizer = rasterizerState.rasterizer;
+  if (rasterizerState.needed && !rasterizer) {
     cliNotes.push("diagram rasterizer unavailable; mermaid diagrams export as code blocks.");
   }
 
@@ -920,7 +842,7 @@ async function exportWithTsEngine(args: TsEngineArgs): Promise<void> {
         getSpace: async (key: string) => (await spaceInfo(key)).space,
         getCurrentUser: currentUser,
         getPageOwner: pageOwner,
-        getSpaceHomepageStorage: (key: string) => client.getSpaceHomepageStorage(key),
+        getSpaceHomepageStorage: spaceHomepage,
         // Spec 005 logo pass: the space icon path feeds $scroll.spacelogo /
         // $scroll.globallogo; bytes then ride the asset fetcher below. A
         // custom logo's icon.path is a cookie-only `/download/attachments/
@@ -942,7 +864,7 @@ async function exportWithTsEngine(args: TsEngineArgs): Promise<void> {
     },
     {
       templates: { getBytes: async () => templateBytes },
-      assets: tokenAssetFetcher(client, baseUrl),
+      assets: tokenAssetFetcher(client, assetCache),
       rasterizer: rasterizer ?? undefined,
       output: fileOutputSink(resolvedOutputPath),
     }

--- a/apps/cli/src/commands/export.ts
+++ b/apps/cli/src/commands/export.ts
@@ -1,6 +1,7 @@
 import { spawn } from "node:child_process";
 import { assertCliAuthSupported } from "./session-guard.js";
 import { existsSync } from "node:fs";
+import { createHash } from "node:crypto";
 import { basename, dirname, join, resolve } from "node:path";
 import { homedir } from "node:os";
 import { fileURLToPath } from "node:url";
@@ -105,14 +106,15 @@ export async function handleExport(
 
   const baseUrl = getConfluenceBaseUrl(profile);
 
-  // Fetch page data (with metadata for export)
-  const page = await client.getPageDetails(pageId);
-  const spaceKey = page.spaceKey ?? "UNKNOWN";
-
   if (engine === "ts") {
+    // The page fetch is NOT awaited here: exportWithTsEngine overlaps it
+    // with template read/scan + rasterizer setup + pre-started resolver
+    // round-trips (perf).
     await exportWithTsEngine({
       client,
-      page,
+      pagePromise: client.getPageDetails(pageId),
+      pageId,
+      baseUrl,
       resolvedTemplatePath,
       outputPath,
       includeChildren,
@@ -121,6 +123,10 @@ export async function handleExport(
     });
     return;
   }
+
+  // Fetch page data (with metadata for export)
+  const page = await client.getPageDetails(pageId);
+  const spaceKey = page.spaceKey ?? "UNKNOWN";
 
   // Convert storage to markdown
   const conversionOpts: ConversionOptions = {
@@ -687,13 +693,16 @@ async function resolveContentByLabel(
 
 interface TsEngineArgs {
   client: ConfluenceClient;
-  page: ConfluencePageDetails;
+  pagePromise: Promise<ConfluencePageDetails>;
+  pageId: string;
+  baseUrl: string;
   resolvedTemplatePath: string;
   outputPath: string;
   includeChildren: boolean;
   embedImages: boolean;
   opts: OutputOptions;
 }
+
 
 /**
  * Spec 006 Task 5: drive the isomorphic `@atlcli/docx` engine — the exact
@@ -714,50 +723,142 @@ interface TsEngineArgs {
  * token auth. The listing is cached per page — one extra round-trip per page,
  * not per image. External image URLs are absolute and fetched without auth.
  */
-function tokenAssetFetcher(client: ConfluenceClient) {
-  const listings = new Map<string, Promise<{ filename: string; downloadUrl: string }[]>>();
+function tokenAssetFetcher(client: ConfluenceClient, baseUrl: string) {
+  const listings = new Map<string, Promise<AttachmentInfo[]>>();
+  const download = async (ref: { url: string; pageId?: string; filename?: string }): Promise<Uint8Array> => {
+    if (/^https?:\/\//i.test(ref.url)) {
+      const res = await fetch(ref.url);
+      if (!res.ok) throw new Error(`image download failed (${res.status}) for ${ref.url}`);
+      return new Uint8Array(await res.arrayBuffer());
+    }
+    if (ref.pageId && ref.filename) {
+      let listing = listings.get(ref.pageId);
+      if (!listing) {
+        listing = client.listAttachments(ref.pageId);
+        listings.set(ref.pageId, listing);
+      }
+      const attachment = (await listing).find((a) => a.filename === ref.filename);
+      if (!attachment) throw new Error(`attachment "${ref.filename}" not found on page ${ref.pageId}`);
+      // An attachment's bytes are immutable per (id, version) — a re-upload
+      // bumps the version — so they cache under that key. The listing above
+      // stays live, so a replaced image is picked up on the next export.
+      return cachedBytes(`attachment:${attachment.id}:v${attachment.version}`, () =>
+        client.downloadAttachment(attachment)
+      );
+    }
+    return client.downloadAttachment({ downloadUrl: ref.url });
+  };
+  const cachedBytes = async (key: string, load: () => Promise<Uint8Array>): Promise<Uint8Array> => {
+    const cachePath = assetCachePath(baseUrl, key);
+    try {
+      const { readFile } = await import("node:fs/promises");
+      return new Uint8Array(await readFile(cachePath));
+    } catch {
+      // cache miss — fall through to the network
+    }
+    const bytes = await load();
+    try {
+      const { mkdir, writeFile } = await import("node:fs/promises");
+      await mkdir(dirname(cachePath), { recursive: true });
+      await writeFile(cachePath, bytes);
+    } catch {
+      // best-effort cache write
+    }
+    return bytes;
+  };
   return {
     async fetch(ref: { url: string; pageId?: string; filename?: string }): Promise<Uint8Array> {
-      if (/^https?:\/\//i.test(ref.url)) {
-        const res = await fetch(ref.url);
-        if (!res.ok) throw new Error(`image download failed (${res.status}) for ${ref.url}`);
-        return new Uint8Array(await res.arrayBuffer());
+      // Version-stamped `/download/attachments/...` URLs (the space logo's
+      // icon path carries `version=…&modificationDate=…`) are immutable per
+      // key, so their bytes are cached on disk — a repeat export skips the
+      // logo's attachment-listing + download round-trips (~450ms measured).
+      // Cache errors never fail an export.
+      if (ref.url.startsWith("/download/") && /[?&](version|modificationDate)=/.test(ref.url)) {
+        return cachedBytes(`url:${ref.url}`, () => download(ref));
       }
-      if (ref.pageId && ref.filename) {
-        let listing = listings.get(ref.pageId);
-        if (!listing) {
-          listing = client.listAttachments(ref.pageId);
-          listings.set(ref.pageId, listing);
-        }
-        const attachment = (await listing).find((a) => a.filename === ref.filename);
-        if (!attachment) throw new Error(`attachment "${ref.filename}" not found on page ${ref.pageId}`);
-        return client.downloadAttachment(attachment);
-      }
-      return client.downloadAttachment({ downloadUrl: ref.url });
+      return download(ref);
     },
   };
 }
 
+/**
+ * Disk-cache location for an immutable asset key (a version-stamped download
+ * URL, or an attachment id + version). Keyed by site + key, so a replaced
+ * logo/attachment (new version stamp) is a new entry.
+ */
+function assetCachePath(baseUrl: string, key: string): string {
+  const hash = createHash("sha256").update(`${baseUrl}\n${key}`).digest("hex").slice(0, 32);
+  return join(homedir(), ".atlcli", "cache", "assets", `${hash}.bin`);
+}
+
 async function exportWithTsEngine(args: TsEngineArgs): Promise<void> {
-  const { client, page, resolvedTemplatePath, outputPath, includeChildren, embedImages, opts } = args;
-  const { runExport, fileTemplateSource, fileOutputSink } = await import("@atlcli/docx");
-  const { buildDiagramRasterizer } = await import("./export-rasterizer.js");
-  const { stat } = await import("node:fs/promises");
+  const {
+    client,
+    pagePromise,
+    pageId,
+    baseUrl,
+    resolvedTemplatePath,
+    outputPath,
+    includeChildren,
+    embedImages,
+    opts,
+  } = args;
+  // Everything local (engine import, rasterizer assets, template bytes) loads
+  // WHILE the page round-trip is in flight (perf).
+  const { readFile, stat } = await import("node:fs/promises");
+  const [{ runExport, fileOutputSink }, { buildDiagramRasterizer }, templateBytesRaw, templateStat] =
+    await Promise.all([
+      import("@atlcli/docx"),
+      import("./export-rasterizer.js"),
+      readFile(resolvedTemplatePath),
+      stat(resolvedTemplatePath),
+    ]);
+  const templateBytes = new Uint8Array(templateBytesRaw);
 
   const cliNotes: string[] = [];
   if (includeChildren) {
     cliNotes.push("--include-children is not supported by the ts engine yet; exported the single page.");
   }
 
+  // Memoized per-export round-trips, shared between the deps below. Space +
+  // icon come from ONE `?expand=icon` call (previously two calls to the same
+  // endpoint when a template used $scroll.space.* and a logo placeholder).
+  let spaceInfoP: Promise<Awaited<ReturnType<ConfluenceClient["getSpaceWithIcon"]>>> | undefined;
+  const spaceInfo = (key: string): NonNullable<typeof spaceInfoP> =>
+    (spaceInfoP ??= client.getSpaceWithIcon(key));
+  let currentUserP: ReturnType<ConfluenceClient["getCurrentUser"]> | undefined;
+  const currentUser = (): NonNullable<typeof currentUserP> => (currentUserP ??= client.getCurrentUser());
+  let ownerP: ReturnType<ConfluenceClient["getPageOwner"]> | undefined;
+  const pageOwner = (id: string): NonNullable<typeof ownerP> => (ownerP ??= client.getPageOwner(id));
+
+  // Pre-start the round-trips this TEMPLATE will need (a quick local scan
+  // names them) so they run concurrently with the page fetch instead of
+  // after it. The resolver keeps its lazy contract — it still only awaits a
+  // dep when a placeholder uses it, and these memoized promises are exactly
+  // what it receives. The `.catch` branches only prevent unhandled-rejection
+  // noise; the resolver observes and reports the original error.
+  try {
+    const { scanZip, unzipDocx } = await import("@atlcli/docx/scan");
+    const { classifyPlaceholder } = await import("@atlcli/docx");
+    const scan = scanZip(unzipDocx(templateBytes));
+    const deps = new Set(
+      scan.supported.flatMap((h) => h.raw).map((raw) => classifyPlaceholder(raw).dependency)
+    );
+    if (deps.has("currentUser")) currentUser().catch(() => {});
+    if (deps.has("owner")) pageOwner(pageId).catch(() => {});
+  } catch {
+    // Pre-scan is a pure optimization; a scan failure surfaces properly
+    // inside runExport.
+  }
+
   // Mermaid diagrams render via resvg-wasm (spec 005a). A missing rasterizer
   // is not an error: the engine degrades those blocks to readable source
   // code and reports each one — the note here names the reason once.
-  const rasterizer = await buildDiagramRasterizer();
+  const [page, rasterizer] = await Promise.all([pagePromise, buildDiagramRasterizer()]);
   if (!rasterizer) {
     cliNotes.push("diagram rasterizer unavailable; mermaid diagrams export as code blocks.");
   }
 
-  const templateStat = await stat(resolvedTemplatePath);
   const resolvedOutputPath = resolve(outputPath);
   const report = await runExport(
     {
@@ -768,9 +869,9 @@ async function exportWithTsEngine(args: TsEngineArgs): Promise<void> {
       },
       embedImages,
       deps: {
-        getSpace: (key: string) => client.getSpace(key),
-        getCurrentUser: () => client.getCurrentUser(),
-        getPageOwner: (id: string) => client.getPageOwner(id),
+        getSpace: async (key: string) => (await spaceInfo(key)).space,
+        getCurrentUser: currentUser,
+        getPageOwner: pageOwner,
         getSpaceHomepageStorage: (key: string) => client.getSpaceHomepageStorage(key),
         // Spec 005 logo pass: the space icon path feeds $scroll.spacelogo /
         // $scroll.globallogo; bytes then ride the asset fetcher below. A
@@ -780,7 +881,7 @@ async function exportWithTsEngine(args: TsEngineArgs): Promise<void> {
         // carried on the ref — the fetcher then resolves them through the
         // REST attachment listing, which honors token auth.
         getSpaceLogo: async (key: string) => {
-          const icon = await client.getSpaceIcon(key);
+          const icon = (await spaceInfo(key)).icon;
           if (!icon) return null;
           const m = icon.path.match(/^\/download\/attachments\/(\d+)\/([^/?]+)/);
           return {
@@ -792,8 +893,8 @@ async function exportWithTsEngine(args: TsEngineArgs): Promise<void> {
       },
     },
     {
-      templates: fileTemplateSource(resolvedTemplatePath),
-      assets: tokenAssetFetcher(client),
+      templates: { getBytes: async () => templateBytes },
+      assets: tokenAssetFetcher(client, baseUrl),
       rasterizer: rasterizer ?? undefined,
       output: fileOutputSink(resolvedOutputPath),
     }

--- a/apps/extension/entrypoints/sidepanel/TemplateSection.tsx
+++ b/apps/extension/entrypoints/sidepanel/TemplateSection.tsx
@@ -121,14 +121,14 @@ export function TemplateSection({
       if (cancelled || !current) return;
       setTemplate(current);
       // A stored template means an export is likely: pull the engine + env
-      // chunks and the mermaid renderer (~1.5 MB elkjs) NOW so the first
-      // export doesn't pay their import cost. Pure warm-up — failures are
-      // swallowed and the export path retries its own imports. A user with
-      // no template still loads nothing (the lazy-load contract).
-      void Promise.all([
-        loadExport().then((m) => m.warmDiagramRenderer()),
-        loadEnv(),
-      ]).catch(() => {});
+      // chunks NOW so the first export doesn't pay their import cost. Pure
+      // warm-up — failures are swallowed and the export path retries its
+      // own imports. A user with no template still loads nothing (the
+      // lazy-load contract). The mermaid renderer chunk is deliberately NOT
+      // warmed here: importing elkjs at mount coincided with a severe
+      // rasterizer slowdown during export (under investigation); the export
+      // path lazy-loads it exactly as before.
+      void Promise.all([loadExport(), loadEnv()]).catch(() => {});
     })().catch(() => {
       // A stored template that no longer scans is unusable; surface it rather
       // than rendering a half-loaded section.
@@ -198,8 +198,9 @@ export function TemplateSection({
     setBusy("export");
     try {
       const { runExport } = await loadExport();
-      const { idbTemplateSource, sessionAssetFetcher, downloadOutputSink, canvasSvgRasterizer } =
-        await loadEnv();
+      const env = await loadEnv();
+      const { idbTemplateSource, sessionAssetFetcher, downloadOutputSink, canvasSvgRasterizer } = env;
+      env.resetRasterizerStats();
       const profile = profileFromTabUrl(pageUrl);
       const client = profile ? new ConfluenceClient(profile) : null;
       // Space + icon share ONE memoized `?expand=icon` round-trip: a template
@@ -238,6 +239,18 @@ export function TemplateSection({
           output: downloadOutputSink(),
         }
       );
+      // Panel-side rasterizer sub-timings (decode/draw/encode sums) join the
+      // report so a slow diagram pipeline names its slow sub-step.
+      const stats = env.getRasterizerStats();
+      if (stats.calls > 0) {
+        rep.notes.push({
+          level: "info",
+          code: "perf-timing",
+          message:
+            `Panel rasterizer: ${stats.calls} call(s) — decode ${stats.decodeMs} ms, ` +
+            `draw ${stats.drawMs} ms, encode ${stats.encodeMs} ms (sums).`,
+        });
+      }
       setReport(rep);
     } catch (err) {
       setError(exportErrorMessage(err));

--- a/apps/extension/entrypoints/sidepanel/TemplateSection.tsx
+++ b/apps/extension/entrypoints/sidepanel/TemplateSection.tsx
@@ -22,6 +22,7 @@ import {
   type StoredTemplate,
 } from "../../utils/docx/template-store.js";
 import { sessionCache } from "../../utils/docx/session-cache.js";
+import { prepareExportDeps } from "../../utils/docx/export-deps.js";
 
 // PizZip + docxtemplater (+ the OOXML serializer and, transitively, lazy Shiki)
 // are heavy and only needed once the user opts into template upload/export.
@@ -37,18 +38,16 @@ const loadEnv = () => import("../../utils/docx/env.js");
 const MAX_MB = 20;
 
 /**
- * Panel-lifetime TTL caches for the resolver deps' METADATA round-trips,
- * keyed by site + entity so multi-site tabs never bleed into each other.
- * Exporting three pages of the same space previously paid the ~100ms
- * space+icon call (and the current-user call) three times; within the TTL
- * they now cost one. Page-specific data (details, owner) stays uncached —
- * always fresh. A renamed space / swapped logo / re-login shows up at most
- * five minutes later, which matches how often that actually happens.
+ * Panel-lifetime TTL cache for the space + icon metadata round-trip, keyed by
+ * site + space so multi-site tabs never bleed into each other. Exporting three
+ * pages of one space previously paid the ~100ms call three times; within the
+ * TTL it now costs one. A renamed space / swapped logo shows up at most five
+ * minutes later. Current user, homepage storage, details, and owner are
+ * deliberately NOT cached across exports: they can change under the same key
+ * without a safe auth/content invalidation signal.
  */
 const DEPS_CACHE_TTL_MS = 5 * 60_000;
 const spaceInfoCache = sessionCache<Awaited<ReturnType<ConfluenceClient["getSpaceWithIcon"]>>>(DEPS_CACHE_TTL_MS);
-const currentUserCache = sessionCache<Awaited<ReturnType<ConfluenceClient["getCurrentUser"]>>>(DEPS_CACHE_TTL_MS);
-const homepageStorageCache = sessionCache<string | null>(DEPS_CACHE_TTL_MS);
 
 interface CurrentTemplate {
   name: string;
@@ -191,6 +190,10 @@ export function TemplateSection({
         );
         return;
       }
+      // A valid upload is an explicit opt-in to the export feature. Warm the
+      // engine + host adapters while IndexedDB persists the template so the
+      // first Export click does not pay the cold dynamic-import cost.
+      void Promise.all([loadExport(), loadEnv()]).catch(() => {});
       await putTemplate(toStored(file.name, buf));
       setTemplate({ name: file.name, uploadedAt: Date.now(), scan, bytes: buf });
     } catch (err) {
@@ -212,10 +215,6 @@ export function TemplateSection({
     setError(null);
     setBusy("export");
     try {
-      const { runExport } = await loadExport();
-      const env = await loadEnv();
-      const { idbTemplateSource, sessionAssetFetcher, downloadOutputSink, canvasSvgRasterizer } = env;
-      env.resetRasterizerStats();
       const profile = profileFromTabUrl(pageUrl);
       const client = profile ? new ConfluenceClient(profile) : null;
       const site = profile ? getConfluenceBaseUrl(profile) : "";
@@ -223,30 +222,36 @@ export function TemplateSection({
       // $scroll.space.* and a logo placeholder previously called the same
       // endpoint twice), served from the panel-lifetime TTL cache above so
       // repeat exports within the same space skip it entirely.
-      const spaceInfo = (key: string): ReturnType<ConfluenceClient["getSpaceWithIcon"]> =>
-        spaceInfoCache.get(`${site}|${key}`, () => client!.getSpaceWithIcon(key));
+      // Start exactly the round-trips named by the already-derived scan BEFORE
+      // host chunks/template setup. Rejections have a consumed branch, while
+      // the original promises still reach the engine's normal report notes.
+      const deps = client
+        ? prepareExportDeps(template.scan, loadedPage.details, {
+            getSpaceWithIcon: (key) =>
+              spaceInfoCache.get(`${site}|${key}`, () => client.getSpaceWithIcon(key)),
+            getCurrentUser: () => client.getCurrentUser(),
+            getPageOwner: (id) => client.getPageOwner(id),
+            getSpaceHomepageStorage: (key) => client.getSpaceHomepageStorage(key),
+          })
+        : {};
+      const [{ runExport }, env] = await Promise.all([loadExport(), loadEnv()]);
+      const {
+        memoryTemplateSource,
+        sessionAssetFetcher,
+        downloadOutputSink,
+        canvasSvgRasterizer,
+      } = env;
+      env.resetRasterizerStats();
       const rep = await runExport(
         {
           details: loadedPage.details,
           template: { name: template.name, modificationDate: new Date(template.uploadedAt) },
-          deps: client
-            ? {
-                getSpace: async (key) => (await spaceInfo(key)).space,
-                getCurrentUser: () => currentUserCache.get(site, () => client.getCurrentUser()),
-                getPageOwner: (id) => client.getPageOwner(id),
-                getSpaceHomepageStorage: (key) =>
-                  homepageStorageCache.get(`${site}|${key}`, () => client.getSpaceHomepageStorage(key)),
-                // Spec 005 logo pass: icon path in, bytes via the session
-                // asset fetcher below ($scroll.spacelogo / $scroll.globallogo).
-                getSpaceLogo: async (key) => {
-                  const icon = (await spaceInfo(key)).icon;
-                  return icon ? { url: icon.path } : null;
-                },
-              }
-            : {},
+          deps,
         },
         {
-          templates: idbTemplateSource(),
+          // The panel already owns these exact bytes; avoid rereading the same
+          // template from IndexedDB on every export.
+          templates: memoryTemplateSource(template.bytes),
           // Attachment refs are wiki-base-relative (spec 005); resolve them
           // against the tab's Confluence root so the session cookies apply.
           assets: sessionAssetFetcher(profile ? getConfluenceBaseUrl(profile) : undefined),
@@ -265,7 +270,8 @@ export function TemplateSection({
           code: "perf-timing",
           message:
             `Panel rasterizer: ${stats.calls} call(s) — decode ${stats.decodeMs} ms, ` +
-            `draw ${stats.drawMs} ms, encode ${stats.encodeMs} ms (sums).`,
+            `draw ${stats.drawMs} ms, encode ${stats.encodeMs} ms (sums; per call ` +
+            `${stats.encodeCallsMs.join("/")} ms).`,
         });
       }
       setReport(rep);

--- a/apps/extension/entrypoints/sidepanel/TemplateSection.tsx
+++ b/apps/extension/entrypoints/sidepanel/TemplateSection.tsx
@@ -21,6 +21,7 @@ import {
   putTemplate,
   type StoredTemplate,
 } from "../../utils/docx/template-store.js";
+import { sessionCache } from "../../utils/docx/session-cache.js";
 
 // PizZip + docxtemplater (+ the OOXML serializer and, transitively, lazy Shiki)
 // are heavy and only needed once the user opts into template upload/export.
@@ -34,6 +35,20 @@ const loadExport = () => import("@atlcli/docx/browser");
 const loadEnv = () => import("../../utils/docx/env.js");
 
 const MAX_MB = 20;
+
+/**
+ * Panel-lifetime TTL caches for the resolver deps' METADATA round-trips,
+ * keyed by site + entity so multi-site tabs never bleed into each other.
+ * Exporting three pages of the same space previously paid the ~100ms
+ * space+icon call (and the current-user call) three times; within the TTL
+ * they now cost one. Page-specific data (details, owner) stays uncached —
+ * always fresh. A renamed space / swapped logo / re-login shows up at most
+ * five minutes later, which matches how often that actually happens.
+ */
+const DEPS_CACHE_TTL_MS = 5 * 60_000;
+const spaceInfoCache = sessionCache<Awaited<ReturnType<ConfluenceClient["getSpaceWithIcon"]>>>(DEPS_CACHE_TTL_MS);
+const currentUserCache = sessionCache<Awaited<ReturnType<ConfluenceClient["getCurrentUser"]>>>(DEPS_CACHE_TTL_MS);
+const homepageStorageCache = sessionCache<string | null>(DEPS_CACHE_TTL_MS);
 
 interface CurrentTemplate {
   name: string;
@@ -203,12 +218,13 @@ export function TemplateSection({
       env.resetRasterizerStats();
       const profile = profileFromTabUrl(pageUrl);
       const client = profile ? new ConfluenceClient(profile) : null;
-      // Space + icon share ONE memoized `?expand=icon` round-trip: a template
-      // using $scroll.space.* and a logo placeholder previously called the
-      // same endpoint twice (perf).
-      let spaceInfoP: ReturnType<ConfluenceClient["getSpaceWithIcon"]> | undefined;
-      const spaceInfo = (key: string): NonNullable<typeof spaceInfoP> =>
-        (spaceInfoP ??= client!.getSpaceWithIcon(key));
+      const site = profile ? getConfluenceBaseUrl(profile) : "";
+      // Space + icon share ONE `?expand=icon` round-trip (a template using
+      // $scroll.space.* and a logo placeholder previously called the same
+      // endpoint twice), served from the panel-lifetime TTL cache above so
+      // repeat exports within the same space skip it entirely.
+      const spaceInfo = (key: string): ReturnType<ConfluenceClient["getSpaceWithIcon"]> =>
+        spaceInfoCache.get(`${site}|${key}`, () => client!.getSpaceWithIcon(key));
       const rep = await runExport(
         {
           details: loadedPage.details,
@@ -216,9 +232,10 @@ export function TemplateSection({
           deps: client
             ? {
                 getSpace: async (key) => (await spaceInfo(key)).space,
-                getCurrentUser: () => client.getCurrentUser(),
+                getCurrentUser: () => currentUserCache.get(site, () => client.getCurrentUser()),
                 getPageOwner: (id) => client.getPageOwner(id),
-                getSpaceHomepageStorage: (key) => client.getSpaceHomepageStorage(key),
+                getSpaceHomepageStorage: (key) =>
+                  homepageStorageCache.get(`${site}|${key}`, () => client.getSpaceHomepageStorage(key)),
                 // Spec 005 logo pass: icon path in, bytes via the session
                 // asset fetcher below ($scroll.spacelogo / $scroll.globallogo).
                 getSpaceLogo: async (key) => {

--- a/apps/extension/entrypoints/sidepanel/TemplateSection.tsx
+++ b/apps/extension/entrypoints/sidepanel/TemplateSection.tsx
@@ -120,6 +120,15 @@ export function TemplateSection({
       const current = await loadCurrentTemplate(getTemplate, async () => (await loadScan()).scanTemplate);
       if (cancelled || !current) return;
       setTemplate(current);
+      // A stored template means an export is likely: pull the engine + env
+      // chunks and the mermaid renderer (~1.5 MB elkjs) NOW so the first
+      // export doesn't pay their import cost. Pure warm-up — failures are
+      // swallowed and the export path retries its own imports. A user with
+      // no template still loads nothing (the lazy-load contract).
+      void Promise.all([
+        loadExport().then((m) => m.warmDiagramRenderer()),
+        loadEnv(),
+      ]).catch(() => {});
     })().catch(() => {
       // A stored template that no longer scans is unusable; surface it rather
       // than rendering a half-loaded section.
@@ -193,20 +202,26 @@ export function TemplateSection({
         await loadEnv();
       const profile = profileFromTabUrl(pageUrl);
       const client = profile ? new ConfluenceClient(profile) : null;
+      // Space + icon share ONE memoized `?expand=icon` round-trip: a template
+      // using $scroll.space.* and a logo placeholder previously called the
+      // same endpoint twice (perf).
+      let spaceInfoP: ReturnType<ConfluenceClient["getSpaceWithIcon"]> | undefined;
+      const spaceInfo = (key: string): NonNullable<typeof spaceInfoP> =>
+        (spaceInfoP ??= client!.getSpaceWithIcon(key));
       const rep = await runExport(
         {
           details: loadedPage.details,
           template: { name: template.name, modificationDate: new Date(template.uploadedAt) },
           deps: client
             ? {
-                getSpace: (key) => client.getSpace(key),
+                getSpace: async (key) => (await spaceInfo(key)).space,
                 getCurrentUser: () => client.getCurrentUser(),
                 getPageOwner: (id) => client.getPageOwner(id),
                 getSpaceHomepageStorage: (key) => client.getSpaceHomepageStorage(key),
                 // Spec 005 logo pass: icon path in, bytes via the session
                 // asset fetcher below ($scroll.spacelogo / $scroll.globallogo).
                 getSpaceLogo: async (key) => {
-                  const icon = await client.getSpaceIcon(key);
+                  const icon = (await spaceInfo(key)).icon;
                   return icon ? { url: icon.path } : null;
                 },
               }

--- a/apps/extension/tests/docx/env.test.ts
+++ b/apps/extension/tests/docx/env.test.ts
@@ -13,6 +13,7 @@ import {
   canvasSvgRasterizer,
   downloadOutputSink,
   idbTemplateSource,
+  memoryTemplateSource,
   sessionAssetFetcher,
 } from "../../utils/docx/env.js";
 import { putTemplate } from "../../utils/docx/template-store.js";
@@ -32,6 +33,15 @@ describe("idbTemplateSource", () => {
     const factory = new IDBFactory();
     expect(idbTemplateSource(factory).getBytes("current")).rejects.toThrow(
       'No template stored under id "current"'
+    );
+  });
+});
+
+describe("memoryTemplateSource", () => {
+  it("serves the panel's already-loaded template bytes", async () => {
+    const buffer = new Uint8Array([80, 75, 3, 4]).buffer;
+    expect(await memoryTemplateSource(buffer).getBytes("current")).toEqual(
+      new Uint8Array([80, 75, 3, 4])
     );
   });
 });
@@ -78,6 +88,34 @@ describe("sessionAssetFetcher", () => {
     expect(calls[0].url).toBe("https://cdn.example.com/pic.png");
   });
 
+  it("isolates versioned asset bytes by canonical site base URL", async () => {
+    const ref = {
+      url: "/download/attachments/321/logo.png?version=cross-site-regression",
+      filename: "logo.png",
+    };
+    const siteACalls: string[] = [];
+    const siteBCalls: string[] = [];
+    const fetchA = (async (url: unknown) => {
+      siteACalls.push(String(url));
+      return new Response(new Uint8Array([1]));
+    }) as typeof fetch;
+    const fetchB = (async (url: unknown) => {
+      siteBCalls.push(String(url));
+      return new Response(new Uint8Array([2]));
+    }) as typeof fetch;
+
+    const a = sessionAssetFetcher("https://A.atlassian.net/wiki/", fetchA);
+    const b = sessionAssetFetcher("https://b.atlassian.net/wiki", fetchB);
+    expect(await a.fetch(ref)).toEqual(new Uint8Array([1]));
+    expect(await b.fetch(ref)).toEqual(new Uint8Array([2]));
+    // The canonical no-trailing-slash form shares A's entry, but never B's.
+    expect(await sessionAssetFetcher("https://a.atlassian.net/wiki", fetchA).fetch(ref)).toEqual(
+      new Uint8Array([1])
+    );
+    expect(siteACalls).toHaveLength(1);
+    expect(siteBCalls).toHaveLength(1);
+  });
+
   it("throws with status + filename on a non-OK response", async () => {
     const fetchFn = (async () => new Response("nope", { status: 403 })) as unknown as typeof fetch;
     expect(
@@ -104,6 +142,53 @@ describe("canvasSvgRasterizer", () => {
       })
     ).rejects.toThrow("did not decode within 50 ms");
   });
+
+  it("encodes synchronously without entering the asynchronous toBlob callback path", async () => {
+    let toBlobCalled = false;
+    let revoked = false;
+    class FakeImage {
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      set src(_value: string) {
+        queueMicrotask(() => this.onload?.());
+      }
+    }
+    const canvas = {
+      width: 0,
+      height: 0,
+      getContext: () => ({ drawImage: () => {} }),
+      toDataURL: () => "data:image/png;base64,AQIDBA==",
+      toBlob: () => {
+        toBlobCalled = true;
+      },
+    };
+    const doc = {
+      defaultView: {
+        URL: {
+          createObjectURL: () => "blob:test",
+          revokeObjectURL: () => {
+            revoked = true;
+          },
+        },
+        Blob,
+        Image: FakeImage,
+        atob,
+      },
+      createElement: () => canvas,
+    } as unknown as Document;
+
+    const bytes = await canvasSvgRasterizer(doc).rasterize("<svg/>", {
+      widthPx: 8,
+      heightPx: 6,
+    });
+
+    expect(bytes).toEqual(new Uint8Array([1, 2, 3, 4]));
+    expect(canvas.width).toBe(8);
+    expect(canvas.height).toBe(6);
+    expect(toBlobCalled).toBe(false);
+    expect(revoked).toBe(true);
+  });
+
 });
 
 describe("downloadOutputSink", () => {

--- a/apps/extension/tests/docx/export-deps.test.ts
+++ b/apps/extension/tests/docx/export-deps.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, mock } from "bun:test";
+import type { ScanResult } from "@atlcli/docx/browser";
+import { prepareExportDeps, scanDependencies } from "../../utils/docx/export-deps.js";
+
+function scan(...raw: string[]): ScanResult {
+  return {
+    supported: raw.map((value) => ({
+      base: value.replace(/\.?\(.*$/, ""),
+      status: "supported" as const,
+      count: 1,
+      raw: [value],
+    })),
+    unsupported: [],
+    never: [],
+    parts: ["word/document.xml"],
+    hasContentPlaceholder: true,
+  };
+}
+
+function loaders() {
+  return {
+    getSpaceWithIcon: mock(async (key: string) => ({
+      space: { id: "1", key, name: key, type: "global" as const },
+      icon: { path: `/download/${key}?version=1` },
+    })),
+    getCurrentUser: mock(async () => ({ accountId: "u", displayName: "User" })),
+    getPageOwner: mock(async () => ({ accountId: "o", displayName: "Owner" })),
+    getSpaceHomepageStorage: mock(async () => "<p>home</p>"),
+  };
+}
+
+describe("scanDependencies", () => {
+  it("recognizes only the resolver/logo calls required by supported placeholders", () => {
+    const deps = scanDependencies(
+      scan(
+        "$scroll.title",
+        "$scroll.space.name",
+        "$scroll.exporter.fullName",
+        "$scroll.pageowner.fullName",
+        "$scroll.spacelogo",
+        "$scroll.pageproperty.(Status,false)",
+        "$scroll.pageproperty.(Owner,macro-id,true,Unknown)"
+      )
+    );
+    expect([...deps].sort().join(",")).toBe(
+      ["currentUser", "owner", "space", "spaceHomepage", "spaceLogo"].sort().join(",")
+    );
+  });
+});
+
+describe("prepareExportDeps", () => {
+  it("pre-starts only scan-indicated calls and coalesces space + logo", async () => {
+    const host = loaders();
+    const deps = prepareExportDeps(
+      scan("$scroll.space.name", "$scroll.spacelogo"),
+      { id: "42", spaceKey: "DOCSY" },
+      host
+    );
+
+    expect(host.getSpaceWithIcon).toHaveBeenCalledTimes(1);
+    expect(host.getCurrentUser).not.toHaveBeenCalled();
+    expect(host.getPageOwner).not.toHaveBeenCalled();
+    expect(host.getSpaceHomepageStorage).not.toHaveBeenCalled();
+    expect(await deps.getSpace!("DOCSY")).toMatchObject({ key: "DOCSY" });
+    expect(await deps.getSpaceLogo!("DOCSY")).toEqual({
+      url: "/download/DOCSY?version=1",
+    });
+    expect(host.getSpaceWithIcon).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps current-user and homepage loads per-export while preserving rejection", async () => {
+    const host = loaders();
+    host.getCurrentUser.mockImplementation(async () => {
+      throw new Error("logged out");
+    });
+    const deps = prepareExportDeps(
+      scan("$scroll.exporter", "$scroll.pageproperty.(Status,true)"),
+      { id: "42", spaceKey: "DOCSY" },
+      host
+    );
+
+    expect(host.getCurrentUser).toHaveBeenCalledTimes(1);
+    expect(host.getSpaceHomepageStorage).toHaveBeenCalledTimes(1);
+    await expect(deps.getCurrentUser!()).rejects.toThrow("logged out");
+    expect(await deps.getSpaceHomepageStorage!("DOCSY")).toBe("<p>home</p>");
+    expect(host.getSpaceHomepageStorage).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retain auth/content-sensitive values across exports", async () => {
+    const host = loaders();
+    const templateScan = scan("$scroll.exporter", "$scroll.pageproperty.(Status,true)");
+
+    prepareExportDeps(templateScan, { id: "42", spaceKey: "DOCSY" }, host);
+    prepareExportDeps(templateScan, { id: "42", spaceKey: "DOCSY" }, host);
+
+    expect(host.getCurrentUser).toHaveBeenCalledTimes(2);
+    expect(host.getSpaceHomepageStorage).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/extension/tests/docx/report-view.test.tsx
+++ b/apps/extension/tests/docx/report-view.test.tsx
@@ -29,6 +29,16 @@ function makeReport(notes: ExportReport["notes"]): ExportReport {
     filename: "page.docx",
     notes,
     scan: emptyScan,
+    timings: {
+      resolveMs: 0,
+      bodyMs: 0,
+      logoFetchMs: 0,
+      renderMs: 0,
+      imageFetchMs: 0,
+      imageFetches: 0,
+      diagramRenderMs: 0,
+      diagramRasterMs: 0,
+    },
   };
 }
 

--- a/apps/extension/tests/docx/session-cache.test.ts
+++ b/apps/extension/tests/docx/session-cache.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "bun:test";
+import { sessionCache } from "../../utils/docx/session-cache.js";
+
+describe("sessionCache (panel deps TTL cache)", () => {
+  it("serves repeat gets within the TTL from one load", async () => {
+    let now = 0;
+    let loads = 0;
+    const cache = sessionCache<string>(1000, 32, () => now);
+    const load = async (): Promise<string> => {
+      loads += 1;
+      return "space";
+    };
+    expect(await cache.get("site|DOCSY", load)).toBe("space");
+    now = 999;
+    expect(await cache.get("site|DOCSY", load)).toBe("space");
+    expect(loads).toBe(1);
+  });
+
+  it("reloads after the TTL expires", async () => {
+    let now = 0;
+    let loads = 0;
+    const cache = sessionCache<number>(1000, 32, () => now);
+    const load = async (): Promise<number> => ++loads;
+    expect(await cache.get("k", load)).toBe(1);
+    now = 1001;
+    expect(await cache.get("k", load)).toBe(2);
+  });
+
+  it("shares an in-flight promise between concurrent gets", async () => {
+    let loads = 0;
+    let release!: (v: string) => void;
+    const cache = sessionCache<string>(1000);
+    const load = (): Promise<string> => {
+      loads += 1;
+      return new Promise<string>((r) => {
+        release = r;
+      });
+    };
+    const a = cache.get("k", load);
+    const b = cache.get("k", load);
+    release("v");
+    expect(await a).toBe("v");
+    expect(await b).toBe("v");
+    expect(loads).toBe(1);
+  });
+
+  it("evicts a rejected load immediately so failures never stick", async () => {
+    let loads = 0;
+    const cache = sessionCache<string>(1000);
+    const failing = (): Promise<string> => {
+      loads += 1;
+      return Promise.reject(new Error("boom"));
+    };
+    await expect(cache.get("k", failing)).rejects.toThrow("boom");
+    // Rejection eviction runs in a microtask; yield once.
+    await Promise.resolve();
+    expect(await cache.get("k", async () => "recovered")).toBe("recovered");
+    expect(loads).toBe(1);
+  });
+
+  it("isolates keys (multi-site: same space key on different sites)", async () => {
+    const cache = sessionCache<string>(1000);
+    expect(await cache.get("siteA|DOCSY", async () => "a")).toBe("a");
+    expect(await cache.get("siteB|DOCSY", async () => "b")).toBe("b");
+  });
+
+  it("bounds entries, dropping the least recently written key", async () => {
+    let loads = 0;
+    const cache = sessionCache<number>(60_000, 2);
+    const load = async (): Promise<number> => ++loads;
+    await cache.get("a", load); // 1
+    await cache.get("b", load); // 2
+    await cache.get("c", load); // 3 → evicts "a"
+    expect(await cache.get("b", load)).toBe(2); // still cached
+    expect(await cache.get("a", load)).toBe(4); // was evicted → reloads
+  });
+});

--- a/apps/extension/utils/docx/env.ts
+++ b/apps/extension/utils/docx/env.ts
@@ -31,6 +31,15 @@ export function idbTemplateSource(factory?: IDBFactory): TemplateSource {
   };
 }
 
+/** Template source over bytes the panel already has in memory. */
+export function memoryTemplateSource(bytes: ArrayBuffer): TemplateSource {
+  return {
+    async getBytes(): Promise<Uint8Array> {
+      return new Uint8Array(bytes);
+    },
+  };
+}
+
 /**
  * {@link AssetFetcher} over the page's own session: attachment downloads are
  * plain GETs that succeed because the browser attaches the Atlassian cookies
@@ -56,13 +65,25 @@ function isVersionedAssetUrl(refUrl: string): boolean {
   return refUrl.startsWith("/download/") && /[?&](version|modificationDate)=/.test(refUrl);
 }
 
+function canonicalAssetBaseUrl(baseUrl?: string): string {
+  if (!baseUrl) return "";
+  try {
+    const url = new URL(baseUrl);
+    return `${url.origin}${url.pathname.replace(/\/+$/, "")}`;
+  } catch {
+    return baseUrl.replace(/\/+$/, "");
+  }
+}
+
 export function sessionAssetFetcher(baseUrl?: string, fetchFn: typeof fetch = fetch): AssetFetcher {
+  const canonicalBaseUrl = canonicalAssetBaseUrl(baseUrl);
   return {
     async fetch(ref: AssetRef): Promise<Uint8Array> {
       const cacheable = isVersionedAssetUrl(ref.url);
-      const cached = cacheable ? versionedAssetCache.get(ref.url) : undefined;
+      const cacheKey = `${canonicalBaseUrl}\n${ref.url}`;
+      const cached = cacheable ? versionedAssetCache.get(cacheKey) : undefined;
       if (cached) return cached;
-      const url = /^https?:\/\//i.test(ref.url) ? ref.url : `${baseUrl ?? ""}${ref.url}`;
+      const url = /^https?:\/\//i.test(ref.url) ? ref.url : `${canonicalBaseUrl}${ref.url}`;
       const res = await fetchFn(url, { credentials: "include" });
       if (!res.ok) {
         throw new Error(`Asset fetch failed (${res.status}) for ${ref.filename ?? ref.url}`);
@@ -74,7 +95,7 @@ export function sessionAssetFetcher(baseUrl?: string, fetchFn: typeof fetch = fe
           const oldest = versionedAssetCache.keys().next().value;
           if (oldest !== undefined) versionedAssetCache.delete(oldest);
         }
-        versionedAssetCache.set(ref.url, bytes);
+        versionedAssetCache.set(cacheKey, bytes);
       }
       return bytes;
     },
@@ -85,7 +106,11 @@ export function sessionAssetFetcher(baseUrl?: string, fetchFn: typeof fetch = fe
  * {@link SvgRasterizer} over the panel's real document (spec 005a §2.4,
  * option 1): the rendered diagram SVG becomes an `<img src="blob:…">`, is
  * drawn onto a `<canvas>` at the requested target size (the engine asks for
- * 2× the intrinsic size), and encoded to PNG via `canvas.toBlob`. The SVG is
+ * 2× the intrinsic size), and encoded to PNG via `canvas.toDataURL`. In real
+ * side-panel E2E runs, the asynchronous `toBlob` callback path incurred
+ * repeated ~1-second scheduling delays; synchronous encoding avoids that task
+ * runner while preparation remains strictly serial.
+ * The SVG is
  * self-contained (beautiful-mermaid output, external font import stripped by
  * the engine), so the blob image decodes without network and the canvas
  * stays untainted. Any failure throws — the engine then routes the diagram
@@ -103,19 +128,39 @@ export interface RasterizerStats {
   decodeMs: number;
   drawMs: number;
   encodeMs: number;
+  encodeCallsMs: number[];
 }
 
-const rasterizerStats: RasterizerStats = { calls: 0, decodeMs: 0, drawMs: 0, encodeMs: 0 };
+const rasterizerStats: RasterizerStats = {
+  calls: 0,
+  decodeMs: 0,
+  drawMs: 0,
+  encodeMs: 0,
+  encodeCallsMs: [],
+};
 
 export function resetRasterizerStats(): void {
   rasterizerStats.calls = 0;
   rasterizerStats.decodeMs = 0;
   rasterizerStats.drawMs = 0;
   rasterizerStats.encodeMs = 0;
+  rasterizerStats.encodeCallsMs.length = 0;
 }
 
 export function getRasterizerStats(): RasterizerStats {
-  return { ...rasterizerStats };
+  return { ...rasterizerStats, encodeCallsMs: [...rasterizerStats.encodeCallsMs] };
+}
+
+function pngDataUrlBytes(dataUrl: string, view: Window & typeof globalThis): Uint8Array {
+  const marker = ";base64,";
+  const offset = dataUrl.indexOf(marker);
+  if (!dataUrl.startsWith("data:image/png") || offset === -1) {
+    throw new Error("PNG encoding failed");
+  }
+  const binary = view.atob(dataUrl.slice(offset + marker.length));
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) bytes[i] = binary.charCodeAt(i);
+  return bytes;
 }
 
 export function canvasSvgRasterizer(doc: Document = document, decodeTimeoutMs = 10_000): SvgRasterizer {
@@ -148,15 +193,12 @@ export function canvasSvgRasterizer(doc: Document = document, decodeTimeoutMs = 
         ctx.drawImage(img, 0, 0, widthPx, heightPx);
         rasterizerStats.drawMs += Date.now() - drawStart;
         const encodeStart = Date.now();
-        const blob = await new Promise<Blob>((resolve, reject) =>
-          canvas.toBlob(
-            (b) => (b ? resolve(b) : reject(new Error("PNG encoding failed"))),
-            "image/png"
-          )
-        );
-        rasterizerStats.encodeMs += Date.now() - encodeStart;
+        const bytes = pngDataUrlBytes(canvas.toDataURL("image/png"), view);
+        const encodeMs = Date.now() - encodeStart;
+        rasterizerStats.encodeMs += encodeMs;
+        rasterizerStats.encodeCallsMs.push(encodeMs);
         rasterizerStats.calls += 1;
-        return new Uint8Array(await blob.arrayBuffer());
+        return bytes;
       } finally {
         clearTimeout(timer);
         view.URL.revokeObjectURL(url);

--- a/apps/extension/utils/docx/env.ts
+++ b/apps/extension/utils/docx/env.ts
@@ -92,6 +92,32 @@ export function sessionAssetFetcher(baseUrl?: string, fetchFn: typeof fetch = fe
  * to the readable code-block fallback; a decode that never settles is cut off
  * by `decodeTimeoutMs` so one broken diagram can't freeze the whole export.
  */
+/**
+ * Sub-phase timing sums of every {@link canvasSvgRasterizer} call since the
+ * last {@link resetRasterizerStats} — the panel appends them to the export
+ * report so a slow rasterizer names its slow sub-step (decode vs draw vs
+ * encode) without devtools.
+ */
+export interface RasterizerStats {
+  calls: number;
+  decodeMs: number;
+  drawMs: number;
+  encodeMs: number;
+}
+
+const rasterizerStats: RasterizerStats = { calls: 0, decodeMs: 0, drawMs: 0, encodeMs: 0 };
+
+export function resetRasterizerStats(): void {
+  rasterizerStats.calls = 0;
+  rasterizerStats.decodeMs = 0;
+  rasterizerStats.drawMs = 0;
+  rasterizerStats.encodeMs = 0;
+}
+
+export function getRasterizerStats(): RasterizerStats {
+  return { ...rasterizerStats };
+}
+
 export function canvasSvgRasterizer(doc: Document = document, decodeTimeoutMs = 10_000): SvgRasterizer {
   return {
     async rasterize(svg, { widthPx, heightPx }): Promise<Uint8Array> {
@@ -101,6 +127,7 @@ export function canvasSvgRasterizer(doc: Document = document, decodeTimeoutMs = 
       const url = view.URL.createObjectURL(new view.Blob([svg], { type: "image/svg+xml" }));
       let timer: ReturnType<typeof setTimeout> | undefined;
       try {
+        const decodeStart = Date.now();
         const img = new view.Image();
         await new Promise<void>((resolve, reject) => {
           timer = setTimeout(
@@ -111,18 +138,24 @@ export function canvasSvgRasterizer(doc: Document = document, decodeTimeoutMs = 
           img.onerror = () => reject(new Error("the diagram SVG could not be decoded"));
           img.src = url;
         });
+        rasterizerStats.decodeMs += Date.now() - decodeStart;
+        const drawStart = Date.now();
         const canvas = doc.createElement("canvas");
         canvas.width = widthPx;
         canvas.height = heightPx;
         const ctx = canvas.getContext("2d");
         if (!ctx) throw new Error("no 2d canvas context available");
         ctx.drawImage(img, 0, 0, widthPx, heightPx);
+        rasterizerStats.drawMs += Date.now() - drawStart;
+        const encodeStart = Date.now();
         const blob = await new Promise<Blob>((resolve, reject) =>
           canvas.toBlob(
             (b) => (b ? resolve(b) : reject(new Error("PNG encoding failed"))),
             "image/png"
           )
         );
+        rasterizerStats.encodeMs += Date.now() - encodeStart;
+        rasterizerStats.calls += 1;
         return new Uint8Array(await blob.arrayBuffer());
       } finally {
         clearTimeout(timer);

--- a/apps/extension/utils/docx/env.ts
+++ b/apps/extension/utils/docx/env.ts
@@ -42,15 +42,41 @@ export function idbTemplateSource(factory?: IDBFactory): TemplateSource {
  * (the site's Confluence root, e.g. `https://x.atlassian.net/wiki`) is
  * prefixed to make them absolute. External image URLs pass through as-is.
  */
+/**
+ * Panel-lifetime cache for IMMUTABLE asset bytes: version-stamped
+ * `/download/attachments/…` URLs (the space logo's icon path carries
+ * `version=…&modificationDate=…`) never change under their key — a replaced
+ * logo gets a new stamp — so repeat exports skip those round-trips entirely.
+ * Bounded so a long panel session can't hoard megabytes.
+ */
+const versionedAssetCache = new Map<string, Uint8Array>();
+const VERSIONED_CACHE_MAX_ENTRIES = 32;
+
+function isVersionedAssetUrl(refUrl: string): boolean {
+  return refUrl.startsWith("/download/") && /[?&](version|modificationDate)=/.test(refUrl);
+}
+
 export function sessionAssetFetcher(baseUrl?: string, fetchFn: typeof fetch = fetch): AssetFetcher {
   return {
     async fetch(ref: AssetRef): Promise<Uint8Array> {
+      const cacheable = isVersionedAssetUrl(ref.url);
+      const cached = cacheable ? versionedAssetCache.get(ref.url) : undefined;
+      if (cached) return cached;
       const url = /^https?:\/\//i.test(ref.url) ? ref.url : `${baseUrl ?? ""}${ref.url}`;
       const res = await fetchFn(url, { credentials: "include" });
       if (!res.ok) {
         throw new Error(`Asset fetch failed (${res.status}) for ${ref.filename ?? ref.url}`);
       }
-      return new Uint8Array(await res.arrayBuffer());
+      const bytes = new Uint8Array(await res.arrayBuffer());
+      if (cacheable && bytes.byteLength > 0) {
+        if (versionedAssetCache.size >= VERSIONED_CACHE_MAX_ENTRIES) {
+          // Map iterates in insertion order — drop the oldest entry.
+          const oldest = versionedAssetCache.keys().next().value;
+          if (oldest !== undefined) versionedAssetCache.delete(oldest);
+        }
+        versionedAssetCache.set(ref.url, bytes);
+      }
+      return bytes;
     },
   };
 }

--- a/apps/extension/utils/docx/export-deps.ts
+++ b/apps/extension/utils/docx/export-deps.ts
@@ -1,0 +1,121 @@
+import type { ConfluenceClient } from "@atlcli/confluence/browser";
+import type { ResolveDeps, ScanResult } from "@atlcli/docx/browser";
+
+type SpaceInfo = Awaited<ReturnType<ConfluenceClient["getSpaceWithIcon"]>>;
+
+export interface ExportDependencyLoaders {
+  getSpaceWithIcon(key: string): Promise<SpaceInfo>;
+  getCurrentUser(): ReturnType<ConfluenceClient["getCurrentUser"]>;
+  getPageOwner(id: string): ReturnType<ConfluenceClient["getPageOwner"]>;
+  getSpaceHomepageStorage(key: string): ReturnType<ConfluenceClient["getSpaceHomepageStorage"]>;
+}
+
+type ExportDependency = "space" | "currentUser" | "owner" | "spaceHomepage" | "spaceLogo";
+
+function pagePropertyUsesHomepage(raw: string): boolean {
+  const open = raw.indexOf("(");
+  const close = raw.lastIndexOf(")");
+  if (open === -1 || close <= open) return false;
+  const parts = raw
+    .slice(open + 1, close)
+    .split(",")
+    .map((part) => part.trim().replace(/^["']|["']$/g, ""));
+  if (parts[1] === "true") return true;
+  return parts[1] !== "false" && parts[2] === "true";
+}
+
+/**
+ * Derive the network dependencies from the scan already shown by the panel.
+ * This deliberately mirrors the small public placeholder dependency contract
+ * without importing the heavy DOCX browser barrel into the panel's static
+ * graph. Raw page-property forms matter because only `(...,true)` needs the
+ * homepage fallback.
+ */
+export function scanDependencies(scan: ScanResult): Set<ExportDependency> {
+  const dependencies = new Set<ExportDependency>();
+  for (const hit of scan.supported) {
+    if (hit.base === "$scroll.space.name" || hit.base === "$scroll.space.url") {
+      dependencies.add("space");
+    } else if (hit.base.startsWith("$scroll.exporter")) {
+      dependencies.add("currentUser");
+    } else if (hit.base === "$scroll.pageowner.fullName") {
+      dependencies.add("owner");
+    } else if (hit.base === "$scroll.spacelogo" || hit.base === "$scroll.globallogo") {
+      dependencies.add("spaceLogo");
+    } else if (
+      hit.base === "$scroll.pageproperty" &&
+      hit.raw.some(pagePropertyUsesHomepage)
+    ) {
+      dependencies.add("spaceHomepage");
+    }
+  }
+  return dependencies;
+}
+
+function memoByKey<T>(
+  entries: Map<string, Promise<T>>,
+  key: string,
+  load: (key: string) => Promise<T>
+): Promise<T> {
+  const hit = entries.get(key);
+  if (hit) return hit;
+  const value = load(key);
+  entries.set(key, value);
+  return value;
+}
+
+function consumeRejection<T>(promise: Promise<T>): void {
+  // Pre-starting is an optimization. This branch prevents an unhandled
+  // rejection before the engine awaits the ORIGINAL promise; the engine still
+  // receives that original rejection and turns it into the normal report note.
+  void promise.catch(() => {});
+}
+
+/**
+ * Build one export's dependency bag and pre-start exactly the calls named by
+ * the uploaded template scan. All calls are memoized for this export, while
+ * cross-export cache policy remains the host's responsibility (currently only
+ * space + icon are safe to keep for five minutes).
+ */
+export function prepareExportDeps(
+  scan: ScanResult,
+  details: { spaceKey?: string; id?: string },
+  loaders: ExportDependencyLoaders
+): ResolveDeps {
+  const spaceInfoEntries = new Map<string, Promise<SpaceInfo>>();
+  const ownerEntries = new Map<string, ReturnType<ConfluenceClient["getPageOwner"]>>();
+  const homepageEntries = new Map<string, ReturnType<ConfluenceClient["getSpaceHomepageStorage"]>>();
+  let currentUserPromise: ReturnType<ConfluenceClient["getCurrentUser"]> | undefined;
+
+  const spaceInfo = (key: string): Promise<SpaceInfo> =>
+    memoByKey(spaceInfoEntries, key, loaders.getSpaceWithIcon);
+  const currentUser = (): ReturnType<ConfluenceClient["getCurrentUser"]> =>
+    (currentUserPromise ??= loaders.getCurrentUser());
+  const pageOwner = (id: string): ReturnType<ConfluenceClient["getPageOwner"]> =>
+    memoByKey(ownerEntries, id, loaders.getPageOwner);
+  const homepageStorage = (key: string): ReturnType<ConfluenceClient["getSpaceHomepageStorage"]> =>
+    memoByKey(homepageEntries, key, loaders.getSpaceHomepageStorage);
+
+  const deps: ResolveDeps = {
+    getSpace: async (key) => (await spaceInfo(key)).space,
+    getCurrentUser: currentUser,
+    getPageOwner: pageOwner,
+    getSpaceHomepageStorage: homepageStorage,
+    getSpaceLogo: async (key) => {
+      const icon = (await spaceInfo(key)).icon;
+      return icon ? { url: icon.path } : null;
+    },
+  };
+
+  const required = scanDependencies(scan);
+  if (details.spaceKey && (required.has("space") || required.has("spaceLogo"))) {
+    consumeRejection(spaceInfo(details.spaceKey));
+  }
+  if (required.has("currentUser")) consumeRejection(currentUser());
+  if (details.id && required.has("owner")) consumeRejection(pageOwner(details.id));
+  if (details.spaceKey && required.has("spaceHomepage")) {
+    consumeRejection(homepageStorage(details.spaceKey));
+  }
+
+  return deps;
+}

--- a/apps/extension/utils/docx/session-cache.ts
+++ b/apps/extension/utils/docx/session-cache.ts
@@ -1,14 +1,11 @@
 /**
- * Small TTL cache for the panel's per-site export metadata (spec 004 deps).
+ * Small TTL cache for the panel's stable per-site export metadata.
  *
- * The engine's resolver deps (space + icon, current user, space-homepage
- * storage) are metadata that changes rarely but was re-fetched on EVERY
- * export — three tabs of the same space each paid the ~100ms space/icon
- * round-trip again. Entries are cached per key for a short TTL: repeat
- * exports within the window skip the round-trip, while a renamed space or
- * swapped logo shows up at most `ttlMs` later. In-flight promises are
- * shared (concurrent exports coalesce); rejections are evicted immediately
- * so a transient failure never sticks.
+ * The extension uses this for space + icon only: current-user and homepage
+ * content have no safe same-site invalidation signal and stay per-export.
+ * Entries are cached per key for a short TTL. In-flight promises are shared
+ * (concurrent exports coalesce); rejections are evicted immediately so a
+ * transient failure never sticks.
  */
 export interface SessionCache<T> {
   get(key: string, load: () => Promise<T>): Promise<T>;

--- a/apps/extension/utils/docx/session-cache.ts
+++ b/apps/extension/utils/docx/session-cache.ts
@@ -1,0 +1,42 @@
+/**
+ * Small TTL cache for the panel's per-site export metadata (spec 004 deps).
+ *
+ * The engine's resolver deps (space + icon, current user, space-homepage
+ * storage) are metadata that changes rarely but was re-fetched on EVERY
+ * export — three tabs of the same space each paid the ~100ms space/icon
+ * round-trip again. Entries are cached per key for a short TTL: repeat
+ * exports within the window skip the round-trip, while a renamed space or
+ * swapped logo shows up at most `ttlMs` later. In-flight promises are
+ * shared (concurrent exports coalesce); rejections are evicted immediately
+ * so a transient failure never sticks.
+ */
+export interface SessionCache<T> {
+  get(key: string, load: () => Promise<T>): Promise<T>;
+}
+
+export function sessionCache<T>(
+  ttlMs: number,
+  maxEntries = 32,
+  now: () => number = Date.now
+): SessionCache<T> {
+  const entries = new Map<string, { at: number; value: Promise<T> }>();
+  return {
+    get(key: string, load: () => Promise<T>): Promise<T> {
+      const hit = entries.get(key);
+      if (hit && now() - hit.at <= ttlMs) return hit.value;
+      const value = load();
+      // Delete-then-set keeps Map insertion order = recency, so the
+      // max-entries eviction below always drops the stalest key.
+      entries.delete(key);
+      entries.set(key, { at: now(), value });
+      value.catch(() => {
+        if (entries.get(key)?.value === value) entries.delete(key);
+      });
+      if (entries.size > maxEntries) {
+        const oldest = entries.keys().next().value;
+        if (oldest !== undefined) entries.delete(oldest);
+      }
+      return value;
+    },
+  };
+}

--- a/packages/confluence/src/client.ts
+++ b/packages/confluence/src/client.ts
@@ -1218,17 +1218,35 @@ export class ConfluenceClient {
    * icon — Cloud normally always has one (the default is an SVG).
    */
   async getSpaceIcon(key: string): Promise<SpaceIcon | null> {
+    return (await this.getSpaceWithIcon(key)).icon;
+  }
+
+  /**
+   * Get a space AND its logo icon in one round-trip
+   * (`GET /space/{key}?expand=icon`). Perf: an export whose template uses
+   * both `$scroll.space.*` and a logo placeholder previously paid two calls
+   * to the same endpoint; hosts memoize this one instead.
+   */
+  async getSpaceWithIcon(key: string): Promise<{ space: ConfluenceSpace; icon: SpaceIcon | null }> {
     const data = (await this.request(`/space/${key}`, {
       query: { expand: "icon" },
     })) as any;
-    const icon = data.icon;
-    if (!icon?.path) return null;
-    return {
-      path: icon.path,
-      width: icon.width,
-      height: icon.height,
-      isDefault: icon.isDefault,
+    const space: ConfluenceSpace = {
+      id: data.id,
+      key: data.key,
+      name: data.name,
+      type: data.type ?? "global",
+      url: data._links?.base ? `${data._links.base}${data._links.webui}` : undefined,
     };
+    const icon = data.icon?.path
+      ? {
+          path: data.icon.path,
+          width: data.icon.width,
+          height: data.icon.height,
+          isDefault: data.icon.isDefault,
+        }
+      : null;
+    return { space, icon };
   }
 
   /**

--- a/packages/diagram/src/index.ts
+++ b/packages/diagram/src/index.ts
@@ -151,6 +151,19 @@ function loadRenderer(): Promise<BeautifulMermaid> {
   return rendererPromise;
 }
 
+/**
+ * Start loading the renderer chunk (~1.5 MB with elkjs) in the background —
+ * a host that knows an export is likely (the extension panel on mount, say)
+ * calls this so the FIRST diagram render doesn't pay the import. Never
+ * throws and never rejects; a failed warm just means {@link renderDiagram}
+ * retries the import itself.
+ */
+export function warmDiagramRenderer(): void {
+  void loadRenderer().catch(() => {
+    rendererPromise = null;
+  });
+}
+
 /** Intrinsic pixel size from the SVG root's width/height attributes. */
 function intrinsicSize(svg: string): { widthPx: number; heightPx: number } | null {
   const w = svg.match(/<svg[^>]*\bwidth="([\d.]+)"/)?.[1];

--- a/packages/docx/src/export.test.ts
+++ b/packages/docx/src/export.test.ts
@@ -1161,3 +1161,58 @@ describe("exportDocx — parallel prefetch determinism (perf regression)", () =>
     assertBalancedXml(readPart(bytes, "word/document.xml"));
   });
 });
+
+describe("exportDocx — prefetch failure modes (Codex review findings)", () => {
+  const plainTemplate = () =>
+    buildDocx({
+      body: para("$scroll.content"),
+      styles: stylesXml(headingStyle("Heading1", "Heading 1")),
+    });
+
+  it("a SYNCHRONOUSLY-throwing asset fetcher degrades every image to a note (no pool deadlock)", async () => {
+    // Seven images > the 6-slot pool: a leaked slot per sync throw would
+    // starve the queue and hang the export instead of degrading (004-F3).
+    const storage = Array.from(
+      { length: 7 },
+      (_, i) => `<ac:image><ri:attachment ri:filename="img${i}.png"/></ac:image>`
+    ).join("");
+    const { report } = await exportDocx({
+      templateBytes: plainTemplate(),
+      details: { ...details, storage },
+      template,
+      deps,
+      assets: {
+        fetch(): Promise<Uint8Array> {
+          throw new Error("sync boom"); // NOT an async rejection
+        },
+      },
+    });
+    expect(report.embeddedImages).toBe(0);
+    expect(report.skippedImages).toBe(7);
+    expect(report.notes.filter((n) => n.code === "image-embed-failed").length).toBe(7);
+  });
+
+  it("two blocks referencing the same attachment share ONE fetch", async () => {
+    let calls = 0;
+    const { report } = await exportDocx({
+      templateBytes: plainTemplate(),
+      details: {
+        ...details,
+        storage:
+          '<ac:image><ri:attachment ri:filename="dup.png"/></ac:image>' +
+          "<p>between</p>" +
+          '<ac:image><ri:attachment ri:filename="dup.png"/></ac:image>',
+      },
+      template,
+      deps,
+      assets: {
+        async fetch(): Promise<Uint8Array> {
+          calls += 1;
+          return pngFixtureBytes(120, 60);
+        },
+      },
+    });
+    expect(report.embeddedImages).toBe(2);
+    expect(calls).toBe(1);
+  });
+});

--- a/packages/docx/src/export.test.ts
+++ b/packages/docx/src/export.test.ts
@@ -893,6 +893,15 @@ describe("exportDocx — mermaid diagrams (spec 005a)", () => {
     `<p>before</p><ac:structured-macro ac:name="code"><ac:parameter ac:name="language">mermaid</ac:parameter>` +
     `<ac:plain-text-body><![CDATA[${source}]]></ac:plain-text-body></ac:structured-macro>`;
 
+  const mermaidBlocks = (...sources: string[]) =>
+    sources
+      .map(
+        (source) =>
+          `<ac:structured-macro ac:name="code"><ac:parameter ac:name="language">mermaid</ac:parameter>` +
+          `<ac:plain-text-body><![CDATA[${source}]]></ac:plain-text-body></ac:structured-macro>`
+      )
+      .join("");
+
   /** A rasterizer recording every call, serving real PNG fixture bytes. */
   function recordingRasterizer() {
     const calls: { svg: string; widthPx: number; heightPx: number }[] = [];
@@ -1051,6 +1060,93 @@ describe("exportDocx — mermaid diagrams (spec 005a)", () => {
     const doc = readPart(bytes, "word/document.xml");
     const ids = [...doc.matchAll(/wp:docPr id="(\d+)"/g)].map((m) => m[1]);
     expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("chains diagram rasterization in document order with at most one active call", async () => {
+    const order: string[] = [];
+    let active = 0;
+    let maxActive = 0;
+    const { report } = await exportDocx({
+      templateBytes: diagramTemplate(),
+      details: {
+        ...details,
+        storage: mermaidBlocks(
+          "graph TD\n  First --> A",
+          "graph TD\n  Second --> B",
+          "graph TD\n  Third --> C"
+        ),
+      },
+      template,
+      deps,
+      rasterizer: {
+        async rasterize(svg, target) {
+          active += 1;
+          maxActive = Math.max(maxActive, active);
+          order.push(svg.includes("First") ? "First" : svg.includes("Second") ? "Second" : "Third");
+          try {
+            await new Promise((resolve) => setTimeout(resolve, 5));
+            return pngFixtureBytes(target.widthPx, target.heightPx);
+          } finally {
+            active -= 1;
+          }
+        },
+      },
+    });
+
+    expect(order).toEqual(["First", "Second", "Third"]);
+    expect(maxActive).toBe(1);
+    expect(report.renderedDiagrams).toBe(3);
+  });
+
+  it("prepares identical diagram sources once but embeds every occurrence in document order", async () => {
+    const source = "graph TD\n  Shared --> Result";
+    let rasterCalls = 0;
+    const { bytes, report } = await exportDocx({
+      templateBytes: diagramTemplate(),
+      details: { ...details, storage: mermaidBlocks(source, source) },
+      template,
+      deps,
+      rasterizer: {
+        async rasterize(_svg, target) {
+          rasterCalls += 1;
+          return pngFixtureBytes(target.widthPx, target.heightPx);
+        },
+      },
+    });
+
+    expect(rasterCalls).toBe(1);
+    expect(report.renderedDiagrams).toBe(2);
+    const doc = readPart(bytes, "word/document.xml");
+    expect(doc.match(/<w:drawing>/g)).toHaveLength(2);
+    const ids = [...doc.matchAll(/<wp:docPr id="(\d+)"/g)].map((m) => m[1]);
+    expect(new Set(ids).size).toBe(2);
+  });
+
+  it("a failed prepared diagram does not reject or poison the remaining chain", async () => {
+    const order: string[] = [];
+    const first = "graph TD\n  Broken --> A";
+    const second = "graph TD\n  Healthy --> B";
+    const { bytes, report } = await exportDocx({
+      templateBytes: diagramTemplate(),
+      details: { ...details, storage: mermaidBlocks(first, second) },
+      template,
+      deps,
+      rasterizer: {
+        async rasterize(svg, target) {
+          const name = svg.includes("Broken") ? "Broken" : "Healthy";
+          order.push(name);
+          if (name === "Broken") throw new Error("first raster failed");
+          return pngFixtureBytes(target.widthPx, target.heightPx);
+        },
+      },
+    });
+
+    expect(order).toEqual(["Broken", "Healthy"]);
+    expect(report.renderedDiagrams).toBe(1);
+    expect(report.notes.filter((n) => n.code === "diagram-render-failed")).toHaveLength(1);
+    const doc = readPart(bytes, "word/document.xml");
+    expect(doc.match(/<w:drawing>/g)).toHaveLength(1);
+    expect(doc).toContain("Broken --&gt; A");
   });
 });
 

--- a/packages/docx/src/export.test.ts
+++ b/packages/docx/src/export.test.ts
@@ -1053,3 +1053,111 @@ describe("exportDocx — mermaid diagrams (spec 005a)", () => {
     expect(new Set(ids).size).toBe(ids.length);
   });
 });
+
+describe("exportDocx — parallel prefetch determinism (perf regression)", () => {
+  // Three attachment images + a space logo, each with DISTINCT bytes so a
+  // mixed-up embed order cannot go unnoticed. The staggered run completes
+  // fetches in REVERSE document order (c before b before a, logo last);
+  // output bytes must be identical to the instant run — media numbering and
+  // relationship ids are allocated in document order, never completion order.
+  const IMG_STORAGE =
+    "<p>intro</p>" +
+    '<ac:image ac:alt="a"><ri:attachment ri:filename="a.png"/></ac:image>' +
+    '<ac:image ac:alt="b"><ri:attachment ri:filename="b.png"/></ac:image>' +
+    '<ac:image ac:alt="c"><ri:attachment ri:filename="c.png"/></ac:image>';
+
+  const SIZES: Record<string, [number, number]> = {
+    "a.png": [200, 100],
+    "b.png": [300, 150],
+    "c.png": [400, 200],
+    logo: [64, 64],
+  };
+
+  function fetcherWithDelays(delays: Record<string, number>) {
+    return {
+      fetch(ref: { url: string; filename?: string }): Promise<Uint8Array> {
+        const key = ref.url.includes("logo") ? "logo" : (ref.filename ?? ref.url);
+        const [w, h] = SIZES[key];
+        return new Promise((res) => setTimeout(() => res(pngFixtureBytes(w, h)), delays[key] ?? 0));
+      },
+    };
+  }
+
+  async function runWith(delays: Record<string, number>) {
+    return exportDocx({
+      templateBytes: buildDocx({
+        body: para("$scroll.spacelogo") + para("$scroll.content"),
+        styles: stylesXml(headingStyle("Heading1", "Heading 1")),
+      }),
+      details: { ...details, storage: IMG_STORAGE },
+      template,
+      exportDate: new Date(2026, 6, 14, 9, 5),
+      deps: {
+        ...deps,
+        getSpaceLogo: async () => ({ url: "/download/attachments/9/logo.png", pageId: "9", filename: "logo.png" }),
+      },
+      assets: fetcherWithDelays(delays),
+    });
+  }
+
+  it("produces byte-identical output whether fetches resolve in document order or reversed", async () => {
+    const instant = await runWith({});
+    const scrambled = await runWith({ "a.png": 60, "b.png": 40, "c.png": 0, logo: 80 });
+
+    expect(instant.report.embeddedImages).toBe(4); // 3 page images + 1 logo
+    expect(scrambled.report.embeddedImages).toBe(4);
+
+    const zipA = new PizZip(instant.bytes);
+    const zipB = new PizZip(scrambled.bytes);
+    const partsA = Object.keys(zipA.files).sort();
+    const partsB = Object.keys(zipB.files).sort();
+    expect(partsB).toEqual(partsA);
+    for (const name of partsA) {
+      if (zipA.files[name].dir) continue;
+      expect([...zipB.file(name)!.asUint8Array()]).toEqual([...zipA.file(name)!.asUint8Array()]);
+    }
+
+    // Media numbering follows document order: image1 is a.png (200px wide).
+    const doc = readPart(instant.bytes, "word/document.xml");
+    const firstImageExtent = doc.indexOf(`<wp:extent cx="${200 * 9525}"`);
+    const secondImageExtent = doc.indexOf(`<wp:extent cx="${300 * 9525}"`);
+    const thirdImageExtent = doc.indexOf(`<wp:extent cx="${400 * 9525}"`);
+    expect(firstImageExtent).toBeGreaterThan(-1);
+    expect(secondImageExtent).toBeGreaterThan(firstImageExtent);
+    expect(thirdImageExtent).toBeGreaterThan(secondImageExtent);
+  });
+
+  it("report note order is stable when a failing fetch resolves last", async () => {
+    // b.png fails SLOWLY; the notes must still appear in document order and
+    // the export must still embed a + c (F3: no dangling relationship).
+    const failing = {
+      fetch(ref: { url: string; filename?: string }): Promise<Uint8Array> {
+        if (ref.filename === "b.png") {
+          return new Promise((_, rej) => setTimeout(() => rej(new Error("boom")), 50));
+        }
+        const key = ref.url.includes("logo") ? "logo" : (ref.filename ?? ref.url);
+        const [w, h] = SIZES[key];
+        return Promise.resolve(pngFixtureBytes(w, h));
+      },
+    };
+    const { bytes, report } = await exportDocx({
+      templateBytes: buildDocx({
+        body: para("$scroll.content"),
+        styles: stylesXml(headingStyle("Heading1", "Heading 1")),
+      }),
+      details: { ...details, storage: IMG_STORAGE },
+      template,
+      deps,
+      assets: failing,
+    });
+    expect(report.embeddedImages).toBe(2);
+    expect(report.skippedImages).toBe(1);
+    const failNote = report.notes.find((n) => n.code === "image-embed-failed");
+    expect(failNote?.message).toContain('"b.png"');
+    // No dangling rel: exactly two media parts exist.
+    const zip = new PizZip(bytes);
+    const media = Object.keys(zip.files).filter((f) => f.startsWith("word/media/"));
+    expect(media.length).toBe(2);
+    assertBalancedXml(readPart(bytes, "word/document.xml"));
+  });
+});

--- a/packages/docx/src/export.ts
+++ b/packages/docx/src/export.ts
@@ -727,10 +727,19 @@ function diagramSeam(
     | { kind: "unsupported"; diagramType: string }
     | { kind: "failed"; reason: string };
   const preps = new Map<CodeBlock, Promise<DiagramPrep>>();
+  // Preparations are CHAINED, not fanned out: render + rasterize are
+  // main-thread CPU work in every host (beautiful-mermaid is synchronous;
+  // the panel's canvas rasterizer and the CLI's resvg-wasm both burn the
+  // one JS thread), so running six at once cannot finish sooner — but it
+  // CAN thrash (observed in the extension panel: six concurrent canvas
+  // rasterizations took seconds each instead of tens of ms). The chain
+  // still starts at prefetch time, so diagram CPU overlaps the export's
+  // network round-trips exactly as before.
+  let chain: Promise<unknown> = Promise.resolve();
   const prepare = (block: CodeBlock): Promise<DiagramPrep> => {
     let p = preps.get(block);
     if (!p) {
-      p = (async (): Promise<DiagramPrep> => {
+      const work = async (): Promise<DiagramPrep> => {
         const renderStart = Date.now();
         const rendered = await renderDiagram(block.code, theme);
         timings.diagramRenderMs += Date.now() - renderStart;
@@ -755,7 +764,9 @@ function diagramSeam(
         } catch (err) {
           return { kind: "failed", reason: err instanceof Error ? err.message : String(err) };
         }
-      })();
+      };
+      p = chain.then(work);
+      chain = p;
       preps.set(block, p);
     }
     return p;

--- a/packages/docx/src/export.ts
+++ b/packages/docx/src/export.ts
@@ -63,6 +63,24 @@ import {
   splitParagraphs,
 } from "./ooxml-text.js";
 
+/**
+ * Wall-clock durations of the export's (deliberately overlapping) phases —
+ * `resolveMs` + `bodyMs` + `logoFetchMs` typically exceed `durationMs`
+ * because they run concurrently. The seam aggregates (`imageFetchMs`,
+ * `diagramRenderMs`, `diagramRasterMs`) are SUMS across calls. Surfaced as a
+ * report note so a slow export names its slow leg.
+ */
+export interface ExportTimings {
+  resolveMs: number;
+  bodyMs: number;
+  logoFetchMs: number;
+  renderMs: number;
+  imageFetchMs: number;
+  imageFetches: number;
+  diagramRenderMs: number;
+  diagramRasterMs: number;
+}
+
 export interface ExportReport {
   /** Placeholders resolved to a non-empty value. */
   resolvedCount: number;
@@ -82,6 +100,8 @@ export interface ExportReport {
   notes: ExportNote[];
   /** The template scan (reused classification), for the panel. */
   scan: ScanResult;
+  /** Per-phase wall clocks (overlapping) + seam aggregates. */
+  timings: ExportTimings;
 }
 
 export interface ExportResult {
@@ -181,6 +201,16 @@ export function toDownloadFilename(title: string): string {
 export async function exportDocx(input: ExportInput): Promise<ExportResult> {
   const start = Date.now();
   const exportDate = input.exportDate ?? new Date();
+  const timings: ExportTimings = {
+    resolveMs: 0,
+    bodyMs: 0,
+    logoFetchMs: 0,
+    renderMs: 0,
+    imageFetchMs: 0,
+    imageFetches: 0,
+    diagramRenderMs: 0,
+    diagramRasterMs: 0,
+  };
 
   const zip = unzipDocx(input.templateBytes);
   const scan = scanZip(zip);
@@ -191,7 +221,12 @@ export async function exportDocx(input: ExportInput): Promise<ExportResult> {
   //    the logo fetch below instead of gating them (perf finding: the
   //    sequential flow paid every network latency back to back).
   const usedRaw = [...scan.supported, ...scan.unsupported, ...scan.never].flatMap((h) => h.raw);
-  const resolvedPromise = resolvePlaceholders(usedRaw, { details: input.details, template: input.template, exportDate }, input.deps);
+  const resolvedPromise = resolvePlaceholders(usedRaw, { details: input.details, template: input.template, exportDate }, input.deps).then(
+    (r) => {
+      timings.resolveMs = Date.now() - start;
+      return r;
+    }
+  );
 
   // 2. Storage → blocks → OOXML body. When the host supplied an asset fetcher
   //    (and images aren't disabled), the serializer's image seam embeds each
@@ -205,10 +240,10 @@ export async function exportDocx(input: ExportInput): Promise<ExportResult> {
   // diagrams additionally need a rasterizer — each seam exists independently.
   const wantImages = Boolean(input.assets) && input.embedImages !== false;
   const embedder = wantImages || input.rasterizer ? new ImageEmbedder(zip) : undefined;
-  const images = embedder && wantImages ? imageSeam(embedder, input.assets!, input.details.id) : undefined;
+  const images = embedder && wantImages ? imageSeam(embedder, input.assets!, input.details.id, timings) : undefined;
   const diagrams =
     embedder && input.rasterizer
-      ? diagramSeam(embedder, input.rasterizer, input.diagramTheme)
+      ? diagramSeam(embedder, input.rasterizer, input.diagramTheme, timings)
       : undefined;
 
   // Logo pass, fetch leg (spec 005, gap G3): the template scan + space-logo
@@ -220,9 +255,14 @@ export async function exportDocx(input: ExportInput): Promise<ExportResult> {
     assets: input.assets,
     getSpaceLogo: input.deps?.getSpaceLogo,
     spaceKey: input.details.spaceKey,
+  }).then((s) => {
+    timings.logoFetchMs = Date.now() - start;
+    return s;
   });
 
+  const bodyStart = Date.now();
   const body = await serializeBlocks(blocks, { styleNames, images, diagrams });
+  timings.bodyMs = Date.now() - bodyStart;
 
   // 3. Swap the $scroll.content paragraph for the rawxml tag paragraph. If the
   //    template has none, inject the tag before the body's final section break.
@@ -261,6 +301,7 @@ export async function exportDocx(input: ExportInput): Promise<ExportResult> {
   //    inserted VERBATIM (the body is a DATA value, never re-parsed for tags), so
   //    literal braces / $scroll text in the page pass through unchanged. PUA
   //    delimiters guarantee the customer's own `{…}` is never a tag.
+  const renderStart = Date.now();
   const rendered = renderContent(zip, body.xml);
 
   // 6. Synthesize the code style if the body referenced it; force TOC refresh.
@@ -268,8 +309,9 @@ export async function exportDocx(input: ExportInput): Promise<ExportResult> {
   ensureUpdateFields(rendered);
 
   const bytes = rendered.generate({ type: "uint8array", compression: "DEFLATE" }) as unknown as Uint8Array;
+  timings.renderMs = Date.now() - renderStart;
 
-  const notes = [...resolved.notes, ...walkNotes, ...body.notes, ...flowNotes];
+  const notes = [...resolved.notes, ...walkNotes, ...body.notes, ...flowNotes, timingNote(timings, Date.now() - start)];
   // Every image-skip note kind counts toward the report's skipped-image total:
   // serializer `image-skipped`/`image-embed-failed`, walker `image-unresolved`
   // and `inline-image-skipped`.
@@ -287,7 +329,31 @@ export async function exportDocx(input: ExportInput): Promise<ExportResult> {
       filename: toDownloadFilename(input.details.title),
       notes,
       scan,
+      timings,
     },
+  };
+}
+
+/**
+ * One compact, always-present report line naming each phase's wall clock —
+ * so a slow export tells the user (and us) WHICH leg was slow without any
+ * extra tooling. Phases overlap by design, so they don't sum to the total.
+ */
+function timingNote(t: ExportTimings, totalMs: number): ExportNote {
+  const parts = [
+    `body ${t.bodyMs} ms` +
+      (t.diagramRenderMs || t.diagramRasterMs
+        ? ` (diagrams: render ${t.diagramRenderMs} ms, rasterize ${t.diagramRasterMs} ms)`
+        : "") +
+      (t.imageFetches ? ` (${t.imageFetches} image fetch(es): ${t.imageFetchMs} ms)` : ""),
+    `placeholders ${t.resolveMs} ms`,
+    ...(t.logoFetchMs ? [`logo fetch ${t.logoFetchMs} ms`] : []),
+    `render+zip ${t.renderMs} ms`,
+  ];
+  return {
+    level: "info",
+    code: "perf-timing",
+    message: `Timing: ${totalMs} ms total — ${parts.join(" · ")} (phases overlap).`,
   };
 }
 
@@ -575,7 +641,12 @@ function pLimit(max: number): <T>(fn: () => Promise<T>) => Promise<T> {
  * instead of N; embedding (and thus relationship-id allocation) still
  * happens in document order through {@link ImageEmbedSeam.embed}.
  */
-function imageSeam(embedder: ImageEmbedder, assets: AssetFetcher, pageId: string): ImageEmbedSeam {
+function imageSeam(
+  embedder: ImageEmbedder,
+  assets: AssetFetcher,
+  pageId: string,
+  timings: ExportTimings
+): ImageEmbedSeam {
   const limit = pLimit(ASSET_FETCH_CONCURRENCY);
   // Keyed by the CANONICAL asset URL, not block identity: a page that shows
   // the same attachment twice downloads it once (the embedder already
@@ -585,7 +656,15 @@ function imageSeam(embedder: ImageEmbedder, assets: AssetFetcher, pageId: string
     const ref = assetRefFor(block, pageId);
     let p = fetches.get(ref.url);
     if (!p) {
-      p = limit(() => assets.fetch(ref));
+      p = limit(async () => {
+        const t = Date.now();
+        try {
+          return await assets.fetch(ref);
+        } finally {
+          timings.imageFetches += 1;
+          timings.imageFetchMs += Date.now() - t;
+        }
+      });
       // The prefetch caller never awaits; without this consumed branch a
       // fetch failing before embed() awaits it would surface as an
       // unhandled rejection. embed() awaits the ORIGINAL promise and still
@@ -634,7 +713,8 @@ function imageSeam(embedder: ImageEmbedder, assets: AssetFetcher, pageId: string
 function diagramSeam(
   embedder: ImageEmbedder,
   rasterizer: SvgRasterizer,
-  theme: DiagramTheme | undefined
+  theme: DiagramTheme | undefined,
+  timings: ExportTimings
 ): DiagramEmbedSeam {
   let count = 0;
   // Render + rasterize results, keyed by block: the serializer's prefetch
@@ -651,16 +731,20 @@ function diagramSeam(
     let p = preps.get(block);
     if (!p) {
       p = (async (): Promise<DiagramPrep> => {
+        const renderStart = Date.now();
         const rendered = await renderDiagram(block.code, theme);
+        timings.diagramRenderMs += Date.now() - renderStart;
         if (rendered.kind === "unsupported") {
           return { kind: "unsupported", diagramType: rendered.diagramType };
         }
         if (rendered.kind === "failed") return { kind: "failed", reason: rendered.reason };
         try {
+          const rasterStart = Date.now();
           const png = await rasterizer.rasterize(rendered.svg, {
             widthPx: rendered.widthPx * 2,
             heightPx: rendered.heightPx * 2,
           });
+          timings.diagramRasterMs += Date.now() - rasterStart;
           return {
             kind: "ready",
             svg: rendered.svg,

--- a/packages/docx/src/export.ts
+++ b/packages/docx/src/export.ts
@@ -717,16 +717,19 @@ function diagramSeam(
   timings: ExportTimings
 ): DiagramEmbedSeam {
   let count = 0;
-  // Render + rasterize results, keyed by block: the serializer's prefetch
+  // Render + rasterize results, keyed by exact source: the serializer's prefetch
   // pass starts this CPU/async work up front so it overlaps the export's
   // network round-trips; embed() then consumes the in-flight result in
-  // document order. The preparation never rejects — every failure is a
-  // value — so an unawaited prefetch can't surface an unhandled rejection.
+  // document order. Repeated occurrences of the same source share preparation
+  // (theme + rasterizer are seam-wide), while each occurrence still embeds in
+  // document order and receives its own drawing id. The preparation never
+  // rejects — every failure is a value — so an unawaited prefetch can't surface
+  // an unhandled rejection.
   type DiagramPrep =
     | { kind: "ready"; svg: string; png: Uint8Array; widthPx: number; heightPx: number }
     | { kind: "unsupported"; diagramType: string }
     | { kind: "failed"; reason: string };
-  const preps = new Map<CodeBlock, Promise<DiagramPrep>>();
+  const preps = new Map<string, Promise<DiagramPrep>>();
   // Preparations are CHAINED, not fanned out: render + rasterize are
   // main-thread CPU work in every host (beautiful-mermaid is synchronous;
   // the panel's canvas rasterizer and the CLI's resvg-wasm both burn the
@@ -737,7 +740,8 @@ function diagramSeam(
   // network round-trips exactly as before.
   let chain: Promise<unknown> = Promise.resolve();
   const prepare = (block: CodeBlock): Promise<DiagramPrep> => {
-    let p = preps.get(block);
+    const key = block.code;
+    let p = preps.get(key);
     if (!p) {
       const work = async (): Promise<DiagramPrep> => {
         const renderStart = Date.now();
@@ -767,7 +771,7 @@ function diagramSeam(
       };
       p = chain.then(work);
       chain = p;
-      preps.set(block, p);
+      preps.set(key, p);
     }
     return p;
   };

--- a/packages/docx/src/export.ts
+++ b/packages/docx/src/export.ts
@@ -540,16 +540,21 @@ function pLimit(max: number): <T>(fn: () => Promise<T>) => Promise<T> {
     new Promise<T>((resolve, reject) => {
       const run = (): void => {
         active += 1;
-        fn().then(
-          (v) => {
-            release();
-            resolve(v);
-          },
-          (e) => {
-            release();
-            reject(e);
-          }
-        );
+        // Promise.resolve().then(fn) also routes a SYNCHRONOUSLY-throwing fn
+        // into the rejection path — a bare fn() call would skip release() and
+        // leak the slot (six such failures would deadlock the queue).
+        Promise.resolve()
+          .then(fn)
+          .then(
+            (v) => {
+              release();
+              resolve(v);
+            },
+            (e) => {
+              release();
+              reject(e);
+            }
+          );
       };
       if (active < max) run();
       else queue.push(run);
@@ -572,17 +577,21 @@ function pLimit(max: number): <T>(fn: () => Promise<T>) => Promise<T> {
  */
 function imageSeam(embedder: ImageEmbedder, assets: AssetFetcher, pageId: string): ImageEmbedSeam {
   const limit = pLimit(ASSET_FETCH_CONCURRENCY);
-  const fetches = new Map<ImageBlock, Promise<Uint8Array>>();
+  // Keyed by the CANONICAL asset URL, not block identity: a page that shows
+  // the same attachment twice downloads it once (the embedder already
+  // deduplicates the media part; this deduplicates the network fetch).
+  const fetches = new Map<string, Promise<Uint8Array>>();
   const fetchBytes = (block: ImageBlock): Promise<Uint8Array> => {
-    let p = fetches.get(block);
+    const ref = assetRefFor(block, pageId);
+    let p = fetches.get(ref.url);
     if (!p) {
-      p = limit(() => assets.fetch(assetRefFor(block, pageId)));
+      p = limit(() => assets.fetch(ref));
       // The prefetch caller never awaits; without this consumed branch a
       // fetch failing before embed() awaits it would surface as an
       // unhandled rejection. embed() awaits the ORIGINAL promise and still
       // sees the real error.
       p.catch(() => {});
-      fetches.set(block, p);
+      fetches.set(ref.url, p);
     }
     return p;
   };

--- a/packages/docx/src/export.ts
+++ b/packages/docx/src/export.ts
@@ -186,8 +186,12 @@ export async function exportDocx(input: ExportInput): Promise<ExportResult> {
   const scan = scanZip(zip);
 
   // 1. Resolve non-content placeholders (lazy fetch driven by the used set).
+  //    STARTED here, awaited only when the values are needed (step 4): the
+  //    resolver's round-trips run concurrently with body serialization and
+  //    the logo fetch below instead of gating them (perf finding: the
+  //    sequential flow paid every network latency back to back).
   const usedRaw = [...scan.supported, ...scan.unsupported, ...scan.never].flatMap((h) => h.raw);
-  const resolved = await resolvePlaceholders(usedRaw, { details: input.details, template: input.template, exportDate }, input.deps);
+  const resolvedPromise = resolvePlaceholders(usedRaw, { details: input.details, template: input.template, exportDate }, input.deps);
 
   // 2. Storage → blocks → OOXML body. When the host supplied an asset fetcher
   //    (and images aren't disabled), the serializer's image seam embeds each
@@ -206,6 +210,18 @@ export async function exportDocx(input: ExportInput): Promise<ExportResult> {
     embedder && input.rasterizer
       ? diagramSeam(embedder, input.rasterizer, input.diagramTheme)
       : undefined;
+
+  // Logo pass, fetch leg (spec 005, gap G3): the template scan + space-logo
+  // byte fetch start NOW so the (up to three-round-trip) logo chain overlaps
+  // body serialization and the resolver; the archive is only touched in step
+  // 3b below, in the same deterministic order as before. Never rejects.
+  const logoFetch = startLogoPass(zip, {
+    embedder,
+    assets: input.assets,
+    getSpaceLogo: input.deps?.getSpaceLogo,
+    spaceKey: input.details.spaceKey,
+  });
+
   const body = await serializeBlocks(blocks, { styleNames, images, diagrams });
 
   // 3. Swap the $scroll.content paragraph for the rawxml tag paragraph. If the
@@ -213,15 +229,14 @@ export async function exportDocx(input: ExportInput): Promise<ExportResult> {
   const contentFound = injectContentTag(zip);
   const flowNotes: ExportNote[] = [];
 
-  // 3b. Logo pass (spec 005, gap G3): replace each $scroll.spacelogo /
+  // 3b. Logo pass, embed leg: replace each $scroll.spacelogo /
   //     $scroll.globallogo placeholder PARAGRAPH with an inline drawing of the
-  //     space logo. Runs before preprocessScrollText so a failed/skipped logo
-  //     still has its token blanked there (never a literal), and before render
-  //     so the drawing paragraphs pass through docxtemplater untouched.
-  await embedLogoPlaceholders(zip, {
+  //     space logo (bytes fetched above). Runs before preprocessScrollText so
+  //     a failed/skipped logo still has its token blanked there (never a
+  //     literal), and before render so the drawing paragraphs pass through
+  //     docxtemplater untouched.
+  finishLogoPass(zip, await logoFetch, {
     embedder,
-    assets: input.assets,
-    getSpaceLogo: input.deps?.getSpaceLogo,
     spaceKey: input.details.spaceKey,
     notes: flowNotes,
   });
@@ -239,6 +254,7 @@ export async function exportDocx(input: ExportInput): Promise<ExportResult> {
   //    is NOT injected yet — so page-authored $scroll.* examples can't be hit).
   //    Runs before render so the engine only ever sees resolved text + the one
   //    rawxml tag.
+  const resolved = await resolvedPromise;
   preprocessScrollText(zip, resolved.values);
 
   // 5. Render with docxtemplater: the rawxml tag expands to the serialized body,
@@ -359,7 +375,6 @@ interface LogoPassInput {
   assets?: AssetFetcher;
   getSpaceLogo?: (spaceKey: string) => Promise<AssetRef | null>;
   spaceKey?: string;
-  notes: ExportNote[];
 }
 
 interface LogoOccurrence {
@@ -370,11 +385,67 @@ interface LogoOccurrence {
   base: string;
 }
 
+/** Outcome of the logo FETCH leg, consumed by {@link finishLogoPass}. */
+interface LogoPassState {
+  occurrences: LogoOccurrence[];
+  /** Distinct bases used, sorted (drives per-base skip notes). */
+  bases: string[];
+  outcome:
+    | { kind: "skip"; message: string; level: "info" | "warning" }
+    | { kind: "bytes"; bytes: Uint8Array };
+}
+
 /**
- * Replace each `$scroll.spacelogo` / `$scroll.globallogo` placeholder
- * paragraph with an inline `<w:drawing>` of the space logo, across the main
- * story and all header/footer parts (the embedder writes the `r:embed`
- * relationship into each part's own rels).
+ * Logo pass (spec 005, gap G3), FETCH leg: scan the template parts for
+ * `$scroll.spacelogo` / `$scroll.globallogo` placeholder paragraphs and — when
+ * any exist — fetch the space-logo bytes. The space-logo round-trip stays lazy
+ * (it fires only when a template actually uses a logo placeholder), but the
+ * returned promise is started EARLY by the caller so the chain (icon lookup →
+ * asset fetch) overlaps the export's other work. Touches nothing in the zip
+ * and never rejects; every failure becomes a `skip` outcome that
+ * {@link finishLogoPass} turns into the same notes as before.
+ */
+async function startLogoPass(zip: PizZip, input: LogoPassInput): Promise<LogoPassState | null> {
+  const { embedder, assets, getSpaceLogo, spaceKey } = input;
+
+  const occurrences: LogoOccurrence[] = [];
+  for (const part of documentPartNames(zip)) {
+    const xml = zip.file(part)?.asText() ?? "";
+    if (!xml.includes("$scroll.spacelogo") && !xml.includes("$scroll.globallogo")) continue;
+    for (const para of splitParagraphs(xml)) {
+      const m = paragraphText(para).match(LOGO_TOKEN_RE);
+      if (m) occurrences.push({ part, paragraph: para, raw: m[0], base: `$scroll.${m[1]}` });
+    }
+  }
+  if (occurrences.length === 0) return null;
+
+  const bases = [...new Set(occurrences.map((o) => o.base))].sort();
+  const state = (outcome: LogoPassState["outcome"]): LogoPassState => ({ occurrences, bases, outcome });
+  const skip = (message: string, level: "info" | "warning" = "warning"): LogoPassState =>
+    state({ kind: "skip", message, level });
+
+  if (!embedder || !assets) {
+    return skip("image embedding is off or no asset fetcher is available; rendered empty.", "info");
+  }
+  if (!getSpaceLogo) return skip("no space-logo fetcher is available; rendered empty.");
+  if (!spaceKey) return skip("the page has no space key; rendered empty.");
+
+  try {
+    const ref = await getSpaceLogo(spaceKey);
+    if (!ref) return skip(`space "${spaceKey}" has no logo; rendered empty.`, "info");
+    return state({ kind: "bytes", bytes: await assets.fetch(ref) });
+  } catch (err) {
+    return skip(
+      `the space logo could not be fetched (${err instanceof Error ? err.message : String(err)}); rendered empty.`
+    );
+  }
+}
+
+/**
+ * Logo pass, EMBED leg: replace each `$scroll.spacelogo` / `$scroll.globallogo`
+ * placeholder paragraph with an inline `<w:drawing>` of the space logo, across
+ * the main story and all header/footer parts (the embedder writes the
+ * `r:embed` relationship into each part's own rels).
  *
  * Both bases resolve to the SPACE logo (`GET /space/{key}?expand=icon`):
  * Confluence Cloud exposes no separately fetchable global logo, so
@@ -390,54 +461,23 @@ interface LogoOccurrence {
  * embedder writes nothing on failure, so no dangling media part or
  * relationship survives (the 004-F3 invariant).
  */
-async function embedLogoPlaceholders(zip: PizZip, input: LogoPassInput): Promise<void> {
-  const { embedder, assets, getSpaceLogo, spaceKey, notes } = input;
+function finishLogoPass(
+  zip: PizZip,
+  fetched: LogoPassState | null,
+  input: { embedder?: ImageEmbedder; spaceKey?: string; notes: ExportNote[] }
+): void {
+  if (!fetched) return;
+  const { embedder, spaceKey, notes } = input;
+  const { occurrences, bases, outcome } = fetched;
 
-  // Collect occurrences first: the space-logo round-trip stays lazy (it fires
-  // only when a template actually uses a logo placeholder).
-  const occurrences: LogoOccurrence[] = [];
-  for (const part of documentPartNames(zip)) {
-    const xml = zip.file(part)?.asText() ?? "";
-    if (!xml.includes("$scroll.spacelogo") && !xml.includes("$scroll.globallogo")) continue;
-    for (const para of splitParagraphs(xml)) {
-      const m = paragraphText(para).match(LOGO_TOKEN_RE);
-      if (m) occurrences.push({ part, paragraph: para, raw: m[0], base: `$scroll.${m[1]}` });
-    }
-  }
-  if (occurrences.length === 0) return;
-
-  const bases = [...new Set(occurrences.map((o) => o.base))].sort();
-  const skipAll = (message: string, level: "info" | "warning" = "warning"): void => {
+  if (outcome.kind === "skip") {
     for (const base of bases) {
-      notes.push({ level, code: "logo-skipped", message: `${base} was not embedded: ${message}` });
+      notes.push({
+        level: outcome.level,
+        code: "logo-skipped",
+        message: `${base} was not embedded: ${outcome.message}`,
+      });
     }
-  };
-
-  if (!embedder || !assets) {
-    skipAll("image embedding is off or no asset fetcher is available; rendered empty.", "info");
-    return;
-  }
-  if (!getSpaceLogo) {
-    skipAll("no space-logo fetcher is available; rendered empty.");
-    return;
-  }
-  if (!spaceKey) {
-    skipAll("the page has no space key; rendered empty.");
-    return;
-  }
-
-  let bytes: Uint8Array;
-  try {
-    const ref = await getSpaceLogo(spaceKey);
-    if (!ref) {
-      skipAll(`space "${spaceKey}" has no logo; rendered empty.`, "info");
-      return;
-    }
-    bytes = await assets.fetch(ref);
-  } catch (err) {
-    skipAll(
-      `the space logo could not be fetched (${err instanceof Error ? err.message : String(err)}); rendered empty.`
-    );
     return;
   }
 
@@ -455,7 +495,7 @@ async function embedLogoPlaceholders(zip: PizZip, input: LogoPassInput): Promise
     if (!xml.includes(occ.paragraph)) continue; // already replaced (identical paragraph)
     const args = parseLogoArgs(occ.raw);
     try {
-      const drawing = embedder.embed(bytes, {
+      const drawing = embedder!.embed(outcome.bytes, {
         name: occ.base === "$scroll.globallogo" ? "Global logo" : "Space logo",
         alt: `${spaceKey} space logo`,
         heightPx: args.heightPx,
@@ -481,6 +521,42 @@ async function embedLogoPlaceholders(zip: PizZip, input: LogoPassInput): Promise
 // ---------------------------------------------------------------------------
 
 /**
+ * How many asset fetches may be in flight at once. 6 is the classic
+ * per-origin browser cap for HTTP/1.1 connections, safe in every host shape
+ * (CLI, extension panel, a future Tauri webview) and gentle on the
+ * Confluence API; HTTP/2 hosts simply multiplex the six.
+ */
+const ASSET_FETCH_CONCURRENCY = 6;
+
+/** Minimal promise pool: run `fn`s with at most `max` concurrently in flight. */
+function pLimit(max: number): <T>(fn: () => Promise<T>) => Promise<T> {
+  let active = 0;
+  const queue: Array<() => void> = [];
+  const release = (): void => {
+    active -= 1;
+    queue.shift()?.();
+  };
+  return <T,>(fn: () => Promise<T>): Promise<T> =>
+    new Promise<T>((resolve, reject) => {
+      const run = (): void => {
+        active += 1;
+        fn().then(
+          (v) => {
+            release();
+            resolve(v);
+          },
+          (e) => {
+            release();
+            reject(e);
+          }
+        );
+      };
+      if (active < max) run();
+      else queue.push(run);
+    });
+}
+
+/**
  * Bridge the serializer's {@link ImageEmbedSeam} to the host's
  * {@link AssetFetcher} + the OOXML {@link ImageEmbedder}: resolve the block's
  * source to an {@link AssetRef}, fetch the bytes, embed. EVERY throw —
@@ -488,12 +564,35 @@ async function embedLogoPlaceholders(zip: PizZip, input: LogoPassInput): Promise
  * writes a report line and the export always succeeds; the embedder writes
  * nothing to the archive unless it returns a fragment, so a failure never
  * leaves a dangling media part or relationship.
+ *
+ * Fetches are started by the serializer's prefetch pass and pooled at
+ * {@link ASSET_FETCH_CONCURRENCY}, so N images cost ~1 network latency
+ * instead of N; embedding (and thus relationship-id allocation) still
+ * happens in document order through {@link ImageEmbedSeam.embed}.
  */
 function imageSeam(embedder: ImageEmbedder, assets: AssetFetcher, pageId: string): ImageEmbedSeam {
+  const limit = pLimit(ASSET_FETCH_CONCURRENCY);
+  const fetches = new Map<ImageBlock, Promise<Uint8Array>>();
+  const fetchBytes = (block: ImageBlock): Promise<Uint8Array> => {
+    let p = fetches.get(block);
+    if (!p) {
+      p = limit(() => assets.fetch(assetRefFor(block, pageId)));
+      // The prefetch caller never awaits; without this consumed branch a
+      // fetch failing before embed() awaits it would surface as an
+      // unhandled rejection. embed() awaits the ORIGINAL promise and still
+      // sees the real error.
+      p.catch(() => {});
+      fetches.set(block, p);
+    }
+    return p;
+  };
   return {
+    prefetch(block: ImageBlock) {
+      void fetchBytes(block);
+    },
     async embed(block: ImageBlock) {
       try {
-        const bytes = await assets.fetch(assetRefFor(block, pageId));
+        const bytes = await fetchBytes(block);
         const name = block.source.kind === "attachment" ? block.source.filename : undefined;
         const xml = embedder.embed(bytes, {
           alt: block.alt,
@@ -529,28 +628,66 @@ function diagramSeam(
   theme: DiagramTheme | undefined
 ): DiagramEmbedSeam {
   let count = 0;
+  // Render + rasterize results, keyed by block: the serializer's prefetch
+  // pass starts this CPU/async work up front so it overlaps the export's
+  // network round-trips; embed() then consumes the in-flight result in
+  // document order. The preparation never rejects — every failure is a
+  // value — so an unawaited prefetch can't surface an unhandled rejection.
+  type DiagramPrep =
+    | { kind: "ready"; svg: string; png: Uint8Array; widthPx: number; heightPx: number }
+    | { kind: "unsupported"; diagramType: string }
+    | { kind: "failed"; reason: string };
+  const preps = new Map<CodeBlock, Promise<DiagramPrep>>();
+  const prepare = (block: CodeBlock): Promise<DiagramPrep> => {
+    let p = preps.get(block);
+    if (!p) {
+      p = (async (): Promise<DiagramPrep> => {
+        const rendered = await renderDiagram(block.code, theme);
+        if (rendered.kind === "unsupported") {
+          return { kind: "unsupported", diagramType: rendered.diagramType };
+        }
+        if (rendered.kind === "failed") return { kind: "failed", reason: rendered.reason };
+        try {
+          const png = await rasterizer.rasterize(rendered.svg, {
+            widthPx: rendered.widthPx * 2,
+            heightPx: rendered.heightPx * 2,
+          });
+          return {
+            kind: "ready",
+            svg: rendered.svg,
+            png,
+            widthPx: rendered.widthPx,
+            heightPx: rendered.heightPx,
+          };
+        } catch (err) {
+          return { kind: "failed", reason: err instanceof Error ? err.message : String(err) };
+        }
+      })();
+      preps.set(block, p);
+    }
+    return p;
+  };
   return {
+    prefetch(block: CodeBlock) {
+      void prepare(block);
+    },
     async embed(block: CodeBlock) {
-      const rendered = await renderDiagram(block.code, theme);
-      if (rendered.kind === "unsupported") {
-        return { ok: false as const, route: "unsupported" as const, diagramType: rendered.diagramType };
+      const prep = await prepare(block);
+      if (prep.kind === "unsupported") {
+        return { ok: false as const, route: "unsupported" as const, diagramType: prep.diagramType };
       }
-      if (rendered.kind === "failed") {
-        return { ok: false as const, route: "failed" as const, reason: rendered.reason };
+      if (prep.kind === "failed") {
+        return { ok: false as const, route: "failed" as const, reason: prep.reason };
       }
       try {
-        const png = await rasterizer.rasterize(rendered.svg, {
-          widthPx: rendered.widthPx * 2,
-          heightPx: rendered.heightPx * 2,
-        });
         count += 1;
-        const xml = embedder.embedSvg(rendered.svg, png, {
+        const xml = embedder.embedSvg(prep.svg, prep.png, {
           name: `Mermaid diagram ${count}`,
           // Accessibility (spec 005a Task 3): the diagram SOURCE is the
           // best available description of the drawing.
           alt: block.code,
-          widthPx: rendered.widthPx,
-          heightPx: rendered.heightPx,
+          widthPx: prep.widthPx,
+          heightPx: prep.heightPx,
         });
         return { ok: true as const, xml };
       } catch (err) {

--- a/packages/docx/src/golden.test.ts
+++ b/packages/docx/src/golden.test.ts
@@ -118,7 +118,11 @@ export function expectMatchesGolden({ bytes, report }: ExportResult): void {
   expect(report.unsupportedNames).toEqual(golden.report.unsupportedNames);
   expect(report.skippedImages).toBe(golden.report.skippedImages);
   expect(report.filename).toBe(golden.report.filename);
-  expect(report.notes.map((n) => n.code)).toEqual(golden.report.noteCodes);
+  // The perf-timing diagnostic note is wall-clock-dependent and can never be
+  // golden-pinned; the golden capture pins the SEMANTIC notes only.
+  expect(report.notes.map((n) => n.code).filter((c) => c !== "perf-timing")).toEqual(
+    golden.report.noteCodes
+  );
 }
 
 describe("golden-file equality (spec 006 Task 4)", () => {

--- a/packages/docx/src/highlight.test.ts
+++ b/packages/docx/src/highlight.test.ts
@@ -7,9 +7,36 @@
  * golden-file equality between the first and second export in a process.
  */
 import { describe, expect, it } from "bun:test";
-import { highlightCode } from "./highlight.js";
+import { canonicalLang, highlightCode } from "./highlight.js";
 
 describe("highlightCode determinism", () => {
+  it("canonicalizes aliases so they share one grammar load/warm promise", () => {
+    const aliases = {
+      ts: "typescript",
+      js: "javascript",
+      py: "python",
+      cs: "csharp",
+      rs: "rust",
+      rb: "ruby",
+      shell: "bash",
+      sh: "bash",
+      yml: "yaml",
+      md: "markdown",
+    };
+    for (const [alias, canonical] of Object.entries(aliases)) {
+      expect(canonicalLang(alias)).toBe(canonical);
+      expect(canonicalLang(canonical)).toBe(canonical);
+    }
+    expect(canonicalLang("brainfuck")).toBeUndefined();
+  });
+
+  it("preserves equivalent token output for a requested alias and canonical id", async () => {
+    const code = "const x: number = 1;";
+    const alias = await highlightCode(code, "ts");
+    const canonical = await highlightCode(code, "typescript");
+    expect(alias).toEqual(canonical);
+  });
+
   it("returns identical tokens on the first and every subsequent call", async () => {
     const code = "const x = 1;\nexport function f(): number { return x; }";
     const first = await highlightCode(code, "ts");

--- a/packages/docx/src/highlight.ts
+++ b/packages/docx/src/highlight.ts
@@ -88,24 +88,112 @@ function canonicalLang(lang: string): string | undefined {
 }
 
 let highlighterPromise: Promise<HighlighterCore> | null = null;
-const loadedLangs = new Set<string>();
+/** Per-language load promise: concurrent callers (prefetch + serializer) share one load. */
+const langLoads = new Map<string, Promise<void>>();
+
+/**
+ * True when this host may COMPILE WebAssembly. `typeof WebAssembly` alone is
+ * not enough: an MV3 extension page exposes the object but its CSP (without
+ * `wasm-unsafe-eval`) rejects compilation — so probe with the smallest valid
+ * module (the 8-byte `\0asm` header). Sub-millisecond, no network.
+ */
+function canCompileWasm(): boolean {
+  try {
+    return (
+      typeof WebAssembly !== "undefined" &&
+      new WebAssembly.Module(Uint8Array.of(0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00)) instanceof
+        WebAssembly.Module
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Pick the fastest regex engine the host allows (perf finding: loading the
+ * TypeScript grammar through the JS engine costs ~650ms of oniguruma-to-es
+ * translation; the Oniguruma WASM engine does the same in ~30ms — it runs
+ * the grammars' original regexes natively):
+ *
+ *  - hosts that can compile WASM (CLI/Bun, Node, Tauri webviews, extensions
+ *    WITH `wasm-unsafe-eval`) get the Oniguruma engine — the reference
+ *    implementation, so token output is at least as faithful;
+ *  - the MV3 panel (no `wasm-unsafe-eval` in its CSP) keeps the JavaScript
+ *    engine, exactly the pre-existing behavior. The probe means the panel
+ *    never even fetches the ~600 KB wasm chunk — and auto-upgrades if the
+ *    permission is ever added.
+ *
+ * Any wasm-path failure falls back to the JS engine rather than degrading
+ * highlighting.
+ */
+async function createEngine(): Promise<import("shiki/core").RegexEngine> {
+  if (canCompileWasm()) {
+    try {
+      const { createOnigurumaEngine } = await import("shiki/engine/oniguruma");
+      return await createOnigurumaEngine(import("shiki/wasm"));
+    } catch {
+      // fall through to the JS engine
+    }
+  }
+  const { createJavaScriptRegexEngine } = await import("shiki/engine/javascript");
+  return createJavaScriptRegexEngine();
+}
 
 async function getHighlighter(): Promise<HighlighterCore> {
   if (!highlighterPromise) {
     highlighterPromise = (async () => {
-      const [{ createHighlighterCore }, { createJavaScriptRegexEngine }, theme] = await Promise.all([
+      const [{ createHighlighterCore }, engine, theme] = await Promise.all([
         import("shiki/core"),
-        import("shiki/engine/javascript"),
+        createEngine(),
         import("shiki/themes/github-light.mjs"),
       ]);
       return createHighlighterCore({
         themes: [theme.default],
         langs: [],
-        engine: createJavaScriptRegexEngine(),
+        engine,
       });
     })();
   }
   return highlighterPromise;
+}
+
+/** Load one language grammar into the highlighter exactly once (shared promise). */
+function loadLang(lang: string): Promise<void> {
+  let p = langLoads.get(lang);
+  if (!p) {
+    p = (async () => {
+      const hl = await getHighlighter();
+      const mod = (await LANG_LOADERS[lang]()) as { default: unknown };
+      await hl.loadLanguage(mod.default as never);
+      // Warm the grammar with a throwaway tokenize: the JS regex engine
+      // compiles rules lazily, and the very FIRST tokenize after loadLanguage
+      // can emit differently-merged tokens than every later call (observed:
+      // `1;` as one number-colored token, then `1` + `;` split ever after).
+      // One dummy call makes all real output deterministic from call one —
+      // which the spec-006 golden-file equality test depends on.
+      hl.codeToTokens("0;", { lang, theme: THEME });
+    })();
+    // A failed load must not poison later attempts (they re-import).
+    p.catch(() => {
+      langLoads.delete(lang);
+    });
+    langLoads.set(lang, p);
+  }
+  return p;
+}
+
+/**
+ * Start loading the highlighter core + the given languages' grammars in the
+ * background (perf: the first Shiki use costs ~700ms of import + grammar
+ * compile, which this overlaps with the export's network round-trips).
+ * Never throws and never rejects — a failed warm just means the later
+ * {@link highlightCode} call retries and degrades on its own.
+ */
+export function warmHighlight(languages: string[]): void {
+  const langs = new Set(
+    languages.map((l) => canonicalLang(l.trim().toLowerCase())).filter((l): l is string => Boolean(l))
+  );
+  for (const lang of langs) void loadLang(lang).catch(() => {});
 }
 
 /** Split code into uncolored lines (the fallback path). */
@@ -130,19 +218,8 @@ export async function highlightCode(code: string, language?: string): Promise<Hi
   }
 
   try {
+    await loadLang(lang);
     const hl = await getHighlighter();
-    if (!loadedLangs.has(lang)) {
-      const mod = (await LANG_LOADERS[lang]()) as { default: unknown };
-      await hl.loadLanguage(mod.default as never);
-      // Warm the grammar with a throwaway tokenize: the JS regex engine
-      // compiles rules lazily, and the very FIRST tokenize after loadLanguage
-      // can emit differently-merged tokens than every later call (observed:
-      // `1;` as one number-colored token, then `1` + `;` split ever after).
-      // One dummy call makes all real output deterministic from call one —
-      // which the spec-006 golden-file equality test depends on.
-      hl.codeToTokens("0;", { lang, theme: THEME });
-      loadedLangs.add(lang);
-    }
     const { tokens } = hl.codeToTokens(code, { lang, theme: THEME });
     return {
       lines: tokens.map((line) => line.map((t) => ({ text: t.content, color: t.color }))),

--- a/packages/docx/src/highlight.ts
+++ b/packages/docx/src/highlight.ts
@@ -7,13 +7,13 @@
  *  - `createHighlighterCore` from `shiki/core` — no built-in language/theme
  *    registry, so Vite does NOT emit a chunk for every one of Shiki's ~200
  *    grammars (the full entry produced a ~10 MB output of per-language chunks).
- *  - the **JavaScript regex engine** (`shiki/engine/javascript`) instead of the
- *    Oniguruma WASM engine — avoids shipping the ~600 KB `.wasm` and keeps the
- *    panel within MV3's `wasm-unsafe-eval` posture without needing WASM at all.
+ *  - a runtime-selected regex engine: Oniguruma WASM where compilation is
+ *    allowed, with the JavaScript engine as the CSP-safe fallback.
  *  - one static `import("shiki/langs/<lang>.mjs")` per **curated** common
  *    language, each its own code-split chunk loaded only when a code block of
  *    that language is actually serialized (PLAN: "lazy-load only needed
- *    languages"). Unknown/uncurated languages degrade to uncolored lines.
+ *    languages"). Aliases resolve to one canonical loader/warm promise;
+ *    unknown/uncurated languages degrade to uncolored lines.
  *
  * The whole module is only reached through the serializer's `await`, so nothing
  * here lands in the main panel bundle.
@@ -43,48 +43,54 @@ export interface HighlightResult {
 const THEME = "github-light";
 
 /**
- * Curated language loaders. Each value is a static dynamic import so the bundler
- * emits exactly these chunks (aliases share a loader). Keep this list tight —
- * every entry is a shipped grammar chunk.
+ * Curated canonical language loaders. Each value is a static dynamic import so
+ * the bundler emits exactly these chunks. Aliases resolve through
+ * {@link LANG_ALIASES}; keep both lists tight — every loader is a shipped
+ * grammar chunk.
  */
 const LANG_LOADERS: Record<string, () => Promise<unknown>> = {
   typescript: () => import("shiki/langs/typescript.mjs"),
-  ts: () => import("shiki/langs/typescript.mjs"),
   tsx: () => import("shiki/langs/tsx.mjs"),
   javascript: () => import("shiki/langs/javascript.mjs"),
-  js: () => import("shiki/langs/javascript.mjs"),
   jsx: () => import("shiki/langs/jsx.mjs"),
   json: () => import("shiki/langs/json.mjs"),
   python: () => import("shiki/langs/python.mjs"),
-  py: () => import("shiki/langs/python.mjs"),
   java: () => import("shiki/langs/java.mjs"),
   kotlin: () => import("shiki/langs/kotlin.mjs"),
   csharp: () => import("shiki/langs/csharp.mjs"),
-  cs: () => import("shiki/langs/csharp.mjs"),
   go: () => import("shiki/langs/go.mjs"),
   rust: () => import("shiki/langs/rust.mjs"),
-  rs: () => import("shiki/langs/rust.mjs"),
   c: () => import("shiki/langs/c.mjs"),
   cpp: () => import("shiki/langs/cpp.mjs"),
   php: () => import("shiki/langs/php.mjs"),
   ruby: () => import("shiki/langs/ruby.mjs"),
-  rb: () => import("shiki/langs/ruby.mjs"),
   bash: () => import("shiki/langs/bash.mjs"),
-  shell: () => import("shiki/langs/bash.mjs"),
-  sh: () => import("shiki/langs/bash.mjs"),
   sql: () => import("shiki/langs/sql.mjs"),
   yaml: () => import("shiki/langs/yaml.mjs"),
-  yml: () => import("shiki/langs/yaml.mjs"),
   html: () => import("shiki/langs/html.mjs"),
   xml: () => import("shiki/langs/xml.mjs"),
   css: () => import("shiki/langs/css.mjs"),
   markdown: () => import("shiki/langs/markdown.mjs"),
-  md: () => import("shiki/langs/markdown.mjs"),
 };
 
-/** The Shiki grammar id a given language alias resolves to (for load caching). */
-function canonicalLang(lang: string): string | undefined {
-  return LANG_LOADERS[lang] ? lang : undefined;
+/** Curated aliases keyed to the one grammar load/warm promise they share. */
+const LANG_ALIASES: Record<string, string> = {
+  ts: "typescript",
+  js: "javascript",
+  py: "python",
+  cs: "csharp",
+  rs: "rust",
+  rb: "ruby",
+  shell: "bash",
+  sh: "bash",
+  yml: "yaml",
+  md: "markdown",
+};
+
+/** The Shiki grammar id a given requested language or alias resolves to. */
+export function canonicalLang(lang: string): string | undefined {
+  const canonical = LANG_ALIASES[lang] ?? lang;
+  return LANG_LOADERS[canonical] ? canonical : undefined;
 }
 
 let highlighterPromise: Promise<HighlighterCore> | null = null;
@@ -218,16 +224,18 @@ function plainLines(code: string): CodeLine[] {
  */
 export async function highlightCode(code: string, language?: string): Promise<HighlightResult> {
   const raw = (language ?? "").trim().toLowerCase();
-  const lang = canonicalLang(raw);
-  if (!lang) {
+  const canonical = canonicalLang(raw);
+  if (!canonical) {
     // Only a REQUESTED-but-unknown language is a skip worth reporting.
     return { lines: plainLines(code), skipped: raw ? "unknown-language" : null };
   }
 
   try {
-    await loadLang(lang);
+    await loadLang(canonical);
     const hl = await getHighlighter();
-    const { tokens } = hl.codeToTokens(code, { lang, theme: THEME });
+    // Tokenize with the requested alias so Shiki preserves its public alias
+    // behavior, while grammar loading/warm-up is shared by canonical id.
+    const { tokens } = hl.codeToTokens(code, { lang: raw, theme: THEME });
     return {
       lines: tokens.map((line) => line.map((t) => ({ text: t.content, color: t.color }))),
       skipped: null,

--- a/packages/docx/src/highlight.ts
+++ b/packages/docx/src/highlight.ts
@@ -141,7 +141,7 @@ async function createEngine(): Promise<import("shiki/core").RegexEngine> {
 
 async function getHighlighter(): Promise<HighlighterCore> {
   if (!highlighterPromise) {
-    highlighterPromise = (async () => {
+    const p = (async () => {
       const [{ createHighlighterCore }, engine, theme] = await Promise.all([
         import("shiki/core"),
         createEngine(),
@@ -153,6 +153,13 @@ async function getHighlighter(): Promise<HighlighterCore> {
         engine,
       });
     })();
+    // A failed init (transient chunk-load error during background warm-up)
+    // must not poison every later highlight — clear the memo so the next
+    // call retries. Callers still observe the original rejection.
+    p.catch(() => {
+      if (highlighterPromise === p) highlighterPromise = null;
+    });
+    highlighterPromise = p;
   }
   return highlighterPromise;
 }

--- a/packages/docx/src/resolver.test.ts
+++ b/packages/docx/src/resolver.test.ts
@@ -366,3 +366,62 @@ describe("resolvePlaceholders — pinning: never a literal", () => {
     expect(res.unsupportedNames.length).toBeGreaterThan(0);
   });
 });
+
+describe("resolvePlaceholders — concurrent dep fetching (perf regression)", () => {
+  const ALL_FOUR = [
+    "$scroll.space.name",
+    "$scroll.exporter.fullName",
+    "$scroll.pageowner.fullName",
+    "$scroll.pageproperty.(status,true)",
+  ];
+
+  it("starts all four round-trips before any of them resolves", async () => {
+    // Each fetcher parks on a shared barrier that only opens once every
+    // fetcher has STARTED. The old sequential implementation awaited getSpace
+    // before calling getCurrentUser, so it can never open the barrier — this
+    // test would time out instead of pass.
+    let started = 0;
+    let open!: () => void;
+    const barrier = new Promise<void>((r) => {
+      open = r;
+    });
+    const arrive = async <T,>(v: T): Promise<T> => {
+      started += 1;
+      if (started === 4) open();
+      await barrier;
+      return v;
+    };
+    const res = await resolvePlaceholders(ALL_FOUR, ctx, {
+      getSpace: () => arrive(space),
+      getCurrentUser: () => arrive(currentUser),
+      getPageOwner: () => arrive(owner),
+      getSpaceHomepageStorage: () => arrive(null),
+    });
+    expect(started).toBe(4);
+    expect(res.values.get("$scroll.space.name")).toBe("Engineering");
+    expect(res.values.get("$scroll.exporter.fullName")).toBe("Björn Schotte");
+    expect(res.values.get("$scroll.pageowner.fullName")).toBe("Olga Owner");
+  });
+
+  it("keeps note order deterministic regardless of completion order", async () => {
+    // All four legs fail, resolving in REVERSE order (homepage first, space
+    // last). The report must still list space → user → owner → homepage.
+    const failAfter = (ms: number) =>
+      new Promise<never>((_, reject) => setTimeout(() => reject(new Error("boom")), ms));
+    const res = await resolvePlaceholders(ALL_FOUR, ctx, {
+      getSpace: () => failAfter(40) as Promise<ConfluenceSpace>,
+      getCurrentUser: () => failAfter(30) as Promise<CurrentUser>,
+      getPageOwner: () => failAfter(20) as Promise<PageOwner>,
+      getSpaceHomepageStorage: () => failAfter(10) as Promise<string | null>,
+    });
+    const fetchNotes = res.notes
+      .map((n) => n.code)
+      .filter((c) => c.endsWith("-fetch-failed"));
+    expect(fetchNotes).toEqual([
+      "space-fetch-failed",
+      "user-fetch-failed",
+      "owner-fetch-failed",
+      "homepage-fetch-failed",
+    ]);
+  });
+});

--- a/packages/docx/src/resolver.ts
+++ b/packages/docx/src/resolver.ts
@@ -342,20 +342,32 @@ export async function resolvePlaceholders(
     else if (cls.dependency === "spaceHomepage") needsHomepage = true;
   }
 
-  let space: ConfluenceSpace | undefined;
-  if (needsSpace) {
+  // The four round-trips are independent, so they run CONCURRENTLY — a
+  // template using space + exporter + owner + homepage pays one network
+  // latency, not four (perf finding: the sequential awaits summed to ~470ms
+  // against Cloud). Each leg collects its notes into its own array; the
+  // arrays are concatenated in the fixed space → user → owner → homepage
+  // order below, so the report stays deterministic regardless of which
+  // response arrives first.
+  const spaceNotes: ExportNote[] = [];
+  const userNotes: ExportNote[] = [];
+  const ownerNotes: ExportNote[] = [];
+  const homepageNotes: ExportNote[] = [];
+
+  const fetchSpace = async (): Promise<ConfluenceSpace | undefined> => {
+    if (!needsSpace) return undefined;
     if (deps.getSpace && ctx.details.spaceKey) {
       try {
-        space = await deps.getSpace(ctx.details.spaceKey);
+        return await deps.getSpace(ctx.details.spaceKey);
       } catch {
-        notes.push({
+        spaceNotes.push({
           level: "warning",
           code: "space-fetch-failed",
           message: `Could not load space "${ctx.details.spaceKey}"; space placeholders will be empty.`,
         });
       }
     } else {
-      notes.push({
+      spaceNotes.push({
         level: "warning",
         code: "space-unavailable",
         message: ctx.details.spaceKey
@@ -363,51 +375,54 @@ export async function resolvePlaceholders(
           : "The template uses $scroll.space.* but the page has no space key; those placeholders will be empty.",
       });
     }
-  }
+    return undefined;
+  };
 
-  let currentUser: CurrentUser | undefined;
-  if (needsUser) {
+  const fetchUser = async (): Promise<CurrentUser | undefined> => {
+    if (!needsUser) return undefined;
     if (deps.getCurrentUser) {
       try {
-        currentUser = await deps.getCurrentUser();
+        return await deps.getCurrentUser();
       } catch {
-        notes.push({
+        userNotes.push({
           level: "warning",
           code: "user-fetch-failed",
           message: "Could not load the current user; exporter placeholders will be empty.",
         });
       }
     } else {
-      notes.push({
+      userNotes.push({
         level: "warning",
         code: "user-unavailable",
         message: "The template uses $scroll.exporter* but no current-user fetcher is available; those placeholders will be empty.",
       });
     }
-  }
+    return undefined;
+  };
 
-  let owner: PageOwner | undefined;
-  if (needsOwner) {
+  const fetchOwner = async (): Promise<PageOwner | undefined> => {
+    if (!needsOwner) return undefined;
     if (deps.getPageOwner && ctx.details.id) {
       try {
-        owner = (await deps.getPageOwner(ctx.details.id)) ?? undefined;
+        const owner = (await deps.getPageOwner(ctx.details.id)) ?? undefined;
         if (!owner) {
-          notes.push({
+          ownerNotes.push({
             level: "info",
             code: "placeholder-empty",
             message:
               "$scroll.pageowner.fullName has no value (the page has no owner, or the account could not be read).",
           });
         }
+        return owner;
       } catch {
-        notes.push({
+        ownerNotes.push({
           level: "warning",
           code: "owner-fetch-failed",
           message: "Could not load the page owner; $scroll.pageowner.* will be empty.",
         });
       }
     } else {
-      notes.push({
+      ownerNotes.push({
         level: "warning",
         code: "owner-unavailable",
         message: ctx.details.id
@@ -415,16 +430,17 @@ export async function resolvePlaceholders(
           : "The template uses $scroll.pageowner.* but the page has no id; those placeholders will be empty.",
       });
     }
-  }
+    return undefined;
+  };
 
-  let homepageProperties: PagePropertiesMacro[] | undefined;
-  if (needsHomepage) {
+  const fetchHomepage = async (): Promise<PagePropertiesMacro[] | undefined> => {
+    if (!needsHomepage) return undefined;
     if (deps.getSpaceHomepageStorage && ctx.details.spaceKey) {
       try {
         const storage = await deps.getSpaceHomepageStorage(ctx.details.spaceKey);
-        homepageProperties = parsePageProperties(storage ?? "");
+        return parsePageProperties(storage ?? "");
       } catch {
-        notes.push({
+        homepageNotes.push({
           level: "warning",
           code: "homepage-fetch-failed",
           message:
@@ -432,7 +448,7 @@ export async function resolvePlaceholders(
         });
       }
     } else {
-      notes.push({
+      homepageNotes.push({
         level: "warning",
         code: "homepage-unavailable",
         message: ctx.details.spaceKey
@@ -440,7 +456,16 @@ export async function resolvePlaceholders(
           : "A page property asks for the space-homepage fallback but the page has no space key; only this page's properties are used.",
       });
     }
-  }
+    return undefined;
+  };
+
+  const [space, currentUser, owner, homepageProperties] = await Promise.all([
+    fetchSpace(),
+    fetchUser(),
+    fetchOwner(),
+    fetchHomepage(),
+  ]);
+  notes.push(...spaceNotes, ...userNotes, ...ownerNotes, ...homepageNotes);
 
   const fetched: Fetched = { space, currentUser, owner, homepageProperties };
 

--- a/packages/docx/src/serialize.ts
+++ b/packages/docx/src/serialize.ts
@@ -19,7 +19,7 @@ import type {
   ListItem,
   TableRow,
 } from "@atlcli/confluence";
-import { highlightCode } from "./highlight.js";
+import { highlightCode, warmHighlight } from "./highlight.js";
 import {
   calloutTable,
   codeLineParagraph,
@@ -52,6 +52,14 @@ export type ImageEmbedOutcome = { ok: true; xml: string } | { ok: false; reason:
  */
 export interface ImageEmbedSeam {
   embed(block: ImageBlock): Promise<ImageEmbedOutcome>;
+  /**
+   * Optional perf hook: start the block's asset fetch NOW, ahead of its
+   * document-order {@link embed} call, so downloads overlap each other and
+   * the export's other round-trips. Must be side-effect-free on the archive
+   * (bytes only) — embedding (and thus relationship-id allocation) still
+   * happens in document order via {@link embed}. Never throws.
+   */
+  prefetch?(block: ImageBlock): void;
 }
 
 /**
@@ -71,6 +79,13 @@ export type DiagramEmbedOutcome =
  */
 export interface DiagramEmbedSeam {
   embed(block: CodeBlock): Promise<DiagramEmbedOutcome>;
+  /**
+   * Optional perf hook: start the block's render + rasterize NOW so the CPU
+   * work overlaps the export's network round-trips. Must not touch the
+   * archive — embedding stays in document order via {@link embed}. Never
+   * throws.
+   */
+  prefetch?(block: CodeBlock): void;
 }
 
 export interface SerializeContext {
@@ -248,6 +263,57 @@ function minHeadingLevel(blocks: ExportBlock[]): number {
   return min;
 }
 
+/**
+ * Kick off every deferrable cost up front (perf): image asset fetches and
+ * diagram render/rasterize runs start through the seams' `prefetch` hooks,
+ * and Shiki grammar loading starts for every code-block language — all
+ * BEFORE the document-order serialization walk begins. The walk then awaits
+ * work that is already in flight instead of paying each cost sequentially.
+ * Archive mutation order (and thus relationship-id allocation) is untouched:
+ * prefetch hooks produce bytes/fragments only.
+ */
+function prefetchBlocks(blocks: ExportBlock[], ctx: SerializeContext): void {
+  const languages: string[] = [];
+  const walk = (list: ExportBlock[]): void => {
+    for (const block of list) {
+      switch (block.type) {
+        case "image":
+          try {
+            ctx.images?.prefetch?.(block);
+          } catch {
+            // prefetch is best-effort; embed() handles + reports failures
+          }
+          break;
+        case "codeBlock": {
+          const lang = (block.language ?? "").trim().toLowerCase();
+          if (lang === "mermaid") {
+            try {
+              ctx.diagrams?.prefetch?.(block);
+            } catch {
+              // best-effort, see above
+            }
+          } else if (lang) {
+            languages.push(lang);
+          }
+          break;
+        }
+        case "callout":
+        case "blockquote":
+          walk(block.content);
+          break;
+        case "list":
+          for (const item of block.items) walk(item.content);
+          break;
+        case "table":
+          for (const row of block.rows) for (const cell of row.cells) walk(cell.content);
+          break;
+      }
+    }
+  };
+  walk(blocks);
+  if (languages.length) warmHighlight(languages);
+}
+
 /** Serialize a block list into an OOXML fragment + report notes. */
 export async function serializeBlocks(
   blocks: ExportBlock[],
@@ -256,6 +322,7 @@ export async function serializeBlocks(
   const notes: ExportNote[] = [];
   const parts: string[] = [];
   const internal: InternalContext = { ...ctx, headingOffset: computeHeadingOffset(blocks) };
+  prefetchBlocks(blocks, internal);
   for (const block of blocks) {
     parts.push(await serializeBlock(block, internal, notes, 0));
   }

--- a/src/content/docs/reference/docx-engine.md
+++ b/src/content/docs/reference/docx-engine.md
@@ -18,6 +18,7 @@ inject.
 - [Image embedding](#image-embedding)
 - [Mermaid diagrams](#mermaid-diagrams)
 - [Plugging in a new surface](#plugging-in-a-new-surface)
+- [Performance model](#performance-model)
 - [Guarantees and gates](#guarantees-and-gates)
 - [Related topics](#related-topics)
 
@@ -201,6 +202,36 @@ A browser surface supplies its own implementations instead (see
 and docxtemplater reference `Buffer.*`; that is a **host** bundling concern — the extension
 installs a `Uint8Array` shim + Vite `define`, a Node host has the real `Buffer`, and the engine
 itself never touches either.
+
+## Performance model
+
+The engine overlaps every independent cost instead of paying them back to back; a page with
+many integrations (images, diagrams, code blocks, logos) exports in roughly one network
+latency plus the heaviest CPU leg:
+
+- **Resolver round-trips run concurrently.** Space, current user, page owner, and space-homepage
+  fetches fire together via `Promise.all`; report notes keep a fixed order regardless of which
+  response arrives first.
+- **Placeholder resolution, body serialization, and the space-logo fetch overlap.** The logo pass
+  is split into a fetch leg (starts immediately, never rejects) and an embed leg (mutates the
+  archive after the body is serialized, in the same deterministic order as before).
+- **Asset fetches are prefetched and pooled.** Before the document-order serialization walk, a
+  prefetch pass starts every image download (max 6 in flight — safe for browser per-origin
+  limits, CLI sockets, and future webview hosts) and every diagram render/rasterize. Embedding
+  still happens in document order, so relationship ids and media numbering never depend on
+  network timing (pinned by the determinism regression tests in `export.test.ts`).
+- **Syntax highlighting warms early and picks the fastest engine.** Code-block languages found
+  during the prefetch pass start their grammar loads immediately. Hosts that may compile
+  WebAssembly (CLI, Node, Tauri) get Shiki's Oniguruma engine (~30 ms for the TypeScript
+  grammar); the MV3 panel (no `wasm-unsafe-eval`) keeps the JavaScript engine and never fetches
+  the wasm chunk — the choice is made by an 8-byte compile probe at runtime.
+- **The CLI overlaps its own legs too.** The page fetch runs concurrently with template
+  read/scan and rasterizer setup; a quick local template scan pre-starts exactly the resolver
+  round-trips the template needs; `$scroll.space.*` and the logo share one `?expand=icon` call.
+- **CLI asset cache.** Immutable asset bytes — version-stamped download URLs (the space logo)
+  and attachments keyed by `id` + `version` — are cached under `~/.atlcli/cache/assets/`. A
+  replaced logo or re-uploaded attachment gets a new version stamp, so the cache never serves
+  stale bytes; deleting the directory is always safe.
 
 ## Guarantees and gates
 

--- a/src/content/docs/reference/docx-engine.md
+++ b/src/content/docs/reference/docx-engine.md
@@ -131,6 +131,11 @@ for its ~1.5 MB elkjs layout chunk; the SVG → PNG rasterization is the host's 
   SVG reaches any rasterizer or the archive (`flattenSvgStyles` in
   `packages/diagram/src/svg-flatten.ts`); the CSS background becomes a real background
   `<rect>`. Browsers render the flattened SVG identically.
+- **Extension rasterizer:** the MV3 side panel draws each flattened SVG to a canvas and encodes
+  its PNG synchronously with `toDataURL`. The asynchronous `toBlob` callback path showed
+  repeatable ~1-second scheduling delays in real side-panel E2E runs. Diagram preparation is
+  already serialized, so synchronous encoding avoids that host task runner without adding
+  concurrent main-thread work.
 - **Node rasterizer (CLI):** `resvgSvgRasterizer()` renders the PNG fallback through
   `@resvg/resvg-wasm` — chosen over the native `@resvg/resvg-js` because release binaries are
   cross-compiled from one Linux runner, which can embed one portable `.wasm` for every target
@@ -217,21 +222,33 @@ latency plus the heaviest CPU leg:
   archive after the body is serialized, in the same deterministic order as before).
 - **Asset fetches are prefetched and pooled.** Before the document-order serialization walk, a
   prefetch pass starts every image download (max 6 in flight — safe for browser per-origin
-  limits, CLI sockets, and future webview hosts) and every diagram render/rasterize. Embedding
-  still happens in document order, so relationship ids and media numbering never depend on
-  network timing (pinned by the determinism regression tests in `export.test.ts`).
+  limits, CLI sockets, and future webview hosts). Diagram preparation stays on a single ordered
+  chain because concurrent canvas rasterization degrades sharply in the extension; repeated
+  occurrences of the exact same Mermaid source share one preparation. Embedding still happens
+  in document order, so relationship ids and media numbering never depend on completion timing
+  (pinned by the determinism regression tests in `export.test.ts`).
 - **Syntax highlighting warms early and picks the fastest engine.** Code-block languages found
-  during the prefetch pass start their grammar loads immediately. Hosts that may compile
-  WebAssembly (CLI, Node, Tauri) get Shiki's Oniguruma engine (~30 ms for the TypeScript
-  grammar); the MV3 panel (no `wasm-unsafe-eval`) keeps the JavaScript engine and never fetches
-  the wasm chunk — the choice is made by an 8-byte compile probe at runtime.
+  during the prefetch pass start their grammar loads immediately; aliases such as `ts` and
+  `typescript` share one canonical grammar load. Hosts that may compile WebAssembly (CLI, Node,
+  Tauri) get Shiki's Oniguruma engine (~30 ms for the TypeScript grammar); the MV3 panel (no
+  `wasm-unsafe-eval`) keeps the JavaScript engine and never fetches the wasm chunk — the choice
+  is made by an 8-byte compile probe at runtime.
 - **The CLI overlaps its own legs too.** The page fetch runs concurrently with template
-  read/scan and rasterizer setup; a quick local template scan pre-starts exactly the resolver
-  round-trips the template needs; `$scroll.space.*` and the logo share one `?expand=icon` call.
+  read/scan; a quick local template scan pre-starts exactly the resolver round-trips the template
+  needs, and page-dependent space/homepage calls start as soon as the page yields its space key.
+  `$scroll.space.*` and the logo share one `?expand=icon` call. The resvg module, WASM, and fonts
+  are loaded only when the page storage contains a Mermaid code block.
 - **CLI asset cache.** Immutable asset bytes — version-stamped download URLs (the space logo)
   and attachments keyed by `id` + `version` — are cached under `~/.atlcli/cache/assets/`. A
   replaced logo or re-uploaded attachment gets a new version stamp, so the cache never serves
-  stale bytes; deleting the directory is always safe.
+  stale bytes. Entries carry a checksum envelope so damaged files are refetched and repaired;
+  the directory is mode `0700` and entries are `0600`. Deleting the directory is always safe.
+- **The extension warms only opted-in export work.** Once a valid template exists, engine and
+  host chunks load in the background. On Export, the existing scan pre-starts only the required
+  resolver calls while host chunks settle, and the already-loaded template bytes are reused from
+  memory. Space/icon metadata is cached for five minutes per canonical site + space. Current user
+  and homepage storage remain per-export because neither has a safe same-site invalidation signal;
+  versioned asset bytes use a separate bounded cache keyed by canonical site + URL.
 
 ## Guarantees and gates
 


### PR DESCRIPTION
## Summary

Makes DOCX exports of integration-heavy wiki pages "blazing fast" by overlapping every independent cost in the isomorphic engine and both hosts. Measured against real DOCSY pages (`report.durationMs`, ts engine, CLI):

| Page | Before | After (cold) | After (warm cache) |
|---|---|---|---|
| Mermaid E2E (6 diagrams, 2 logos) | 1450 ms | ~600 ms | **~290 ms** |
| Spec-005 Logo/Image (5 images) | 2790 ms | ~510 ms | **~150 ms** |
| Feature-Zoo (code-heavy) | 2500 ms | ~150 ms | **~150 ms** |

## Engine (`packages/docx`, isomorphic — CLI + extension + future Tauri)

- Resolver round-trips (space / current user / page owner / homepage) run concurrently; per-leg note buffers keep report order deterministic
- Placeholder resolution ∥ body serialization ∥ space-logo fetch; logo pass split into a never-rejecting fetch leg and a deterministic embed leg
- Serializer prefetch pass: image downloads (6-slot pool, browser-per-origin-safe) start before the document-order walk; diagram render/rasterize runs as a prefetch-started sequential CHAIN (main-thread CPU work must not fan out — six concurrent panel rasterizations measured seconds each vs tens of ms chained); embeds stay in document order → relationship ids provably independent of network timing (byte-equality regression test)
- Image fetches dedupe by canonical asset URL
- Shiki: runtime engine choice via an 8-byte wasm compile probe — Oniguruma wasm where CSP allows (~30 ms TS-grammar load vs ~700 ms JS-engine translation), JS engine fallback otherwise; race-safe per-language load promises + `warmHighlight()`
- `report.timings` + a `perf-timing` note names each phase's wall clock in every export

## CLI host

- Page fetch overlaps template read/scan + rasterizer setup; a local template scan pre-starts exactly the resolver round-trips the template needs (lazy contract intact)
- `getSpace` + `getSpaceIcon` coalesced into one memoized `?expand=icon` call (new `ConfluenceClient.getSpaceWithIcon`)
- Disk cache `~/.atlcli/cache/assets/` for immutable bytes (version-stamped logo URL, attachments by id+version): atomic write-then-rename, zero-length = miss, once-per-process eviction (30 d, orphaned `.tmp` after 60 s)

## Extension host

- Panel mount preloads engine/env chunks once a template exists (NOT the mermaid renderer chunk — see open item below)
- Bounded panel-lifetime cache for version-stamped assets (space logo)
- Space+icon share one round-trip
- Panel appends rasterizer decode/draw/encode sub-timings to the report

## Hardening (external Codex review)

Codex confirmed: no PizZip races, determinism, lazy contract, browser safety. Its findings fixed in e5e36ec: sync-throw slot leak in the fetch pool (deadlock risk), unhandled-rejection window on the pre-started page fetch, non-atomic cache writes, rejected-highlighter memo poisoning, unbounded cache growth.

## Testing

- 1678 tests green, incl. new regression tests: resolver concurrency + note ordering under scrambled completion, byte-determinism with reversed fetch completion, F3 invariant with a slow-failing fetch, sync-throwing fetcher with >pool-size images, fetch dedupe
- Output proven byte-identical to the sequential engine on all three E2E pages
- `bun run typecheck`, `check:browser`, extension `check:output` green

## Panel rasterizer regression (found & fixed on this branch)

During E2E, the panel showed a reproducible ~6.8 s export where the CLI does ~290 ms; the new timing notes pinned it on six CONCURRENT canvas rasterizations (~20.5 s summed rasterize). 01b0200 chains diagram preparation (main-thread CPU work must not fan out; only network fetches do) — re-test confirms: **178 ms total on a cold panel** (rasterize 40 ms, decode 15/draw 1/encode 24). Extension baseline 661 ms → 178 ms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)