### PR TITLE
feat(pdf): ship browser-native Typst export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ dist
 .env
 .atlcli
 .tmp
+/tmp/
 .bun
 site/
 .venv/
@@ -12,6 +13,9 @@ spec/internal/
 .astro/
 .playwright-cli/
 opensrc/
+
+# Reproducible PDF font cache (downloaded from pinned Adobe releases).
+packages/pdf/.fonts/
 
 # SonarQube coverage artifact
 coverage/

--- a/.impeccable.md
+++ b/.impeccable.md
@@ -1,0 +1,25 @@
+## Design Context
+
+This context currently applies to atlcli's generated document and export surfaces. The
+extension application UI is intentionally not specified here while its screen designs are
+still in progress.
+
+### Users
+
+atlcli serves technical and business users who work with Atlassian content and need dependable exports for review, sharing, archiving, and further editing. Exported documents must remain comfortable to read across long, dense Confluence pages with prose, lists, tables, diagrams, and screenshots.
+
+### Brand Personality
+
+Precise, calm, and trustworthy. atlcli should feel fast and technically rigorous without looking developer-only, decorative, or tied to a specific customer brand.
+
+### Aesthetic Direction
+
+Use a refined editorial-document direction: neutral light surfaces, restrained blue accents, strong information hierarchy, generous but efficient vertical rhythm, and print-quality typography. The built-in PDF design must be brand-neutral and reproducible with bundled assets. Preserve the running title, fine horizontal rule, and centered page number as the export's recognizable navigation system. Do not transfer this page-layout aesthetic to the extension UI without its separate design context.
+
+### Design Principles
+
+1. Optimize first for sustained reading and scanning in long documents.
+2. Use spacing to express semantic hierarchy; keep related content grouped and sections clearly separated.
+3. Preserve author intent when explicit layout information exists, and apply conservative content-aware defaults otherwise.
+4. Prefer deterministic, accessible, locally bundled output over decorative or environment-dependent styling.
+5. Make performance and degradation visible so users can trust the export result.

--- a/NOTICE
+++ b/NOTICE
@@ -11,6 +11,10 @@ original attribution preserved.
 
 Third-party notices:
 
+- typst.ts web compiler (https://github.com/Myriad-Dreamin/typst.ts),
+  version 0.7.0 with embedded Typst 0.14.2, licensed under the Apache License
+  2.0. The WebAssembly build is distributed in object-code form inside the
+  extension; source is available at the URL above.
 - beautiful-mermaid (https://github.com/lukilabs/beautiful-mermaid),
   Copyright Craft Docs / Luki Labs, licensed under the MIT License.
 - elkjs (https://github.com/kieler/elkjs), a JavaScript build of the Eclipse
@@ -29,3 +33,12 @@ Third-party notices:
 - JetBrains Mono font family (https://github.com/JetBrains/JetBrainsMono),
   Copyright 2020 The JetBrains Mono Project Authors, licensed under the SIL
   Open Font License 1.1 (see packages/docx/fonts/LICENSE-JetBrainsMono.txt).
+- Source Sans 3 font family (https://github.com/adobe-fonts/source-sans),
+  Copyright 2010-2024 Adobe, licensed under the SIL Open Font License 1.1
+  (see packages/pdf/licenses/LICENSE-Source-Sans-3.txt).
+- Source Serif 4 font family (https://github.com/adobe-fonts/source-serif),
+  Copyright 2014-2023 Adobe, licensed under the SIL Open Font License 1.1
+  (see packages/pdf/licenses/LICENSE-Source-Serif-4.txt).
+- Source Code Pro font family (https://github.com/adobe-fonts/source-code-pro),
+  Copyright 2010-2023 Adobe, licensed under the SIL Open Font License 1.1
+  (see packages/pdf/licenses/LICENSE-Source-Code-Pro.txt).

--- a/apps/extension/entrypoints/background.ts
+++ b/apps/extension/entrypoints/background.ts
@@ -44,6 +44,8 @@ const offscreenIdle = createIdleTimer({
   },
 });
 
+let activePdfJobs = 0;
+
 /**
  * Effect wired into the pure router: ensure the offscreen document exists,
  * then round-trip the WASM computation through it. Rejects on failure so the
@@ -51,7 +53,7 @@ const offscreenIdle = createIdleTimer({
  * timer so the document is closed once traffic stops.
  */
 async function runWasmSmoke(a: number, b: number): Promise<number> {
-  offscreenIdle.reset();
+  if (activePdfJobs === 0) offscreenIdle.reset();
   await ensureOffscreen();
   const res = (await chrome.runtime.sendMessage({
     kind: "offscreen:wasm-add",
@@ -64,6 +66,39 @@ async function runWasmSmoke(a: number, b: number): Promise<number> {
   }
   if (!res.ok) throw new Error(res.error);
   return res.result;
+}
+
+async function runPdfCompile(jobId: string): Promise<{ ok: true } | { ok: false; error: string }> {
+  activePdfJobs += 1;
+  offscreenIdle.stop();
+  try {
+    await ensureOffscreen();
+    const response = (await chrome.runtime.sendMessage({
+      kind: "offscreen:pdf-compile",
+      jobId,
+    })) as OffscreenResponse | undefined;
+    if (!response || response.kind !== "offscreen:pdf-compile-result" || response.jobId !== jobId) {
+      return { ok: false, error: "Offscreen PDF compiler returned no correlated result." };
+    }
+    return response.ok ? { ok: true } : { ok: false, error: response.error };
+  } finally {
+    activePdfJobs = Math.max(0, activePdfJobs - 1);
+    if (activePdfJobs === 0) offscreenIdle.reset();
+  }
+}
+
+async function runPdfCancel(jobId: string): Promise<boolean> {
+  await ensureOffscreen();
+  const response = (await chrome.runtime.sendMessage({
+    kind: "offscreen:pdf-cancel",
+    jobId,
+  })) as OffscreenResponse | undefined;
+  return Boolean(
+    response &&
+      response.kind === "offscreen:pdf-cancel-result" &&
+      response.jobId === jobId &&
+      response.cancelled
+  );
 }
 
 /**
@@ -132,7 +167,12 @@ export default defineBackground({
   // The `true` return from handleExtMessage keeps the channel open for the
   // async sendResponse — see utils/listeners.ts (covered by listeners.test.ts).
   chrome.runtime.onMessage.addListener((message, _sender, sendResponse) =>
-    handleExtMessage(message, sendResponse, { runWasmSmoke, getCurrentEntity })
+    handleExtMessage(message, sendResponse, {
+      runWasmSmoke,
+      getCurrentEntity,
+      runPdfCompile,
+      runPdfCancel,
+    })
   );
 
   // Tab switch: resolve the newly-active tab's URL, then observe it.

--- a/apps/extension/entrypoints/offscreen/main.ts
+++ b/apps/extension/entrypoints/offscreen/main.ts
@@ -8,7 +8,26 @@
  * load-bearing `true` return is unit-tested.
  */
 import { handleOffscreenMessage } from "../../utils/listeners.js";
+import { PdfCompilerHost } from "../../utils/pdf/compiler-host.js";
+
+const pdfHost = new PdfCompilerHost({
+  createWorker: () =>
+    new Worker(new URL("../../workers/pdf-compiler.ts", import.meta.url), {
+      type: "module",
+      name: "atlcli-pdf-compiler",
+    }),
+});
 
 chrome.runtime.onMessage.addListener((message, _sender, sendResponse) =>
-  handleOffscreenMessage(message, sendResponse)
+  handleOffscreenMessage(message, sendResponse, {
+    runWasmAdd: async (a, b) => {
+      const { runWasmAdd } = await import("../../utils/wasm-smoke.js");
+      return runWasmAdd(a, b);
+    },
+    runPdfCompile: async (jobId) => {
+      const result = await pdfHost.compile(jobId);
+      return result.ok ? { ok: true } : { ok: false, error: result.error };
+    },
+    runPdfCancel: (jobId) => pdfHost.cancel(jobId),
+  })
 );

--- a/apps/extension/entrypoints/sidepanel/App.tsx
+++ b/apps/extension/entrypoints/sidepanel/App.tsx
@@ -29,6 +29,7 @@ import {
   type PanelState,
 } from "../../utils/panel-state.js";
 import { TemplateSection } from "./TemplateSection.js";
+import { PdfSection } from "./PdfSection.js";
 
 const manifest = chrome.runtime.getManifest();
 
@@ -162,6 +163,11 @@ export function App(): React.JSX.Element {
       <DetectionView state={state} onRetry={() => dispatch({ type: "retry" })} />
 
       <TemplateSection
+        loadedPage={state.status === "loaded" ? state.page : null}
+        pageUrl={state.status === "loaded" ? state.ref.url : null}
+      />
+
+      <PdfSection
         loadedPage={state.status === "loaded" ? state.page : null}
         pageUrl={state.status === "loaded" ? state.ref.url : null}
       />

--- a/apps/extension/entrypoints/sidepanel/PdfSection.tsx
+++ b/apps/extension/entrypoints/sidepanel/PdfSection.tsx
@@ -1,0 +1,125 @@
+import React, { useEffect, useRef, useState } from "react";
+import type { PdfExportReport } from "@atlcli/pdf/browser";
+import type { LoadedPage } from "../../utils/read-path.js";
+import type { PdfExportPhase } from "../../utils/pdf/run-export.js";
+
+const PHASE_LABEL: Record<PdfExportPhase, string> = {
+  preparing: "Preparing content…",
+  fetching: "Fetching attachments…",
+  queued: "Queued for PDF compiler…",
+  compiling: "Compiling PDF…",
+  validating: "Validating PDF…",
+  downloading: "Downloading…",
+};
+
+export function PdfSection({
+  loadedPage,
+  pageUrl,
+}: {
+  loadedPage: LoadedPage | null;
+  pageUrl: string | null;
+}): React.JSX.Element {
+  const [phase, setPhase] = useState<PdfExportPhase | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [report, setReport] = useState<PdfExportReport | null>(null);
+  const active = useRef<{ identity: string; controller: AbortController } | null>(null);
+  const identity = loadedPage && pageUrl
+    ? `${pageUrl}|${loadedPage.details.id}|${loadedPage.details.version ?? ""}`
+    : "";
+
+  useEffect(() => {
+    if (active.current && active.current.identity !== identity) {
+      active.current.controller.abort();
+      active.current = null;
+      setPhase(null);
+      setReport(null);
+    }
+  }, [identity]);
+
+  useEffect(() => () => active.current?.controller.abort(), []);
+
+  async function exportPdf(): Promise<void> {
+    if (!loadedPage || !pageUrl || phase) return;
+    const controller = new AbortController();
+    active.current = { identity, controller };
+    setError(null);
+    setReport(null);
+    setPhase("preparing");
+    try {
+      const { runPdfExport } = await import("../../utils/pdf/run-export.js");
+      const result = await runPdfExport({
+        page: loadedPage,
+        pageUrl,
+        signal: controller.signal,
+        onPhase: setPhase,
+      });
+      if (!controller.signal.aborted && active.current?.identity === identity) setReport(result);
+    } catch (reason) {
+      if (!controller.signal.aborted) {
+        setError(reason instanceof Error ? reason.message : String(reason));
+      }
+    } finally {
+      if (active.current?.controller === controller) active.current = null;
+      if (!controller.signal.aborted) setPhase(null);
+    }
+  }
+
+  function cancel(): void {
+    active.current?.controller.abort();
+    active.current = null;
+    setPhase(null);
+    setError("PDF export was cancelled.");
+  }
+
+  return (
+    <section data-testid="pdf-section" style={{ marginBottom: 16 }}>
+      <h2 style={{ fontSize: 12, textTransform: "uppercase", color: "#666" }}>PDF export</h2>
+      <p style={{ color: "#6b778c", margin: "0 0 8px" }}>
+        Uses the built-in atlcli document design. No template upload required.
+      </p>
+      <button
+        type="button"
+        onClick={() => void exportPdf()}
+        disabled={!loadedPage || Boolean(phase)}
+        data-testid="pdf-export"
+        title={loadedPage ? "Export this page to PDF" : "Open a Confluence page to export"}
+      >
+        {phase ? PHASE_LABEL[phase] : "Export to PDF"}
+      </button>
+      {phase && (
+        <button type="button" onClick={cancel} data-testid="pdf-cancel" style={{ marginLeft: 8 }}>
+          Cancel
+        </button>
+      )}
+      {error && <p role="alert" data-testid="pdf-error" style={{ color: "#bf2600" }}>{error}</p>}
+      {report && <PdfReportView report={report} />}
+    </section>
+  );
+}
+
+export function PdfReportView({ report }: { report: PdfExportReport }): React.JSX.Element {
+  return (
+    <div data-testid="pdf-report" style={{ marginTop: 8, padding: 8, background: "#e3fcef", borderRadius: 4 }}>
+      <strong>{report.filename}</strong>
+      <div>{formatDuration(report.timings.totalMs)} · {report.embeddedImages} image(s) · {report.renderedDiagrams} diagram(s)</div>
+      <div
+        aria-label="PDF export timing breakdown"
+        style={{ marginTop: 2, color: "#42526e", fontSize: 12 }}
+      >
+        Prepare {formatDuration(report.timings.prepareMs)} · Compile {formatDuration(report.timings.compileMs)} · Download {formatDuration(report.timings.downloadMs)}
+      </div>
+      {report.notes.length > 0 && (
+        <details>
+          <summary>{report.notes.length} note(s)</summary>
+          <ul>{report.notes.map((note, index) => <li key={`${note.code}-${index}`}>{note.message}</li>)}</ul>
+        </details>
+      )}
+    </div>
+  );
+}
+
+function formatDuration(milliseconds: number): string {
+  const safeMilliseconds = Math.max(0, milliseconds);
+  if (safeMilliseconds < 1000) return `${Math.round(safeMilliseconds)} ms`;
+  return `${(safeMilliseconds / 1000).toFixed(1)} s`;
+}

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -15,6 +15,8 @@
     "@atlcli/confluence": "workspace:*",
     "@atlcli/core": "workspace:*",
     "@atlcli/docx": "workspace:*",
+    "@atlcli/pdf": "workspace:*",
+    "@myriaddreamin/typst-ts-web-compiler": "0.7.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"
   },

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -5,9 +5,14 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "predev": "bun run --cwd ../.. fonts:ensure",
     "dev": "wxt",
+    "prebuild": "bun run --cwd ../.. fonts:ensure",
     "build": "wxt build",
+    "prepdf:fixture": "bun run --cwd ../.. fonts:ensure",
+    "pdf:fixture": "bun scripts/render-pdf-fixture.ts",
     "postinstall": "wxt prepare",
+    "pretypecheck": "bun run --cwd ../.. fonts:ensure",
     "typecheck": "wxt prepare && tsc --noEmit",
     "check:output": "bun scripts/check-output-build.ts"
   },

--- a/apps/extension/scripts/check-output-build.ts
+++ b/apps/extension/scripts/check-output-build.ts
@@ -9,7 +9,12 @@
  *   1. zero `node:`/`bun:` module specifiers,
  *   2. zero remote script origins (import / importScripts / <script src> from
  *      an http(s) URL) — the extension must load only bundled, local assets, and
- *   3. zero bare node GLOBALS (`Buffer.`, `process.env`, `__dirname`). These are
+ *   3. zero bare node GLOBALS (`Buffer.`, `process.env`, `__dirname`),
+ *   4. zero string-to-code constructors (`Function(...)`, `eval(...)`) that
+ *      violate Manifest V3's extension-page CSP, and
+ *   5. a complete, locally bundled PDF runtime (worker, WASM and ten fonts).
+ *
+ * Bare node globals are
  *      invisible to an import-specifier scan — nothing is imported, the symbol is
  *      just assumed to exist — yet they are `undefined` in the extension runtime,
  *      so code touching them throws at use (spec 003, finding #6: unknown-macro
@@ -20,6 +25,7 @@
  */
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join, relative } from "node:path";
+import { createHash } from "node:crypto";
 
 /** Quoted `node:`/`bun:` module specifier — a real import/require target. */
 const NODE_BUN_RE = /["'`](node|bun):[A-Za-z0-9_./-]*["'`]/g;
@@ -32,6 +38,95 @@ const NODE_BUN_RE = /["'`](node|bun):[A-Za-z0-9_./-]*["'`]/g;
  * code will throw `ReferenceError`/`undefined` at runtime in the panel/worker.
  */
 const NODE_GLOBAL_RE = /\bBuffer\.|\bprocess\.env\b|\b__dirname\b|\b__filename\b/g;
+
+/** Dynamic code execution is forbidden by the extension page CSP. */
+const DYNAMIC_CODE_RES: RegExp[] = [
+  /\bnew\s+Function\s*\(/g,
+  /(?:^|[=(:,!&|?;{}])\s*Function\s*\(\s*["'`]/g,
+  /(?:^|[^\w.])eval\s*\(/g,
+];
+
+export interface OutputArtifact {
+  path: string;
+  size: number;
+  sha256?: string;
+}
+
+const REQUIRED_PDF_ARTIFACTS = [
+  { label: "PDF compiler worker", pattern: /(?:^|\/)assets\/pdf-compiler-[^/]+\.js$/ },
+  {
+    label: "Typst compiler WASM",
+    pattern: /(?:^|\/)assets\/typst_ts_web_compiler_bg-[^/]+\.wasm$/,
+    minimumSize: 20_000_000,
+    sha256: "1fc968438a672366dfec39c96c842c26ed29caff4eb1bcaab19a6c60867de5fd",
+  },
+  {
+    label: "Source Sans 3 Regular",
+    pattern: /(?:^|\/)assets\/SourceSans3-Regular-[^/]+\.ttf$/,
+    sha256: "4644c81b86ec9caaa76b634889968ed3c4f4f52f054855933acc7c2b21e53b0f",
+  },
+  {
+    label: "Source Sans 3 Italic",
+    pattern: /(?:^|\/)assets\/SourceSans3-It-[^/]+\.ttf$/,
+    sha256: "192afd78f0f54a3c69eaf02d43f4d9a821e9d6110e41d3d25d61a7385cd580e4",
+  },
+  {
+    label: "Source Sans 3 SemiBold",
+    pattern: /(?:^|\/)assets\/SourceSans3-Semibold-[^/]+\.ttf$/,
+    sha256: "a3f4f8dcf343a8f24dc61951de93f3ba1558b15cd250ba24af8a40e957081b7d",
+  },
+  {
+    label: "Source Sans 3 Bold",
+    pattern: /(?:^|\/)assets\/SourceSans3-Bold-[^/]+\.ttf$/,
+    sha256: "9214b9d95e4231c609802815c2646c98174e2102d0d37f88978a7f8e71006e6a",
+  },
+  {
+    label: "Source Serif 4 Regular",
+    pattern: /(?:^|\/)assets\/SourceSerif4-Regular-[^/]+\.ttf$/,
+    sha256: "e5a4ee6a3d87bb9024796be390c6771e2a0eb1883dae25effaf57ca01668e24b",
+  },
+  {
+    label: "Source Serif 4 Italic",
+    pattern: /(?:^|\/)assets\/SourceSerif4-It-[^/]+\.ttf$/,
+    sha256: "9d2950a8f1da66e21502c35d646a1d2148e79f9ea43fd2158cf02f5232e7f430",
+  },
+  {
+    label: "Source Serif 4 SemiBold",
+    pattern: /(?:^|\/)assets\/SourceSerif4-Semibold-[^/]+\.ttf$/,
+    sha256: "36db62940cb5728b12b1802476dc7fcf4c6c519a7bdd476ba23a4e555fc4655f",
+  },
+  {
+    label: "Source Serif 4 Bold",
+    pattern: /(?:^|\/)assets\/SourceSerif4-Bold-[^/]+\.ttf$/,
+    sha256: "7cf4f4e1ad74f45058d5bc61716b82560442fbdcd9d3654d2dea96bf6c683d86",
+  },
+  {
+    label: "Source Code Pro Regular",
+    pattern: /(?:^|\/)assets\/SourceCodePro-Regular-[^/]+\.ttf$/,
+    sha256: "74bd80d3e42a08517cd7e1108ba3d86f2da29ac0f3065be95e0357956ab9db37",
+  },
+  {
+    label: "Source Code Pro Bold",
+    pattern: /(?:^|\/)assets\/SourceCodePro-Bold-[^/]+\.ttf$/,
+    sha256: "b2095e0d657e6d28dc32444a9dacabab0c9241d0bf39d96371756cc9bdbc3a5f",
+  },
+  {
+    label: "Source Sans 3 font license",
+    pattern: /(?:^|\/)assets\/LICENSE-Source-Sans-3-[^/]+\.txt$/,
+  },
+  {
+    label: "Source Serif 4 font license",
+    pattern: /(?:^|\/)assets\/LICENSE-Source-Serif-4-[^/]+\.txt$/,
+  },
+  {
+    label: "Source Code Pro font license",
+    pattern: /(?:^|\/)assets\/LICENSE-Source-Code-Pro-[^/]+\.txt$/,
+  },
+  {
+    label: "compiler Apache-2.0 license",
+    pattern: /(?:^|\/)assets\/LICENSE-[A-Za-z0-9_-]+\.$/,
+  },
+] as const;
 
 /**
  * Remote script origin: any executable form that would pull code from an
@@ -85,7 +180,47 @@ export function scanText(text: string): string[] {
     for (const m of text.matchAll(re)) found.add(m[0]);
   }
   for (const m of text.matchAll(NODE_GLOBAL_RE)) found.add(m[0]);
+  for (const re of DYNAMIC_CODE_RES) {
+    for (const m of text.matchAll(re)) found.add(m[0].trim());
+  }
   return [...found];
+}
+
+/** Verify that every runtime asset needed for a browser-only PDF export exists. */
+export function validatePdfArtifactInventory(artifacts: OutputArtifact[]): string[] {
+  const issues: string[] = [];
+  for (const requirement of REQUIRED_PDF_ARTIFACTS) {
+    const matches = artifacts.filter((artifact) => requirement.pattern.test(artifact.path));
+    if (matches.length !== 1) {
+      issues.push(
+        `${requirement.label}: expected exactly one bundled artifact, found ${matches.length}`
+      );
+      continue;
+    }
+    if ("minimumSize" in requirement && matches[0]!.size < requirement.minimumSize) {
+      issues.push(
+        `${requirement.label}: artifact is unexpectedly small (${matches[0]!.size} bytes)`
+      );
+    }
+    if ("sha256" in requirement && matches[0]!.sha256 !== requirement.sha256) {
+      issues.push(`${requirement.label}: SHA-256 does not match the pinned artifact`);
+    }
+  }
+  return issues;
+}
+
+function collectArtifacts(root: string): OutputArtifact[] {
+  return walk(root, [""]).map((file) => {
+    const path = relative(root, file);
+    const needsHash = file.endsWith(".wasm") || file.endsWith(".ttf");
+    return {
+      path,
+      size: statSync(file).size,
+      sha256: needsHash
+        ? createHash("sha256").update(readFileSync(file)).digest("hex")
+        : undefined,
+    };
+  });
 }
 
 /**
@@ -108,8 +243,10 @@ async function main(): Promise<void> {
     process.argv[2] ?? join(import.meta.dir, "..", ".output", "chrome-mv3");
 
   let leaks: FileLeak[];
+  let artifactIssues: string[];
   try {
     leaks = scanOutputDir(root);
+    artifactIssues = validatePdfArtifactInventory(collectArtifacts(root));
   } catch (err) {
     console.error(
       `✗ extension output scan could not read '${root}': ${
@@ -120,14 +257,23 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
-  if (leaks.length === 0) {
-    console.log(`✓ extension output clean — no node:/bun:/remote leaks in ${root}`);
+  if (leaks.length === 0 && artifactIssues.length === 0) {
+    console.log(
+      `✓ extension output clean — CSP-safe and complete PDF runtime in ${root}`
+    );
     return;
   }
 
-  console.error("✗ extension output scan FAILED — disallowed content in bundle:");
-  for (const leak of leaks) {
-    console.error(`  ${leak.file}: ${leak.findings.join(", ")}`);
+  console.error("✗ extension output scan FAILED:");
+  if (leaks.length > 0) {
+    console.error("  disallowed content in bundle:");
+    for (const leak of leaks) {
+      console.error(`    ${leak.file}: ${leak.findings.join(", ")}`);
+    }
+  }
+  if (artifactIssues.length > 0) {
+    console.error("  incomplete PDF runtime:");
+    for (const issue of artifactIssues) console.error(`    ${issue}`);
   }
   process.exit(1);
 }

--- a/apps/extension/scripts/render-pdf-fixture.ts
+++ b/apps/extension/scripts/render-pdf-fixture.ts
@@ -1,0 +1,152 @@
+#!/usr/bin/env bun
+import { mkdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { join } from "node:path";
+import type { ExportBlock } from "@atlcli/confluence/browser";
+import { preparePdfDocument, serializePdfDocument } from "@atlcli/pdf/browser";
+import { BrowserPdfCompiler } from "../utils/pdf/compiler.js";
+import { validatePdfOutput } from "../utils/pdf/validate.js";
+import { ensurePdfFonts } from "../../../packages/pdf/scripts/ensure-fonts.js";
+
+await ensurePdfFonts({ logger: () => {} });
+
+async function packageBytes(specifier: string): Promise<Uint8Array<ArrayBuffer>> {
+  const resolved = import.meta.resolve(specifier);
+  return new Uint8Array(await Bun.file(fileURLToPath(resolved)).arrayBuffer());
+}
+
+const [wasm, ...fonts] = await Promise.all([
+  packageBytes("@myriaddreamin/typst-ts-web-compiler/wasm"),
+  packageBytes("@atlcli/pdf/fonts/SourceSans3-Regular.ttf"),
+  packageBytes("@atlcli/pdf/fonts/SourceSans3-It.ttf"),
+  packageBytes("@atlcli/pdf/fonts/SourceSans3-Semibold.ttf"),
+  packageBytes("@atlcli/pdf/fonts/SourceSans3-Bold.ttf"),
+  packageBytes("@atlcli/pdf/fonts/SourceSerif4-Regular.ttf"),
+  packageBytes("@atlcli/pdf/fonts/SourceSerif4-It.ttf"),
+  packageBytes("@atlcli/pdf/fonts/SourceSerif4-Semibold.ttf"),
+  packageBytes("@atlcli/pdf/fonts/SourceSerif4-Bold.ttf"),
+  packageBytes("@atlcli/pdf/fonts/SourceCodePro-Regular.ttf"),
+  packageBytes("@atlcli/pdf/fonts/SourceCodePro-Bold.ttf"),
+]);
+
+const blocks: ExportBlock[] = [
+  { type: "heading", level: 2, content: [{ type: "text", text: "Overview" }] },
+  {
+    type: "paragraph",
+    content: [
+      { type: "text", text: "A semantic PDF fixture with ", marks: ["italic"] },
+      { type: "text", text: "strong text", marks: ["bold"] },
+      { type: "text", text: ", links and a status. " },
+      {
+        type: "link",
+        target: { kind: "external", href: "https://example.com/docs" },
+        content: [{ type: "text", text: "Documentation" }],
+      },
+      { type: "text", text: " " },
+      { type: "status", text: "READY", color: "#00875A" },
+    ],
+  },
+  {
+    type: "callout",
+    kind: "info",
+    title: "Built locally",
+    content: [
+      {
+        type: "paragraph",
+        content: [{ type: "text", text: "Compiler, template and fonts are packaged with the extension." }],
+      },
+    ],
+  },
+  { type: "heading", level: 3, content: [{ type: "text", text: "Lists and tasks" }] },
+  {
+    type: "list",
+    ordered: false,
+    items: [
+      {
+        checked: true,
+        content: [{
+          type: "paragraph",
+          content: [{ type: "text", text: "PDF generated with enough breathing room for a multi-line item that carries real explanatory content." }],
+        }],
+      },
+      {
+        checked: false,
+        content: [{
+          type: "paragraph",
+          content: [{ type: "text", text: "Visual review confirms that adjacent list items remain distinct without looking disconnected." }],
+        }],
+      },
+    ],
+  },
+  { type: "heading", level: 3, content: [{ type: "text", text: "Table" }] },
+  {
+    type: "table",
+    columnWidths: [1, 1, 1, 1],
+    rows: [
+      {
+        cells: [
+          { header: true, colspan: 1, rowspan: 1, content: [{ type: "paragraph", content: [{ type: "text", text: "Capability" }] }] },
+          { header: true, colspan: 1, rowspan: 1, content: [{ type: "paragraph", content: [{ type: "text", text: "Result" }] }] },
+          { header: true, colspan: 1, rowspan: 1, content: [{ type: "paragraph", content: [{ type: "text", text: "Owner" }] }] },
+          { header: true, colspan: 1, rowspan: 1, content: [{ type: "paragraph", content: [{ type: "text", text: "State" }] }] },
+        ],
+      },
+      {
+        cells: [
+          { header: false, colspan: 1, rowspan: 1, content: [{ type: "paragraph", content: [{ type: "text", text: "Capability-/Reifegradbewertung (1)" }] }] },
+          { header: false, colspan: 1, rowspan: 1, content: [{ type: "paragraph", content: [{ type: "text", text: "Enabled" }] }] },
+          { header: false, colspan: 1, rowspan: 1, content: [{ type: "paragraph", content: [{ type: "text", text: "Team" }] }] },
+          { header: false, colspan: 1, rowspan: 1, content: [{ type: "paragraph", content: [{ type: "text", text: "Ready" }] }] },
+        ],
+      },
+      {
+        cells: [
+          { header: false, colspan: 1, rowspan: 1, content: [{ type: "paragraph", content: [{ type: "text", text: "Installation, configuration, and rollout planning (2)" }] }] },
+          { header: false, colspan: 1, rowspan: 1, content: [{ type: "paragraph", content: [{ type: "text", text: "Active" }] }] },
+          { header: false, colspan: 1, rowspan: 1, content: [{ type: "paragraph", content: [{ type: "text", text: "Team" }] }] },
+          { header: false, colspan: 1, rowspan: 1, content: [{ type: "paragraph", content: [{ type: "text", text: "Planned" }] }] },
+        ],
+      },
+    ],
+  },
+  { type: "heading", level: 3, content: [{ type: "text", text: "Code and diagram" }] },
+  { type: "codeBlock", language: "typescript", code: "const format: 'pdf' | 'docx' = 'pdf';" },
+  { type: "codeBlock", language: "mermaid", code: "flowchart LR\n  Page --> Blocks --> Typst --> PDF" },
+  {
+    type: "blockquote",
+    content: [{ type: "paragraph", content: [{ type: "text", text: "Word export remains a separate, unchanged path." }] }],
+  },
+  ...Array.from({ length: 18 }, (_, index): ExportBlock => ({
+    type: "paragraph",
+    content: [{ type: "text", text: `Fixture paragraph ${index + 1}. ` + "Readable pagination and running headers. ".repeat(8) }],
+  })),
+];
+
+const prepared = await preparePdfDocument(blocks, {
+  resolve: async () => {
+    throw new Error("fixture has no attachment images");
+  },
+});
+const bundle = serializePdfDocument(prepared, {
+  metadata: {
+    title: "atlcli PDF export fixture",
+    space: "DOCSY",
+    version: 1,
+    author: "atlcli",
+    exporter: "atlcli",
+    language: "de",
+    region: "DE",
+    exportedAt: new Date("2026-07-16T12:00:00Z"),
+  },
+});
+const compiler = new BrowserPdfCompiler({ wasm: wasm.buffer, fonts });
+const started = performance.now();
+const result = await compiler.compile(bundle);
+const compileMs = performance.now() - started;
+if (!result.pdf) throw new Error(JSON.stringify(result.diagnostics, null, 2));
+const inspection = validatePdfOutput(result.pdf);
+const outputDir = join(import.meta.dir, "..", "..", "..", "tmp", "pdfs");
+mkdirSync(outputDir, { recursive: true });
+const outputPath = process.argv[2] ?? join(outputDir, "pdf-export-feature-zoo.pdf");
+await Bun.write(outputPath, result.pdf);
+console.log(JSON.stringify({ outputPath, bytes: result.pdf.byteLength, compileMs, ...inspection }, null, 2));

--- a/apps/extension/tests/build-helper.ts
+++ b/apps/extension/tests/build-helper.ts
@@ -4,9 +4,9 @@
  * `build` step, so tests that inspect `.output/chrome-mv3` build on-demand.
  *
  * The build is reused only when it is NOT stale: a rebuild is forced when any
- * build input (wxt.config.ts, package.json, entrypoints/**, utils/**) is newer
- * than the emitted manifest — otherwise a stale `.output` from an earlier
- * source revision would be asserted against.
+ * build input (extension sources plus the PDF template, font manifest and
+ * licenses) is newer than the emitted manifest — otherwise a stale `.output`
+ * from an earlier source revision would be asserted against.
  */
 import { existsSync, readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
@@ -17,7 +17,17 @@ export const OUTPUT_DIR = join(EXTENSION_ROOT, ".output", "chrome-mv3");
 export const MANIFEST_PATH = join(OUTPUT_DIR, "manifest.json");
 
 /** Build inputs (relative to the extension root) that invalidate the output. */
-export const BUILD_INPUTS = ["wxt.config.ts", "package.json", "entrypoints", "utils"];
+export const BUILD_INPUTS = [
+  "wxt.config.ts",
+  "package.json",
+  "entrypoints",
+  "utils",
+  "workers",
+  "types",
+  "../../packages/pdf/src",
+  "../../packages/pdf/scripts/ensure-fonts.ts",
+  "../../packages/pdf/licenses",
+];
 
 /**
  * Pure decision: is the built output stale relative to its sources?

--- a/apps/extension/tests/listeners.test.ts
+++ b/apps/extension/tests/listeners.test.ts
@@ -10,8 +10,14 @@ import type { RouterDeps } from "../utils/router.js";
 const okRouterDeps: RouterDeps = {
   runWasmSmoke: async (a, b) => a + b,
   getCurrentEntity: async () => ({ url: null, entity: null, seq: 0 }),
+  runPdfCompile: async () => ({ ok: true }),
+  runPdfCancel: async () => true,
 };
-const okOffscreenDeps: OffscreenListenerDeps = { runWasmAdd: async (a, b) => a + b };
+const okOffscreenDeps: OffscreenListenerDeps = {
+  runWasmAdd: async (a, b) => a + b,
+  runPdfCompile: async () => ({ ok: true }),
+  runPdfCancel: async () => true,
+};
 
 /**
  * A sendResponse spy that also exposes a promise resolving when it is called,
@@ -76,6 +82,8 @@ describe("handleExtMessage (background listener adapter)", () => {
           throw new Error("boom");
         },
         getCurrentEntity: async () => ({ url: null, entity: null, seq: 0 }),
+        runPdfCompile: okRouterDeps.runPdfCompile,
+        runPdfCancel: okRouterDeps.runPdfCancel,
       }
     );
     expect(ret).toBe(true);
@@ -83,6 +91,15 @@ describe("handleExtMessage (background listener adapter)", () => {
     expect(cap.values).toEqual([
       { kind: "wasm-smoke-result", ok: false, error: "boom" },
     ]);
+  });
+
+  it("returns true and responds to PDF compile", async () => {
+    const cap = captureResponse<ExtResponse>();
+    const jobId = "123e4567-e89b-42d3-a456-426614174000";
+    const ret = handleExtMessage({ kind: "pdf:compile", jobId }, cap.sendResponse, okRouterDeps);
+    expect(ret).toBe(true);
+    await cap.called;
+    expect(cap.values).toEqual([{ kind: "pdf:compile-result", jobId, ok: true }]);
   });
 });
 
@@ -117,6 +134,8 @@ describe("handleOffscreenMessage (offscreen listener adapter)", () => {
         runWasmAdd: async () => {
           throw new Error("instantiate boom");
         },
+        runPdfCompile: okOffscreenDeps.runPdfCompile,
+        runPdfCancel: okOffscreenDeps.runPdfCancel,
       }
     );
     expect(ret).toBe(true);
@@ -124,5 +143,18 @@ describe("handleOffscreenMessage (offscreen listener adapter)", () => {
     expect(cap.values).toEqual([
       { kind: "offscreen:wasm-add-result", ok: false, error: "instantiate boom" },
     ]);
+  });
+
+  it("returns true and responds to an offscreen PDF compile", async () => {
+    const cap = captureResponse<OffscreenResponse>();
+    const jobId = "123e4567-e89b-42d3-a456-426614174000";
+    const ret = handleOffscreenMessage(
+      { kind: "offscreen:pdf-compile", jobId },
+      cap.sendResponse,
+      okOffscreenDeps
+    );
+    expect(ret).toBe(true);
+    await cap.called;
+    expect(cap.values).toEqual([{ kind: "offscreen:pdf-compile-result", jobId, ok: true }]);
   });
 });

--- a/apps/extension/tests/messages.test.ts
+++ b/apps/extension/tests/messages.test.ts
@@ -3,9 +3,13 @@ import { isEntityChanged, isExtRequest, isOffscreenRequest } from "../utils/mess
 
 describe("message guards", () => {
   it("isExtRequest accepts panel requests only", () => {
+    const jobId = "123e4567-e89b-42d3-a456-426614174000";
     expect(isExtRequest({ kind: "ping" })).toBe(true);
     expect(isExtRequest({ kind: "wasm-smoke", a: 1, b: 2 })).toBe(true);
     expect(isExtRequest({ kind: "get-current-entity" })).toBe(true);
+    expect(isExtRequest({ kind: "pdf:compile", jobId })).toBe(true);
+    expect(isExtRequest({ kind: "pdf:cancel", jobId })).toBe(true);
+    expect(isExtRequest({ kind: "pdf:compile", jobId: "bad" })).toBe(false);
     expect(isExtRequest({ kind: "offscreen:wasm-add", a: 1, b: 2 })).toBe(false);
     expect(isExtRequest({ kind: "pong" })).toBe(false);
     expect(isExtRequest({ kind: "entity-changed", detection: { url: null, entity: null } })).toBe(
@@ -27,7 +31,11 @@ describe("message guards", () => {
   });
 
   it("isOffscreenRequest accepts offscreen-bound requests only", () => {
+    const jobId = "123e4567-e89b-42d3-a456-426614174000";
     expect(isOffscreenRequest({ kind: "offscreen:wasm-add", a: 1, b: 2 })).toBe(true);
+    expect(isOffscreenRequest({ kind: "offscreen:pdf-compile", jobId })).toBe(true);
+    expect(isOffscreenRequest({ kind: "offscreen:pdf-cancel", jobId })).toBe(true);
+    expect(isOffscreenRequest({ kind: "offscreen:pdf-compile", jobId: "bad" })).toBe(false);
     expect(isOffscreenRequest({ kind: "wasm-smoke", a: 1, b: 2 })).toBe(false);
     expect(isOffscreenRequest(undefined)).toBe(false);
   });

--- a/apps/extension/tests/output-scan.test.ts
+++ b/apps/extension/tests/output-scan.test.ts
@@ -3,7 +3,10 @@ import { cpSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
-import { scanText } from "../scripts/check-output-build.js";
+import {
+  scanText,
+  validatePdfArtifactInventory,
+} from "../scripts/check-output-build.js";
 import { EXTENSION_ROOT, ensureExtensionBuilt, OUTPUT_DIR } from "./build-helper.js";
 
 const CLI_PATH = join(EXTENSION_ROOT, "scripts", "check-output-build.ts");
@@ -79,6 +82,62 @@ describe("scanText classification", () => {
     // A property literally named `Buffer` or a `processEnv` variable must not trip.
     expect(scanText(`const myBuffer = new Uint8Array(4);`)).toEqual([]);
     expect(scanText(`const processEnvironment = cfg.processEnvironment;`)).toEqual([]);
+  });
+
+  it.each([
+    ["Function constructor", `const make = Function("return 1");`, "Function("],
+    ["new Function constructor", `const make = new Function("return 1");`, "Function("],
+    ["direct eval", `const value = eval("1 + 1");`, "eval("],
+  ])("flags MV3-incompatible %s", (_label, source, expected) => {
+    expect(scanText(source).some((finding) => finding.includes(expected))).toBe(true);
+  });
+
+  it("does not confuse method names with direct eval", () => {
+    expect(scanText(`const value = parser.eval(source);`)).toEqual([]);
+  });
+});
+
+describe("PDF artifact inventory", () => {
+  const complete = [
+    { path: "assets/pdf-compiler-abc.js", size: 30_000 },
+    { path: "assets/typst_ts_web_compiler_bg-abc.wasm", size: 28_000_000, sha256: "1fc968438a672366dfec39c96c842c26ed29caff4eb1bcaab19a6c60867de5fd" },
+    { path: "assets/SourceSans3-Regular-abc.ttf", size: 100_000, sha256: "4644c81b86ec9caaa76b634889968ed3c4f4f52f054855933acc7c2b21e53b0f" },
+    { path: "assets/SourceSans3-It-abc.ttf", size: 100_000, sha256: "192afd78f0f54a3c69eaf02d43f4d9a821e9d6110e41d3d25d61a7385cd580e4" },
+    { path: "assets/SourceSans3-Semibold-abc.ttf", size: 100_000, sha256: "a3f4f8dcf343a8f24dc61951de93f3ba1558b15cd250ba24af8a40e957081b7d" },
+    { path: "assets/SourceSans3-Bold-abc.ttf", size: 100_000, sha256: "9214b9d95e4231c609802815c2646c98174e2102d0d37f88978a7f8e71006e6a" },
+    { path: "assets/SourceSerif4-Regular-abc.ttf", size: 100_000, sha256: "e5a4ee6a3d87bb9024796be390c6771e2a0eb1883dae25effaf57ca01668e24b" },
+    { path: "assets/SourceSerif4-It-abc.ttf", size: 100_000, sha256: "9d2950a8f1da66e21502c35d646a1d2148e79f9ea43fd2158cf02f5232e7f430" },
+    { path: "assets/SourceSerif4-Semibold-abc.ttf", size: 100_000, sha256: "36db62940cb5728b12b1802476dc7fcf4c6c519a7bdd476ba23a4e555fc4655f" },
+    { path: "assets/SourceSerif4-Bold-abc.ttf", size: 100_000, sha256: "7cf4f4e1ad74f45058d5bc61716b82560442fbdcd9d3654d2dea96bf6c683d86" },
+    { path: "assets/SourceCodePro-Regular-abc.ttf", size: 100_000, sha256: "74bd80d3e42a08517cd7e1108ba3d86f2da29ac0f3065be95e0357956ab9db37" },
+    { path: "assets/SourceCodePro-Bold-abc.ttf", size: 100_000, sha256: "b2095e0d657e6d28dc32444a9dacabab0c9241d0bf39d96371756cc9bdbc3a5f" },
+    { path: "assets/LICENSE-Source-Sans-3-abc.txt", size: 4_000 },
+    { path: "assets/LICENSE-Source-Serif-4-abc.txt", size: 4_000 },
+    { path: "assets/LICENSE-Source-Code-Pro-abc.txt", size: 4_000 },
+    { path: "assets/LICENSE-abc.", size: 11_000 },
+  ];
+
+  it("accepts a complete local PDF runtime", () => {
+    expect(validatePdfArtifactInventory(complete)).toEqual([]);
+  });
+
+  it("names missing and truncated compiler artifacts", () => {
+    const missingWorker = complete.filter((artifact) => !artifact.path.includes("pdf-compiler"));
+    expect(validatePdfArtifactInventory(missingWorker).join("\n")).toContain(
+      "PDF compiler worker"
+    );
+
+    const truncated = complete.map((artifact) =>
+      artifact.path.endsWith(".wasm") ? { ...artifact, size: 1024 } : artifact
+    );
+    expect(validatePdfArtifactInventory(truncated).join("\n")).toContain(
+      "unexpectedly small"
+    );
+
+    const tampered = complete.map((artifact) =>
+      artifact.path.includes("SourceSans3-Regular") ? { ...artifact, sha256: "tampered" } : artifact
+    );
+    expect(validatePdfArtifactInventory(tampered).join("\n")).toContain("SHA-256");
   });
 });
 

--- a/apps/extension/tests/pdf/compiler-host.test.ts
+++ b/apps/extension/tests/pdf/compiler-host.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "bun:test";
+import { PdfCompilerHost, type PdfWorkerLike } from "../../utils/pdf/compiler-host.js";
+import type { PdfWorkerRequest, PdfWorkerResponse } from "../../utils/pdf/worker-protocol.js";
+
+class FakeWorker implements PdfWorkerLike {
+  onmessage: ((event: MessageEvent<unknown>) => void) | null = null;
+  onerror: ((event: ErrorEvent) => void) | null = null;
+  posted: PdfWorkerRequest[] = [];
+  terminated = false;
+  postMessage(message: PdfWorkerRequest): void { this.posted.push(message); }
+  terminate(): void { this.terminated = true; }
+  reply(response: PdfWorkerResponse): void { this.onmessage?.({ data: response } as MessageEvent); }
+}
+
+describe("PdfCompilerHost", () => {
+  it("runs jobs FIFO on one worker", async () => {
+    const worker = new FakeWorker();
+    const host = new PdfCompilerHost({ createWorker: () => worker, timeoutMs: 1_000 });
+    const first = host.compile("a");
+    const second = host.compile("b");
+    expect(worker.posted).toEqual([{ kind: "pdf-worker:compile", jobId: "a" }]);
+    worker.reply({ kind: "pdf-worker:complete", jobId: "a", ok: true });
+    expect(await first).toEqual({ kind: "pdf-worker:complete", jobId: "a", ok: true });
+    expect(worker.posted[1]).toEqual({ kind: "pdf-worker:compile", jobId: "b" });
+    worker.reply({ kind: "pdf-worker:complete", jobId: "b", ok: true });
+    expect(await second).toEqual({ kind: "pdf-worker:complete", jobId: "b", ok: true });
+  });
+
+  it("terminates a timed-out worker and uses a fresh worker for the next job", async () => {
+    const workers: FakeWorker[] = [];
+    let timeout: (() => void) | undefined;
+    const failed: string[] = [];
+    const host = new PdfCompilerHost({
+      createWorker: () => { const worker = new FakeWorker(); workers.push(worker); return worker; },
+      schedule: (fn) => { timeout = fn; return 1 as unknown as ReturnType<typeof setTimeout>; },
+      clear: () => undefined,
+      failJob: async (jobId) => { failed.push(jobId); },
+    });
+    const first = host.compile("slow");
+    timeout?.();
+    expect((await first).ok).toBe(false);
+    expect(workers[0].terminated).toBe(true);
+    expect(failed).toEqual(["slow"]);
+    const second = host.compile("next");
+    expect(workers).toHaveLength(2);
+    workers[1].reply({ kind: "pdf-worker:complete", jobId: "next", ok: true });
+    expect((await second).ok).toBe(true);
+  });
+
+  it("cancels active and queued jobs without running stale work", async () => {
+    const workers: FakeWorker[] = [];
+    const cancelled: string[] = [];
+    const host = new PdfCompilerHost({
+      createWorker: () => { const worker = new FakeWorker(); workers.push(worker); return worker; },
+      cancelJob: async (jobId) => { cancelled.push(jobId); },
+    });
+    const first = host.compile("active");
+    const second = host.compile("queued");
+    expect(await host.cancel("queued")).toBe(true);
+    expect((await second).ok).toBe(false);
+    expect(await host.cancel("active")).toBe(true);
+    expect((await first).ok).toBe(false);
+    expect(workers[0].terminated).toBe(true);
+    expect(cancelled).toEqual(["queued", "active"]);
+  });
+
+  it("recovers with a fresh worker after a fatal job between two successful jobs", async () => {
+    const workers: FakeWorker[] = [];
+    const host = new PdfCompilerHost({
+      createWorker: () => {
+        const worker = new FakeWorker();
+        workers.push(worker);
+        return worker;
+      },
+    });
+
+    const first = host.compile("first");
+    workers[0]!.reply({ kind: "pdf-worker:complete", jobId: "first", ok: true });
+    expect((await first).ok).toBe(true);
+
+    const failed = host.compile("failed");
+    workers[0]!.reply({
+      kind: "pdf-worker:complete",
+      jobId: "failed",
+      ok: false,
+      error: "compiler crashed",
+      fatal: true,
+    });
+    expect((await failed).ok).toBe(false);
+    expect(workers[0]!.terminated).toBe(true);
+
+    const last = host.compile("last");
+    expect(workers).toHaveLength(2);
+    workers[1]!.reply({ kind: "pdf-worker:complete", jobId: "last", ok: true });
+    expect((await last).ok).toBe(true);
+  });
+
+  it("detaches a terminated worker so late events cannot fail the next job", async () => {
+    const workers: FakeWorker[] = [];
+    const host = new PdfCompilerHost({
+      createWorker: () => {
+        const worker = new FakeWorker();
+        workers.push(worker);
+        return worker;
+      },
+      cancelJob: async () => undefined,
+    });
+    const cancelled = host.compile("cancelled");
+    await host.cancel("cancelled");
+    expect((await cancelled).ok).toBe(false);
+
+    const next = host.compile("next");
+    expect(workers[0]!.onerror).toBeNull();
+    expect(workers[0]!.onmessage).toBeNull();
+    workers[0]!.reply({ kind: "pdf-worker:complete", jobId: "cancelled", ok: true });
+    expect(host.activeCount).toBe(1);
+    workers[1]!.reply({ kind: "pdf-worker:complete", jobId: "next", ok: true });
+    expect((await next).ok).toBe(true);
+  });
+});

--- a/apps/extension/tests/pdf/compiler.test.ts
+++ b/apps/extension/tests/pdf/compiler.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { beforeAll, describe, expect, it } from "bun:test";
 import { fileURLToPath } from "node:url";
 import type { ExportBlock } from "@atlcli/confluence/browser";
 import type { PdfSourceBundle } from "@atlcli/pdf/browser";
@@ -7,27 +7,80 @@ import {
   preparePdfDocument,
   serializePdfDocument,
 } from "@atlcli/pdf/browser";
-import { BrowserPdfCompiler } from "../../utils/pdf/compiler.js";
+import { BrowserPdfCompiler, formatPdfDiagnostics } from "../../utils/pdf/compiler.js";
+import { validatePdfOutput } from "../../utils/pdf/validate.js";
+import { ensurePdfFonts } from "../../../../packages/pdf/scripts/ensure-fonts.js";
 
-async function packageBytes(specifier: string): Promise<Uint8Array> {
+beforeAll(async () => {
+  await ensurePdfFonts({ logger: () => {} });
+});
+
+async function packageBytes(specifier: string): Promise<Uint8Array<ArrayBuffer>> {
   const resolved = import.meta.resolve(specifier);
   return new Uint8Array(await Bun.file(fileURLToPath(resolved)).arrayBuffer());
 }
 
 async function createCompiler(): Promise<BrowserPdfCompiler> {
-  const [wasm, inter, mono] = await Promise.all([
+  const [wasm, ...fonts] = await Promise.all([
     packageBytes("@myriaddreamin/typst-ts-web-compiler/wasm"),
-    packageBytes("@atlcli/docx/fonts/Inter-Regular.ttf"),
-    packageBytes("@atlcli/docx/fonts/JetBrainsMono-Regular.ttf"),
+    packageBytes("@atlcli/pdf/fonts/SourceSans3-Regular.ttf"),
+    packageBytes("@atlcli/pdf/fonts/SourceSans3-It.ttf"),
+    packageBytes("@atlcli/pdf/fonts/SourceSans3-Semibold.ttf"),
+    packageBytes("@atlcli/pdf/fonts/SourceSans3-Bold.ttf"),
+    packageBytes("@atlcli/pdf/fonts/SourceSerif4-Regular.ttf"),
+    packageBytes("@atlcli/pdf/fonts/SourceSerif4-It.ttf"),
+    packageBytes("@atlcli/pdf/fonts/SourceSerif4-Semibold.ttf"),
+    packageBytes("@atlcli/pdf/fonts/SourceSerif4-Bold.ttf"),
+    packageBytes("@atlcli/pdf/fonts/SourceCodePro-Regular.ttf"),
+    packageBytes("@atlcli/pdf/fonts/SourceCodePro-Bold.ttf"),
   ]);
-  return new BrowserPdfCompiler({ wasm, fonts: [inter, mono] });
+  return new BrowserPdfCompiler({ wasm: wasm.buffer, fonts });
 }
 
 function sourceBundle(main: string): PdfSourceBundle {
   return { main, template: ATLCLI_TYPST_TEMPLATE, assets: [], sourceMap: [], notes: [] };
 }
 
+function anonymousText(length: number, special: Record<number, string> = {}): string {
+  const characters = Array<string>(length).fill("x");
+  for (const [offset, value] of Object.entries(special)) characters[Number(offset)] = value;
+  return characters.join("");
+}
+
 describe("BrowserPdfCompiler", () => {
+  it("maps a Typst source range back to its nested content path", () => {
+    expect(
+      formatPdfDiagnostics(
+        [{ package: "", path: "/main.typ", severity: "error", range: "27:5-27:6", message: "bad content" }],
+        [
+          {
+            blockPath: "blocks[2].content[0]",
+            blockType: "paragraph",
+            startLine: 25,
+            startColumn: 1,
+            endLine: 29,
+            endColumn: 80,
+          },
+        ]
+      )
+    ).toBe("blocks[2].content[0]: error: bad content");
+  });
+
+  it("registers every pinned PDF font with the compiler", async () => {
+    const compiler = await createCompiler();
+    const result = await compiler.compile(
+      sourceBundle(
+        `#set text(font: "Source Serif 4")\n#text(weight: "semibold")[Semibold] #text(weight: "bold")[Bold] #emph[Italic]\n#text(font: "Source Sans 3")[Sans #text(weight: "bold")[Bold] #emph[Italic]]\n#text(font: "Source Code Pro")[Code #text(weight: "bold")[Bold]]`
+      )
+    );
+    expect(result.diagnostics).toEqual([]);
+    const fonts = await compiler.getLoadedFonts();
+    expect(fonts.length).toBeGreaterThanOrEqual(3);
+    expect(fonts.join("\n")).toContain("Source Serif 4");
+    expect(fonts.join("\n")).toContain("Source Sans 3");
+    expect(fonts.join("\n")).toContain("Source Code Pro");
+  }, 30_000);
+
   it("compiles a real PDF with the bundled template and fonts", async () => {
     const compiler = await createCompiler();
     const result = await compiler.compile(
@@ -50,6 +103,8 @@ This is a real PDF.
     expect(result.pdf).toBeDefined();
     expect(new TextDecoder().decode(result.pdf?.slice(0, 8))).toStartWith("%PDF-");
     expect(result.pdf?.byteLength).toBeGreaterThan(1_000);
+    expect(new TextDecoder().decode(result.pdf)).toContain("https://atlcli.sh/");
+    expect(validatePdfOutput(result.pdf!)).toMatchObject({ tagged: true, hasOutline: true });
   }, 30_000);
 
   it("returns structured diagnostics for invalid Typst", async () => {
@@ -85,6 +140,27 @@ This is a real PDF.
         ],
       },
       {
+        type: "list",
+        ordered: false,
+        items: [
+          {
+            content: [
+              { type: "paragraph", content: [{ type: "text", text: "Editorial marker" }] },
+              {
+                type: "list",
+                ordered: false,
+                items: [{ content: [{ type: "paragraph", content: [{ type: "text", text: "Nested marker" }] }] }],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        type: "list",
+        ordered: true,
+        items: [{ content: [{ type: "paragraph", content: [{ type: "text", text: "Numbered item" }] }] }],
+      },
+      {
         type: "table",
         rows: [
           { cells: [{ header: true, colspan: 1, rowspan: 1, content: [{ type: "paragraph", content: [{ type: "text", text: "Key" }] }] }] },
@@ -114,6 +190,139 @@ This is a real PDF.
     expect(new TextDecoder().decode(result.pdf?.slice(0, 8))).toStartWith("%PDF-");
   }, 30_000);
 
+  it("compiles narrow German table cells with explicit hyphenation", async () => {
+    const blocks: ExportBlock[] = [
+      {
+        type: "table",
+        columnWidths: [1, 1, 1, 1],
+        rows: [
+          {
+            cells: [
+              { header: true, colspan: 1, rowspan: 1, content: [{ type: "paragraph", content: [{ type: "text", text: "Aktivität" }] }] },
+              { header: true, colspan: 1, rowspan: 1, content: [{ type: "paragraph", content: [{ type: "text", text: "Team" }] }] },
+              { header: true, colspan: 1, rowspan: 1, content: [{ type: "paragraph", content: [{ type: "text", text: "Owner" }] }] },
+              { header: true, colspan: 1, rowspan: 1, content: [{ type: "paragraph", content: [{ type: "text", text: "State" }] }] },
+            ],
+          },
+          {
+            cells: [
+              { header: false, colspan: 1, rowspan: 1, content: [{ type: "paragraph", content: [{ type: "text", text: "Capability-/Reifegradbewertung (1)" }] }] },
+              { header: false, colspan: 1, rowspan: 1, content: [{ type: "paragraph", content: [{ type: "text", text: "A" }] }] },
+              { header: false, colspan: 1, rowspan: 1, content: [{ type: "paragraph", content: [{ type: "text", text: "B" }] }] },
+              { header: false, colspan: 1, rowspan: 1, content: [{ type: "paragraph", content: [{ type: "text", text: "C" }] }] },
+            ],
+          },
+        ],
+      },
+    ];
+    const prepared = await preparePdfDocument(blocks, {
+      resolve: async () => { throw new Error("no assets in fixture"); },
+    });
+    const bundle = serializePdfDocument(prepared, {
+      metadata: {
+        title: "Table wrapping regression",
+        language: "de",
+        region: "DE",
+        exporter: "atlcli",
+        exportedAt: new Date("2026-07-16T12:00:00Z"),
+      },
+    });
+    const compiler = await createCompiler();
+    const result = await compiler.compile(bundle);
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.pdf).toBeDefined();
+  }, 30_000);
+
+  it("compiles literal office-style text safely inside lists and tables", async () => {
+    const blocks: ExportBlock[] = [
+      {
+        type: "list",
+        ordered: false,
+        items: [
+          {
+            content: [
+              {
+                type: "paragraph",
+                content: [
+                  { type: "text", marks: ["bold"], text: anonymousText(38, { 16: "&", 24: "-", 37: ":" }) },
+                  { type: "text", text: anonymousText(23, { 0: "\u00a0", 22: "\u00a0" }) },
+                  { type: "text", marks: ["bold"], text: anonymousText(27, { 9: "-", 14: "-" }) },
+                  { type: "text", text: anonymousText(52, { 0: "\u00a0", 1: "—", 51: "\u00a0" }) },
+                  { type: "text", marks: ["bold"], text: anonymousText(15, { 5: "-" }) },
+                  { type: "text", text: anonymousText(71, { 0: ".", 64: ":", 70: "\u00a0" }) },
+                  { type: "text", marks: ["bold"], text: anonymousText(20) },
+                  { type: "text", text: anonymousText(43, { 0: "(", 8: "/", 37: ")", 42: "\u00a0" }) },
+                  { type: "text", marks: ["bold"], text: anonymousText(23, { 8: "-" }) },
+                  { type: "text", text: anonymousText(113, { 0: ".", 48: "—", 65: ",", 112: "\u00a0" }) },
+                  { type: "text", marks: ["bold"], text: anonymousText(17, { 5: "-" }) },
+                  {
+                    type: "text",
+                    text: anonymousText(162, {
+                      0: "\u00a0",
+                      27: ".",
+                      121: "-",
+                      130: "-",
+                      131: "/",
+                      136: "-",
+                      144: "-",
+                      152: "-",
+                      161: ".",
+                    }),
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+      {
+        type: "table",
+        rows: [
+          {
+            cells: [
+              {
+                header: false,
+                colspan: 1,
+                rowspan: 1,
+                content: [
+                  {
+                    type: "paragraph",
+                    content: [
+                      {
+                        type: "text",
+                        text: anonymousText(32, { 10: "-", 11: "/", 19: "-", 30: "+", 31: "\u00a0" }),
+                      },
+                      { type: "text", marks: ["bold"], text: anonymousText(13, { 3: "-" }) },
+                      { type: "text", text: anonymousText(25, { 0: "(", 3: "/", 6: ",", 24: ")" }) },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ];
+    const prepared = await preparePdfDocument(blocks, {
+      resolve: async () => {
+        throw new Error("no assets in fixture");
+      },
+    });
+    const bundle = serializePdfDocument(prepared, {
+      metadata: {
+        title: "Literal text regression",
+        exporter: "atlcli",
+        exportedAt: new Date("2026-07-16T12:00:00Z"),
+      },
+    });
+    const compiler = await createCompiler();
+    const result = await compiler.compile(bundle);
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.pdf).toBeDefined();
+  }, 30_000);
+
   it("initializes and compiles when dynamic Function construction is blocked", async () => {
     const original = globalThis.Function;
     const blocked = new Proxy(original, {
@@ -133,5 +342,15 @@ This is a real PDF.
     } finally {
       Object.defineProperty(globalThis, "Function", { configurable: true, value: original });
     }
+  }, 30_000);
+
+  it("produces byte-identical output on a warm repeat compile", async () => {
+    const compiler = await createCompiler();
+    const bundle = sourceBundle("= Deterministic\n\nSame source, same PDF.");
+    const first = await compiler.compile(bundle);
+    const second = await compiler.compile(bundle);
+    expect(first.diagnostics).toEqual([]);
+    expect(second.diagnostics).toEqual([]);
+    expect(second.pdf).toEqual(first.pdf);
   }, 30_000);
 });

--- a/apps/extension/tests/pdf/compiler.test.ts
+++ b/apps/extension/tests/pdf/compiler.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "bun:test";
+import { fileURLToPath } from "node:url";
+import type { ExportBlock } from "@atlcli/confluence/browser";
+import type { PdfSourceBundle } from "@atlcli/pdf/browser";
+import {
+  ATLCLI_TYPST_TEMPLATE,
+  preparePdfDocument,
+  serializePdfDocument,
+} from "@atlcli/pdf/browser";
+import { BrowserPdfCompiler } from "../../utils/pdf/compiler.js";
+
+async function packageBytes(specifier: string): Promise<Uint8Array> {
+  const resolved = import.meta.resolve(specifier);
+  return new Uint8Array(await Bun.file(fileURLToPath(resolved)).arrayBuffer());
+}
+
+async function createCompiler(): Promise<BrowserPdfCompiler> {
+  const [wasm, inter, mono] = await Promise.all([
+    packageBytes("@myriaddreamin/typst-ts-web-compiler/wasm"),
+    packageBytes("@atlcli/docx/fonts/Inter-Regular.ttf"),
+    packageBytes("@atlcli/docx/fonts/JetBrainsMono-Regular.ttf"),
+  ]);
+  return new BrowserPdfCompiler({ wasm, fonts: [inter, mono] });
+}
+
+function sourceBundle(main: string): PdfSourceBundle {
+  return { main, template: ATLCLI_TYPST_TEMPLATE, assets: [], sourceMap: [], notes: [] };
+}
+
+describe("BrowserPdfCompiler", () => {
+  it("compiles a real PDF with the bundled template and fonts", async () => {
+    const compiler = await createCompiler();
+    const result = await compiler.compile(
+      sourceBundle(String.raw`#import "atlcli.typ": atlcli-doc, callout, status-badge
+#show: atlcli-doc.with(meta: (
+  title: "Compiler smoke",
+  space: "DOCSY",
+  version: "v1",
+  author: "atlcli",
+  exporter: "atlcli",
+  exported-at: datetime(year: 2026, month: 7, day: 16),
+  exported-label: "2026-07-16",
+))
+= Hello
+This is a real PDF.
+`)
+    );
+
+    expect(result.diagnostics).toEqual([]);
+    expect(result.pdf).toBeDefined();
+    expect(new TextDecoder().decode(result.pdf?.slice(0, 8))).toStartWith("%PDF-");
+    expect(result.pdf?.byteLength).toBeGreaterThan(1_000);
+  }, 30_000);
+
+  it("returns structured diagnostics for invalid Typst", async () => {
+    const compiler = await createCompiler();
+    const result = await compiler.compile(sourceBundle("#this-function-does-not-exist()"));
+    expect(result.pdf).toBeUndefined();
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+    expect(result.diagnostics[0]?.path).toContain("main.typ");
+  }, 30_000);
+
+  it("compiles the generated semantic block source", async () => {
+    const blocks: ExportBlock[] = [
+      { type: "heading", level: 2, content: [{ type: "text", text: "Overview" }] },
+      {
+        type: "paragraph",
+        content: [
+          { type: "text", text: "A bold statement", marks: ["bold"] },
+          { type: "lineBreak" },
+          { type: "status", text: "DONE", color: "#00875A" },
+        ],
+      },
+      {
+        type: "callout",
+        kind: "info",
+        title: "Context",
+        content: [{ type: "paragraph", content: [{ type: "text", text: "Read me" }] }],
+      },
+      {
+        type: "list",
+        ordered: false,
+        items: [
+          { checked: true, content: [{ type: "paragraph", content: [{ type: "text", text: "Task" }] }] },
+        ],
+      },
+      {
+        type: "table",
+        rows: [
+          { cells: [{ header: true, colspan: 1, rowspan: 1, content: [{ type: "paragraph", content: [{ type: "text", text: "Key" }] }] }] },
+          { cells: [{ header: false, colspan: 1, rowspan: 1, content: [{ type: "paragraph", content: [{ type: "text", text: "Value" }] }] }] },
+        ],
+      },
+      { type: "codeBlock", language: "javascript", code: "const answer = 42;" },
+    ];
+    const prepared = await preparePdfDocument(blocks, {
+      resolve: async () => {
+        throw new Error("no image in fixture");
+      },
+    });
+    const bundle = serializePdfDocument(prepared, {
+      metadata: {
+        title: "Generated PDF",
+        space: "DOCSY",
+        version: 1,
+        exporter: "atlcli",
+        exportedAt: new Date("2026-07-16T12:00:00Z"),
+      },
+    });
+    const compiler = await createCompiler();
+    const result = await compiler.compile(bundle);
+
+    expect(result.diagnostics).toEqual([]);
+    expect(new TextDecoder().decode(result.pdf?.slice(0, 8))).toStartWith("%PDF-");
+  }, 30_000);
+
+  it("initializes and compiles when dynamic Function construction is blocked", async () => {
+    const original = globalThis.Function;
+    const blocked = new Proxy(original, {
+      construct() {
+        throw new Error("dynamic Function construction is forbidden by MV3 CSP");
+      },
+      apply() {
+        throw new Error("dynamic Function construction is forbidden by MV3 CSP");
+      },
+    });
+    Object.defineProperty(globalThis, "Function", { configurable: true, value: blocked });
+    try {
+      const compiler = await createCompiler();
+      const result = await compiler.compile(sourceBundle("= CSP-safe\n\nNo unsafe eval."));
+      expect(result.diagnostics).toEqual([]);
+      expect(new TextDecoder().decode(result.pdf?.slice(0, 8))).toStartWith("%PDF-");
+    } finally {
+      Object.defineProperty(globalThis, "Function", { configurable: true, value: original });
+    }
+  }, 30_000);
+});

--- a/apps/extension/tests/pdf/download.test.ts
+++ b/apps/extension/tests/pdf/download.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "bun:test";
+import { Window } from "happy-dom";
+import { downloadBytes, sanitizeDownloadName } from "../../utils/download.js";
+
+describe("downloadBytes", () => {
+  it("sanitizes filenames for both export formats", () => {
+    expect(sanitizeDownloadName('A: B/C?*', "pdf")).toBe("A- B-C--.pdf");
+    expect(sanitizeDownloadName("  ", ".docx")).toBe("Confluence export.docx");
+  });
+
+  it("downloads a PDF with its MIME type", async () => {
+    const window = new Window();
+    const doc = window.document as unknown as Document;
+    let clicked: HTMLAnchorElement | null = null;
+    doc.body.addEventListener("click", (event) => {
+      clicked = event.target as HTMLAnchorElement;
+      event.preventDefault();
+    });
+    await downloadBytes({
+      name: "Page.pdf",
+      bytes: new Uint8Array([37, 80, 68, 70]),
+      mimeType: "application/pdf",
+      document: doc,
+    });
+    const clickedAnchor = clicked as unknown as HTMLAnchorElement;
+    expect(clickedAnchor.download).toBe("Page.pdf");
+    expect(clickedAnchor.href).toStartWith("blob:");
+    expect(doc.body.querySelector("a")).toBeNull();
+  });
+});

--- a/apps/extension/tests/pdf/job-store.test.ts
+++ b/apps/extension/tests/pdf/job-store.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+import { IDBFactory, IDBKeyRange } from "fake-indexeddb";
+import type { PdfSourceBundle } from "@atlcli/pdf/browser";
+import {
+  PDF_JOB_MAX_BYTES,
+  PDF_STORE_MAX_BYTES,
+  cancelPdfJob,
+  claimPdfJob,
+  cleanupPdfJobs,
+  completePdfJob,
+  createPdfJobId,
+  deletePdfJob,
+  getPdfJob,
+  putPdfJob,
+  openPdfJobDb,
+} from "../../utils/pdf/job-store.js";
+
+globalThis.IDBKeyRange = IDBKeyRange;
+
+let factory: IDBFactory;
+const id = "123e4567-e89b-42d3-a456-426614174000";
+
+beforeEach(() => {
+  factory = new IDBFactory();
+});
+
+function bundle(size = 4): PdfSourceBundle {
+  return {
+    main: "= Job",
+    template: "template",
+    assets: [{ path: "assets/a.png", mediaType: "image/png", bytes: new Uint8Array(size) }],
+    sourceMap: [],
+    notes: [],
+  };
+}
+
+describe("PDF job store", () => {
+  it("stores, claims and completes a binary job", async () => {
+    await putPdfJob({ id, sourceIdentity: "page:1", bundle: bundle() }, factory);
+    expect((await getPdfJob(id, factory))?.status).toBe("prepared");
+    expect((await claimPdfJob(id, factory))?.status).toBe("compiling");
+    await completePdfJob(id, {
+      pdf: new Uint8Array([37, 80, 68, 70]),
+      diagnostics: [],
+      compilerVersion: "test",
+    }, factory);
+    const result = await getPdfJob(id, factory);
+    expect(result?.status).toBe("complete");
+    expect([...result!.pdf!]).toEqual([37, 80, 68, 70]);
+  });
+
+  it("does not resurrect a deleted or cancelled job on late completion", async () => {
+    await putPdfJob({ id, sourceIdentity: "page:1", bundle: bundle() }, factory);
+    await claimPdfJob(id, factory);
+    await deletePdfJob(id, factory);
+    expect(await completePdfJob(id, { pdf: new Uint8Array([1]), diagnostics: [], compilerVersion: "test" }, factory)).toBeUndefined();
+    expect(await getPdfJob(id, factory)).toBeUndefined();
+
+    const id2 = "223e4567-e89b-42d3-a456-426614174000";
+    await putPdfJob({ id: id2, sourceIdentity: "page:2", bundle: bundle() }, factory);
+    await claimPdfJob(id2, factory);
+    await cancelPdfJob(id2, factory);
+    await completePdfJob(id2, { pdf: new Uint8Array([1]), diagnostics: [], compilerVersion: "test" }, factory);
+    expect((await getPdfJob(id2, factory))?.status).toBe("cancelled");
+  });
+
+  it("rejects oversized input before writing", async () => {
+    await expect(
+      putPdfJob({ id, sourceIdentity: "large", bundle: bundle(PDF_JOB_MAX_BYTES + 1) }, factory)
+    ).rejects.toThrow("job limit");
+    expect(await getPdfJob(id, factory)).toBeUndefined();
+  });
+
+  it("enforces the total store quota before accepting another job", async () => {
+    const db = await openPdfJobDb(factory);
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction("jobs", "readwrite");
+      tx.objectStore("jobs").add({
+        id: "423e4567-e89b-42d3-a456-426614174000",
+        sourceIdentity: "seed",
+        createdAt: 1,
+        status: "prepared",
+        inputBytes: PDF_STORE_MAX_BYTES,
+        bundle: bundle(),
+      });
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+    });
+    db.close();
+
+    await expect(
+      putPdfJob({ id, sourceIdentity: "over-total", bundle: bundle() }, factory)
+    ).rejects.toThrow("total quota");
+  });
+
+  it("keeps source bundles isolated by unguessable job id", async () => {
+    const other = "523e4567-e89b-42d3-a456-426614174000";
+    await putPdfJob({ id, sourceIdentity: "page:a", bundle: bundle(3) }, factory);
+    await putPdfJob({ id: other, sourceIdentity: "page:b", bundle: bundle(7) }, factory);
+    expect((await getPdfJob(id, factory))?.bundle.assets[0]?.bytes.byteLength).toBe(3);
+    expect((await getPdfJob(other, factory))?.bundle.assets[0]?.bytes.byteLength).toBe(7);
+  });
+
+  it("cleans stale jobs without touching fresh jobs", async () => {
+    const fresh = "323e4567-e89b-42d3-a456-426614174000";
+    await putPdfJob({ id, sourceIdentity: "old", bundle: bundle(), createdAt: 100 }, factory);
+    await putPdfJob({ id: fresh, sourceIdentity: "fresh", bundle: bundle(), createdAt: 900 }, factory);
+    expect(await cleanupPdfJobs({ now: 1_000, maxAgeMs: 500 }, factory)).toBe(1);
+    expect(await getPdfJob(id, factory)).toBeUndefined();
+    expect(await getPdfJob(fresh, factory)).toBeDefined();
+  });
+
+  it("validates generated UUIDs", () => {
+    expect(createPdfJobId(() => id)).toBe(id);
+    expect(() => createPdfJobId(() => "not-an-id")).toThrow("invalid UUID");
+  });
+});

--- a/apps/extension/tests/pdf/report-view.test.tsx
+++ b/apps/extension/tests/pdf/report-view.test.tsx
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "bun:test";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { PdfReportView } from "../../entrypoints/sidepanel/PdfSection.js";
+
+describe("PdfReportView", () => {
+  it("renders PDF-specific counts and notes", () => {
+    const html = renderToStaticMarkup(
+      <PdfReportView report={{
+        filename: "Guide.pdf",
+        profile: "tagged",
+        compilerVersion: "test",
+        embeddedImages: 2,
+        renderedDiagrams: 1,
+        skippedAssets: 0,
+        notes: [{ level: "warning", code: "pdf-image-alt-fallback", message: "Alt text missing" }],
+        timings: { prepareMs: 1, compileMs: 2, downloadMs: 1, totalMs: 4 },
+      }} />
+    );
+    expect(html).toContain("Guide.pdf");
+    expect(html).toContain("2 image(s)");
+    expect(html).toContain("1 diagram(s)");
+    expect(html).toContain("Alt text missing");
+    expect(html).toContain("4 ms");
+    expect(html).toContain("Prepare 1 ms");
+    expect(html).toContain("Compile 2 ms");
+    expect(html).toContain("Download 1 ms");
+    expect(html).toContain('aria-label="PDF export timing breakdown"');
+  });
+
+  it("formats long export phases in readable seconds", () => {
+    const html = renderToStaticMarkup(
+      <PdfReportView report={{
+        filename: "Long.pdf",
+        profile: "tagged",
+        compilerVersion: "test",
+        embeddedImages: 5,
+        renderedDiagrams: 0,
+        skippedAssets: 0,
+        notes: [],
+        timings: { prepareMs: 3650, compileMs: 1042, downloadMs: 200, totalMs: 4892 },
+      }} />
+    );
+
+    expect(html).toContain("4.9 s");
+    expect(html).toContain("Prepare 3.6 s");
+    expect(html).toContain("Compile 1.0 s");
+    expect(html).toContain("Download 200 ms");
+  });
+});

--- a/apps/extension/tests/pdf/run-export.test.ts
+++ b/apps/extension/tests/pdf/run-export.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, it } from "bun:test";
+import type { PdfSourceBundle } from "@atlcli/pdf/browser";
+import type { LoadedPage } from "../../utils/read-path.js";
+import {
+  normalizePdfLocale,
+  runPdfExport,
+  type PdfExportPhase,
+} from "../../utils/pdf/run-export.js";
+import type { StoredPdfJob } from "../../utils/pdf/job-store.js";
+
+const jobId = "123e4567-e89b-42d3-a456-426614174000";
+const validPdf = new TextEncoder().encode(
+  "%PDF-1.7\n/Type/Page /StructTreeRoot /MarkInfo /Outlines /FontFile2\n%%EOF\n"
+);
+const page: LoadedPage = {
+  details: {
+    id: "123",
+    title: "Guide: A/B?",
+    spaceKey: "DOCSY",
+    version: 4,
+    modifiedBy: { accountId: "a1", displayName: "Ada" },
+    storage: "<h2>Overview</h2><p>Hello <strong>PDF</strong>.</p>",
+  },
+  markdown: "## Overview\n\nHello **PDF**.",
+  wordCount: 4,
+  attachments: [],
+};
+
+describe("runPdfExport", () => {
+  it("normalizes browser locales for Typst language and region metadata", () => {
+    expect(normalizePdfLocale("de-DE")).toEqual({ language: "de", region: "DE" });
+    expect(normalizePdfLocale("pt_BR")).toEqual({ language: "pt", region: "BR" });
+    expect(normalizePdfLocale("zh-Hant-TW")).toEqual({ language: "zh", region: "TW" });
+    expect(normalizePdfLocale("invalid-locale")).toEqual({ language: "en" });
+  });
+
+  it("prepares, compiles, downloads and cleans a correlated job", async () => {
+    let bundle: PdfSourceBundle | undefined;
+    let stored: StoredPdfJob | undefined;
+    let deleted = false;
+    const phases: PdfExportPhase[] = [];
+    const downloads: Array<{ name: string; bytes: number[] }> = [];
+    let clock = 1_000;
+
+    const report = await runPdfExport(
+      { page, pageUrl: "https://acme.atlassian.net/wiki/spaces/DOCSY/pages/123/Guide", onPhase: (phase) => phases.push(phase) },
+      {
+        now: () => (clock += 5),
+        makeJobId: () => jobId,
+        cleanupJobs: async () => 0,
+        createJob: async (input) => {
+          bundle = input.bundle;
+          stored = {
+            id: input.id,
+            sourceIdentity: input.sourceIdentity,
+            createdAt: 1,
+            status: "prepared",
+            inputBytes: 1,
+            bundle: input.bundle,
+          };
+          return stored;
+        },
+        sendMessage: async (message) => {
+          if (message.kind === "pdf:compile") {
+            stored = {
+              ...stored!,
+              status: "complete",
+              pdf: validPdf,
+              compilerVersion: "test",
+            };
+            return { kind: "pdf:compile-result", jobId, ok: true };
+          }
+          return { kind: "pdf:cancel-result", jobId, cancelled: true };
+        },
+        getJob: async () => stored,
+        deleteJob: async () => { deleted = true; },
+        download: async (name, bytes) => { downloads.push({ name, bytes: [...bytes] }); },
+      }
+    );
+
+    expect(bundle?.main).toContain("#heading(level: 1");
+    expect(phases).toEqual([
+      "preparing",
+      "fetching",
+      "queued",
+      "compiling",
+      "validating",
+      "downloading",
+    ]);
+    expect(downloads).toEqual([{ name: "Guide- A-B-.pdf", bytes: [...validPdf] }]);
+    expect(report.filename).toBe("Guide- A-B-.pdf");
+    expect(report.compilerVersion).toBe("test");
+    expect(report.pageCount).toBe(1);
+    expect(deleted).toBe(true);
+  });
+
+  it("cancels and never downloads after navigation abort", async () => {
+    const controller = new AbortController();
+    let resolveCompile: ((value: unknown) => void) | undefined;
+    let cancelMessages = 0;
+    let downloads = 0;
+    let stored: StoredPdfJob | undefined;
+    const promise = runPdfExport(
+      { page, pageUrl: "https://acme.atlassian.net/wiki/spaces/DOCSY/pages/123/Guide", signal: controller.signal },
+      {
+        makeJobId: () => jobId,
+        cleanupJobs: async () => 0,
+        createJob: async (input) => {
+          stored = { id: input.id, sourceIdentity: input.sourceIdentity, createdAt: 1, status: "prepared", inputBytes: 1, bundle: input.bundle };
+          return stored;
+        },
+        sendMessage: (message) => {
+          if (message.kind === "pdf:cancel") {
+            cancelMessages += 1;
+            return Promise.resolve({ kind: "pdf:cancel-result", jobId, cancelled: true });
+          }
+          return new Promise((resolve) => { resolveCompile = resolve; });
+        },
+        getJob: async () => stored,
+        deleteJob: async () => undefined,
+        download: async () => { downloads += 1; },
+      }
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    controller.abort();
+    resolveCompile?.({ kind: "pdf:compile-result", jobId, ok: false, error: "cancelled" });
+    await expect(promise).rejects.toHaveProperty("name", "AbortError");
+    expect(cancelMessages).toBe(1);
+    expect(downloads).toBe(0);
+  });
+
+  it("cleans a job when navigation aborts while it is being stored", async () => {
+    const controller = new AbortController();
+    let deleted = false;
+    let compileMessages = 0;
+    await expect(
+      runPdfExport(
+        { page, pageUrl: "https://acme.atlassian.net/wiki/spaces/DOCSY/pages/123/Guide", signal: controller.signal },
+        {
+          makeJobId: () => jobId,
+          cleanupJobs: async () => 0,
+          createJob: async (input) => {
+            controller.abort();
+            return {
+              id: input.id,
+              sourceIdentity: input.sourceIdentity,
+              createdAt: 1,
+              status: "prepared",
+              inputBytes: 1,
+              bundle: input.bundle,
+            };
+          },
+          sendMessage: async () => {
+            compileMessages += 1;
+            return undefined;
+          },
+          deleteJob: async () => {
+            deleted = true;
+          },
+        }
+      )
+    ).rejects.toHaveProperty("name", "AbortError");
+    expect(compileMessages).toBe(0);
+    expect(deleted).toBe(true);
+  });
+});

--- a/apps/extension/tests/pdf/validate.test.ts
+++ b/apps/extension/tests/pdf/validate.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "bun:test";
+import { validatePdfOutput } from "../../utils/pdf/validate.js";
+
+function fixture(body: string): Uint8Array {
+  return new TextEncoder().encode(`%PDF-1.7\n${body}\n%%EOF\n`);
+}
+
+describe("validatePdfOutput", () => {
+  it("reports pages, tags, outline and embedded fonts", () => {
+    expect(
+      validatePdfOutput(
+        fixture("/Type /Page /Type/Page /StructTreeRoot /MarkInfo /Outlines /FontFile2")
+      )
+    ).toEqual({ pageCount: 2, tagged: true, hasOutline: true, embeddedFontFiles: 1 });
+  });
+
+  it.each([
+    ["truncated", new Uint8Array([37, 80, 68, 70]), "truncated"],
+    ["no pages", fixture("/StructTreeRoot /MarkInfo /FontFile2"), "no pages"],
+    ["untagged", fixture("/Type/Page /FontFile2"), "tag structure"],
+    ["fontless", fixture("/Type/Page /StructTreeRoot /MarkInfo"), "font files"],
+  ])("rejects %s output", (_label, bytes, expected) => {
+    expect(() => validatePdfOutput(bytes)).toThrow(expected);
+  });
+});

--- a/apps/extension/tests/router.test.ts
+++ b/apps/extension/tests/router.test.ts
@@ -7,6 +7,8 @@ const noEntity: EntityDetection = { url: null, entity: null, seq: 0 };
 const okDeps: RouterDeps = {
   runWasmSmoke: async (a, b) => a + b,
   getCurrentEntity: async () => noEntity,
+  runPdfCompile: async () => ({ ok: true }),
+  runPdfCancel: async () => true,
 };
 
 describe("routeMessage (pure router)", () => {
@@ -30,6 +32,8 @@ describe("routeMessage (pure router)", () => {
           return a + b;
         },
         getCurrentEntity: async () => noEntity,
+        runPdfCompile: okDeps.runPdfCompile,
+        runPdfCancel: okDeps.runPdfCancel,
       }
     );
     expect(called).toBe(false);
@@ -43,6 +47,8 @@ describe("routeMessage (pure router)", () => {
           throw new Error("instantiate boom");
         },
         getCurrentEntity: async () => noEntity,
+        runPdfCompile: okDeps.runPdfCompile,
+        runPdfCancel: okDeps.runPdfCancel,
       }
     );
     expect(res).toEqual({
@@ -61,6 +67,8 @@ describe("routeMessage (pure router)", () => {
           throw "plain string";
         },
         getCurrentEntity: async () => noEntity,
+        runPdfCompile: okDeps.runPdfCompile,
+        runPdfCancel: okDeps.runPdfCancel,
       }
     );
     expect(res).toEqual({
@@ -78,8 +86,29 @@ describe("routeMessage (pure router)", () => {
     };
     const res = await routeMessage(
       { kind: "get-current-entity" },
-      { runWasmSmoke: async (a, b) => a + b, getCurrentEntity: async () => detection }
+      { ...okDeps, getCurrentEntity: async () => detection }
     );
     expect(res).toEqual({ kind: "current-entity", detection });
+  });
+
+  it("routes PDF compile and cancellation by job id", async () => {
+    const jobId = "123e4567-e89b-42d3-a456-426614174000";
+    expect(await routeMessage({ kind: "pdf:compile", jobId }, okDeps)).toEqual({
+      kind: "pdf:compile-result", jobId, ok: true,
+    });
+    expect(await routeMessage({ kind: "pdf:cancel", jobId }, okDeps)).toEqual({
+      kind: "pdf:cancel-result", jobId, cancelled: true,
+    });
+  });
+
+  it("captures PDF compiler failures", async () => {
+    const jobId = "123e4567-e89b-42d3-a456-426614174000";
+    const response = await routeMessage(
+      { kind: "pdf:compile", jobId },
+      { ...okDeps, runPdfCompile: async () => { throw new Error("compiler offline"); } }
+    );
+    expect(response).toEqual({
+      kind: "pdf:compile-result", jobId, ok: false, error: "compiler offline",
+    });
   });
 });

--- a/apps/extension/turbo.json
+++ b/apps/extension/turbo.json
@@ -9,6 +9,11 @@
       "inputs": [
         "entrypoints/**",
         "utils/**",
+        "workers/**",
+        "types/**",
+        "$TURBO_ROOT$/packages/pdf/src/**",
+        "$TURBO_ROOT$/packages/pdf/scripts/ensure-fonts.ts",
+        "$TURBO_ROOT$/packages/pdf/licenses/**",
         "wxt.config.ts",
         "package.json",
         "tsconfig.json"
@@ -20,6 +25,8 @@
       "inputs": [
         "entrypoints/**",
         "utils/**",
+        "workers/**",
+        "types/**",
         "scripts/**",
         "tests/**",
         "wxt.config.ts",

--- a/apps/extension/types/vendor.d.ts
+++ b/apps/extension/types/vendor.d.ts
@@ -33,3 +33,53 @@ declare module "turndown-plugin-gfm" {
   export function strikethrough(service: TurndownService): void;
   export function taskListItems(service: TurndownService): void;
 }
+
+declare module "*.ttf?url" {
+  const url: string;
+  export default url;
+}
+
+declare module "*.wasm?url" {
+  const url: string;
+  export default url;
+}
+
+declare module "*.txt?url&no-inline" {
+  const url: string;
+  export default url;
+}
+
+declare module "*?url&no-inline" {
+  const url: string;
+  export default url;
+}
+
+/**
+ * The package ships this declaration next to the ESM file but omits an exports
+ * mapping for it. Keep the adapter's deliberately small API surface typed.
+ */
+declare module "@myriaddreamin/typst-ts-web-compiler/pkg/typst_ts_web_compiler.mjs" {
+  export interface TypstCompiler {
+    free(): void;
+    reset(): void;
+    add_source(path: string, content: string): boolean;
+    map_shadow(path: string, content: Uint8Array): boolean;
+    reset_shadow(): void;
+    get_loaded_fonts(): string[];
+    compile(
+      mainFilePath: string,
+      inputs: Array<unknown>,
+      format: string,
+      diagnosticsFormat: number
+    ): unknown;
+  }
+
+  export class TypstCompilerBuilder {
+    add_raw_font(data: Uint8Array): Promise<void>;
+    build(): Promise<TypstCompiler>;
+  }
+
+  export default function initTypst(options: {
+    module_or_path: ArrayBuffer | URL | Response;
+  }): Promise<unknown>;
+}

--- a/apps/extension/utils/docx/env.ts
+++ b/apps/extension/utils/docx/env.ts
@@ -14,6 +14,7 @@ import type {
   TemplateSource,
 } from "@atlcli/docx/browser";
 import { getTemplate } from "./template-store.js";
+import { downloadBytes } from "../download.js";
 
 /**
  * {@link TemplateSource} over the panel's IndexedDB template store. The id is
@@ -214,17 +215,12 @@ export function canvasSvgRasterizer(doc: Document = document, decodeTimeoutMs = 
 export function downloadOutputSink(doc: Document = document): OutputSink {
   return {
     async emit(name: string, bytes: Uint8Array): Promise<void> {
-      const blob = new Blob([bytes as BlobPart], {
-        type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      await downloadBytes({
+        name,
+        bytes,
+        mimeType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        document: doc,
       });
-      const url = URL.createObjectURL(blob);
-      const a = doc.createElement("a");
-      a.href = url;
-      a.download = name;
-      doc.body.appendChild(a);
-      a.click();
-      a.remove();
-      setTimeout(() => URL.revokeObjectURL(url), 1000);
     },
   };
 }

--- a/apps/extension/utils/download.ts
+++ b/apps/extension/utils/download.ts
@@ -1,0 +1,29 @@
+export interface DownloadOptions {
+  name: string;
+  bytes: Uint8Array;
+  mimeType: string;
+  document?: Document;
+}
+
+export function sanitizeDownloadName(title: string, extension: string): string {
+  const cleanExtension = extension.replace(/^\.+/, "").toLowerCase();
+  const base = title.replace(/[<>:"/\\|?*\u0000-\u001f]/g, "-").replace(/\s+/g, " ").trim();
+  return `${base || "Confluence export"}.${cleanExtension}`;
+}
+
+export async function downloadBytes(options: DownloadOptions): Promise<void> {
+  const doc = options.document ?? document;
+  const view = doc.defaultView ?? window;
+  const blob = new view.Blob([options.bytes as BlobPart], { type: options.mimeType });
+  const url = view.URL.createObjectURL(blob);
+  try {
+    const anchor = doc.createElement("a");
+    anchor.href = url;
+    anchor.download = options.name;
+    doc.body.appendChild(anchor);
+    anchor.click();
+    anchor.remove();
+  } finally {
+    view.setTimeout(() => view.URL.revokeObjectURL(url), 1_000);
+  }
+}

--- a/apps/extension/utils/listeners.ts
+++ b/apps/extension/utils/listeners.ts
@@ -21,6 +21,8 @@ import { runWasmAdd } from "./wasm-smoke.js";
 /** Effects the offscreen listener depends on (injectable for tests). */
 export interface OffscreenListenerDeps {
   runWasmAdd: (a: number, b: number, bytes?: Uint8Array) => Promise<number>;
+  runPdfCompile: (jobId: string) => Promise<{ ok: true } | { ok: false; error: string }>;
+  runPdfCancel: (jobId: string) => Promise<boolean>;
 }
 
 const toMessage = (err: unknown): string =>
@@ -43,9 +45,21 @@ export function handleExtMessage(
   // catch is belt-and-suspenders so a listener bug still yields a response.
   routeMessage(message, deps)
     .then((response) => sendResponse(response))
-    .catch((err) =>
-      sendResponse({ kind: "wasm-smoke-result", ok: false, error: toMessage(err) })
-    );
+    .catch((err) => {
+      switch (message.kind) {
+        case "pdf:compile":
+          sendResponse({ kind: "pdf:compile-result", jobId: message.jobId, ok: false, error: toMessage(err) });
+          break;
+        case "pdf:cancel":
+          sendResponse({ kind: "pdf:cancel-result", jobId: message.jobId, cancelled: false });
+          break;
+        case "ping":
+        case "wasm-smoke":
+        case "get-current-entity":
+          sendResponse({ kind: "wasm-smoke-result", ok: false, error: toMessage(err) });
+          break;
+      }
+    });
 
   return true;
 }
@@ -58,18 +72,33 @@ export function handleExtMessage(
 export function handleOffscreenMessage(
   message: unknown,
   sendResponse: (response: OffscreenResponse) => void,
-  deps: OffscreenListenerDeps = { runWasmAdd }
+  deps: OffscreenListenerDeps = {
+    runWasmAdd,
+    runPdfCompile: async () => ({ ok: false, error: "PDF compiler host is not configured." }),
+    runPdfCancel: async () => false,
+  }
 ): boolean {
   if (!isOffscreenRequest(message)) return false;
 
-  deps
-    .runWasmAdd(message.a, message.b)
-    .then((result) =>
-      sendResponse({ kind: "offscreen:wasm-add-result", ok: true, result })
-    )
-    .catch((err) =>
-      sendResponse({ kind: "offscreen:wasm-add-result", ok: false, error: toMessage(err) })
-    );
+  switch (message.kind) {
+    case "offscreen:wasm-add":
+      deps.runWasmAdd(message.a, message.b)
+        .then((result) => sendResponse({ kind: "offscreen:wasm-add-result", ok: true, result }))
+        .catch((err) => sendResponse({ kind: "offscreen:wasm-add-result", ok: false, error: toMessage(err) }));
+      break;
+    case "offscreen:pdf-compile":
+      deps.runPdfCompile(message.jobId)
+        .then((result) => sendResponse(result.ok
+          ? { kind: "offscreen:pdf-compile-result", jobId: message.jobId, ok: true }
+          : { kind: "offscreen:pdf-compile-result", jobId: message.jobId, ok: false, error: result.error }))
+        .catch((err) => sendResponse({ kind: "offscreen:pdf-compile-result", jobId: message.jobId, ok: false, error: toMessage(err) }));
+      break;
+    case "offscreen:pdf-cancel":
+      deps.runPdfCancel(message.jobId)
+        .then((cancelled) => sendResponse({ kind: "offscreen:pdf-cancel-result", jobId: message.jobId, cancelled }))
+        .catch(() => sendResponse({ kind: "offscreen:pdf-cancel-result", jobId: message.jobId, cancelled: false }));
+      break;
+  }
 
   return true;
 }

--- a/apps/extension/utils/messages.ts
+++ b/apps/extension/utils/messages.ts
@@ -38,14 +38,19 @@ export interface EntityDetection {
 export type ExtRequest =
   | { kind: "ping" }
   | { kind: "wasm-smoke"; a: number; b: number }
-  | { kind: "get-current-entity" };
+  | { kind: "get-current-entity" }
+  | { kind: "pdf:compile"; jobId: string }
+  | { kind: "pdf:cancel"; jobId: string };
 
 /** Response messages returned to the panel. */
 export type ExtResponse =
   | { kind: "pong" }
   | { kind: "wasm-smoke-result"; ok: true; result: number }
   | { kind: "wasm-smoke-result"; ok: false; error: string }
-  | { kind: "current-entity"; detection: EntityDetection };
+  | { kind: "current-entity"; detection: EntityDetection }
+  | { kind: "pdf:compile-result"; jobId: string; ok: true }
+  | { kind: "pdf:compile-result"; jobId: string; ok: false; error: string }
+  | { kind: "pdf:cancel-result"; jobId: string; cancelled: boolean };
 
 /**
  * Push message: the service worker (canonical tab observer, PLAN §2.1) notifies
@@ -60,10 +65,16 @@ export type EntityChanged = { kind: "entity-changed"; detection: EntityDetection
  * Namespaced (`offscreen:`) so the SW's own panel-facing listener ignores them
  * (no self-delivery loop over the shared `chrome.runtime` message bus).
  */
-export type OffscreenRequest = { kind: "offscreen:wasm-add"; a: number; b: number };
+export type OffscreenRequest =
+  | { kind: "offscreen:wasm-add"; a: number; b: number }
+  | { kind: "offscreen:pdf-compile"; jobId: string }
+  | { kind: "offscreen:pdf-cancel"; jobId: string };
 export type OffscreenResponse =
   | { kind: "offscreen:wasm-add-result"; ok: true; result: number }
-  | { kind: "offscreen:wasm-add-result"; ok: false; error: string };
+  | { kind: "offscreen:wasm-add-result"; ok: false; error: string }
+  | { kind: "offscreen:pdf-compile-result"; jobId: string; ok: true }
+  | { kind: "offscreen:pdf-compile-result"; jobId: string; ok: false; error: string }
+  | { kind: "offscreen:pdf-cancel-result"; jobId: string; cancelled: boolean };
 
 /** Every message that can travel over the protocol. */
 export type ExtMessage =
@@ -84,6 +95,8 @@ export interface ResponseMap {
   ping: Extract<ExtResponse, { kind: "pong" }>;
   "wasm-smoke": Extract<ExtResponse, { kind: "wasm-smoke-result" }>;
   "get-current-entity": Extract<ExtResponse, { kind: "current-entity" }>;
+  "pdf:compile": Extract<ExtResponse, { kind: "pdf:compile-result" }>;
+  "pdf:cancel": Extract<ExtResponse, { kind: "pdf:cancel-result" }>;
 }
 
 export type ResponseFor<K extends ExtRequestKind> = ResponseMap[K];
@@ -91,7 +104,9 @@ export type ResponseFor<K extends ExtRequestKind> = ResponseMap[K];
 /** Narrowing type guard for panel-facing request messages. */
 export function isExtRequest(value: unknown): value is ExtRequest {
   if (typeof value !== "object" || value === null) return false;
-  const kind = (value as { kind?: unknown }).kind;
+  const candidate = value as { kind?: unknown; jobId?: unknown };
+  const kind = candidate.kind;
+  if (kind === "pdf:compile" || kind === "pdf:cancel") return isPdfJobId(candidate.jobId);
   return kind === "ping" || kind === "wasm-smoke" || kind === "get-current-entity";
 }
 
@@ -104,5 +119,13 @@ export function isEntityChanged(value: unknown): value is EntityChanged {
 /** Narrowing type guard for offscreen-bound request messages. */
 export function isOffscreenRequest(value: unknown): value is OffscreenRequest {
   if (typeof value !== "object" || value === null) return false;
-  return (value as { kind?: unknown }).kind === "offscreen:wasm-add";
+  const candidate = value as { kind?: unknown; jobId?: unknown };
+  if (candidate.kind === "offscreen:pdf-compile" || candidate.kind === "offscreen:pdf-cancel") {
+    return isPdfJobId(candidate.jobId);
+  }
+  return candidate.kind === "offscreen:wasm-add";
+}
+
+function isPdfJobId(value: unknown): value is string {
+  return typeof value === "string" && /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value);
 }

--- a/apps/extension/utils/pdf/compiler-host.ts
+++ b/apps/extension/utils/pdf/compiler-host.ts
@@ -1,0 +1,137 @@
+import { cancelPdfJob, failPdfJob } from "./job-store.js";
+import {
+  isPdfWorkerResponse,
+  type PdfWorkerRequest,
+  type PdfWorkerResponse,
+} from "./worker-protocol.js";
+
+export interface PdfWorkerLike {
+  postMessage(message: PdfWorkerRequest): void;
+  terminate(): void;
+  onmessage: ((event: MessageEvent<unknown>) => void) | null;
+  onerror: ((event: ErrorEvent) => void) | null;
+}
+
+export interface PdfCompilerHostOptions {
+  createWorker: () => PdfWorkerLike;
+  timeoutMs?: number;
+  schedule?: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>;
+  clear?: (id: ReturnType<typeof setTimeout>) => void;
+  failJob?: (jobId: string, error: string) => Promise<unknown>;
+  cancelJob?: (jobId: string) => Promise<unknown>;
+}
+
+interface QueueItem {
+  jobId: string;
+  resolve: (value: PdfWorkerResponse) => void;
+}
+
+/** Single-worker FIFO with hard timeout and cancellation. */
+export class PdfCompilerHost {
+  private readonly queue: QueueItem[] = [];
+  private worker: PdfWorkerLike | null = null;
+  private active: QueueItem | null = null;
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  private readonly timeoutMs: number;
+  private readonly schedule: NonNullable<PdfCompilerHostOptions["schedule"]>;
+  private readonly clear: NonNullable<PdfCompilerHostOptions["clear"]>;
+
+  constructor(private readonly options: PdfCompilerHostOptions) {
+    this.timeoutMs = options.timeoutMs ?? 60_000;
+    this.schedule = options.schedule ?? ((fn, ms) => setTimeout(fn, ms));
+    this.clear = options.clear ?? ((id) => clearTimeout(id));
+  }
+
+  compile(jobId: string): Promise<PdfWorkerResponse> {
+    return new Promise((resolve) => {
+      this.queue.push({ jobId, resolve });
+      this.pump();
+    });
+  }
+
+  async cancel(jobId: string): Promise<boolean> {
+    const queued = this.queue.findIndex((item) => item.jobId === jobId);
+    if (queued >= 0) {
+      const [item] = this.queue.splice(queued, 1);
+      await (this.options.cancelJob ?? cancelPdfJob)(jobId).catch(() => undefined);
+      item.resolve({ kind: "pdf-worker:complete", jobId, ok: false, error: "PDF export was cancelled.", fatal: false });
+      return true;
+    }
+    if (this.active?.jobId !== jobId) return false;
+    const item = this.active;
+    await (this.options.cancelJob ?? cancelPdfJob)(jobId).catch(() => undefined);
+    this.destroyWorker();
+    this.active = null;
+    item.resolve({ kind: "pdf-worker:complete", jobId, ok: false, error: "PDF export was cancelled.", fatal: false });
+    this.pump();
+    return true;
+  }
+
+  get activeCount(): number {
+    return this.active ? 1 : 0;
+  }
+
+  private getWorker(): PdfWorkerLike {
+    if (this.worker) return this.worker;
+    const worker = this.options.createWorker();
+    worker.onmessage = (event) => this.handleMessage(event.data);
+    worker.onerror = (event) => this.handleFatal(event.message || "PDF compiler worker failed.");
+    this.worker = worker;
+    return worker;
+  }
+
+  private pump(): void {
+    if (this.active || this.queue.length === 0) return;
+    const item = this.queue.shift()!;
+    this.active = item;
+    const worker = this.getWorker();
+    this.timer = this.schedule(() => this.handleTimeout(item.jobId), this.timeoutMs);
+    worker.postMessage({ kind: "pdf-worker:compile", jobId: item.jobId });
+  }
+
+  private handleMessage(value: unknown): void {
+    if (!isPdfWorkerResponse(value) || !this.active || value.jobId !== this.active.jobId) return;
+    const item = this.active;
+    this.clearTimer();
+    this.active = null;
+    if (!value.ok && value.fatal) this.destroyWorker();
+    item.resolve(value);
+    this.pump();
+  }
+
+  private handleTimeout(jobId: string): void {
+    if (!this.active || this.active.jobId !== jobId) return;
+    const item = this.active;
+    this.active = null;
+    this.destroyWorker();
+    const error = `PDF compilation timed out after ${this.timeoutMs} ms.`;
+    void (this.options.failJob ?? failPdfJob)(jobId, error).catch(() => undefined);
+    item.resolve({ kind: "pdf-worker:complete", jobId, ok: false, error, fatal: true });
+    this.pump();
+  }
+
+  private handleFatal(error: string): void {
+    if (!this.active) return;
+    const item = this.active;
+    this.active = null;
+    this.destroyWorker();
+    void (this.options.failJob ?? failPdfJob)(item.jobId, error).catch(() => undefined);
+    item.resolve({ kind: "pdf-worker:complete", jobId: item.jobId, ok: false, error, fatal: true });
+    this.pump();
+  }
+
+  private clearTimer(): void {
+    if (this.timer !== null) this.clear(this.timer);
+    this.timer = null;
+  }
+
+  private destroyWorker(): void {
+    this.clearTimer();
+    if (this.worker) {
+      this.worker.onmessage = null;
+      this.worker.onerror = null;
+      this.worker.terminate();
+    }
+    this.worker = null;
+  }
+}

--- a/apps/extension/utils/pdf/compiler.ts
+++ b/apps/extension/utils/pdf/compiler.ts
@@ -1,0 +1,100 @@
+import initTypst, {
+  TypstCompilerBuilder,
+  type TypstCompiler,
+} from "@myriaddreamin/typst-ts-web-compiler/pkg/typst_ts_web_compiler.mjs";
+import type { PdfSourceBundle } from "@atlcli/pdf/browser";
+
+export const PDF_COMPILER_VERSION = "typst.ts 0.7.0 / Typst 0.14.2";
+
+export interface PdfCompilerAssets {
+  wasm: BufferSource | URL | Response;
+  fonts: Uint8Array[];
+}
+
+export interface RawPdfDiagnostic {
+  package: string;
+  path: string;
+  severity: string;
+  range: string;
+  message: string;
+}
+
+export interface PdfCompileResult {
+  pdf?: Uint8Array;
+  diagnostics: RawPdfDiagnostic[];
+}
+
+/**
+ * Thin version-pinned adapter around typst.ts. The adapter is the only place
+ * allowed to know the wrapper's mutable VFS/font APIs.
+ */
+export class BrowserPdfCompiler {
+  private compiler: TypstCompiler | null = null;
+  private initPromise: Promise<TypstCompiler> | null = null;
+
+  constructor(private readonly assets: PdfCompilerAssets) {}
+
+  private initialize(): Promise<TypstCompiler> {
+    if (this.compiler) return Promise.resolve(this.compiler);
+    if (this.initPromise) return this.initPromise;
+
+    this.initPromise = (async () => {
+      await initTypst({ module_or_path: this.assets.wasm });
+      const builder = new TypstCompilerBuilder();
+      for (const font of this.assets.fonts) await builder.add_raw_font(font);
+      const compiler = await builder.build();
+      this.compiler = compiler;
+      return compiler;
+    })().catch((error) => {
+      this.initPromise = null;
+      throw error;
+    });
+
+    return this.initPromise;
+  }
+
+  async compile(bundle: PdfSourceBundle): Promise<PdfCompileResult> {
+    const compiler = await this.initialize();
+    compiler.reset_shadow();
+    try {
+      compiler.add_source("/main.typ", bundle.main);
+      compiler.add_source("/atlcli.typ", bundle.template);
+      for (const asset of bundle.assets) {
+        compiler.map_shadow(`/${asset.path}`, asset.bytes);
+      }
+      const result = compiler.compile("/main.typ", [], "pdf", 3) as {
+        result?: Uint8Array;
+        diagnostics?: RawPdfDiagnostic[];
+      };
+      return {
+        pdf: result.result,
+        diagnostics: (result.diagnostics ?? []) as RawPdfDiagnostic[],
+      };
+    } finally {
+      compiler.reset_shadow();
+    }
+  }
+
+  /** Drop all compiler state after a fatal job; the next call initializes anew. */
+  async reset(): Promise<void> {
+    const compiler = this.compiler;
+    this.compiler = null;
+    this.initPromise = null;
+    if (compiler) {
+      compiler.reset();
+      compiler.free();
+    }
+  }
+}
+
+export function formatPdfDiagnostics(diagnostics: RawPdfDiagnostic[]): string {
+  if (diagnostics.length === 0) return "Typst produced no PDF and no diagnostics.";
+  return diagnostics
+    .map((diagnostic) => {
+      const at = diagnostic.path
+        ? `${diagnostic.path}${diagnostic.range ? `:${diagnostic.range}` : ""}: `
+        : "";
+      return `${at}${diagnostic.severity}: ${diagnostic.message}`;
+    })
+    .join("\n");
+}

--- a/apps/extension/utils/pdf/compiler.ts
+++ b/apps/extension/utils/pdf/compiler.ts
@@ -2,12 +2,16 @@ import initTypst, {
   TypstCompilerBuilder,
   type TypstCompiler,
 } from "@myriaddreamin/typst-ts-web-compiler/pkg/typst_ts_web_compiler.mjs";
-import type { PdfSourceBundle } from "@atlcli/pdf/browser";
+import {
+  mapPdfDiagnostics,
+  type PdfSourceBundle,
+  type PdfSourceMapEntry,
+} from "@atlcli/pdf/browser";
 
 export const PDF_COMPILER_VERSION = "typst.ts 0.7.0 / Typst 0.14.2";
 
 export interface PdfCompilerAssets {
-  wasm: BufferSource | URL | Response;
+  wasm: ArrayBuffer | URL | Response;
   fonts: Uint8Array[];
 }
 
@@ -75,6 +79,10 @@ export class BrowserPdfCompiler {
     }
   }
 
+  async getLoadedFonts(): Promise<string[]> {
+    return (await this.initialize()).get_loaded_fonts();
+  }
+
   /** Drop all compiler state after a fatal job; the next call initializes anew. */
   async reset(): Promise<void> {
     const compiler = this.compiler;
@@ -87,14 +95,34 @@ export class BrowserPdfCompiler {
   }
 }
 
-export function formatPdfDiagnostics(diagnostics: RawPdfDiagnostic[]): string {
+export function formatPdfDiagnostics(
+  diagnostics: RawPdfDiagnostic[],
+  sourceMap: PdfSourceMapEntry[] = []
+): string {
   if (diagnostics.length === 0) return "Typst produced no PDF and no diagnostics.";
-  return diagnostics
+  const mapped = mapPdfDiagnostics(
+    diagnostics.map((diagnostic) => {
+      const match = diagnostic.range.match(/^(\d+):(\d+)-(\d+):(\d+)$/);
+      return {
+        severity: diagnostic.severity,
+        message: diagnostic.message,
+        path: diagnostic.path,
+        line: match ? Number(match[1]) : undefined,
+        column: match ? Number(match[2]) : undefined,
+        endLine: match ? Number(match[3]) : undefined,
+        endColumn: match ? Number(match[4]) : undefined,
+      };
+    }),
+    sourceMap
+  );
+  return mapped
     .map((diagnostic) => {
-      const at = diagnostic.path
-        ? `${diagnostic.path}${diagnostic.range ? `:${diagnostic.range}` : ""}: `
-        : "";
-      return `${at}${diagnostic.severity}: ${diagnostic.message}`;
+      const location = diagnostic.blockPath
+        ? `${diagnostic.blockPath}: `
+        : diagnostic.path
+          ? `${diagnostic.path}${diagnostic.startLine ? `:${diagnostic.startLine}` : ""}: `
+          : "";
+      return `${location}${diagnostic.severity}: ${diagnostic.message}`;
     })
     .join("\n");
 }

--- a/apps/extension/utils/pdf/job-store.ts
+++ b/apps/extension/utils/pdf/job-store.ts
@@ -1,0 +1,291 @@
+import type { PdfSourceBundle } from "@atlcli/pdf/browser";
+import type { RawPdfDiagnostic } from "./compiler.js";
+
+const DB_NAME = "atlcli-pdf";
+const DB_VERSION = 1;
+const STORE = "jobs";
+export const PDF_JOB_MAX_BYTES = 64 * 1024 * 1024;
+export const PDF_STORE_MAX_BYTES = 128 * 1024 * 1024;
+export const PDF_JOB_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+
+export type PdfJobStatus = "prepared" | "compiling" | "complete" | "failed" | "cancelled";
+
+export interface StoredPdfJob {
+  id: string;
+  sourceIdentity: string;
+  createdAt: number;
+  status: PdfJobStatus;
+  inputBytes: number;
+  bundle: PdfSourceBundle;
+  pdf?: Uint8Array;
+  diagnostics?: RawPdfDiagnostic[];
+  compilerVersion?: string;
+  error?: string;
+}
+
+function resolveFactory(factory?: IDBFactory): IDBFactory {
+  const value = factory ?? globalThis.indexedDB;
+  if (!value) throw new Error("IndexedDB is unavailable for PDF export.");
+  return value;
+}
+
+export function isPdfJobId(value: unknown): value is string {
+  return typeof value === "string" && /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value);
+}
+
+export function createPdfJobId(randomUUID: () => string = () => crypto.randomUUID()): string {
+  const id = randomUUID();
+  if (!isPdfJobId(id)) throw new Error("PDF job id generator returned an invalid UUID.");
+  return id;
+}
+
+function sourceBundleBytes(bundle: PdfSourceBundle): number {
+  const encoder = new TextEncoder();
+  return (
+    encoder.encode(bundle.main).byteLength +
+    encoder.encode(bundle.template).byteLength +
+    bundle.assets.reduce((total, asset) => total + asset.bytes.byteLength, 0)
+  );
+}
+
+function storedJobBytes(job: StoredPdfJob): number {
+  return job.inputBytes + (job.pdf?.byteLength ?? 0);
+}
+
+export function openPdfJobDb(factory?: IDBFactory): Promise<IDBDatabase> {
+  const idb = resolveFactory(factory);
+  return new Promise((resolve, reject) => {
+    const request = idb.open(DB_NAME, DB_VERSION);
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      if (!db.objectStoreNames.contains(STORE)) {
+        const store = db.createObjectStore(STORE, { keyPath: "id" });
+        store.createIndex("createdAt", "createdAt");
+      }
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error ?? new Error("Failed to open PDF job database."));
+  });
+}
+
+function transaction<T>(
+  db: IDBDatabase,
+  mode: IDBTransactionMode,
+  run: (store: IDBObjectStore, resolve: (value: T) => void, reject: (reason?: unknown) => void) => void
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const tx = db.transaction(STORE, mode);
+    let value: T;
+    let hasValue = false;
+    const finish = (result: T): void => {
+      value = result;
+      hasValue = true;
+    };
+    try {
+      run(tx.objectStore(STORE), finish, reject);
+    } catch (error) {
+      reject(error);
+      return;
+    }
+    tx.oncomplete = () => {
+      if (!hasValue) reject(new Error("PDF job transaction completed without a result."));
+      else resolve(value!);
+    };
+    tx.onabort = () => reject(tx.error ?? new Error("PDF job transaction aborted."));
+    tx.onerror = () => reject(tx.error ?? new Error("PDF job transaction failed."));
+  });
+}
+
+export async function putPdfJob(
+  input: { id: string; sourceIdentity: string; bundle: PdfSourceBundle; createdAt?: number },
+  factory?: IDBFactory
+): Promise<StoredPdfJob> {
+  if (!isPdfJobId(input.id)) throw new Error("Invalid PDF job id.");
+  const inputBytes = sourceBundleBytes(input.bundle);
+  if (inputBytes > PDF_JOB_MAX_BYTES) {
+    throw new Error(`PDF export input exceeds the ${PDF_JOB_MAX_BYTES} byte job limit.`);
+  }
+  const job: StoredPdfJob = {
+    id: input.id,
+    sourceIdentity: input.sourceIdentity,
+    createdAt: input.createdAt ?? Date.now(),
+    status: "prepared",
+    inputBytes,
+    bundle: input.bundle,
+  };
+  const db = await openPdfJobDb(factory);
+  try {
+    return await transaction(db, "readwrite", (store, done, reject) => {
+      const inventory = store.getAll();
+      inventory.onerror = () => reject(inventory.error);
+      inventory.onsuccess = () => {
+        const total = (inventory.result as StoredPdfJob[]).reduce(
+          (sum, stored) => sum + storedJobBytes(stored),
+          0
+        );
+        if (total + inputBytes > PDF_STORE_MAX_BYTES) {
+          reject(new Error("PDF export storage exceeds the 128 MB total quota."));
+          return;
+        }
+        const request = store.add(job);
+        request.onsuccess = () => done(job);
+        request.onerror = () => reject(request.error ?? new Error("Failed to store PDF job."));
+      };
+    });
+  } finally {
+    db.close();
+  }
+}
+
+export async function getPdfJob(id: string, factory?: IDBFactory): Promise<StoredPdfJob | undefined> {
+  const db = await openPdfJobDb(factory);
+  try {
+    return await transaction(db, "readonly", (store, done, reject) => {
+      const request = store.get(id);
+      request.onsuccess = () => done(request.result as StoredPdfJob | undefined);
+      request.onerror = () => reject(request.error);
+    });
+  } finally {
+    db.close();
+  }
+}
+
+async function updateExisting(
+  id: string,
+  update: (job: StoredPdfJob) => StoredPdfJob | null,
+  factory?: IDBFactory
+): Promise<StoredPdfJob | undefined> {
+  const db = await openPdfJobDb(factory);
+  try {
+    return await transaction(db, "readwrite", (store, done, reject) => {
+      const request = store.get(id);
+      request.onerror = () => reject(request.error);
+      request.onsuccess = () => {
+        const current = request.result as StoredPdfJob | undefined;
+        if (!current) {
+          done(undefined);
+          return;
+        }
+        const next = update(current);
+        if (!next) {
+          done(current);
+          return;
+        }
+        const write = store.put(next);
+        write.onsuccess = () => done(next);
+        write.onerror = () => reject(write.error);
+      };
+    });
+  } finally {
+    db.close();
+  }
+}
+
+export function claimPdfJob(id: string, factory?: IDBFactory): Promise<StoredPdfJob | undefined> {
+  return updateExisting(id, (job) =>
+    job.status === "prepared" ? { ...job, status: "compiling" } : null, factory
+  );
+}
+
+export async function completePdfJob(
+  id: string,
+  output: { pdf: Uint8Array; diagnostics: RawPdfDiagnostic[]; compilerVersion: string },
+  factory?: IDBFactory
+): Promise<StoredPdfJob | undefined> {
+  if (output.pdf.byteLength > PDF_JOB_MAX_BYTES) {
+    throw new Error(`PDF result exceeds the ${PDF_JOB_MAX_BYTES} byte job limit.`);
+  }
+  const db = await openPdfJobDb(factory);
+  try {
+    return await transaction(db, "readwrite", (store, done, reject) => {
+      const inventory = store.getAll();
+      inventory.onerror = () => reject(inventory.error);
+      inventory.onsuccess = () => {
+        const jobs = inventory.result as StoredPdfJob[];
+        const current = jobs.find((job) => job.id === id);
+        if (!current || current.status !== "compiling") {
+          done(current);
+          return;
+        }
+        const total = jobs.reduce((sum, job) => sum + storedJobBytes(job), 0);
+        if (total + output.pdf.byteLength > PDF_STORE_MAX_BYTES) {
+          reject(new Error("PDF export storage exceeds the 128 MB total quota."));
+          return;
+        }
+        const next: StoredPdfJob = {
+          ...current,
+          status: "complete",
+          pdf: output.pdf,
+          diagnostics: output.diagnostics,
+          compilerVersion: output.compilerVersion,
+        };
+        const write = store.put(next);
+        write.onsuccess = () => done(next);
+        write.onerror = () => reject(write.error);
+      };
+    });
+  } finally {
+    db.close();
+  }
+}
+
+export function failPdfJob(
+  id: string,
+  error: string,
+  diagnostics: RawPdfDiagnostic[] = [],
+  factory?: IDBFactory
+): Promise<StoredPdfJob | undefined> {
+  return updateExisting(id, (job) =>
+    job.status === "prepared" || job.status === "compiling"
+      ? { ...job, status: "failed", error, diagnostics }
+      : null, factory
+  );
+}
+
+export function cancelPdfJob(id: string, factory?: IDBFactory): Promise<StoredPdfJob | undefined> {
+  return updateExisting(id, (job) =>
+    job.status === "complete" || job.status === "failed"
+      ? null
+      : { ...job, status: "cancelled", error: "PDF export was cancelled." }, factory
+  );
+}
+
+export async function deletePdfJob(id: string, factory?: IDBFactory): Promise<void> {
+  const db = await openPdfJobDb(factory);
+  try {
+    await transaction(db, "readwrite", (store, done, reject) => {
+      const request = store.delete(id);
+      request.onsuccess = () => done(undefined);
+      request.onerror = () => reject(request.error);
+    });
+  } finally {
+    db.close();
+  }
+}
+
+export async function cleanupPdfJobs(
+  options: { now?: number; maxAgeMs?: number } = {},
+  factory?: IDBFactory
+): Promise<number> {
+  const cutoff = (options.now ?? Date.now()) - (options.maxAgeMs ?? PDF_JOB_MAX_AGE_MS);
+  const db = await openPdfJobDb(factory);
+  try {
+    return await transaction(db, "readwrite", (store, done, reject) => {
+      let deleted = 0;
+      const request = store.index("createdAt").openCursor(IDBKeyRange.upperBound(cutoff, true));
+      request.onerror = () => reject(request.error);
+      request.onsuccess = () => {
+        const cursor = request.result;
+        if (!cursor) {
+          done(deleted);
+          return;
+        }
+        cursor.delete();
+        deleted += 1;
+        cursor.continue();
+      };
+    });
+  } finally {
+    db.close();
+  }
+}

--- a/apps/extension/utils/pdf/run-export.ts
+++ b/apps/extension/utils/pdf/run-export.ts
@@ -1,0 +1,258 @@
+import { storageToBlocks, type ExportBlock, type ExportNote } from "@atlcli/confluence/browser";
+import {
+  preparePdfDocument,
+  serializePdfDocument,
+  type PdfAssetResolver,
+  type PdfExportReport,
+  type PdfSourceBundle,
+  type PreparedPdfBlock,
+} from "@atlcli/pdf/browser";
+import type { LoadedPage } from "../read-path.js";
+import { profileFromTabUrl } from "../profile.js";
+import { sessionAssetFetcher } from "../docx/env.js";
+import { downloadBytes, sanitizeDownloadName } from "../download.js";
+import {
+  cleanupPdfJobs,
+  createPdfJobId,
+  deletePdfJob,
+  getPdfJob,
+  putPdfJob,
+} from "./job-store.js";
+import { validatePdfOutput } from "./validate.js";
+
+export type PdfExportPhase =
+  | "preparing"
+  | "fetching"
+  | "queued"
+  | "compiling"
+  | "validating"
+  | "downloading";
+
+export interface RunPdfExportInput {
+  page: LoadedPage;
+  pageUrl: string;
+  signal?: AbortSignal;
+  onPhase?: (phase: PdfExportPhase) => void;
+}
+
+export interface RunPdfExportDeps {
+  now: () => number;
+  makeJobId: () => string;
+  createJob: typeof putPdfJob;
+  getJob: typeof getPdfJob;
+  deleteJob: typeof deletePdfJob;
+  cleanupJobs: typeof cleanupPdfJobs;
+  sendMessage: (message: { kind: "pdf:compile" | "pdf:cancel"; jobId: string }) => Promise<unknown>;
+  download: (name: string, bytes: Uint8Array) => Promise<void>;
+  prepare: typeof preparePdfDocument;
+  serialize: typeof serializePdfDocument;
+  resolver?: PdfAssetResolver;
+}
+
+const defaultDeps: RunPdfExportDeps = {
+  now: () => Date.now(),
+  makeJobId: () => createPdfJobId(),
+  createJob: putPdfJob,
+  getJob: getPdfJob,
+  deleteJob: deletePdfJob,
+  cleanupJobs: cleanupPdfJobs,
+  sendMessage: (message) => chrome.runtime.sendMessage(message),
+  download: (name, bytes) => downloadBytes({ name, bytes, mimeType: "application/pdf" }),
+  prepare: preparePdfDocument,
+  serialize: serializePdfDocument,
+};
+
+export function normalizePdfLocale(locale: string | undefined): {
+  language: string;
+  region?: string;
+} {
+  const parts = (locale ?? "")
+    .trim()
+    .replaceAll("_", "-")
+    .split("-")
+    .filter(Boolean);
+  const rawLanguage = parts[0] ?? "";
+  const language = /^[a-z]{2,3}$/i.test(rawLanguage) ? rawLanguage.toLowerCase() : "en";
+  const rawRegion = parts.slice(1).find((part) => /^(?:[a-z]{2}|[0-9]{3})$/i.test(part));
+  return rawRegion ? { language, region: rawRegion.toUpperCase() } : { language };
+}
+
+function mimeFromFilename(filename: string): string {
+  const extension = filename.split(".").pop()?.toLowerCase();
+  switch (extension) {
+    case "png": return "image/png";
+    case "jpg":
+    case "jpeg": return "image/jpeg";
+    case "gif": return "image/gif";
+    case "svg": return "image/svg+xml";
+    case "webp": return "image/webp";
+    default: return "application/octet-stream";
+  }
+}
+
+function pageResolver(page: LoadedPage, pageUrl: string, signal?: AbortSignal): PdfAssetResolver {
+  const profile = profileFromTabUrl(pageUrl);
+  if (!profile) {
+    return { resolve: async () => { throw new Error("The active page is not on an approved Atlassian host."); } };
+  }
+  const baseUrl = `${profile.baseUrl.replace(/\/+$/, "")}/wiki`;
+  const fetcher = sessionAssetFetcher(
+    baseUrl,
+    ((request: RequestInfo | URL, init?: RequestInit) =>
+      fetch(request, { ...init, signal })) as typeof fetch
+  );
+  return {
+    async resolve(ref) {
+      throwIfAborted(signal);
+      if (ref.kind === "external") {
+        throw new Error("External image hosts are not fetched by the PDF exporter.");
+      }
+      const filename = ref.filename ?? "attachment";
+      const bytes = await fetcher.fetch({
+        url: `/download/attachments/${encodeURIComponent(page.details.id)}/${encodeURIComponent(filename)}`,
+        pageId: page.details.id,
+        filename,
+      });
+      throwIfAborted(signal);
+      if (bytes.byteLength === 0) throw new Error("Attachment response was empty.");
+      return { bytes, mediaType: mimeFromFilename(filename), filename };
+    },
+  };
+}
+
+function countPrepared(blocks: PreparedPdfBlock[]): { images: number; diagrams: number; skipped: number } {
+  const total = { images: 0, diagrams: 0, skipped: 0 };
+  const walk = (list: PreparedPdfBlock[]): void => {
+    for (const block of list) {
+      switch (block.type) {
+        case "image":
+          if (block.assetPath) total.images += 1;
+          else total.skipped += 1;
+          break;
+        case "diagram":
+          total.diagrams += 1;
+          break;
+        case "callout":
+        case "blockquote":
+          walk(block.content);
+          break;
+        case "list":
+          for (const item of block.items) walk(item.content);
+          break;
+        case "table":
+          for (const row of block.rows) for (const cell of row.cells) walk(cell.content);
+          break;
+      }
+    }
+  };
+  walk(blocks);
+  return total;
+}
+
+function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) throw new DOMException("PDF export was cancelled.", "AbortError");
+}
+
+export async function runPdfExport(
+  input: RunPdfExportInput,
+  overrides: Partial<RunPdfExportDeps> = {}
+): Promise<PdfExportReport> {
+  const deps = { ...defaultDeps, ...overrides };
+  const startedAt = deps.now();
+  await deps.cleanupJobs().catch(() => 0);
+  throwIfAborted(input.signal);
+
+  input.onPhase?.("preparing");
+  const { blocks, notes: walkerNotes } = storageToBlocks(input.page.details.storage ?? "");
+  input.onPhase?.("fetching");
+  const prepareStarted = deps.now();
+  const prepared = await deps.prepare(
+    blocks,
+    deps.resolver ?? pageResolver(input.page, input.pageUrl, input.signal)
+  );
+  const prepareMs = deps.now() - prepareStarted;
+  throwIfAborted(input.signal);
+
+  const exportedAt = new Date(deps.now());
+  const runtimeLocale =
+    (typeof document !== "undefined" ? document.documentElement.lang : "") ||
+    (typeof navigator !== "undefined" ? navigator.language : "") ||
+    "en";
+  const locale = normalizePdfLocale(runtimeLocale);
+  const bundle: PdfSourceBundle = deps.serialize(prepared, {
+    metadata: {
+      title: input.page.details.title,
+      space: input.page.details.spaceKey,
+      version: input.page.details.version,
+      author: input.page.details.modifiedBy?.displayName,
+      exporter: input.page.details.modifiedBy?.displayName ?? "atlcli",
+      language: locale.language,
+      region: locale.region,
+      exportedAt,
+    },
+  });
+  const notes: ExportNote[] = [...walkerNotes, ...bundle.notes];
+  const counts = countPrepared(prepared.blocks);
+  const jobId = deps.makeJobId();
+  const sourceIdentity = `${input.pageUrl}|${input.page.details.id}|${input.page.details.version ?? ""}`;
+  input.onPhase?.("queued");
+  await deps.createJob({ id: jobId, sourceIdentity, bundle });
+
+  let cancelSent = false;
+  const cancel = (): void => {
+    if (cancelSent) return;
+    cancelSent = true;
+    void deps.sendMessage({ kind: "pdf:cancel", jobId }).catch(() => undefined);
+  };
+  input.signal?.addEventListener("abort", cancel, { once: true });
+
+  try {
+    throwIfAborted(input.signal);
+    input.onPhase?.("compiling");
+    const compileStarted = deps.now();
+    const response = (await deps.sendMessage({ kind: "pdf:compile", jobId })) as
+      | { kind?: string; jobId?: string; ok?: boolean; error?: string }
+      | undefined;
+    const compileMs = deps.now() - compileStarted;
+    throwIfAborted(input.signal);
+    if (!response || response.kind !== "pdf:compile-result" || response.jobId !== jobId) {
+      throw new Error("PDF compiler returned no correlated response.");
+    }
+    if (!response.ok) throw new Error(response.error || "PDF compilation failed.");
+    const completed = await deps.getJob(jobId);
+    if (!completed || completed.status !== "complete" || !completed.pdf) {
+      throw new Error(completed?.error ?? "PDF compiler completed without a stored result.");
+    }
+    throwIfAborted(input.signal);
+    input.onPhase?.("validating");
+    const inspection = validatePdfOutput(completed.pdf);
+    input.onPhase?.("downloading");
+    const downloadStarted = deps.now();
+    const filename = sanitizeDownloadName(input.page.details.title, "pdf");
+    await deps.download(filename, completed.pdf);
+    const downloadMs = deps.now() - downloadStarted;
+    return {
+      filename,
+      profile: "tagged",
+      compilerVersion: completed.compilerVersion ?? "unknown",
+      pageCount: inspection.pageCount,
+      embeddedImages: counts.images,
+      renderedDiagrams: counts.diagrams,
+      skippedAssets: counts.skipped,
+      notes,
+      timings: {
+        prepareMs,
+        compileMs,
+        downloadMs,
+        totalMs: deps.now() - startedAt,
+      },
+    };
+  } finally {
+    input.signal?.removeEventListener("abort", cancel);
+    await deps.deleteJob(jobId).catch(() => undefined);
+  }
+}
+
+export function hasPdfRelevantBlocks(blocks: ExportBlock[]): boolean {
+  return blocks.length > 0;
+}

--- a/apps/extension/utils/pdf/validate.ts
+++ b/apps/extension/utils/pdf/validate.ts
@@ -1,0 +1,32 @@
+export interface PdfOutputInspection {
+  pageCount: number;
+  tagged: boolean;
+  hasOutline: boolean;
+  embeddedFontFiles: number;
+}
+
+/**
+ * Cheap in-browser structural gate before download. Deep parsing and visual QA
+ * stay in the automated fixture workflow, but malformed or untagged output
+ * must never be presented as a successful export.
+ */
+export function validatePdfOutput(bytes: Uint8Array): PdfOutputInspection {
+  if (bytes.byteLength < 32) throw new Error("PDF compiler returned a truncated document.");
+  const text = new TextDecoder("latin1").decode(bytes);
+  if (!text.startsWith("%PDF-")) throw new Error("PDF compiler returned invalid file bytes.");
+  if (!/%%EOF\s*$/.test(text)) throw new Error("PDF compiler returned an incomplete document.");
+
+  const pageCount = text.match(/\/Type\s*\/Page\b/g)?.length ?? 0;
+  if (pageCount === 0) throw new Error("PDF contains no pages.");
+  const tagged = /\/StructTreeRoot\b/.test(text) && /\/MarkInfo\b/.test(text);
+  if (!tagged) throw new Error("PDF compiler output is missing the required tag structure.");
+  const embeddedFontFiles = text.match(/\/FontFile(?:2|3)?\b/g)?.length ?? 0;
+  if (embeddedFontFiles === 0) throw new Error("PDF compiler output has no embedded font files.");
+
+  return {
+    pageCount,
+    tagged,
+    hasOutline: /\/Outlines\b/.test(text),
+    embeddedFontFiles,
+  };
+}

--- a/apps/extension/utils/pdf/worker-protocol.ts
+++ b/apps/extension/utils/pdf/worker-protocol.ts
@@ -1,0 +1,11 @@
+export type PdfWorkerRequest = { kind: "pdf-worker:compile"; jobId: string };
+
+export type PdfWorkerResponse =
+  | { kind: "pdf-worker:complete"; jobId: string; ok: true }
+  | { kind: "pdf-worker:complete"; jobId: string; ok: false; error: string; fatal: boolean };
+
+export function isPdfWorkerResponse(value: unknown): value is PdfWorkerResponse {
+  if (typeof value !== "object" || value === null) return false;
+  const candidate = value as Partial<PdfWorkerResponse>;
+  return candidate.kind === "pdf-worker:complete" && typeof candidate.jobId === "string" && typeof candidate.ok === "boolean";
+}

--- a/apps/extension/utils/router.ts
+++ b/apps/extension/utils/router.ts
@@ -15,6 +15,10 @@ export interface RouterDeps {
   runWasmSmoke: (a: number, b: number) => Promise<number>;
   /** Resolves the active tab's current entity (queries `chrome.tabs`). */
   getCurrentEntity: () => Promise<EntityDetection>;
+  /** Compiles a prepared PDF job through the offscreen worker. */
+  runPdfCompile: (jobId: string) => Promise<{ ok: true } | { ok: false; error: string }>;
+  /** Cancels a queued or active PDF job. */
+  runPdfCancel: (jobId: string) => Promise<boolean>;
 }
 
 /**
@@ -44,6 +48,25 @@ export async function routeMessage(
     case "get-current-entity": {
       const detection = await deps.getCurrentEntity();
       return { kind: "current-entity", detection };
+    }
+    case "pdf:compile": {
+      try {
+        const result = await deps.runPdfCompile(msg.jobId);
+        return result.ok
+          ? { kind: "pdf:compile-result", jobId: msg.jobId, ok: true }
+          : { kind: "pdf:compile-result", jobId: msg.jobId, ok: false, error: result.error };
+      } catch (error) {
+        return {
+          kind: "pdf:compile-result",
+          jobId: msg.jobId,
+          ok: false,
+          error: error instanceof Error ? error.message : String(error),
+        };
+      }
+    }
+    case "pdf:cancel": {
+      const cancelled = await deps.runPdfCancel(msg.jobId).catch(() => false);
+      return { kind: "pdf:cancel-result", jobId: msg.jobId, cancelled };
     }
     default: {
       // Exhaustiveness: adding a request kind without handling it fails typecheck.

--- a/apps/extension/workers/pdf-compiler.ts
+++ b/apps/extension/workers/pdf-compiler.ts
@@ -1,0 +1,104 @@
+/// <reference lib="webworker" />
+
+import wasmUrl from "@myriaddreamin/typst-ts-web-compiler/wasm?url";
+import sansRegularUrl from "@atlcli/pdf/fonts/SourceSans3-Regular.ttf?url";
+import sansItalicUrl from "@atlcli/pdf/fonts/SourceSans3-It.ttf?url";
+import sansSemiBoldUrl from "@atlcli/pdf/fonts/SourceSans3-Semibold.ttf?url";
+import sansBoldUrl from "@atlcli/pdf/fonts/SourceSans3-Bold.ttf?url";
+import serifRegularUrl from "@atlcli/pdf/fonts/SourceSerif4-Regular.ttf?url";
+import serifItalicUrl from "@atlcli/pdf/fonts/SourceSerif4-It.ttf?url";
+import serifSemiBoldUrl from "@atlcli/pdf/fonts/SourceSerif4-Semibold.ttf?url";
+import serifBoldUrl from "@atlcli/pdf/fonts/SourceSerif4-Bold.ttf?url";
+import codeRegularUrl from "@atlcli/pdf/fonts/SourceCodePro-Regular.ttf?url";
+import codeBoldUrl from "@atlcli/pdf/fonts/SourceCodePro-Bold.ttf?url";
+import sansLicenseUrl from "@atlcli/pdf/licenses/LICENSE-Source-Sans-3.txt?url&no-inline";
+import serifLicenseUrl from "@atlcli/pdf/licenses/LICENSE-Source-Serif-4.txt?url&no-inline";
+import codeLicenseUrl from "@atlcli/pdf/licenses/LICENSE-Source-Code-Pro.txt?url&no-inline";
+import compilerLicenseUrl from "../../../LICENSE?url&no-inline";
+import {
+  BrowserPdfCompiler,
+  PDF_COMPILER_VERSION,
+  formatPdfDiagnostics,
+} from "../utils/pdf/compiler.js";
+import {
+  claimPdfJob,
+  completePdfJob,
+  failPdfJob,
+  getPdfJob,
+} from "../utils/pdf/job-store.js";
+import type { PdfWorkerRequest, PdfWorkerResponse } from "../utils/pdf/worker-protocol.js";
+
+const workerScope = self as unknown as DedicatedWorkerGlobalScope;
+
+async function fetchBytes(url: string): Promise<Uint8Array<ArrayBuffer>> {
+  const response = await fetch(url);
+  if (!response.ok) throw new Error(`Packaged PDF compiler asset failed to load (${response.status}).`);
+  return new Uint8Array(await response.arrayBuffer());
+}
+
+let compilerPromise: Promise<BrowserPdfCompiler> | null = null;
+const packagedLicenses = [sansLicenseUrl, serifLicenseUrl, codeLicenseUrl, compilerLicenseUrl];
+
+function getCompiler(): Promise<BrowserPdfCompiler> {
+  if (!compilerPromise) {
+    if (packagedLicenses.some((url) => !url)) {
+      return Promise.reject(new Error("PDF runtime license assets are missing."));
+    }
+    compilerPromise = Promise.all([
+      fetchBytes(wasmUrl),
+      fetchBytes(sansRegularUrl),
+      fetchBytes(sansItalicUrl),
+      fetchBytes(sansSemiBoldUrl),
+      fetchBytes(sansBoldUrl),
+      fetchBytes(serifRegularUrl),
+      fetchBytes(serifItalicUrl),
+      fetchBytes(serifSemiBoldUrl),
+      fetchBytes(serifBoldUrl),
+      fetchBytes(codeRegularUrl),
+      fetchBytes(codeBoldUrl),
+    ])
+      .then(([wasm, ...fonts]) => new BrowserPdfCompiler({ wasm: wasm.buffer, fonts }))
+      .catch((error) => {
+        compilerPromise = null;
+        throw error;
+      });
+  }
+  return compilerPromise;
+}
+
+async function compileJob(jobId: string): Promise<PdfWorkerResponse> {
+  try {
+    const claimed = await claimPdfJob(jobId);
+    if (!claimed || claimed.status !== "compiling") {
+      throw new Error("PDF job is missing, cancelled, or no longer ready to compile.");
+    }
+    const compiler = await getCompiler();
+    const result = await compiler.compile(claimed.bundle);
+    if (!result.pdf) {
+      const error = formatPdfDiagnostics(result.diagnostics, claimed.bundle.sourceMap);
+      await failPdfJob(jobId, error, result.diagnostics);
+      return { kind: "pdf-worker:complete", jobId, ok: false, error, fatal: false };
+    }
+    const completed = await completePdfJob(jobId, {
+      pdf: result.pdf,
+      diagnostics: result.diagnostics,
+      compilerVersion: PDF_COMPILER_VERSION,
+    });
+    if (!completed || completed.status !== "complete") {
+      throw new Error("PDF job was cancelled before the result could be stored.");
+    }
+    return { kind: "pdf-worker:complete", jobId, ok: true };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const current = await getPdfJob(jobId).catch(() => undefined);
+    if (current?.status === "prepared" || current?.status === "compiling") {
+      await failPdfJob(jobId, message).catch(() => undefined);
+    }
+    return { kind: "pdf-worker:complete", jobId, ok: false, error: message, fatal: true };
+  }
+}
+
+workerScope.addEventListener("message", (event: MessageEvent<PdfWorkerRequest>) => {
+  if (event.data?.kind !== "pdf-worker:compile") return;
+  void compileJob(event.data.jobId).then((response) => workerScope.postMessage(response));
+});

--- a/bun.lock
+++ b/bun.lock
@@ -42,6 +42,8 @@
         "@atlcli/confluence": "workspace:*",
         "@atlcli/core": "workspace:*",
         "@atlcli/docx": "workspace:*",
+        "@atlcli/pdf": "workspace:*",
+        "@myriaddreamin/typst-ts-web-compiler": "0.7.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
       },
@@ -110,10 +112,21 @@
         "@atlcli/core": "workspace:*",
       },
     },
+    "packages/pdf": {
+      "name": "@atlcli/pdf",
+      "version": "0.6.0",
+      "dependencies": {
+        "@atlcli/confluence": "workspace:*",
+        "@atlcli/diagram": "workspace:*",
+      },
+    },
     "packages/plugin-api": {
       "name": "@atlcli/plugin-api",
       "version": "0.6.0",
     },
+  },
+  "patchedDependencies": {
+    "@myriaddreamin/typst-ts-web-compiler@0.7.0": "patches/@myriaddreamin%2Ftypst-ts-web-compiler@0.7.0.patch",
   },
   "packages": {
     "@1natsu/wait-element": ["@1natsu/wait-element@4.2.0", "", { "dependencies": { "defu": "^6.1.4", "many-keys-map": "^3.0.0" } }, "sha512-Om0Q+WE9mNrpY4AwMTvkFiYHv8VM7TML3PvOqXy+w6kAjLjKhGYHYX+305+a6J8RVpds9s7IF2Z5aOPYwULFNw=="],
@@ -179,6 +192,8 @@
     "@atlcli/extension": ["@atlcli/extension@workspace:apps/extension"],
 
     "@atlcli/jira": ["@atlcli/jira@workspace:packages/jira"],
+
+    "@atlcli/pdf": ["@atlcli/pdf@workspace:packages/pdf"],
 
     "@atlcli/plugin-api": ["@atlcli/plugin-api@workspace:packages/plugin-api"],
 
@@ -371,6 +386,8 @@
     "@mdx-js/mdx": ["@mdx-js/mdx@3.1.1", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdx": "^2.0.0", "acorn": "^8.0.0", "collapse-white-space": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "estree-util-scope": "^1.0.0", "estree-walker": "^3.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "markdown-extensions": "^2.0.0", "recma-build-jsx": "^1.0.0", "recma-jsx": "^1.0.0", "recma-stringify": "^1.0.0", "rehype-recma": "^1.0.0", "remark-mdx": "^3.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "source-map": "^0.7.0", "unified": "^11.0.0", "unist-util-position-from-estree": "^2.0.0", "unist-util-stringify-position": "^4.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ=="],
 
     "@mixmark-io/domino": ["@mixmark-io/domino@2.2.0", "", {}, "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw=="],
+
+    "@myriaddreamin/typst-ts-web-compiler": ["@myriaddreamin/typst-ts-web-compiler@0.7.0", "", {}, "sha512-nMwMcfOBy5pABPDuVM7/u8425SxhPUM+OJe6daqqgVOT3+neCTz4JKwx2L8XasfEHTNvd0cUI07LR9q5ADo7Gw=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
   ],
   "scripts": {
     "start": "bun run --cwd apps/cli src/index.ts",
+    "fonts:ensure": "bun packages/pdf/scripts/ensure-fonts.ts",
+    "prebuild": "bun run fonts:ensure",
     "build": "turbo run build",
     "release": "bun scripts/release.ts",
     "build:cli": "bun run --cwd apps/cli build",
@@ -21,6 +23,7 @@
     "typecheck:extension": "turbo run typecheck --filter=@atlcli/extension",
     "check:extension-output": "bun run --cwd apps/extension check:output",
     "obfuscate": "terser dist/index.js --compress --mangle --output dist/index.js",
+    "prebuild:prod": "bun run fonts:ensure",
     "build:prod": "turbo run build && bun run obfuscate",
     "version:core": "npm version --no-git-tag-version -w @atlcli/core -w @atlcli/confluence -w @atlcli/plugin-api",
     "version:cli": "npm version --no-git-tag-version -w @atlcli/cli",

--- a/package.json
+++ b/package.json
@@ -43,5 +43,8 @@
     "terser": "^5.44.1",
     "turbo": "^2.7.4",
     "typescript": "^5.9.3"
+  },
+  "patchedDependencies": {
+    "@myriaddreamin/typst-ts-web-compiler@0.7.0": "patches/@myriaddreamin%2Ftypst-ts-web-compiler@0.7.0.patch"
   }
 }

--- a/packages/confluence/src/export-blocks.test.ts
+++ b/packages/confluence/src/export-blocks.test.ts
@@ -211,8 +211,8 @@ describe("storageToBlocks — tables", () => {
 
   test("modern Cloud markup: <colgroup> + ac:local-id + <p local-id> wrappers (regression)", () => {
     // This is the exact shape that broke the markdown table path: a leading
-    // <colgroup> made <tbody> a non-first sibling. The walker shares the same
-    // column-metadata strip, and its own parser tolerates the id attributes.
+    // <colgroup> made <tbody> a non-first sibling. The rich walker tolerates
+    // the metadata and retains the author's column proportions.
     const storage =
       '<table data-layout="default" ac:local-id="1f2e3d4c">' +
       '<colgroup><col style="width: 226.0px;"/><col style="width: 226.0px;"/></colgroup>' +
@@ -222,9 +222,11 @@ describe("storageToBlocks — tables", () => {
       "</tbody></table>";
     const table = blocks(storage)[0] as {
       type: "table";
+      columnWidths?: number[];
       rows: { cells: { header: boolean; content: ExportBlock[] }[] }[];
     };
     expect(table.type).toBe("table");
+    expect(table.columnWidths).toEqual([226, 226]);
     expect(table.rows).toHaveLength(2);
     expect(table.rows[0].cells.every((c) => c.header)).toBe(true);
     expect(table.rows[0].cells[0].content).toEqual([
@@ -233,6 +235,22 @@ describe("storageToBlocks — tables", () => {
     expect(table.rows[1].cells[1].content).toEqual([
       { type: "paragraph", content: [{ type: "text", text: "Engineer" }] },
     ]);
+  });
+
+  test("normalizes absolute colgroup units and expands spans", () => {
+    const table = blocks(
+      '<table><colgroup><col width="72pt"/><col style="width: 25.4mm" span="2"/></colgroup>' +
+        '<tbody><tr><td>A</td><td>B</td><td>C</td></tr></tbody></table>'
+    )[0] as Extract<ExportBlock, { type: "table" }>;
+    expect(table.columnWidths).toEqual([96, 96, 96]);
+  });
+
+  test("drops incomplete colgroup widths instead of inventing proportions", () => {
+    const table = blocks(
+      '<table><colgroup><col style="width: 100px"/><col/></colgroup>' +
+        '<tbody><tr><td>A</td><td>B</td></tr></tbody></table>'
+    )[0] as Extract<ExportBlock, { type: "table" }>;
+    expect(table.columnWidths).toBeUndefined();
   });
 });
 

--- a/packages/confluence/src/export-blocks.ts
+++ b/packages/confluence/src/export-blocks.ts
@@ -15,16 +15,17 @@
  *   service workers) and no node deps.
  * - **Consumer-neutral.** No DOCX-isms bake in here (no OOXML, no EMU sizing).
  *   The model describes *content*, serializers decide *presentation*.
- * - **Shared normalization.** Reuses {@link stripTableColumnMetadata} and
- *   {@link KNOWN_MACROS} from the markdown converter so both paths see the same
- *   normalized markup (notably the modern-Cloud `<colgroup>` table strip).
+ * - **Shared macro vocabulary.** Reuses {@link KNOWN_MACROS} from the markdown
+ *   converter. Unlike markdown, the rich export model deliberately retains
+ *   modern-Cloud `<colgroup>` widths so DOCX/PDF serializers can preserve the
+ *   author's table geometry.
  * - **Never silently drop.** Unknown macros become an explicit
  *   {@link UnknownBlock} plus an {@link ExportNote}; raw storage XML is never
  *   passed through verbatim.
  */
 
 import { decodeHTML } from "entities";
-import { KNOWN_MACROS, stripTableColumnMetadata } from "./markdown.js";
+import { KNOWN_MACROS } from "./markdown.js";
 
 // ---------------------------------------------------------------------------
 // Model
@@ -102,7 +103,7 @@ export type ExportBlock =
   | { type: "codeBlock"; language?: string; code: string }
   | { type: "callout"; kind: CalloutKind; title?: string; content: ExportBlock[] }
   | { type: "list"; ordered: boolean; items: ListItem[] }
-  | { type: "table"; rows: TableRow[] }
+  | { type: "table"; rows: TableRow[]; columnWidths?: number[] }
   | { type: "image"; source: ImageSource; alt?: string; width?: number; height?: number }
   | { type: "blockquote"; content: ExportBlock[] }
   | { type: "divider" }
@@ -326,10 +327,7 @@ const TRANSPARENT_BLOCK_TAGS = new Set([
  */
 export function storageToBlocks(storage: string): StorageToBlocksResult {
   const ctx: WalkCtx = { notes: [] };
-  // Share the converter's column-metadata strip so both paths normalize the
-  // modern-Cloud `<colgroup>` table markup identically.
-  const normalized = stripTableColumnMetadata(storage);
-  const nodes = parseXml(normalized);
+  const nodes = parseXml(storage);
   const blocks = walkBlocks(nodes, ctx);
   return { blocks, notes: ctx.notes };
 }
@@ -489,6 +487,42 @@ function walkTaskList(el: XmlElement, ctx: WalkCtx): ExportBlock {
 
 // ---- Tables ---------------------------------------------------------------
 
+/** Convert a CSS absolute length to a common pixel-like weight. */
+function parseColumnWidth(value: string | undefined): number | undefined {
+  if (!value) return undefined;
+  const match = value.trim().match(/^([0-9]+(?:\.[0-9]+)?)\s*(px|pt|pc|in|cm|mm|%)?$/i);
+  if (!match) return undefined;
+  const amount = Number.parseFloat(match[1]!);
+  if (!Number.isFinite(amount) || amount <= 0) return undefined;
+  switch ((match[2] ?? "px").toLowerCase()) {
+    case "pt": return amount * (96 / 72);
+    case "pc": return amount * 16;
+    case "in": return amount * 96;
+    case "cm": return amount * (96 / 2.54);
+    case "mm": return amount * (96 / 25.4);
+    case "%":
+    case "px":
+    default: return amount;
+  }
+}
+
+function tableColumnWidths(table: XmlElement): number[] | undefined {
+  const colgroup = table.children.find(
+    (child): child is XmlElement => child.type === "element" && child.name === "colgroup"
+  );
+  if (!colgroup) return undefined;
+  const widths: number[] = [];
+  for (const child of colgroup.children) {
+    if (child.type !== "element" || child.name !== "col") continue;
+    const styleWidth = child.attrs.style?.match(/(?:^|;)\s*width\s*:\s*([^;]+)/i)?.[1];
+    const width = parseColumnWidth(styleWidth ?? child.attrs.width);
+    if (width === undefined) return undefined;
+    const span = parsePositiveInt(child.attrs.span) ?? 1;
+    for (let index = 0; index < span; index += 1) widths.push(width);
+  }
+  return widths.length > 0 ? widths : undefined;
+}
+
 function walkTable(el: XmlElement, ctx: WalkCtx): ExportBlock {
   const rows: TableRow[] = [];
   const rowEls: XmlElement[] = [];
@@ -516,7 +550,8 @@ function walkTable(el: XmlElement, ctx: WalkCtx): ExportBlock {
     }
     rows.push({ cells });
   }
-  return { type: "table", rows };
+  const columnWidths = tableColumnWidths(el);
+  return { type: "table", rows, ...(columnWidths ? { columnWidths } : {}) };
 }
 
 function parsePositiveInt(value: string | undefined): number | undefined {

--- a/packages/pdf/licenses/LICENSE-Source-Code-Pro.txt
+++ b/packages/pdf/licenses/LICENSE-Source-Code-Pro.txt
@@ -1,0 +1,93 @@
+© 2023 Adobe (http://www.adobe.com/), with Reserved Font Name 'Source'. All Rights Reserved. Source is a trademark of Adobe in the United States and/or other countries.
+
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+
+This license is copied below, and is also available with a FAQ at: http://scripts.sil.org/OFL
+
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font creation
+efforts of academic and linguistic communities, and to provide a free and
+open framework in which fonts may be shared and improved in partnership
+with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded,
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply
+to any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components as
+distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting -- in part or in whole -- any of the components of the
+Original Version, by changing formats or by porting the Font Software to a
+new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components,
+in Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the corresponding
+Copyright Holder. This restriction only applies to the primary font name as
+presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created
+using the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.

--- a/packages/pdf/licenses/LICENSE-Source-Sans-3.txt
+++ b/packages/pdf/licenses/LICENSE-Source-Sans-3.txt
@@ -1,0 +1,93 @@
+Copyright 2010-2024 Adobe (http://www.adobe.com/), with Reserved Font Name 'Source'. All Rights Reserved. Source is a trademark of Adobe in the United States and/or other countries.
+
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+
+This license is copied below, and is also available with a FAQ at: http://scripts.sil.org/OFL
+
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font creation
+efforts of academic and linguistic communities, and to provide a free and
+open framework in which fonts may be shared and improved in partnership
+with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded, 
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply
+to any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components as
+distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting -- in part or in whole -- any of the components of the
+Original Version, by changing formats or by porting the Font Software to a
+new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components,
+in Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the corresponding
+Copyright Holder. This restriction only applies to the primary font name as
+presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created
+using the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.

--- a/packages/pdf/licenses/LICENSE-Source-Serif-4.txt
+++ b/packages/pdf/licenses/LICENSE-Source-Serif-4.txt
@@ -1,0 +1,93 @@
+Copyright 2014 - 2023 Adobe (http://www.adobe.com/), with Reserved Font Name ‘Source’. All Rights Reserved. Source is a trademark of Adobe in the United States and/or other countries.
+
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+
+This license is copied below, and is also available with a FAQ at: http://scripts.sil.org/OFL
+
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font creation
+efforts of academic and linguistic communities, and to provide a free and
+open framework in which fonts may be shared and improved in partnership
+with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded,
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply
+to any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components as
+distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting -- in part or in whole -- any of the components of the
+Original Version, by changing formats or by porting the Font Software to a
+new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components,
+in Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the corresponding
+Copyright Holder. This restriction only applies to the primary font name as
+presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created
+using the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.

--- a/packages/pdf/package.json
+++ b/packages/pdf/package.json
@@ -10,7 +10,9 @@
       "default": "./src/index.ts"
     },
     "./browser": "./src/index.browser.ts",
-    "./template": "./src/template.ts"
+    "./template": "./src/template.ts",
+    "./fonts/*": "./.fonts/*",
+    "./licenses/*": "./licenses/*"
   },
   "dependencies": {
     "@atlcli/confluence": "workspace:*",

--- a/packages/pdf/package.json
+++ b/packages/pdf/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@atlcli/pdf",
+  "version": "0.6.0",
+  "license": "Apache-2.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "browser": "./src/index.browser.ts",
+      "default": "./src/index.ts"
+    },
+    "./browser": "./src/index.browser.ts",
+    "./template": "./src/template.ts"
+  },
+  "dependencies": {
+    "@atlcli/confluence": "workspace:*",
+    "@atlcli/diagram": "workspace:*"
+  }
+}

--- a/packages/pdf/scripts/ensure-fonts.test.ts
+++ b/packages/pdf/scripts/ensure-fonts.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { createHash } from "node:crypto";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { ensurePdfFonts, type PdfFontAsset } from "./ensure-fonts.js";
+
+const temporaryDirectories: string[] = [];
+
+function digest(bytes: Uint8Array): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+async function temporaryDirectory(): Promise<string> {
+  const path = await mkdtemp(join(tmpdir(), "atlcli-pdf-fonts-"));
+  temporaryDirectories.push(path);
+  return path;
+}
+
+function asset(bytes: Uint8Array): PdfFontAsset {
+  return {
+    fileName: "Fixture.ttf",
+    url: "https://fonts.example/Fixture.ttf",
+    sha256: digest(bytes),
+  };
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories.splice(0).map((path) => rm(path, { recursive: true, force: true })),
+  );
+});
+
+describe("ensurePdfFonts", () => {
+  it("reuses a checksum-valid cached font without network access", async () => {
+    const cacheDir = await temporaryDirectory();
+    const bytes = new Uint8Array([1, 2, 3]);
+    await writeFile(join(cacheDir, "Fixture.ttf"), bytes);
+    let fetches = 0;
+
+    const result = await ensurePdfFonts({
+      cacheDir,
+      assets: [asset(bytes)],
+      fetchImpl: async () => {
+        fetches += 1;
+        return new Response(null, { status: 500 });
+      },
+      logger: () => {},
+    });
+
+    expect(fetches).toBe(0);
+    expect(result.downloaded).toEqual([]);
+    expect(result.reused).toEqual(["Fixture.ttf"]);
+  });
+
+  it("downloads a missing font and writes only checksum-valid bytes", async () => {
+    const cacheDir = await temporaryDirectory();
+    const bytes = new Uint8Array([4, 5, 6]);
+
+    const result = await ensurePdfFonts({
+      cacheDir,
+      assets: [asset(bytes)],
+      fetchImpl: async () => new Response(bytes),
+      logger: () => {},
+    });
+
+    expect(result.downloaded).toEqual(["Fixture.ttf"]);
+    expect(await readFile(join(cacheDir, "Fixture.ttf"))).toEqual(Buffer.from(bytes));
+  });
+
+  it("rejects a tampered download and never installs it", async () => {
+    const cacheDir = await temporaryDirectory();
+    const expected = new Uint8Array([7, 8, 9]);
+    const tampered = new Uint8Array([9, 8, 7]);
+
+    await expect(
+      ensurePdfFonts({
+        cacheDir,
+        assets: [asset(expected)],
+        fetchImpl: async () => new Response(tampered),
+        logger: () => {},
+      }),
+    ).rejects.toThrow("Checksum mismatch for Fixture.ttf");
+    expect(await Bun.file(join(cacheDir, "Fixture.ttf")).exists()).toBe(false);
+  });
+});

--- a/packages/pdf/scripts/ensure-fonts.ts
+++ b/packages/pdf/scripts/ensure-fonts.ts
@@ -1,0 +1,165 @@
+import { createHash, randomUUID } from "node:crypto";
+import { mkdir, readFile, rename, unlink, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export interface PdfFontAsset {
+  fileName: string;
+  url: string;
+  sha256: string;
+}
+
+export interface EnsurePdfFontsOptions {
+  cacheDir?: string;
+  assets?: readonly PdfFontAsset[];
+  fetchImpl?: typeof fetch;
+  logger?: (message: string) => void;
+}
+
+export interface EnsurePdfFontsResult {
+  cacheDir: string;
+  downloaded: string[];
+  reused: string[];
+}
+
+const SOURCE_SANS_COMMIT = "ed1808970eb3c7301c9a523bee26473ba0bb62fa";
+const SOURCE_SERIF_COMMIT = "2823e993c53fca27c5c8749f529b56a5a7c77b6b";
+const SOURCE_CODE_PRO_COMMIT = "d3f1a5962cde503f9409c21e58527611d4a19ef1";
+
+function adobeRaw(repo: string, commit: string, fileName: string): string {
+  return `https://raw.githubusercontent.com/adobe-fonts/${repo}/${commit}/TTF/${fileName}`;
+}
+
+export const PDF_FONT_ASSETS: readonly PdfFontAsset[] = [
+  {
+    fileName: "SourceSans3-Regular.ttf",
+    url: adobeRaw("source-sans", SOURCE_SANS_COMMIT, "SourceSans3-Regular.ttf"),
+    sha256: "4644c81b86ec9caaa76b634889968ed3c4f4f52f054855933acc7c2b21e53b0f",
+  },
+  {
+    fileName: "SourceSans3-It.ttf",
+    url: adobeRaw("source-sans", SOURCE_SANS_COMMIT, "SourceSans3-It.ttf"),
+    sha256: "192afd78f0f54a3c69eaf02d43f4d9a821e9d6110e41d3d25d61a7385cd580e4",
+  },
+  {
+    fileName: "SourceSans3-Semibold.ttf",
+    url: adobeRaw("source-sans", SOURCE_SANS_COMMIT, "SourceSans3-Semibold.ttf"),
+    sha256: "a3f4f8dcf343a8f24dc61951de93f3ba1558b15cd250ba24af8a40e957081b7d",
+  },
+  {
+    fileName: "SourceSans3-Bold.ttf",
+    url: adobeRaw("source-sans", SOURCE_SANS_COMMIT, "SourceSans3-Bold.ttf"),
+    sha256: "9214b9d95e4231c609802815c2646c98174e2102d0d37f88978a7f8e71006e6a",
+  },
+  {
+    fileName: "SourceSerif4-Regular.ttf",
+    url: adobeRaw("source-serif", SOURCE_SERIF_COMMIT, "SourceSerif4-Regular.ttf"),
+    sha256: "e5a4ee6a3d87bb9024796be390c6771e2a0eb1883dae25effaf57ca01668e24b",
+  },
+  {
+    fileName: "SourceSerif4-It.ttf",
+    url: adobeRaw("source-serif", SOURCE_SERIF_COMMIT, "SourceSerif4-It.ttf"),
+    sha256: "9d2950a8f1da66e21502c35d646a1d2148e79f9ea43fd2158cf02f5232e7f430",
+  },
+  {
+    fileName: "SourceSerif4-Semibold.ttf",
+    url: adobeRaw("source-serif", SOURCE_SERIF_COMMIT, "SourceSerif4-Semibold.ttf"),
+    sha256: "36db62940cb5728b12b1802476dc7fcf4c6c519a7bdd476ba23a4e555fc4655f",
+  },
+  {
+    fileName: "SourceSerif4-Bold.ttf",
+    url: adobeRaw("source-serif", SOURCE_SERIF_COMMIT, "SourceSerif4-Bold.ttf"),
+    sha256: "7cf4f4e1ad74f45058d5bc61716b82560442fbdcd9d3654d2dea96bf6c683d86",
+  },
+  {
+    fileName: "SourceCodePro-Regular.ttf",
+    url: adobeRaw("source-code-pro", SOURCE_CODE_PRO_COMMIT, "SourceCodePro-Regular.ttf"),
+    sha256: "74bd80d3e42a08517cd7e1108ba3d86f2da29ac0f3065be95e0357956ab9db37",
+  },
+  {
+    fileName: "SourceCodePro-Bold.ttf",
+    url: adobeRaw("source-code-pro", SOURCE_CODE_PRO_COMMIT, "SourceCodePro-Bold.ttf"),
+    sha256: "b2095e0d657e6d28dc32444a9dacabab0c9241d0bf39d96371756cc9bdbc3a5f",
+  },
+];
+
+export const PDF_FONT_CACHE_DIR = fileURLToPath(new URL("../.fonts/", import.meta.url));
+
+function sha256(bytes: Uint8Array): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+async function cachedChecksum(path: string): Promise<string | null> {
+  try {
+    return sha256(await readFile(path));
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw error;
+  }
+}
+
+async function downloadVerified(
+  asset: PdfFontAsset,
+  targetPath: string,
+  fetchImpl: typeof fetch,
+): Promise<void> {
+  const response = await fetchImpl(asset.url, { redirect: "follow" });
+  if (!response.ok) {
+    throw new Error(`Failed to download ${asset.fileName} (${response.status} ${response.statusText}).`);
+  }
+  const bytes = new Uint8Array(await response.arrayBuffer());
+  const actual = sha256(bytes);
+  if (actual !== asset.sha256) {
+    throw new Error(
+      `Checksum mismatch for ${asset.fileName}: expected ${asset.sha256}, received ${actual}.`,
+    );
+  }
+
+  const temporaryPath = join(
+    dirname(targetPath),
+    `.${asset.fileName}.${process.pid}.${randomUUID()}.tmp`,
+  );
+  await writeFile(temporaryPath, bytes, { mode: 0o644 });
+  try {
+    await rename(temporaryPath, targetPath);
+  } finally {
+    await unlink(temporaryPath).catch(() => {});
+  }
+}
+
+export async function ensurePdfFonts(
+  options: EnsurePdfFontsOptions = {},
+): Promise<EnsurePdfFontsResult> {
+  const cacheDir = options.cacheDir ?? PDF_FONT_CACHE_DIR;
+  const assets = options.assets ?? PDF_FONT_ASSETS;
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const logger = options.logger ?? console.log;
+  await mkdir(cacheDir, { recursive: true });
+
+  const downloaded: string[] = [];
+  const reused: string[] = [];
+  await Promise.all(
+    assets.map(async (asset) => {
+      const targetPath = join(cacheDir, asset.fileName);
+      if ((await cachedChecksum(targetPath)) === asset.sha256) {
+        reused.push(asset.fileName);
+        return;
+      }
+      await downloadVerified(asset, targetPath, fetchImpl);
+      downloaded.push(asset.fileName);
+    }),
+  );
+
+  downloaded.sort();
+  reused.sort();
+  logger(
+    downloaded.length > 0
+      ? `PDF fonts ready: downloaded and verified ${downloaded.length} file(s).`
+      : `PDF fonts ready: verified ${reused.length} cached file(s).`,
+  );
+  return { cacheDir, downloaded, reused };
+}
+
+if (import.meta.main) {
+  await ensurePdfFonts();
+}

--- a/packages/pdf/src/escape.test.ts
+++ b/packages/pdf/src/escape.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "bun:test";
+import { escapeTypstContent, escapeTypstString, typstLabel } from "./escape.js";
+
+describe("Typst escaping", () => {
+  it("escapes markup metacharacters", () => {
+    expect(escapeTypstContent("# * _ $ @ < > [ ] ` \\")).toBe(
+      "\\# \\* \\_ \\$ \\@ \\< \\> \\[ \\] \\` \\\\"
+    );
+  });
+
+  it("escapes string literals and control characters", () => {
+    expect(escapeTypstString('a\\b\n"c"')).toBe('a\\\\b\\n\\"c\\"');
+  });
+
+  it("creates stable non-empty labels", () => {
+    expect(typstLabel("Überblick & Ziele")).toBe("uberblick-ziele");
+    expect(typstLabel("!!!")).toBe("section");
+  });
+});

--- a/packages/pdf/src/escape.ts
+++ b/packages/pdf/src/escape.ts
@@ -1,0 +1,35 @@
+/** Escape literal text for Typst markup content. */
+export function escapeTypstContent(value: string): string {
+  return value.replace(/[\\#*_$@<>\[\]`]/g, (char) => `\\${char}`);
+}
+
+/** Escape a value embedded in a Typst string literal. */
+export function escapeTypstString(value: string): string {
+  return value
+    .replace(/\\/g, "\\\\")
+    .replace(/\"/g, '\\"')
+    .replace(/\r/g, "\\r")
+    .replace(/\n/g, "\\n")
+    .replace(/\t/g, "\\t");
+}
+
+export function typstString(value: string): string {
+  return `"${escapeTypstString(value)}"`;
+}
+
+/** Stable Typst label component. */
+export function typstLabel(value: string): string {
+  const normalized = value
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return normalized || "section";
+}
+
+export function safeColor(value: string | undefined, fallback = "#42526E"): string {
+  if (!value) return fallback;
+  const raw = value.startsWith("#") ? value : `#${value}`;
+  return /^#[0-9a-f]{6}$/i.test(raw) ? raw.toUpperCase() : fallback;
+}

--- a/packages/pdf/src/index.browser.ts
+++ b/packages/pdf/src/index.browser.ts
@@ -1,0 +1,5 @@
+export * from "./escape.js";
+export * from "./prepare.js";
+export * from "./serialize.js";
+export * from "./template.js";
+export type * from "./types.js";

--- a/packages/pdf/src/index.ts
+++ b/packages/pdf/src/index.ts
@@ -1,0 +1,5 @@
+export * from "./escape.js";
+export * from "./prepare.js";
+export * from "./serialize.js";
+export * from "./template.js";
+export type * from "./types.js";

--- a/packages/pdf/src/prepare.test.ts
+++ b/packages/pdf/src/prepare.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "bun:test";
+import type { ExportBlock } from "@atlcli/confluence";
+import { PDF_ASSET_CONCURRENCY, preparePdfDocument } from "./prepare.js";
+
+function pngBytes(unique = 0): Uint8Array {
+  return new Uint8Array([
+    0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+    0, 0, 0, 13, 0x49, 0x48, 0x44, 0x52,
+    0, 0, 0, 1, 0, 0, 0, 1 + unique,
+  ]);
+}
+
+function images(count: number): ExportBlock[] {
+  return Array.from({ length: count }, (_, index) => ({
+    type: "image" as const,
+    source: { kind: "attachment" as const, filename: `${index}.png` },
+    alt: `Image ${index}`,
+  }));
+}
+
+describe("PDF asset preparation", () => {
+  it("rejects corrupt bytes and preserves a readable fallback", async () => {
+    const prepared = await preparePdfDocument(images(1), {
+      resolve: async () => ({
+        bytes: new TextEncoder().encode("not an image"),
+        mediaType: "image/png",
+      }),
+    });
+    expect(prepared.assets).toEqual([]);
+    expect(prepared.blocks[0]).toMatchObject({ type: "image", fallbackLabel: "Image 0" });
+    expect(prepared.notes[0]?.code).toBe("pdf-image-skipped");
+    expect(prepared.notes[0]?.message).toContain("corrupt");
+  });
+
+  it("rejects active SVG content instead of compiling it", async () => {
+    const prepared = await preparePdfDocument(images(1), {
+      resolve: async () => ({
+        bytes: new TextEncoder().encode(
+          `<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>`
+        ),
+        mediaType: "image/svg+xml",
+      }),
+    });
+    expect(prepared.assets).toEqual([]);
+    expect(prepared.notes[0]?.message).toContain("active");
+  });
+
+  it("rejects a declared MIME type that disagrees with magic bytes", async () => {
+    const prepared = await preparePdfDocument(images(1), {
+      resolve: async () => ({ bytes: pngBytes(), mediaType: "image/jpeg" }),
+    });
+    expect(prepared.assets).toEqual([]);
+    expect(prepared.notes[0]?.message).toContain("declared media type");
+  });
+
+  it("bounds parallel attachment resolution and preserves deterministic order", async () => {
+    let active = 0;
+    let peak = 0;
+    const prepared = await preparePdfDocument(images(8), {
+      resolve: async (ref) => {
+        active += 1;
+        peak = Math.max(peak, active);
+        await new Promise((resolve) => setTimeout(resolve, 2));
+        active -= 1;
+        const index = Number.parseInt(ref.filename ?? "0", 10);
+        return { bytes: pngBytes(index), mediaType: "image/png" };
+      },
+    });
+    expect(peak).toBe(PDF_ASSET_CONCURRENCY);
+    expect(prepared.assets.map((asset) => asset.path.match(/image-(\d+)-/)?.[1])).toEqual(
+      ["1", "2", "3", "4", "5", "6", "7", "8"]
+    );
+  });
+});

--- a/packages/pdf/src/prepare.ts
+++ b/packages/pdf/src/prepare.ts
@@ -1,0 +1,148 @@
+import { renderDiagram } from "@atlcli/diagram";
+import type { ExportBlock, ExportNote } from "@atlcli/confluence";
+import type {
+  PdfAssetResolver,
+  PdfResolvedAsset,
+  PreparedPdfAsset,
+  PreparedPdfBlock,
+  PreparedPdfDocument,
+} from "./types.js";
+
+const EXTENSIONS: Record<string, string> = {
+  "image/png": "png",
+  "image/jpeg": "jpg",
+  "image/gif": "gif",
+  "image/svg+xml": "svg",
+  "image/webp": "webp",
+};
+
+function extensionFor(asset: PdfResolvedAsset): string {
+  const fromMime = EXTENSIONS[asset.mediaType.toLowerCase()];
+  if (fromMime) return fromMime;
+  const fromName = asset.filename?.match(/\.([a-z0-9]{2,5})$/i)?.[1]?.toLowerCase();
+  return fromName ?? "bin";
+}
+
+function assetKey(bytes: Uint8Array, mediaType: string): string {
+  // Fast deterministic non-cryptographic hash for job-local deduplication.
+  let hash = 0x811c9dc5;
+  for (const byte of bytes) {
+    hash ^= byte;
+    hash = Math.imul(hash, 0x01000193);
+  }
+  for (let i = 0; i < mediaType.length; i += 1) {
+    hash ^= mediaType.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(16).padStart(8, "0");
+}
+
+export async function preparePdfDocument(
+  blocks: ExportBlock[],
+  resolver: PdfAssetResolver
+): Promise<PreparedPdfDocument> {
+  const assets: PreparedPdfAsset[] = [];
+  const notes: ExportNote[] = [];
+  const paths = new Map<string, string>();
+
+  const addAsset = (asset: PdfResolvedAsset, prefix: string): string => {
+    const key = assetKey(asset.bytes, asset.mediaType);
+    const existing = paths.get(key);
+    if (existing) return existing;
+    const path = `assets/${prefix}-${assets.length + 1}-${key}.${extensionFor(asset)}`;
+    assets.push({ path, bytes: asset.bytes, mediaType: asset.mediaType });
+    paths.set(key, path);
+    return path;
+  };
+
+  const walk = async (list: ExportBlock[]): Promise<PreparedPdfBlock[]> =>
+    Promise.all(
+      list.map(async (block): Promise<PreparedPdfBlock> => {
+        switch (block.type) {
+          case "callout":
+            return { ...block, content: await walk(block.content) };
+          case "blockquote":
+            return { ...block, content: await walk(block.content) };
+          case "list":
+            return {
+              ...block,
+              items: await Promise.all(
+                block.items.map(async (item) => ({ ...item, content: await walk(item.content) }))
+              ),
+            };
+          case "table":
+            return {
+              ...block,
+              rows: await Promise.all(
+                block.rows.map(async (row) => ({
+                  cells: await Promise.all(
+                    row.cells.map(async (cell) => ({ ...cell, content: await walk(cell.content) }))
+                  ),
+                }))
+              ),
+            };
+          case "image": {
+            const fallbackLabel =
+              block.alt ?? (block.source.kind === "attachment" ? block.source.filename : "Image");
+            try {
+              const resolved = await resolver.resolve(
+                block.source.kind === "attachment"
+                  ? { kind: "attachment", filename: block.source.filename }
+                  : { kind: "external", url: block.source.url }
+              );
+              return {
+                type: "image",
+                assetPath: addAsset(resolved, "image"),
+                alt: block.alt,
+                width: block.width,
+                height: block.height,
+                fallbackLabel,
+              };
+            } catch (error) {
+              notes.push({
+                level: "warning",
+                code: "pdf-image-skipped",
+                message: `${fallbackLabel} was not embedded: ${error instanceof Error ? error.message : String(error)}`,
+              });
+              return { type: "image", alt: block.alt, fallbackLabel };
+            }
+          }
+          case "codeBlock": {
+            if ((block.language ?? "").trim().toLowerCase() !== "mermaid") return block;
+            const rendered = await renderDiagram(block.code);
+            if (rendered.kind === "svg") {
+              const bytes = new TextEncoder().encode(rendered.svg);
+              const assetPath = addAsset(
+                { bytes, mediaType: "image/svg+xml", filename: "diagram.svg" },
+                "diagram"
+              );
+              return { type: "diagram", assetPath, source: block.code };
+            }
+            notes.push({
+              level: rendered.kind === "unsupported" ? "info" : "warning",
+              code:
+                rendered.kind === "unsupported"
+                  ? "pdf-diagram-unsupported"
+                  : "pdf-diagram-failed",
+              message:
+                rendered.kind === "unsupported"
+                  ? `${rendered.diagramType} diagram rendered as source code.`
+                  : `Diagram rendered as source code: ${rendered.reason}`,
+            });
+            return block;
+          }
+          case "heading":
+          case "paragraph":
+          case "divider":
+          case "unknown":
+            return block;
+          default: {
+            const exhaustive: never = block;
+            return exhaustive;
+          }
+        }
+      })
+    );
+
+  return { blocks: await walk(blocks), assets, notes };
+}

--- a/packages/pdf/src/prepare.ts
+++ b/packages/pdf/src/prepare.ts
@@ -16,6 +16,125 @@ const EXTENSIONS: Record<string, string> = {
   "image/webp": "webp",
 };
 
+export const PDF_MAX_ASSET_BYTES = 25 * 1024 * 1024;
+export const PDF_MAX_TOTAL_ASSET_BYTES = 50 * 1024 * 1024;
+export const PDF_ASSET_CONCURRENCY = 4;
+
+function ascii(bytes: Uint8Array, start: number, length: number): string {
+  return String.fromCharCode(...bytes.subarray(start, start + length));
+}
+
+function sniffMediaType(bytes: Uint8Array): string | null {
+  if (
+    bytes.length >= 24 &&
+    [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a].every(
+      (byte, index) => bytes[index] === byte
+    )
+  ) return "image/png";
+  if (bytes.length >= 4 && bytes[0] === 0xff && bytes[1] === 0xd8) return "image/jpeg";
+  if (bytes.length >= 10 && /GIF8[79]a/.test(ascii(bytes, 0, 6))) return "image/gif";
+  if (
+    bytes.length >= 12 &&
+    ascii(bytes, 0, 4) === "RIFF" &&
+    ascii(bytes, 8, 4) === "WEBP"
+  ) return "image/webp";
+  const head = new TextDecoder().decode(bytes.subarray(0, Math.min(bytes.length, 2048)));
+  if (/<svg(?:\s|>)/i.test(head.replace(/^\uFEFF/, "").trimStart())) return "image/svg+xml";
+  return null;
+}
+
+function validateResolvedAsset(asset: PdfResolvedAsset): PdfResolvedAsset {
+  if (asset.bytes.byteLength === 0) throw new Error("the fetched image was empty");
+  if (asset.bytes.byteLength > PDF_MAX_ASSET_BYTES) {
+    throw new Error("the image exceeds the 25 MB per-file limit");
+  }
+  const sniffed = sniffMediaType(asset.bytes);
+  if (!sniffed) throw new Error("unsupported or corrupt image bytes");
+  const declared = asset.mediaType.toLowerCase().split(";", 1)[0]!.trim();
+  if (declared !== "application/octet-stream" && declared !== sniffed) {
+    throw new Error(`image content does not match its declared media type (${declared})`);
+  }
+  if (sniffed === "image/svg+xml") {
+    const source = new TextDecoder().decode(asset.bytes);
+    if (
+      /<\s*(?:script|foreignObject)\b/i.test(source) ||
+      /\son[a-z]+\s*=/i.test(source) ||
+      /(?:href|xlink:href)\s*=\s*["']\s*(?:https?:|data:)/i.test(source)
+    ) {
+      throw new Error("SVG contains active or externally loaded content");
+    }
+  }
+  return { ...asset, mediaType: sniffed };
+}
+
+function sameBytes(left: Uint8Array, right: Uint8Array): boolean {
+  if (left.byteLength !== right.byteLength) return false;
+  for (let index = 0; index < left.byteLength; index += 1) {
+    if (left[index] !== right[index]) return false;
+  }
+  return true;
+}
+
+function createLimiter(limit: number): <T>(task: () => Promise<T>) => Promise<T> {
+  let active = 0;
+  let issued = 0;
+  let nextToDeliver = 0;
+  const queue: Array<{
+    index: number;
+    task: () => Promise<unknown>;
+    resolve: (value: unknown) => void;
+    reject: (reason: unknown) => void;
+  }> = [];
+  const finished = new Map<
+    number,
+    { ok: true; value: unknown } | { ok: false; reason: unknown }
+  >();
+
+  const flush = (): void => {
+    while (finished.has(nextToDeliver)) {
+      const result = finished.get(nextToDeliver)!;
+      finished.delete(nextToDeliver);
+      const item = delivered.get(nextToDeliver)!;
+      delivered.delete(nextToDeliver);
+      if (result.ok) item.resolve(result.value);
+      else item.reject(result.reason);
+      nextToDeliver += 1;
+    }
+  };
+  const delivered = new Map<
+    number,
+    { resolve: (value: unknown) => void; reject: (reason: unknown) => void }
+  >();
+  const next = (): void => {
+    while (active < limit) {
+      const item = queue.shift();
+      if (!item) return;
+      active += 1;
+      void item.task()
+        .then(
+          (value) => finished.set(item.index, { ok: true, value }),
+          (reason) => finished.set(item.index, { ok: false, reason })
+        )
+        .finally(() => {
+          active -= 1;
+          flush();
+          next();
+        });
+    }
+  };
+  return <T>(task: () => Promise<T>): Promise<T> =>
+    new Promise<T>((resolve, reject) => {
+      const index = issued;
+      issued += 1;
+      delivered.set(index, {
+        resolve: resolve as (value: unknown) => void,
+        reject,
+      });
+      queue.push({ index, task, resolve: resolve as (value: unknown) => void, reject });
+      next();
+    });
+}
+
 function extensionFor(asset: PdfResolvedAsset): string {
   const fromMime = EXTENSIONS[asset.mediaType.toLowerCase()];
   if (fromMime) return fromMime;
@@ -43,15 +162,30 @@ export async function preparePdfDocument(
 ): Promise<PreparedPdfDocument> {
   const assets: PreparedPdfAsset[] = [];
   const notes: ExportNote[] = [];
-  const paths = new Map<string, string>();
+  const paths = new Map<
+    string,
+    Array<{ bytes: Uint8Array; mediaType: string; path: string }>
+  >();
+  const limit = createLimiter(PDF_ASSET_CONCURRENCY);
+  let totalAssetBytes = 0;
 
-  const addAsset = (asset: PdfResolvedAsset, prefix: string): string => {
+  const addAsset = (rawAsset: PdfResolvedAsset, prefix: string): string => {
+    const asset = validateResolvedAsset(rawAsset);
     const key = assetKey(asset.bytes, asset.mediaType);
-    const existing = paths.get(key);
-    if (existing) return existing;
+    const bucket = paths.get(key) ?? [];
+    const existing = bucket.find(
+      (candidate) =>
+        candidate.mediaType === asset.mediaType && sameBytes(candidate.bytes, asset.bytes)
+    );
+    if (existing) return existing.path;
+    if (totalAssetBytes + asset.bytes.byteLength > PDF_MAX_TOTAL_ASSET_BYTES) {
+      throw new Error("the PDF exceeds the 50 MB total image limit");
+    }
     const path = `assets/${prefix}-${assets.length + 1}-${key}.${extensionFor(asset)}`;
     assets.push({ path, bytes: asset.bytes, mediaType: asset.mediaType });
-    paths.set(key, path);
+    totalAssetBytes += asset.bytes.byteLength;
+    bucket.push({ bytes: asset.bytes, mediaType: asset.mediaType, path });
+    paths.set(key, bucket);
     return path;
   };
 
@@ -85,10 +219,12 @@ export async function preparePdfDocument(
             const fallbackLabel =
               block.alt ?? (block.source.kind === "attachment" ? block.source.filename : "Image");
             try {
-              const resolved = await resolver.resolve(
-                block.source.kind === "attachment"
-                  ? { kind: "attachment", filename: block.source.filename }
-                  : { kind: "external", url: block.source.url }
+              const resolved = await limit(() =>
+                resolver.resolve(
+                  block.source.kind === "attachment"
+                    ? { kind: "attachment", filename: block.source.filename }
+                    : { kind: "external", url: block.source.url }
+                )
               );
               return {
                 type: "image",

--- a/packages/pdf/src/serialize.test.ts
+++ b/packages/pdf/src/serialize.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import type { ExportBlock } from "@atlcli/confluence";
 import { preparePdfDocument } from "./prepare.js";
-import { serializePdfDocument } from "./serialize.js";
+import { mapPdfDiagnostics, serializePdfDocument } from "./serialize.js";
 
 const metadata = {
   title: "PDF # Guide",
@@ -10,8 +10,17 @@ const metadata = {
   author: "Ada",
   exporter: "Grace",
   language: "en",
+  region: "US",
   exportedAt: new Date("2026-07-16T12:00:00Z"),
 };
+
+function pngBytes(): Uint8Array {
+  return new Uint8Array([
+    0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+    0, 0, 0, 13, 0x49, 0x48, 0x44, 0x52,
+    0, 0, 0, 1, 0, 0, 0, 1,
+  ]);
+}
 
 describe("PDF preparation and serialization", () => {
   it("promotes headings and serializes every common semantic block", async () => {
@@ -43,10 +52,147 @@ describe("PDF preparation and serialization", () => {
     expect(bundle.main).toContain('#status-badge("DONE"');
     expect(bundle.main).toContain('#callout(kind: "info"');
     expect(bundle.main).toContain("#list(");
+    expect(bundle.main).toContain("#list(marker: none, body-indent: 0pt,");
+    expect(bundle.main).toContain("#task-item(true)[");
+    expect(bundle.main).toContain('#text("Task")');
+    expect(bundle.main).not.toContain("\\[x\\]");
     expect(bundle.main).toContain("table.header(");
+    expect(bundle.main).toContain("#block(width: 100%)[\n#table(columns: (1fr,)");
     expect(bundle.main).toContain("#quote(block: true)");
     expect(bundle.main).toContain("#line(length: 100%");
     expect(bundle.sourceMap.length).toBeGreaterThanOrEqual(blocks.length);
+    expect(bundle.template).toContain('font: "Source Serif 4"');
+    expect(bundle.template).toContain('font: "Source Sans 3"');
+    expect(bundle.template).toContain('font: "Source Code Pro"');
+    expect(bundle.template).toContain(`[${String.fromCodePoint(0x2013)}]`);
+    expect(bundle.template).toContain(`[${String.fromCodePoint(0x2022)}]`);
+    expect(bundle.template).toContain(`[${String.fromCodePoint(0x25e6)}]`);
+    expect(bundle.template).toContain(`"${String.fromCodePoint(0x2713)}"`);
+    expect(bundle.template).toContain(`"${String.fromCodePoint(0x25a1)}"`);
+    expect(bundle.template).not.toMatch(/\\u(?:2013|2022|25E6|2713|25A1)/i);
+    expect(bundle.template).toContain("spacing: 8pt");
+    expect(bundle.template).toContain('pattern = if values.len() == 1 { "1." }');
+    expect(bundle.template).toContain("leading: 0.74em");
+    expect(bundle.template).toContain("above: 28pt, below: 14pt");
+    expect(bundle.template).toContain("above: 24pt, below: 12pt");
+    expect(bundle.template).toContain("above: 18pt, below: 8pt");
+    expect(bundle.template).toContain("sticky: true");
+    expect(bundle.template).toContain("hyphenate: true");
+    expect(bundle.template).toContain('linebreaks: "optimized"');
+    expect(bundle.main).toContain('region: "US"');
+    expect(bundle.main).toContain("inset: (x: 6pt, y: 7pt)");
+    expect(bundle.template).toContain('let indigo = rgb("#4B57A3")');
+    expect(bundle.template).toContain('let cover-paper = rgb("#FCFBF8")');
+    expect(bundle.template).toContain('text(font: "Source Serif 4", size: 31pt');
+    expect(bundle.template).toContain("current-page > 1 and current-page < final-page");
+    expect(bundle.template).toContain("[DOKUMENTENDE]");
+    expect(bundle.template).toContain('link("https://atlcli.sh/")');
+    expect(bundle.template).toContain("counter(page).final().first()");
+    expect(bundle.main).toContain('exported-label: "July 16, 2026"');
+  });
+
+  it("localizes the editorial cover and integrity-page export date", () => {
+    const bundle = serializePdfDocument(
+      { blocks: [], assets: [], notes: [] },
+      {
+        metadata: {
+          ...metadata,
+          language: "de",
+          region: "DE",
+        },
+      }
+    );
+
+    expect(bundle.main).toContain('language: "de"');
+    expect(bundle.main).toContain('region: "DE"');
+    expect(bundle.main).toContain('exported-label: "16. Juli 2026"');
+  });
+
+  it("uses retained table proportions and equal-width fallback tracks", async () => {
+    const blocks: ExportBlock[] = [
+      {
+        type: "table",
+        columnWidths: [100, 300],
+        rows: [
+          {
+            cells: [
+              { header: false, colspan: 1, rowspan: 1, content: [{ type: "paragraph", content: [{ type: "text", text: "A" }] }] },
+              { header: false, colspan: 1, rowspan: 1, content: [{ type: "paragraph", content: [{ type: "text", text: "B" }] }] },
+            ],
+          },
+        ],
+      },
+      {
+        type: "table",
+        rows: [
+          {
+            cells: [
+              { header: false, colspan: 1, rowspan: 1, content: [{ type: "paragraph", content: [{ type: "text", text: "A" }] }] },
+              { header: false, colspan: 1, rowspan: 1, content: [{ type: "paragraph", content: [{ type: "text", text: "B" }] }] },
+            ],
+          },
+        ],
+      },
+    ];
+    const prepared = await preparePdfDocument(blocks, {
+      resolve: async () => { throw new Error("unused"); },
+    });
+    const bundle = serializePdfDocument(prepared, { metadata });
+    expect(bundle.main).toContain("columns: (0.25fr, 0.75fr,)");
+    expect(bundle.main).toContain("columns: (1fr, 1fr,)");
+  });
+
+  it("widens a dominant narrative column when source tracks are only equal defaults", async () => {
+    const paragraph = (text: string): ExportBlock => ({
+      type: "paragraph",
+      content: [{ type: "text", text }],
+    });
+    const cell = (text: string) => ({
+      header: false,
+      colspan: 1,
+      rowspan: 1,
+      content: [paragraph(text)],
+    });
+    const blocks: ExportBlock[] = [
+      {
+        type: "table",
+        columnWidths: [100, 100, 100, 100],
+        rows: [
+          { cells: [cell("Architecture and platform readiness"), cell("R"), cell("A"), cell("C")] },
+          { cells: [cell("Installation, configuration, and rollout"), cell("R"), cell("C"), cell("I")] },
+        ],
+      },
+    ];
+    const prepared = await preparePdfDocument(blocks, {
+      resolve: async () => { throw new Error("unused"); },
+    });
+    const bundle = serializePdfDocument(prepared, { metadata });
+
+    expect(bundle.main).toContain("columns: (0.4fr, 0.2fr, 0.2fr, 0.2fr,)");
+  });
+
+  it("keeps balanced prose tables equal when no useful source widths exist", async () => {
+    const cell = (text: string) => ({
+      header: false,
+      colspan: 1,
+      rowspan: 1,
+      content: [{ type: "paragraph" as const, content: [{ type: "text" as const, text }] }],
+    });
+    const blocks: ExportBlock[] = [
+      {
+        type: "table",
+        rows: [
+          { cells: [cell("Alpha description"), cell("Beta description"), cell("Gamma description")] },
+          { cells: [cell("Alpha details"), cell("Beta details"), cell("Gamma details")] },
+        ],
+      },
+    ];
+    const prepared = await preparePdfDocument(blocks, {
+      resolve: async () => { throw new Error("unused"); },
+    });
+    const bundle = serializePdfDocument(prepared, { metadata });
+
+    expect(bundle.main).toContain("columns: (1fr, 1fr, 1fr,)");
   });
 
   it("deduplicates image bytes and reports missing alt text", async () => {
@@ -56,7 +202,7 @@ describe("PDF preparation and serialization", () => {
     ];
     const prepared = await preparePdfDocument(blocks, {
       resolve: async () => ({
-        bytes: new Uint8Array([137, 80, 78, 71]),
+        bytes: pngBytes(),
         mediaType: "image/png",
         filename: "same.png",
       }),
@@ -64,6 +210,39 @@ describe("PDF preparation and serialization", () => {
     const bundle = serializePdfDocument(prepared, { metadata });
     expect(bundle.assets).toHaveLength(1);
     expect(bundle.notes.filter((note) => note.code === "pdf-image-alt-fallback")).toHaveLength(2);
+  });
+
+  it("keeps images and diagrams in document flow instead of floating past headings", () => {
+    const bundle = serializePdfDocument(
+      {
+        blocks: [
+          { type: "heading", level: 2, content: [{ type: "text", text: "Diagram" }] },
+          {
+            type: "diagram",
+            assetPath: "assets/diagram.svg",
+            alt: "A flowchart",
+            source: "flowchart LR\nA --> B",
+          },
+          {
+            type: "image",
+            assetPath: "assets/image.png",
+            alt: "A screenshot",
+            fallbackLabel: "image.png",
+          },
+        ],
+        assets: [],
+        notes: [],
+      },
+      { metadata }
+    );
+
+    expect(bundle.main).not.toContain("placement: auto");
+    expect(bundle.main.indexOf("#heading(")).toBeLessThan(
+      bundle.main.indexOf('image("assets/diagram.svg"')
+    );
+    expect(bundle.main.indexOf('image("assets/diagram.svg"')).toBeLessThan(
+      bundle.main.indexOf('image("assets/image.png"')
+    );
   });
 
   it("renders unsafe links as text and reports them", async () => {
@@ -78,5 +257,101 @@ describe("PDF preparation and serialization", () => {
     expect(bundle.main).toContain("Nope");
     expect(bundle.main).not.toContain("javascript:");
     expect(bundle.notes.some((note) => note.code === "pdf-link-unresolved")).toBe(true);
+  });
+
+  it("maps generated main.typ lines to the most specific nested block", async () => {
+    const blocks: ExportBlock[] = [
+      {
+        type: "callout",
+        kind: "info",
+        content: [
+          {
+            type: "table",
+            rows: [
+              {
+                cells: [
+                  {
+                    header: false,
+                    colspan: 1,
+                    rowspan: 1,
+                    content: [
+                      { type: "paragraph", content: [{ type: "text", text: "Nested" }] },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ];
+    const prepared = await preparePdfDocument(blocks, {
+      resolve: async () => {
+        throw new Error("unused");
+      },
+    });
+    const bundle = serializePdfDocument(prepared, { metadata });
+    const paragraph = bundle.sourceMap.find(
+      (entry) => entry.blockPath === "blocks[0].content[0].rows[0].cells[0].content[0]"
+    );
+    expect(paragraph).toBeDefined();
+    expect(bundle.main.split("\n")[paragraph!.startLine - 1]).toContain('#par[#text("Nested")]');
+    expect(
+      mapPdfDiagnostics(
+        [{ severity: "error", message: "fixture", path: "main.typ", line: paragraph!.startLine }],
+        bundle.sourceMap
+      )[0]?.blockPath
+    ).toBe(paragraph!.blockPath);
+  });
+
+  it("maps same-line diagnostics to the containing table cell by column", async () => {
+    const blocks: ExportBlock[] = [
+      {
+        type: "table",
+        rows: [
+          {
+            cells: [
+              {
+                header: true,
+                colspan: 1,
+                rowspan: 1,
+                content: [{ type: "paragraph", content: [{ type: "text", text: "First" }] }],
+              },
+              {
+                header: true,
+                colspan: 1,
+                rowspan: 1,
+                content: [{ type: "paragraph", content: [{ type: "text", text: "Second" }] }],
+              },
+            ],
+          },
+        ],
+      },
+    ];
+    const prepared = await preparePdfDocument(blocks, {
+      resolve: async () => {
+        throw new Error("unused");
+      },
+    });
+    const bundle = serializePdfDocument(prepared, { metadata });
+    const second = bundle.sourceMap.find(
+      (entry) => entry.blockPath === "blocks[0].rows[0].cells[1].content[0]"
+    );
+    expect(second).toBeDefined();
+
+    expect(
+      mapPdfDiagnostics(
+        [
+          {
+            severity: "error",
+            message: "fixture",
+            path: "main.typ",
+            line: second!.startLine,
+            column: second!.startColumn + 1,
+          },
+        ],
+        bundle.sourceMap
+      )[0]?.blockPath
+    ).toBe(second!.blockPath);
   });
 });

--- a/packages/pdf/src/serialize.test.ts
+++ b/packages/pdf/src/serialize.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "bun:test";
+import type { ExportBlock } from "@atlcli/confluence";
+import { preparePdfDocument } from "./prepare.js";
+import { serializePdfDocument } from "./serialize.js";
+
+const metadata = {
+  title: "PDF # Guide",
+  space: "DOCSY",
+  version: 7,
+  author: "Ada",
+  exporter: "Grace",
+  language: "en",
+  exportedAt: new Date("2026-07-16T12:00:00Z"),
+};
+
+describe("PDF preparation and serialization", () => {
+  it("promotes headings and serializes every common semantic block", async () => {
+    const blocks: ExportBlock[] = [
+      { type: "heading", level: 2, content: [{ type: "text", text: "Overview" }] },
+      {
+        type: "paragraph",
+        content: [
+          { type: "text", text: "Hello ", marks: ["bold"] },
+          { type: "status", text: "DONE", color: "#00875A" },
+          { type: "lineBreak" },
+          { type: "mention", accountId: "a1", displayName: "Ada" },
+        ],
+      },
+      { type: "callout", kind: "info", title: "Note", content: [{ type: "paragraph", content: [{ type: "text", text: "Body" }] }] },
+      { type: "list", ordered: false, items: [{ checked: true, content: [{ type: "paragraph", content: [{ type: "text", text: "Task" }] }] }] },
+      { type: "table", rows: [{ cells: [{ header: true, colspan: 1, rowspan: 1, content: [{ type: "paragraph", content: [{ type: "text", text: "Header" }] }] }] }] },
+      { type: "blockquote", content: [{ type: "paragraph", content: [{ type: "text", text: "Quoted" }] }] },
+      { type: "divider" },
+    ];
+    const prepared = await preparePdfDocument(blocks, {
+      resolve: async () => {
+        throw new Error("unused");
+      },
+    });
+    const bundle = serializePdfDocument(prepared, { metadata });
+
+    expect(bundle.main).toContain("#heading(level: 1");
+    expect(bundle.main).toContain('#status-badge("DONE"');
+    expect(bundle.main).toContain('#callout(kind: "info"');
+    expect(bundle.main).toContain("#list(");
+    expect(bundle.main).toContain("table.header(");
+    expect(bundle.main).toContain("#quote(block: true)");
+    expect(bundle.main).toContain("#line(length: 100%");
+    expect(bundle.sourceMap.length).toBeGreaterThanOrEqual(blocks.length);
+  });
+
+  it("deduplicates image bytes and reports missing alt text", async () => {
+    const blocks: ExportBlock[] = [
+      { type: "image", source: { kind: "attachment", filename: "same.png" } },
+      { type: "image", source: { kind: "attachment", filename: "same.png" } },
+    ];
+    const prepared = await preparePdfDocument(blocks, {
+      resolve: async () => ({
+        bytes: new Uint8Array([137, 80, 78, 71]),
+        mediaType: "image/png",
+        filename: "same.png",
+      }),
+    });
+    const bundle = serializePdfDocument(prepared, { metadata });
+    expect(bundle.assets).toHaveLength(1);
+    expect(bundle.notes.filter((note) => note.code === "pdf-image-alt-fallback")).toHaveLength(2);
+  });
+
+  it("renders unsafe links as text and reports them", async () => {
+    const blocks: ExportBlock[] = [
+      {
+        type: "paragraph",
+        content: [{ type: "link", target: { kind: "external", href: "javascript:alert(1)" }, content: [{ type: "text", text: "Nope" }] }],
+      },
+    ];
+    const prepared = await preparePdfDocument(blocks, { resolve: async () => { throw new Error("unused"); } });
+    const bundle = serializePdfDocument(prepared, { metadata });
+    expect(bundle.main).toContain("Nope");
+    expect(bundle.main).not.toContain("javascript:");
+    expect(bundle.notes.some((note) => note.code === "pdf-link-unresolved")).toBe(true);
+  });
+});

--- a/packages/pdf/src/serialize.ts
+++ b/packages/pdf/src/serialize.ts
@@ -1,0 +1,362 @@
+import type { ExportNote, InlineNode, LinkTarget } from "@atlcli/confluence";
+import { escapeTypstContent, safeColor, typstLabel, typstString } from "./escape.js";
+import { ATLCLI_TYPST_TEMPLATE } from "./template.js";
+import type {
+  PdfSerializeOptions,
+  PdfSourceBundle,
+  PdfSourceMapEntry,
+  PreparedPdfBlock,
+  PreparedPdfDocument,
+} from "./types.js";
+
+function inlinePlainText(nodes: InlineNode[]): string {
+  return nodes
+    .map((node) => {
+      switch (node.type) {
+        case "text":
+          return node.text;
+        case "link":
+          return inlinePlainText(node.content);
+        case "mention":
+          return `@${node.displayName ?? node.accountId}`;
+        case "status":
+          return node.text;
+        case "lineBreak":
+          return " ";
+        default: {
+          const exhaustive: never = node;
+          return exhaustive;
+        }
+      }
+    })
+    .join("");
+}
+
+function resolveLink(target: LinkTarget, labels: Map<string, string>): string | null {
+  switch (target.kind) {
+    case "external":
+      return /^(https?:|mailto:)/i.test(target.href) ? target.href : null;
+    case "anchor":
+      return labels.get(target.anchor) ? `<${labels.get(target.anchor)}>` : null;
+    case "page":
+      return null;
+    case "attachment":
+      return null;
+    default: {
+      const exhaustive: never = target;
+      return exhaustive;
+    }
+  }
+}
+
+function serializeInline(nodes: InlineNode[], labels: Map<string, string>, notes: ExportNote[]): string {
+  return nodes
+    .map((node) => {
+      switch (node.type) {
+        case "text": {
+          let out = escapeTypstContent(node.text);
+          for (const mark of node.marks ?? []) {
+            switch (mark) {
+              case "bold":
+                out = `#strong[${out}]`;
+                break;
+              case "italic":
+                out = `#emph[${out}]`;
+                break;
+              case "underline":
+                out = `#underline[${out}]`;
+                break;
+              case "strike":
+                out = `#strike[${out}]`;
+                break;
+              case "code":
+                out = `#raw(${typstString(node.text)})`;
+                break;
+              case "subscript":
+                out = `#sub[${out}]`;
+                break;
+              case "superscript":
+                out = `#super[${out}]`;
+                break;
+              default: {
+                const exhaustive: never = mark;
+                out = exhaustive;
+              }
+            }
+          }
+          if (node.color) out = `#text(fill: rgb(${typstString(safeColor(node.color))}))[${out}]`;
+          return out;
+        }
+        case "lineBreak":
+          return "#linebreak()";
+        case "mention":
+          return `#text(fill: rgb(\"#0747A6\"))[${escapeTypstContent(`@${node.displayName ?? node.accountId}`)}]`;
+        case "status":
+          return `#status-badge(${typstString(node.text || node.color)}, color: ${typstString(safeColor(node.color))})`;
+        case "link": {
+          const content = serializeInline(node.content, labels, notes);
+          const href = resolveLink(node.target, labels);
+          if (!href) {
+            notes.push({
+              level: "info",
+              code: "pdf-link-unresolved",
+              message: `Link target could not be represented in PDF: ${inlinePlainText(node.content) || "link"}`,
+            });
+            return content;
+          }
+          if (href.startsWith("<")) return `#link(${href})[${content}]`;
+          return `#link(${typstString(href)})[${content}]`;
+        }
+        default: {
+          const exhaustive: never = node;
+          return exhaustive;
+        }
+      }
+    })
+    .join("");
+}
+
+function minHeadingLevel(blocks: PreparedPdfBlock[]): number {
+  let min = Infinity;
+  for (const block of blocks) {
+    switch (block.type) {
+      case "heading":
+        min = Math.min(min, block.level);
+        break;
+      case "callout":
+      case "blockquote":
+        min = Math.min(min, minHeadingLevel(block.content));
+        break;
+      case "list":
+        for (const item of block.items) min = Math.min(min, minHeadingLevel(item.content));
+        break;
+      case "table":
+        for (const row of block.rows) {
+          for (const cell of row.cells) min = Math.min(min, minHeadingLevel(cell.content));
+        }
+        break;
+    }
+  }
+  return min;
+}
+
+function collectHeadingLabels(blocks: PreparedPdfBlock[]): Map<string, string> {
+  const labels = new Map<string, string>();
+  const counts = new Map<string, number>();
+  const walk = (list: PreparedPdfBlock[]): void => {
+    for (const block of list) {
+      switch (block.type) {
+        case "heading": {
+          const text = inlinePlainText(block.content);
+          const base = typstLabel(text);
+          const count = (counts.get(base) ?? 0) + 1;
+          counts.set(base, count);
+          const label = count === 1 ? base : `${base}-${count}`;
+          if (!labels.has(text)) labels.set(text, label);
+          break;
+        }
+        case "callout":
+        case "blockquote":
+          walk(block.content);
+          break;
+        case "list":
+          for (const item of block.items) walk(item.content);
+          break;
+        case "table":
+          for (const row of block.rows) for (const cell of row.cells) walk(cell.content);
+          break;
+      }
+    }
+  };
+  walk(blocks);
+  return labels;
+}
+
+interface Writer {
+  lines: string[];
+  sourceMap: PdfSourceMapEntry[];
+  notes: ExportNote[];
+  labels: Map<string, string>;
+  headingOffset: number;
+  headingCounts: Map<string, number>;
+}
+
+function serializeBlocks(blocks: PreparedPdfBlock[], writer: Writer, parentPath = "blocks"): string {
+  return blocks
+    .map((block, index) => serializeBlock(block, writer, `${parentPath}[${index}]`))
+    .join("\n");
+}
+
+function writeMapped(block: PreparedPdfBlock, writer: Writer, path: string, value: string, summary?: string): string {
+  const startLine = writer.lines.length + 1;
+  const marker = `// atlcli:${path}`;
+  const chunk = `${marker}\n${value}`;
+  writer.lines.push(...chunk.split("\n"));
+  writer.sourceMap.push({
+    blockPath: path,
+    blockType: block.type,
+    startLine,
+    endLine: writer.lines.length,
+    summary,
+  });
+  return chunk;
+}
+
+function serializeBlock(block: PreparedPdfBlock, writer: Writer, path: string): string {
+  let value: string;
+  let summary: string | undefined;
+  switch (block.type) {
+    case "heading": {
+      summary = inlinePlainText(block.content);
+      const base = typstLabel(summary);
+      const count = (writer.headingCounts.get(base) ?? 0) + 1;
+      writer.headingCounts.set(base, count);
+      const label = count === 1 ? base : `${base}-${count}`;
+      const level = Math.max(1, Math.min(6, block.level - writer.headingOffset));
+      value = `#heading(level: ${level}, outlined: true)[${serializeInline(block.content, writer.labels, writer.notes)}] <${label}>`;
+      break;
+    }
+    case "paragraph":
+      value = `#par[${serializeInline(block.content, writer.labels, writer.notes)}]`;
+      break;
+    case "codeBlock":
+      value = `#raw(${typstString(block.code)}, lang: ${typstString(block.language ?? "text")}, block: true)`;
+      break;
+    case "diagram":
+      value = `#figure(image(${typstString(block.assetPath)}, alt: ${typstString(block.alt ?? "Diagram")}), placement: auto)`;
+      break;
+    case "image":
+      if (!block.assetPath) {
+        value = `#par[#emph[${escapeTypstContent(`[Image unavailable: ${block.fallbackLabel}]`)}]]`;
+      } else {
+        if (!block.alt) {
+          writer.notes.push({
+            level: "warning",
+            code: "pdf-image-alt-fallback",
+            message: `${block.fallbackLabel} uses a technical filename fallback for alternative text.`,
+          });
+        }
+        value = `#figure(image(${typstString(block.assetPath)}, alt: ${typstString(block.alt ?? block.fallbackLabel)}), placement: auto)`;
+      }
+      break;
+    case "callout": {
+      const title = block.title ? `[${escapeTypstContent(block.title)}]` : "none";
+      value = `#callout(kind: ${typstString(block.kind)}, title: ${title})[\n${serializeBlocks(block.content, writer, `${path}.content`)}\n]`;
+      break;
+    }
+    case "blockquote":
+      value = `#quote(block: true)[\n${serializeBlocks(block.content, writer, `${path}.content`)}\n]`;
+      break;
+    case "list": {
+      const fn = block.ordered ? "enum" : "list";
+      const items = block.items.map((item, index) => {
+        const state = item.checked === undefined ? "" : item.checked ? "☑ " : "☐ ";
+        return `[${escapeTypstContent(state)}${serializeBlocks(item.content, writer, `${path}.items[${index}].content`)}]`;
+      });
+      value = `#${fn}(\n${items.join(",\n")}\n)`;
+      break;
+    }
+    case "table": {
+      const columns = Math.max(1, ...block.rows.map((row) => row.cells.reduce((sum, cell) => sum + cell.colspan, 0)));
+      const rows = block.rows.map((row, rowIndex) => {
+        const cells = row.cells.map((cell, cellIndex) => {
+          const args = [
+            cell.colspan > 1 ? `colspan: ${cell.colspan}` : "",
+            cell.rowspan > 1 ? `rowspan: ${cell.rowspan}` : "",
+            cell.header ? 'fill: rgb("#F4F5F7")' : "",
+          ].filter(Boolean);
+          const content = serializeBlocks(cell.content, writer, `${path}.rows[${rowIndex}].cells[${cellIndex}].content`);
+          return `table.cell(${args.length ? `${args.join(", ")}, ` : ""}[${content}])`;
+        });
+        return row.cells.every((cell) => cell.header)
+          ? `table.header(${cells.join(", ")})`
+          : cells.join(", ");
+      });
+      value = `#table(columns: ${columns}, inset: 6pt, stroke: rgb(\"#DFE1E6\"),\n${rows.join(",\n")}\n)`;
+      break;
+    }
+    case "divider":
+      value = `#line(length: 100%, stroke: rgb(\"#DFE1E6\"))`;
+      break;
+    case "unknown":
+      writer.notes.push({
+        level: "warning",
+        code: "pdf-unknown-block",
+        message: `Unsupported ${block.macroName} macro was omitted from the PDF.`,
+        macroName: block.macroName,
+      });
+      value = "";
+      break;
+    default: {
+      const exhaustive: never = block;
+      return exhaustive;
+    }
+  }
+  return writeMapped(block, writer, path, value, summary);
+}
+
+function typstDate(date: Date): string {
+  return `datetime(year: ${date.getUTCFullYear()}, month: ${date.getUTCMonth() + 1}, day: ${date.getUTCDate()})`;
+}
+
+export function serializePdfDocument(
+  document: PreparedPdfDocument,
+  options: PdfSerializeOptions
+): PdfSourceBundle {
+  const labels = collectHeadingLabels(document.blocks);
+  const min = minHeadingLevel(document.blocks);
+  const writer: Writer = {
+    lines: [],
+    sourceMap: [],
+    notes: [...document.notes],
+    labels,
+    headingOffset: min === Infinity ? 0 : min - 1,
+    headingCounts: new Map(),
+  };
+  const body = serializeBlocks(document.blocks, writer);
+  const meta = options.metadata;
+  const author = meta.author ?? meta.exporter ?? "atlcli";
+  const exportedLabel = meta.exportedAt.toISOString().slice(0, 10);
+  const main = String.raw`#import "atlcli.typ": atlcli-doc, callout, status-badge
+
+#show: atlcli-doc.with(meta: (
+  title: ${typstString(meta.title)},
+  space: ${typstString(meta.space ?? "Confluence")},
+  version: ${typstString(meta.version === undefined ? "—" : `v${meta.version}`)},
+  author: ${typstString(author)},
+  exporter: ${typstString(meta.exporter ?? author)},
+  exported-at: ${typstDate(meta.exportedAt)},
+  exported-label: ${typstString(exportedLabel)},
+))
+
+${body}
+`;
+
+  return {
+    main,
+    template: ATLCLI_TYPST_TEMPLATE,
+    assets: document.assets,
+    sourceMap: writer.sourceMap,
+    notes: writer.notes,
+  };
+}
+
+export function mapPdfDiagnostics(
+  diagnostics: Array<{ severity?: string; message: string; path?: string; line?: number }>,
+  sourceMap: PdfSourceMapEntry[]
+): Array<{ severity: "error" | "warning"; message: string; path?: string; startLine?: number; blockPath?: string }> {
+  return diagnostics.map((diagnostic) => {
+    const line = diagnostic.line;
+    const mapped =
+      diagnostic.path === "main.typ" && line !== undefined
+        ? sourceMap.find((entry) => line >= entry.startLine && line <= entry.endLine)
+        : undefined;
+    return {
+      severity: diagnostic.severity === "warning" ? "warning" : "error",
+      message: diagnostic.message,
+      path: diagnostic.path,
+      startLine: line,
+      blockPath: mapped?.blockPath,
+    };
+  });
+}

--- a/packages/pdf/src/serialize.ts
+++ b/packages/pdf/src/serialize.ts
@@ -32,6 +32,125 @@ function inlinePlainText(nodes: InlineNode[]): string {
     .join("");
 }
 
+/**
+ * Emit user-controlled text as a string value, never as Typst markup.
+ *
+ * Escaping markup metacharacters is not sufficient here: punctuation,
+ * non-breaking whitespace and future Typst syntax can still become meaningful
+ * when content is nested inside function arguments. A string passed to
+ * `text(...)` remains literal in every surrounding list/table context.
+ */
+function literalText(value: string): string {
+  return `#text(${typstString(value)})`;
+}
+
+type PreparedTableRow = Extract<PreparedPdfBlock, { type: "table" }>["rows"][number];
+
+function blocksPlainText(blocks: PreparedPdfBlock[]): string {
+  return blocks
+    .map((block) => {
+      switch (block.type) {
+        case "heading":
+        case "paragraph":
+          return inlinePlainText(block.content);
+        case "codeBlock":
+          return block.code;
+        case "callout":
+        case "blockquote":
+          return blocksPlainText(block.content);
+        case "list":
+          return block.items.map((item) => blocksPlainText(item.content)).join(" ");
+        case "table":
+          return block.rows
+            .flatMap((row) => row.cells.map((cell) => blocksPlainText(cell.content)))
+            .join(" ");
+        case "image":
+          return block.alt ?? block.fallbackLabel;
+        case "diagram":
+          return block.alt ?? "Diagram";
+        case "divider":
+          return "";
+        case "unknown":
+          return block.macroName;
+        default: {
+          const exhaustive: never = block;
+          return exhaustive;
+        }
+      }
+    })
+    .join(" ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
+ * Give a narrative column more room in status/RACI-style matrices when the
+ * source contains only default equal tracks. Explicit unequal author widths
+ * always win. The conservative thresholds avoid reshaping prose-heavy tables.
+ */
+function inferredTableTracks(columnCount: number, rows: PreparedTableRow[]): number[] | undefined {
+  if (columnCount < 3 || columnCount > 8) return undefined;
+  const bodyRows = rows.filter((row) => row.cells.some((cell) => !cell.header));
+  if (
+    bodyRows.length < 2 ||
+    bodyRows.some(
+      (row) =>
+        row.cells.length !== columnCount ||
+        row.cells.some((cell) => cell.colspan !== 1 || cell.rowspan !== 1)
+    )
+  ) return undefined;
+
+  const averageLengths = Array.from({ length: columnCount }, (_, columnIndex) => {
+    const total = bodyRows.reduce(
+      (sum, row) => sum + blocksPlainText(row.cells[columnIndex]!.content).length,
+      0
+    );
+    return total / bodyRows.length;
+  });
+  const ranked = averageLengths
+    .map((length, index) => ({ index, length }))
+    .sort((left, right) => right.length - left.length);
+  const dominant = ranked[0]!;
+  const runnerUp = ranked[1]!;
+  const otherAverage = ranked.slice(1).reduce((sum, item) => sum + item.length, 0) / (columnCount - 1);
+
+  if (
+    dominant.length < 18 ||
+    dominant.length < runnerUp.length * 1.8 ||
+    dominant.length < otherAverage * 2.4 ||
+    otherAverage > 24
+  ) return undefined;
+
+  return Array.from({ length: columnCount }, (_, index) => index === dominant.index ? 2 : 1);
+}
+
+function tableColumns(
+  columnCount: number,
+  sourceWidths: number[] | undefined,
+  rows: PreparedTableRow[]
+): string {
+  const validSourceWidths =
+    sourceWidths?.length === columnCount &&
+    sourceWidths.every((width) => Number.isFinite(width) && width > 0)
+      ? sourceWidths
+      : undefined;
+  const sourceSpread = validSourceWidths
+    ? Math.max(...validSourceWidths) / Math.min(...validSourceWidths)
+    : 1;
+  const selectedWidths = validSourceWidths && sourceSpread > 1.05
+    ? validSourceWidths
+    : inferredTableTracks(columnCount, rows);
+  if (!selectedWidths) {
+    return `(${Array.from({ length: columnCount }, () => "1fr").join(", ")},)`;
+  }
+  const total = selectedWidths.reduce((sum, width) => sum + width, 0);
+  const tracks = selectedWidths.map((width) => {
+    const ratio = width / total;
+    return `${Number(ratio.toFixed(6))}fr`;
+  });
+  return `(${tracks.join(", ")},)`;
+}
+
 function resolveLink(target: LinkTarget, labels: Map<string, string>): string | null {
   switch (target.kind) {
     case "external":
@@ -54,7 +173,7 @@ function serializeInline(nodes: InlineNode[], labels: Map<string, string>, notes
     .map((node) => {
       switch (node.type) {
         case "text": {
-          let out = escapeTypstContent(node.text);
+          let out = literalText(node.text);
           for (const mark of node.marks ?? []) {
             switch (mark) {
               case "bold":
@@ -90,7 +209,7 @@ function serializeInline(nodes: InlineNode[], labels: Map<string, string>, notes
         case "lineBreak":
           return "#linebreak()";
         case "mention":
-          return `#text(fill: rgb(\"#0747A6\"))[${escapeTypstContent(`@${node.displayName ?? node.accountId}`)}]`;
+          return `#text(fill: rgb(\"#0747A6\"))[${literalText(`@${node.displayName ?? node.accountId}`)}]`;
         case "status":
           return `#status-badge(${typstString(node.text || node.color)}, color: ${typstString(safeColor(node.color))})`;
         case "link": {
@@ -173,7 +292,6 @@ function collectHeadingLabels(blocks: PreparedPdfBlock[]): Map<string, string> {
 }
 
 interface Writer {
-  lines: string[];
   sourceMap: PdfSourceMapEntry[];
   notes: ExportNote[];
   labels: Map<string, string>;
@@ -188,18 +306,64 @@ function serializeBlocks(blocks: PreparedPdfBlock[], writer: Writer, parentPath 
 }
 
 function writeMapped(block: PreparedPdfBlock, writer: Writer, path: string, value: string, summary?: string): string {
-  const startLine = writer.lines.length + 1;
-  const marker = `// atlcli:${path}`;
-  const chunk = `${marker}\n${value}`;
-  writer.lines.push(...chunk.split("\n"));
   writer.sourceMap.push({
     blockPath: path,
     blockType: block.type,
-    startLine,
-    endLine: writer.lines.length,
+    startLine: 0,
+    startColumn: 0,
+    endLine: 0,
+    endColumn: 0,
     summary,
   });
-  return chunk;
+  return `/* atlcli:start:${path} */${value}/* atlcli:end:${path} */`;
+}
+
+function resolveSourceMap(main: string, entries: PdfSourceMapEntry[]): PdfSourceMapEntry[] {
+  const byPath = new Map(entries.map((entry) => [entry.blockPath, { ...entry }]));
+  const lineStarts = [0];
+  for (let index = 0; index < main.length; index += 1) {
+    if (main[index] === "\n") lineStarts.push(index + 1);
+  }
+  const positionAt = (offset: number): { line: number; column: number } => {
+    let low = 0;
+    let high = lineStarts.length - 1;
+    while (low <= high) {
+      const middle = Math.floor((low + high) / 2);
+      if (lineStarts[middle]! <= offset) low = middle + 1;
+      else high = middle - 1;
+    }
+    const lineIndex = Math.max(0, high);
+    return { line: lineIndex + 1, column: offset - lineStarts[lineIndex]! + 1 };
+  };
+  const stack: Array<{ path: string; startLine: number; startColumn: number }> = [];
+  const marker = /\/\* atlcli:(start|end):([^*]+) \*\//g;
+  for (const match of main.matchAll(marker)) {
+    const action = match[1];
+    const path = match[2]!;
+    if (action === "start") {
+      const start = positionAt(match.index! + match[0].length);
+      stack.push({ path, startLine: start.line, startColumn: start.column });
+      continue;
+    }
+    let openIndex = -1;
+    for (let index = stack.length - 1; index >= 0; index -= 1) {
+      if (stack[index]?.path === path) {
+        openIndex = index;
+        break;
+      }
+    }
+    if (openIndex < 0) continue;
+    const [open] = stack.splice(openIndex, 1);
+    const entry = byPath.get(path);
+    if (entry) {
+      const end = positionAt(match.index!);
+      entry.startLine = open!.startLine;
+      entry.startColumn = open!.startColumn;
+      entry.endLine = Math.max(open!.startLine, end.line);
+      entry.endColumn = end.column;
+    }
+  }
+  return entries.map((entry) => byPath.get(entry.blockPath) ?? entry);
 }
 
 function serializeBlock(block: PreparedPdfBlock, writer: Writer, path: string): string {
@@ -223,11 +387,14 @@ function serializeBlock(block: PreparedPdfBlock, writer: Writer, path: string): 
       value = `#raw(${typstString(block.code)}, lang: ${typstString(block.language ?? "text")}, block: true)`;
       break;
     case "diagram":
-      value = `#figure(image(${typstString(block.assetPath)}, alt: ${typstString(block.alt ?? "Diagram")}), placement: auto)`;
+      // Keep exported content in source order. `placement: auto` turns figures
+      // into top/bottom floats, which can move a diagram before its heading or
+      // collect multiple headings away from their diagrams in real documents.
+      value = `#figure(image(${typstString(block.assetPath)}, alt: ${typstString(block.alt ?? "Diagram")}))`;
       break;
     case "image":
       if (!block.assetPath) {
-        value = `#par[#emph[${escapeTypstContent(`[Image unavailable: ${block.fallbackLabel}]`)}]]`;
+        value = `#par[#emph[${literalText(`[Image unavailable: ${block.fallbackLabel}]`)}]]`;
       } else {
         if (!block.alt) {
           writer.notes.push({
@@ -236,11 +403,11 @@ function serializeBlock(block: PreparedPdfBlock, writer: Writer, path: string): 
             message: `${block.fallbackLabel} uses a technical filename fallback for alternative text.`,
           });
         }
-        value = `#figure(image(${typstString(block.assetPath)}, alt: ${typstString(block.alt ?? block.fallbackLabel)}), placement: auto)`;
+        value = `#figure(image(${typstString(block.assetPath)}, alt: ${typstString(block.alt ?? block.fallbackLabel)}))`;
       }
       break;
     case "callout": {
-      const title = block.title ? `[${escapeTypstContent(block.title)}]` : "none";
+      const title = block.title ? `[${literalText(block.title)}]` : "none";
       value = `#callout(kind: ${typstString(block.kind)}, title: ${title})[\n${serializeBlocks(block.content, writer, `${path}.content`)}\n]`;
       break;
     }
@@ -249,15 +416,34 @@ function serializeBlock(block: PreparedPdfBlock, writer: Writer, path: string): 
       break;
     case "list": {
       const fn = block.ordered ? "enum" : "list";
+      const isTaskList = !block.ordered && block.items.some((item) => item.checked !== undefined);
       const items = block.items.map((item, index) => {
-        const state = item.checked === undefined ? "" : item.checked ? "☑ " : "☐ ";
-        return `[${escapeTypstContent(state)}${serializeBlocks(item.content, writer, `${path}.items[${index}].content`)}]`;
+        const itemPath = `${path}.items[${index}].content`;
+        const [first, ...rest] = item.content;
+        let content: string;
+        if (first?.type === "paragraph") {
+          const inline = writeMapped(
+            first,
+            writer,
+            `${itemPath}[0]`,
+            serializeInline(first.content, writer.labels, writer.notes)
+          );
+          const tail = rest.length > 0 ? serializeBlocks(rest, writer, itemPath) : "";
+          content = `${inline}${tail}`;
+        } else {
+          content = serializeBlocks(item.content, writer, itemPath);
+        }
+        if (!isTaskList) return `[${content}]`;
+        const checked = item.checked === true ? "true" : "false";
+        return `[#task-item(${checked})[${content}]]`;
       });
-      value = `#${fn}(\n${items.join(",\n")}\n)`;
+      const options = isTaskList ? "marker: none, body-indent: 0pt, " : "";
+      value = `#${fn}(${options}\n${items.join(",\n")}\n)`;
       break;
     }
     case "table": {
-      const columns = Math.max(1, ...block.rows.map((row) => row.cells.reduce((sum, cell) => sum + cell.colspan, 0)));
+      const columnCount = Math.max(1, ...block.rows.map((row) => row.cells.reduce((sum, cell) => sum + cell.colspan, 0)));
+      const columns = tableColumns(columnCount, block.columnWidths, block.rows);
       const rows = block.rows.map((row, rowIndex) => {
         const cells = row.cells.map((cell, cellIndex) => {
           const args = [
@@ -272,7 +458,7 @@ function serializeBlock(block: PreparedPdfBlock, writer: Writer, path: string): 
           ? `table.header(${cells.join(", ")})`
           : cells.join(", ");
       });
-      value = `#table(columns: ${columns}, inset: 6pt, stroke: rgb(\"#DFE1E6\"),\n${rows.join(",\n")}\n)`;
+      value = `#block(width: 100%)[\n#table(columns: ${columns}, inset: (x: 6pt, y: 7pt), stroke: rgb(\"#DFE1E6\"),\n${rows.join(",\n")}\n)\n]`;
       break;
     }
     case "divider":
@@ -299,6 +485,16 @@ function typstDate(date: Date): string {
   return `datetime(year: ${date.getUTCFullYear()}, month: ${date.getUTCMonth() + 1}, day: ${date.getUTCDate()})`;
 }
 
+function exportedDateLabel(date: Date, language?: string, region?: string): string {
+  const locale = [language, region].filter(Boolean).join("-") || "en";
+  return new Intl.DateTimeFormat(locale, {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+    timeZone: "UTC",
+  }).format(date);
+}
+
 export function serializePdfDocument(
   document: PreparedPdfDocument,
   options: PdfSerializeOptions
@@ -306,7 +502,6 @@ export function serializePdfDocument(
   const labels = collectHeadingLabels(document.blocks);
   const min = minHeadingLevel(document.blocks);
   const writer: Writer = {
-    lines: [],
     sourceMap: [],
     notes: [...document.notes],
     labels,
@@ -316,8 +511,8 @@ export function serializePdfDocument(
   const body = serializeBlocks(document.blocks, writer);
   const meta = options.metadata;
   const author = meta.author ?? meta.exporter ?? "atlcli";
-  const exportedLabel = meta.exportedAt.toISOString().slice(0, 10);
-  const main = String.raw`#import "atlcli.typ": atlcli-doc, callout, status-badge
+  const exportedLabel = exportedDateLabel(meta.exportedAt, meta.language, meta.region);
+  const main = String.raw`#import "atlcli.typ": atlcli-doc, callout, status-badge, task-item
 
 #show: atlcli-doc.with(meta: (
   title: ${typstString(meta.title)},
@@ -325,6 +520,8 @@ export function serializePdfDocument(
   version: ${typstString(meta.version === undefined ? "—" : `v${meta.version}`)},
   author: ${typstString(author)},
   exporter: ${typstString(meta.exporter ?? author)},
+  language: ${typstString(meta.language ?? "en")},
+  region: ${meta.region ? typstString(meta.region) : "none"},
   exported-at: ${typstDate(meta.exportedAt)},
   exported-label: ${typstString(exportedLabel)},
 ))
@@ -336,26 +533,59 @@ ${body}
     main,
     template: ATLCLI_TYPST_TEMPLATE,
     assets: document.assets,
-    sourceMap: writer.sourceMap,
+    sourceMap: resolveSourceMap(main, writer.sourceMap),
     notes: writer.notes,
   };
 }
 
 export function mapPdfDiagnostics(
-  diagnostics: Array<{ severity?: string; message: string; path?: string; line?: number }>,
+  diagnostics: Array<{
+    severity?: string;
+    message: string;
+    path?: string;
+    line?: number;
+    column?: number;
+    endLine?: number;
+    endColumn?: number;
+  }>,
   sourceMap: PdfSourceMapEntry[]
-): Array<{ severity: "error" | "warning"; message: string; path?: string; startLine?: number; blockPath?: string }> {
+): Array<{
+  severity: "error" | "warning";
+  message: string;
+  path?: string;
+  startLine?: number;
+  startColumn?: number;
+  endLine?: number;
+  endColumn?: number;
+  blockPath?: string;
+}> {
   return diagnostics.map((diagnostic) => {
     const line = diagnostic.line;
+    const column = diagnostic.column;
     const mapped =
-      diagnostic.path === "main.typ" && line !== undefined
-        ? sourceMap.find((entry) => line >= entry.startLine && line <= entry.endLine)
+      diagnostic.path?.replace(/^\/+/, "") === "main.typ" && line !== undefined
+        ? sourceMap
+            .filter((entry) => {
+              if (line < entry.startLine || line > entry.endLine) return false;
+              if (column === undefined) return true;
+              if (line === entry.startLine && column < entry.startColumn) return false;
+              if (line === entry.endLine && column > entry.endColumn) return false;
+              return true;
+            })
+            .sort(
+              (left, right) =>
+                left.endLine - left.startLine - (right.endLine - right.startLine) ||
+                left.endColumn - left.startColumn - (right.endColumn - right.startColumn)
+            )[0]
         : undefined;
     return {
       severity: diagnostic.severity === "warning" ? "warning" : "error",
       message: diagnostic.message,
       path: diagnostic.path,
       startLine: line,
+      startColumn: column,
+      endLine: diagnostic.endLine,
+      endColumn: diagnostic.endColumn,
       blockPath: mapped?.blockPath,
     };
   });

--- a/packages/pdf/src/template.ts
+++ b/packages/pdf/src/template.ts
@@ -2,77 +2,172 @@
  * Pinned atlcli Typst standard template. It uses semantic Typst elements and
  * show rules so PDF tagging/outline information survives visual styling.
  */
+const EDITORIAL_DASH = String.fromCodePoint(0x2013);
+const EDITORIAL_BULLET = String.fromCodePoint(0x2022);
+const EDITORIAL_NESTED_BULLET = String.fromCodePoint(0x25e6);
+const TASK_CHECKED = String.fromCodePoint(0x2713);
+const TASK_UNCHECKED = String.fromCodePoint(0x25a1);
+
 export const ATLCLI_TYPST_TEMPLATE = String.raw`
+#let editorial-numbering(..nums) = {
+  let values = nums.pos()
+  let current = values.last()
+  let pattern = if values.len() == 1 { "1." } else if values.len() == 2 { "a)" } else { "i." }
+  text(
+    font: "Source Sans 3",
+    size: 0.95em,
+    weight: "semibold",
+    fill: rgb("#6B778C"),
+    numbering(pattern, current),
+  )
+}
+
 #let atlcli-doc(meta: (:), body) = {
+  let is-german = meta.at("language", default: "en") == "de"
+  let version-label = [Version]
+  let exported-label = if is-german { [Exportiert] } else { [Exported] }
+  let exporter-label = if is-german { [Exportiert von] } else { [Exported by] }
+  let contents-label = if is-german { [Inhalt] } else { [Contents] }
+  let end-label = if is-german { [DOKUMENTENDE] } else { [END OF DOCUMENT] }
+  let pages-label = if is-german { [Seiten] } else { [Pages] }
+  let indigo = rgb("#4B57A3")
+  let ink = rgb("#202A44")
+  let warm-slate = rgb("#74727A")
+  let cover-paper = rgb("#FCFBF8")
+
   set document(
     title: meta.title,
     author: meta.author,
     date: meta.exported-at,
   )
-  set text(font: "Inter", size: 10pt, fill: rgb("#172B4D"))
-  set par(leading: 0.68em, justify: false)
+  set text(
+    font: "Source Serif 4",
+    size: 10pt,
+    fill: rgb("#172B4D"),
+    lang: meta.at("language", default: "en"),
+    region: meta.at("region", default: none),
+  )
+  set par(leading: 0.74em, spacing: 10pt, justify: false)
+  set list(
+    marker: (
+      [#text(font: "Source Sans 3", fill: rgb("#6B778C"))[${EDITORIAL_DASH}]],
+      [#text(font: "Source Sans 3", fill: rgb("#6B778C"))[${EDITORIAL_BULLET}]],
+      [#text(font: "Source Sans 3", fill: rgb("#6B778C"))[${EDITORIAL_NESTED_BULLET}]],
+    ),
+    body-indent: 0.7em,
+    spacing: 8pt,
+  )
+  set enum(
+    numbering: editorial-numbering,
+    body-indent: 0.7em,
+    spacing: 8pt,
+  )
   set page(
     paper: "a4",
+    fill: cover-paper,
     margin: (top: 23mm, bottom: 20mm, left: 22mm, right: 22mm),
     header: context {
-      if counter(page).get().first() > 1 {
-        set text(size: 8pt, fill: rgb("#6B778C"))
+      let current-page = counter(page).get().first()
+      let final-page = counter(page).final().first()
+      if current-page > 1 and current-page < final-page {
+        set text(font: "Source Sans 3", size: 8pt, fill: rgb("#6B778C"))
         grid(columns: (1fr, auto), meta.title, meta.space)
         line(length: 100%, stroke: rgb("#DFE1E6"))
       }
     },
     footer: context {
-      set text(size: 8pt, fill: rgb("#6B778C"))
-      align(center)[#counter(page).display("1")]
+      if counter(page).get().first() > 1 {
+        set text(font: "Source Sans 3", size: 8pt, fill: rgb("#6B778C"))
+        align(center)[#counter(page).display("1")]
+      }
     },
   )
 
   show heading.where(level: 1): it => {
-    set text(size: 18pt, weight: "semibold", fill: rgb("#172B4D"))
-    block(above: 18pt, below: 8pt, it)
+    set text(font: "Source Sans 3", size: 18pt, weight: "semibold", fill: rgb("#172B4D"))
+    block(above: 28pt, below: 14pt, sticky: true, it)
   }
   show heading.where(level: 2): it => {
-    set text(size: 14pt, weight: "semibold", fill: rgb("#172B4D"))
-    block(above: 14pt, below: 6pt, it)
+    set text(font: "Source Sans 3", size: 14pt, weight: "semibold", fill: rgb("#172B4D"))
+    block(above: 24pt, below: 12pt, sticky: true, it)
   }
   show heading.where(level: 3): it => {
-    set text(size: 11.5pt, weight: "semibold", fill: rgb("#253858"))
-    block(above: 10pt, below: 4pt, it)
+    set text(font: "Source Sans 3", size: 11.5pt, weight: "semibold", fill: rgb("#253858"))
+    block(above: 18pt, below: 8pt, sticky: true, it)
   }
   show raw.where(block: true): it => block(
     fill: rgb("#F4F5F7"),
     inset: 9pt,
     radius: 4pt,
     width: 100%,
-    text(font: "JetBrains Mono", size: 8.5pt, it),
+    text(font: "Source Code Pro", size: 8.5pt, it),
   )
   show table.cell: it => {
-    set text(size: 9pt)
+    set text(font: "Source Sans 3", size: 9pt, hyphenate: true)
+    set par(linebreaks: "optimized")
     it
   }
 
-  align(center + horizon)[
-    #block(width: 82%)[
-      #text(size: 30pt, weight: "semibold", fill: rgb("#172B4D"))[#meta.title]
-      #v(12pt)
-      #text(size: 11pt, fill: rgb("#6B778C"))[#meta.space]
-      #v(24pt)
-      #line(length: 72pt, stroke: 2pt + rgb("#0052CC"))
-      #v(24pt)
-      #grid(
-        columns: (auto, 1fr),
-        column-gutter: 12pt,
-        row-gutter: 5pt,
-        [*Version*], [#meta.version],
-        [*Exported*], [#meta.exported-label],
-        [*Exporter*], [#meta.exporter],
-      )
+  v(37mm)
+  block(width: 90%)[
+    #set text(font: "Source Sans 3")
+    #text(size: 8pt, weight: "semibold", tracking: 0.12em, fill: indigo)[CONFLUENCE SPACE / #meta.space]
+    #v(17pt)
+    #block(width: 100%)[
+      #set par(leading: 0.98em)
+      #text(font: "Source Serif 4", size: 31pt, weight: "semibold", fill: ink)[#meta.title]
     ]
+    #v(25pt)
+    #line(length: 52mm, stroke: 0.9pt + indigo)
+    #v(23pt)
+    #grid(
+      columns: (30mm, 1fr),
+      column-gutter: 12pt,
+      row-gutter: 8pt,
+      text(size: 7.5pt, weight: "semibold", tracking: 0.08em, fill: warm-slate, upper(version-label)),
+      text(size: 9.5pt, fill: ink, meta.version),
+      text(size: 7.5pt, weight: "semibold", tracking: 0.08em, fill: warm-slate, upper(exported-label)),
+      text(size: 9.5pt, fill: ink, meta.exported-label),
+      text(size: 7.5pt, weight: "semibold", tracking: 0.08em, fill: warm-slate, upper(exporter-label)),
+      text(size: 9.5pt, fill: ink, meta.exporter),
+    )
   ]
   pagebreak()
-  outline(title: [Contents], depth: 3)
+  set page(fill: white)
+  outline(title: contents-label, depth: 3)
   pagebreak()
   body
+  pagebreak()
+  set page(fill: cover-paper)
+  v(57mm)
+  block(width: 82%)[
+    #set text(font: "Source Sans 3")
+    #text(size: 8pt, weight: "semibold", tracking: 0.14em, fill: indigo)[#end-label]
+    #v(14pt)
+    #block(width: 100%)[
+      #set par(leading: 1.02em)
+      #text(font: "Source Serif 4", size: 24pt, weight: "semibold", fill: ink)[#meta.title]
+    ]
+    #v(22pt)
+    #line(length: 52mm, stroke: 0.9pt + indigo)
+    #v(22pt)
+    #grid(
+      columns: (30mm, 1fr),
+      column-gutter: 12pt,
+      row-gutter: 8pt,
+      text(size: 7.5pt, weight: "semibold", tracking: 0.08em, fill: warm-slate, upper(version-label)),
+      text(size: 9.5pt, fill: ink, meta.version),
+      text(size: 7.5pt, weight: "semibold", tracking: 0.08em, fill: warm-slate, upper(exported-label)),
+      text(size: 9.5pt, fill: ink, meta.exported-label),
+      text(size: 7.5pt, weight: "semibold", tracking: 0.08em, fill: warm-slate, upper(pages-label)),
+      context text(size: 9.5pt, fill: ink, str(counter(page).final().first())),
+    )
+    #v(24pt)
+    #text(size: 8.5pt, fill: warm-slate)[
+      #if is-german { [Erzeugt aus Confluence mit] } else { [Generated from Confluence with] }
+      #link("https://atlcli.sh/")[#text(weight: "semibold", fill: indigo)[atlcli]]
+    ]
+  ]
 }
 
 #let callout(kind: "info", title: none, body) = {
@@ -93,6 +188,7 @@ export const ATLCLI_TYPST_TEMPLATE = String.raw`
     above: 6pt,
     below: 8pt,
   )[
+    #set text(font: "Source Sans 3")
     #if title != none { text(weight: "semibold", fill: colors.last(), title); linebreak() }
     #body
   ]
@@ -102,6 +198,20 @@ export const ATLCLI_TYPST_TEMPLATE = String.raw`
   fill: rgb(color).lighten(82%),
   inset: (x: 5pt, y: 2pt),
   radius: 3pt,
-  text(size: 7.5pt, weight: "semibold", fill: rgb(color), label),
+  text(font: "Source Sans 3", size: 7.5pt, weight: "semibold", fill: rgb(color), label),
+)
+
+#let task-item(checked, body) = grid(
+  columns: (1.05em, 1fr),
+  column-gutter: 0.45em,
+  align: top,
+  text(
+    font: "Source Sans 3",
+    size: 8.5pt,
+    weight: "semibold",
+    fill: rgb(if checked { "#0052CC" } else { "#6B778C" }),
+    if checked { "${TASK_CHECKED}" } else { "${TASK_UNCHECKED}" },
+  ),
+  body,
 )
 `;

--- a/packages/pdf/src/template.ts
+++ b/packages/pdf/src/template.ts
@@ -1,0 +1,107 @@
+/**
+ * Pinned atlcli Typst standard template. It uses semantic Typst elements and
+ * show rules so PDF tagging/outline information survives visual styling.
+ */
+export const ATLCLI_TYPST_TEMPLATE = String.raw`
+#let atlcli-doc(meta: (:), body) = {
+  set document(
+    title: meta.title,
+    author: meta.author,
+    date: meta.exported-at,
+  )
+  set text(font: "Inter", size: 10pt, fill: rgb("#172B4D"))
+  set par(leading: 0.68em, justify: false)
+  set page(
+    paper: "a4",
+    margin: (top: 23mm, bottom: 20mm, left: 22mm, right: 22mm),
+    header: context {
+      if counter(page).get().first() > 1 {
+        set text(size: 8pt, fill: rgb("#6B778C"))
+        grid(columns: (1fr, auto), meta.title, meta.space)
+        line(length: 100%, stroke: rgb("#DFE1E6"))
+      }
+    },
+    footer: context {
+      set text(size: 8pt, fill: rgb("#6B778C"))
+      align(center)[#counter(page).display("1")]
+    },
+  )
+
+  show heading.where(level: 1): it => {
+    set text(size: 18pt, weight: "semibold", fill: rgb("#172B4D"))
+    block(above: 18pt, below: 8pt, it)
+  }
+  show heading.where(level: 2): it => {
+    set text(size: 14pt, weight: "semibold", fill: rgb("#172B4D"))
+    block(above: 14pt, below: 6pt, it)
+  }
+  show heading.where(level: 3): it => {
+    set text(size: 11.5pt, weight: "semibold", fill: rgb("#253858"))
+    block(above: 10pt, below: 4pt, it)
+  }
+  show raw.where(block: true): it => block(
+    fill: rgb("#F4F5F7"),
+    inset: 9pt,
+    radius: 4pt,
+    width: 100%,
+    text(font: "JetBrains Mono", size: 8.5pt, it),
+  )
+  show table.cell: it => {
+    set text(size: 9pt)
+    it
+  }
+
+  align(center + horizon)[
+    #block(width: 82%)[
+      #text(size: 30pt, weight: "semibold", fill: rgb("#172B4D"))[#meta.title]
+      #v(12pt)
+      #text(size: 11pt, fill: rgb("#6B778C"))[#meta.space]
+      #v(24pt)
+      #line(length: 72pt, stroke: 2pt + rgb("#0052CC"))
+      #v(24pt)
+      #grid(
+        columns: (auto, 1fr),
+        column-gutter: 12pt,
+        row-gutter: 5pt,
+        [*Version*], [#meta.version],
+        [*Exported*], [#meta.exported-label],
+        [*Exporter*], [#meta.exporter],
+      )
+    ]
+  ]
+  pagebreak()
+  outline(title: [Contents], depth: 3)
+  pagebreak()
+  body
+}
+
+#let callout(kind: "info", title: none, body) = {
+  let palette = (
+    info: (rgb("#DEEBFF"), rgb("#0747A6")),
+    note: (rgb("#EAE6FF"), rgb("#403294")),
+    warning: (rgb("#FFFAE6"), rgb("#974F0C")),
+    tip: (rgb("#E3FCEF"), rgb("#006644")),
+    panel: (rgb("#F4F5F7"), rgb("#42526E")),
+  )
+  let colors = palette.at(kind, default: palette.panel)
+  block(
+    width: 100%,
+    fill: colors.first(),
+    stroke: (left: 3pt + colors.last()),
+    inset: (x: 11pt, y: 9pt),
+    radius: (right: 4pt),
+    above: 6pt,
+    below: 8pt,
+  )[
+    #if title != none { text(weight: "semibold", fill: colors.last(), title); linebreak() }
+    #body
+  ]
+}
+
+#let status-badge(label, color: "#42526E") = box(
+  fill: rgb(color).lighten(82%),
+  inset: (x: 5pt, y: 2pt),
+  radius: 3pt,
+  text(size: 7.5pt, weight: "semibold", fill: rgb(color), label),
+)
+`;

--- a/packages/pdf/src/types.ts
+++ b/packages/pdf/src/types.ts
@@ -7,6 +7,7 @@ export interface PdfExportMetadata {
   author?: string;
   exporter?: string;
   language?: string;
+  region?: string;
   exportedAt: Date;
 }
 
@@ -36,7 +37,11 @@ export type PreparedPdfBlock =
   | Exclude<ExportBlock, { type: "callout" | "list" | "table" | "image" | "blockquote" | "codeBlock" }>
   | { type: "callout"; kind: Extract<ExportBlock, { type: "callout" }>["kind"]; title?: string; content: PreparedPdfBlock[] }
   | { type: "list"; ordered: boolean; items: Array<{ content: PreparedPdfBlock[]; checked?: boolean }> }
-  | { type: "table"; rows: Array<{ cells: Array<{ header: boolean; colspan: number; rowspan: number; content: PreparedPdfBlock[] }> }> }
+  | {
+      type: "table";
+      rows: Array<{ cells: Array<{ header: boolean; colspan: number; rowspan: number; content: PreparedPdfBlock[] }> }>;
+      columnWidths?: number[];
+    }
   | { type: "image"; assetPath?: string; alt?: string; width?: number; height?: number; fallbackLabel: string }
   | { type: "blockquote"; content: PreparedPdfBlock[] }
   | { type: "codeBlock"; language?: string; code: string }
@@ -51,7 +56,9 @@ export interface PreparedPdfDocument {
 export interface PdfSourceMapEntry {
   blockPath: string;
   startLine: number;
+  startColumn: number;
   endLine: number;
+  endColumn: number;
   blockType: PreparedPdfBlock["type"];
   summary?: string;
 }
@@ -95,7 +102,9 @@ export interface PdfCompilerDiagnostic {
   message: string;
   path?: string;
   startLine?: number;
+  startColumn?: number;
   endLine?: number;
+  endColumn?: number;
   blockPath?: string;
 }
 

--- a/packages/pdf/src/types.ts
+++ b/packages/pdf/src/types.ts
@@ -1,0 +1,102 @@
+import type { ExportBlock, ExportNote, InlineNode, LinkTarget } from "@atlcli/confluence";
+
+export interface PdfExportMetadata {
+  title: string;
+  space?: string;
+  version?: number;
+  author?: string;
+  exporter?: string;
+  language?: string;
+  exportedAt: Date;
+}
+
+export interface PdfAssetRef {
+  kind: "attachment" | "external";
+  filename?: string;
+  url?: string;
+}
+
+export interface PdfResolvedAsset {
+  bytes: Uint8Array;
+  mediaType: string;
+  filename?: string;
+}
+
+export interface PdfAssetResolver {
+  resolve(ref: PdfAssetRef): Promise<PdfResolvedAsset>;
+}
+
+export interface PreparedPdfAsset {
+  path: string;
+  bytes: Uint8Array;
+  mediaType: string;
+}
+
+export type PreparedPdfBlock =
+  | Exclude<ExportBlock, { type: "callout" | "list" | "table" | "image" | "blockquote" | "codeBlock" }>
+  | { type: "callout"; kind: Extract<ExportBlock, { type: "callout" }>["kind"]; title?: string; content: PreparedPdfBlock[] }
+  | { type: "list"; ordered: boolean; items: Array<{ content: PreparedPdfBlock[]; checked?: boolean }> }
+  | { type: "table"; rows: Array<{ cells: Array<{ header: boolean; colspan: number; rowspan: number; content: PreparedPdfBlock[] }> }> }
+  | { type: "image"; assetPath?: string; alt?: string; width?: number; height?: number; fallbackLabel: string }
+  | { type: "blockquote"; content: PreparedPdfBlock[] }
+  | { type: "codeBlock"; language?: string; code: string }
+  | { type: "diagram"; assetPath: string; alt?: string; source: string };
+
+export interface PreparedPdfDocument {
+  blocks: PreparedPdfBlock[];
+  assets: PreparedPdfAsset[];
+  notes: ExportNote[];
+}
+
+export interface PdfSourceMapEntry {
+  blockPath: string;
+  startLine: number;
+  endLine: number;
+  blockType: PreparedPdfBlock["type"];
+  summary?: string;
+}
+
+export interface PdfSourceBundle {
+  main: string;
+  template: string;
+  assets: PreparedPdfAsset[];
+  sourceMap: PdfSourceMapEntry[];
+  notes: ExportNote[];
+}
+
+export type PdfProfile = "tagged" | "pdf-ua-1";
+
+export interface PdfSerializeOptions {
+  metadata: PdfExportMetadata;
+  profile?: PdfProfile;
+}
+
+export interface PdfExportTimings {
+  prepareMs: number;
+  compileMs: number;
+  downloadMs: number;
+  totalMs: number;
+}
+
+export interface PdfExportReport {
+  filename: string;
+  profile: PdfProfile;
+  compilerVersion: string;
+  pageCount?: number;
+  embeddedImages: number;
+  renderedDiagrams: number;
+  skippedAssets: number;
+  notes: ExportNote[];
+  timings: PdfExportTimings;
+}
+
+export interface PdfCompilerDiagnostic {
+  severity: "error" | "warning";
+  message: string;
+  path?: string;
+  startLine?: number;
+  endLine?: number;
+  blockPath?: string;
+}
+
+export type { ExportBlock, ExportNote, InlineNode, LinkTarget };

--- a/patches/@myriaddreamin%2Ftypst-ts-web-compiler@0.7.0.patch
+++ b/patches/@myriaddreamin%2Ftypst-ts-web-compiler@0.7.0.patch
@@ -1,0 +1,40 @@
+diff --git a/pkg/typst_ts_web_compiler.mjs b/pkg/typst_ts_web_compiler.mjs
+index 89d9a7e62c3db42a20972542a4f3bf0e23d87eed..17796490b7292a6cb2c7e91e880a85da8e2e6fa6 100644
+--- a/pkg/typst_ts_web_compiler.mjs
++++ b/pkg/typst_ts_web_compiler.mjs
+@@ -1406,11 +1406,33 @@ function __wbg_get_imports() {
+         return addHeapObject(ret);
+     };
+     imports.wbg.__wbg_new_no_args_cb138f77cf6151ee = function(arg0, arg1) {
+-        const ret = new Function(getStringFromWasm0(arg0, arg1));
++        const body = getStringFromWasm0(arg0, arg1);
++        let ret;
++        switch (body) {
++            case 'return 0':
++                ret = () => 0;
++                break;
++            case 'return true':
++                ret = () => true;
++                break;
++            case "throw new Error('Dummy AccessModel, please initialize compiler with withAccessModel()')":
++                ret = () => { throw new Error('Dummy AccessModel, please initialize compiler with withAccessModel()'); };
++                break;
++            case "throw new Error('Dummy Registry, please initialize compiler with withPackageRegistry()')":
++                ret = () => { throw new Error('Dummy Registry, please initialize compiler with withPackageRegistry()'); };
++                break;
++            default:
++                throw new Error(`Blocked unexpected dynamic function body from typst WASM: ${body}`);
++        }
+         return addHeapObject(ret);
+     };
+     imports.wbg.__wbg_new_with_args_df9e7125ffe55248 = function(arg0, arg1, arg2, arg3) {
+-        const ret = new Function(getStringFromWasm0(arg0, arg1), getStringFromWasm0(arg2, arg3));
++        const args = getStringFromWasm0(arg0, arg1);
++        const body = getStringFromWasm0(arg2, arg3);
++        if (args !== 'path' || body !== 'return path') {
++            throw new Error(`Blocked unexpected dynamic function from typst WASM: (${args}) ${body}`);
++        }
++        const ret = (path) => path;
+         return addHeapObject(ret);
+     };
+     imports.wbg.__wbg_next_138a17bbf04e926c = function(arg0) {

--- a/scripts/check-browser-build.test.ts
+++ b/scripts/check-browser-build.test.ts
@@ -27,7 +27,7 @@ function fixtureDir(): string {
 }
 
 describe("browser-build gate (spec 001 task 6)", () => {
-  test("the gate's entrypoint set is exactly the seven browser entrypoints", () => {
+  test("the gate's entrypoint set includes every browser entrypoint", () => {
     expect(BROWSER_ENTRYPOINTS).toEqual([
       "packages/confluence/src/markdown.ts",
       "packages/confluence/src/client.ts",
@@ -36,6 +36,7 @@ describe("browser-build gate (spec 001 task 6)", () => {
       "packages/confluence/src/index.browser.ts",
       "packages/docx/src/index.browser.ts",
       "packages/diagram/src/index.ts",
+      "packages/pdf/src/index.browser.ts",
     ]);
   });
 

--- a/scripts/check-browser-build.ts
+++ b/scripts/check-browser-build.ts
@@ -20,6 +20,7 @@ export const BROWSER_ENTRYPOINTS = [
   "packages/confluence/src/index.browser.ts",
   "packages/docx/src/index.browser.ts",
   "packages/diagram/src/index.ts",
+  "packages/pdf/src/index.browser.ts",
 ];
 
 /**

--- a/specs/007-pdf-export/PLAN.md
+++ b/specs/007-pdf-export/PLAN.md
@@ -15,6 +15,9 @@ Depends on:
 Handoff to: `008-export-poc-validation` (final cross-format quality and performance verdict)
 
 Related strategy: FAHRPLAN Phase 1 Task 1.4 · `TYPST-EXPORT-ANGLE.md` §1b, §5.2, §7.5 Schritt 4 · `EXPORT-QUALITY-ANGLE.md` §3–§5, §7 (quality proofs 1+3)
+Follow-up product direction: [`TEMPLATE-UX.md`](./TEMPLATE-UX.md) — curated Typst
+templates, Git-friendly packages and a focused PDF stationery-import wizard without a
+general-purpose template studio.
 Origin: FAHRPLAN Phase 1 — "PDF-Export"
 
 ---
@@ -48,7 +51,8 @@ The cheap-but-decisive quality proofs ship inside this spec:
 - Preserve the existing export model: paragraphs, text marks, links, mentions,
   callouts, statuses, code, nested lists, task state, tables, images, blockquotes,
   dividers and documented fallback behavior for unsupported content.
-- Bundle and embed pinned **Inter** 400/500/600 and **JetBrains Mono** 400/700 files.
+- Bundle and embed pinned **Source Serif 4** 400/600/700 + italic 400,
+  **Source Sans 3** 400/600/700 + italic 400 and **Source Code Pro** 400/700 files.
   No system-font lookup and no runtime font, compiler or package download.
 - Keep the panel responsive and expose job phases, diagnostics and a useful export
   report.
@@ -79,9 +83,9 @@ The cheap-but-decisive quality proofs ship inside this spec:
   and `@atlcli/diagram`. `packages/confluence` does not gain presentation-format code.
 - The extension owns authenticated asset resolution, job storage, compiler lifecycle,
   offscreen/worker integration and the browser download adapter.
-- Fonts have one canonical, format-neutral repository location. Task 0 moves or exposes
-  the already pinned files without duplicating them in DOCX and extension source trees;
-  DOCX must remain green after the move.
+- PDF fonts have one canonical, gitignored build cache populated from immutable upstream
+  commits with mandatory SHA-256 verification. Only the manifest and OFL texts are tracked;
+  DOCX keeps its independent template-driven contract and diagram-rasterizer assets.
 
 ### 2.2 Process and transport topology
 
@@ -332,8 +336,8 @@ than reusing the DOCX template report type directly. It includes:
 ### Task 0 — Refresh contracts and shared assets
 
 - [ ] Add `@atlcli/pdf` with browser-safe package boundaries and explicit exports.
-- [ ] Establish one canonical font source and keep DOCX tests/output green after the
-  asset-path change.
+- [ ] Establish a canonical, checksum-verified PDF font build cache while leaving the
+  template-driven DOCX font contract and its diagram-rasterizer assets unchanged.
 - [ ] Pin wrapper, web compiler/WASM, embedded Typst engine, diagram renderer, template
   and fonts; record source URL, version, checksum and license.
 - [ ] Update `NOTICE` and ensure licenses ship in the extension artifact.
@@ -343,7 +347,7 @@ than reusing the DOCX template report type directly. It includes:
 
 - [ ] In the built WXT extension, initialize the exact pinned compiler and produce a
   valid hello-world PDF from packaged WASM with network access denied.
-- [ ] Prove font registration with Inter and JetBrains Mono and prove that an unknown
+- [ ] Prove font registration with Source Serif 4, Source Sans 3 and Source Code Pro and prove that an unknown
   font fails rather than silently resolving from the environment.
 - [ ] Record whether and how the browser API selects tagged default and PDF/UA-1 output.
   If UA selection is unavailable, record the follow-up boundary before template work.
@@ -529,8 +533,10 @@ mutate it in this spec; final cleanup belongs to 008.
 
 - **F1 — serializer location:** ✅ `packages/pdf` / `@atlcli/pdf`; host-neutral and
   browser-safe. Extension owns only browser adapters and compiler hosting.
-- **F2 — bundled font set:** ✅ Inter 400/500/600 + JetBrains Mono 400/700, full Phase 1
-  character sets, exact files/versions/checksums/licenses pinned, no system fallback.
+- **F2 — bundled font set:** ✅ Source Serif 4 400/600/700 + italic 400,
+  Source Sans 3 400/600/700 + italic 400 and Source Code Pro 400/700, exact
+  upstream commits/checksums/licenses pinned, gitignored build cache, no system fallback.
+  DOCX remains template-driven.
 - **F3 — binary transport:** ✅ JSON control messages plus job-scoped same-origin binary
   storage; no `Map`/`ArrayBuffer` payloads through runtime messaging.
 - **F4 — compiler concurrency:** ✅ one active compile per worker with FIFO queue until a

--- a/specs/007-pdf-export/PLAN.md
+++ b/specs/007-pdf-export/PLAN.md
@@ -1,206 +1,544 @@
 # PDF Export — typst.ts in the Offscreen Document, atlcli Standard Template
 
-Status: **Planned**
+Status: **Planned — implementation-ready after feasibility gates**
 
 Spec ID: `007-pdf-export`
-Depends on: `003-page-detection-read-path`, `004-docx-export` Task 2 (shared `ExportBlock` intermediate model), `002-extension-workspace` Task 5 (offscreen WASM proof)
+Depends on:
+
+- `002-extension-workspace` Task 5 (offscreen WASM proof)
+- `003-page-detection-read-path`
+- `004-docx-export` (shared `ExportBlock` model, report and download lessons)
+- `005-docx-image-module` (authenticated attachment pipeline)
+- `005a-mermaid-diagrams` (`@atlcli/diagram` SVG renderer)
+- `006-isomorphic-export-fup` (browser-safe walker and reusable export engine)
+
+Handoff to: `008-export-poc-validation` (final cross-format quality and performance verdict)
+
 Related strategy: FAHRPLAN Phase 1 Task 1.4 · `TYPST-EXPORT-ANGLE.md` §1b, §5.2, §7.5 Schritt 4 · `EXPORT-QUALITY-ANGLE.md` §3–§5, §7 (quality proofs 1+3)
 Origin: FAHRPLAN Phase 1 — "PDF-Export"
 
 ---
 
-## 1. Overview
+## 1. Current baseline and objective
 
-Secondary export path, but the one with **visible world-class potential**: compile the
-detected page to PDF via `typst.ts` (Apache-2.0 WASM compiler) running in the extension's
-**offscreen document**, using an **atlcli-owned standard Typst template** with embedded
-open fonts — deliberately *not* a customer-template path (that's DOCX's job, per the
-research verdict).
+The DOCX path, authenticated image embedding, Mermaid-to-SVG rendering and the
+isomorphic export engine are implemented. This spec adds the next output adapter; it
+does not rebuild those capabilities.
 
-The cheap-but-decisive quality proofs from EXPORT-QUALITY §7 ship inside this spec, because
-they are what turns "a PDF export" into "visibly better than Scroll":
+PDF is the secondary export path, but the one with **visible world-class potential**:
+compile the detected page via a pinned `typst.ts` browser compiler running outside the
+panel thread, using an **atlcli-owned standard Typst template** with embedded open fonts.
+PDF deliberately remains a standard-template path rather than a customer-template path.
 
-- **beautiful-mermaid** diagrams embedded as native vector SVG,
-- native **code highlighting** (Typst `raw`/syntect — no extra tooling),
-- one **Tagged PDF (PDF/UA-1)** reference document with cover + bookmarks as the
-  accessibility/archival proof point.
+The cheap-but-decisive quality proofs ship inside this spec:
+
+- Mermaid diagrams embedded as native vector SVG through `@atlcli/diagram`;
+- native Typst code highlighting without an additional highlighter;
+- tagged, semantic PDF by default;
+- one separately selected and independently validated PDF/UA-1 reference export, if the
+  pinned browser compiler exposes the required standard option.
 
 ### Goals
 
-- "Export as PDF" button in the panel: page → `ExportBlock[]` (004's walker) → Typst
-  markup → offscreen compile → downloaded PDF.
-- atlcli standard template (`tech-doc` flavor, single layout for the PoC): cover (title,
-  space, version, date, exporter), TOC with correct page numbers (Typst computes them —
-  a 🏆 over the Word path), numbered headings, header with running chapter title, footer
-  with page numbers, PDF outline/bookmarks from headings, internal links.
-- Confluence semantics mapped: callout boxes (styled per EXPORT-QUALITY §4 example),
-  status → inline badge, code blocks with syntax highlighting + language label, tables
-  with repeated headers and basic merges, images (attachment blobs), expand macro inlined.
-- Open fonts bundled and embedded — **Inter** (text; weights 400/500/600) +
-  **JetBrains Mono** (code; weights 400/700), per decision F2; the `atlcli.typ` template
-  is designed sans-serif-only. Font files and versions are **pinned** (exact release
-  recorded in the repo); **no fallback to locally installed fonts** — otherwise the 006
-  quality comparison isn't reproducible. Deterministic output.
-- Tagged PDF on by default (Typst ≥ 0.14); one reference export validated as PDF/UA-1.
-- Compile runs off the panel thread (offscreen doc), panel shows progress and stays
-  responsive; errors surface as readable messages, not hangs.
+- **Export as PDF** in the side panel: page → `ExportBlock[]` → prepared assets and
+  Typst source → offscreen compiler worker → downloaded PDF.
+- One atlcli `tech-doc` template: cover, TOC with computed page numbers, numbered
+  headings, running chapter header, page-number footer, PDF outline/bookmarks and
+  internal links.
+- Preserve the existing export model: paragraphs, text marks, links, mentions,
+  callouts, statuses, code, nested lists, task state, tables, images, blockquotes,
+  dividers and documented fallback behavior for unsupported content.
+- Bundle and embed pinned **Inter** 400/500/600 and **JetBrains Mono** 400/700 files.
+  No system-font lookup and no runtime font, compiler or package download.
+- Keep the panel responsive and expose job phases, diagnostics and a useful export
+  report.
+- Produce reproducible output from fixed inputs. Compiler, WASM, template, diagram
+  renderer, fonts, locale, metadata and clock are explicit inputs.
 
 ### Non-goals
 
-- No customer .docx/.typ template support, no template upload for PDF (Phase 2's design
-  system + `brand.typ` add themes; PoC ships exactly one good layout).
-- No corporate font upload (Phase 2, EXPORT-QUALITY §3 strategy step b).
-- No PDF/A profile selection UI — default output + the single tagged reference doc suffice.
-- No multi-page/page-tree export; no PlantUML/draw.io/Gliffy embedding (v1 roadmap).
-- No mermaid.js fallback for exotic diagram types (beautiful-mermaid's 6 types only;
-  others render as code blocks with a report note).
+- No customer `.docx` or `.typ` template support and no PDF template upload.
+- No corporate font upload or template/theme marketplace.
+- No PDF/A claim or archival-conformance claim in this spec.
+- No PDF-standard selection UI. Standard tagged output is the user path; PDF/UA-1 is a
+  reference-validation mode.
+- No multi-page/page-tree export and no PlantUML, draw.io or Gliffy embedding.
+- No server or companion compiler and no CLI command in this spec. The serializer stays
+  host-neutral so a CLI adapter can follow without redesign.
 
 ---
 
-## 2. Architecture
+## 2. Fixed architecture decisions
 
-### 2.1 Process topology
+### 2.1 Ownership boundaries
 
+- New browser-safe workspace package: `packages/pdf` / `@atlcli/pdf`.
+- `@atlcli/pdf` owns the PDF preparation types, Typst serializer, semantic template
+  contract, source-map model and PDF-specific report model.
+- `@atlcli/pdf` depends only on browser-safe packages, including `@atlcli/confluence`
+  and `@atlcli/diagram`. `packages/confluence` does not gain presentation-format code.
+- The extension owns authenticated asset resolution, job storage, compiler lifecycle,
+  offscreen/worker integration and the browser download adapter.
+- Fonts have one canonical, format-neutral repository location. Task 0 moves or exposes
+  the already pinned files without duplicating them in DOCX and extension source trees;
+  DOCX must remain green after the move.
+
+### 2.2 Process and transport topology
+
+```text
+side panel                    service worker                 offscreen document
+──────────                    ──────────────                 ──────────────────
+walk page + prepare assets ─▶ create job in shared store ─▶ compiler host
+send { jobId, inputKey }      route JSON control message     dedicated worker + WASM
+receive phase updates     ◀── small JSON messages        ◀── init / compile / reset
+read PDF Blob by resultKey ◀─ { jobId, resultKey, report }  write result to job store
+download application/pdf
 ```
-side panel                     service worker              offscreen document
-──────────                     ──────────────              ──────────────────
-blocks = walker(storage)   ──▶ ensureOffscreen()      ──▶  typst.ts compiler (WASM)
-typstSrc = serialize(blocks)   route compile-request       + bundled fonts
-images fetched as blobs    ──▶ (transferables)        ──▶  vfs: main.typ, template.typ,
-                                                            images/*, fonts/*
-report + PDF bytes         ◀── compile-response       ◀──  PDF bytes | diagnostics
+
+`chrome.runtime.sendMessage` is the **control plane only**. Runtime messages contain
+JSON-safe, bounded values such as `jobId`, keys, phases, progress, diagnostics and
+report summaries. They never contain `Map`, fonts, image bytes, source bundles or PDF
+bytes.
+
+Large inputs and outputs use a same-origin, job-scoped store accessible by the extension
+contexts (IndexedDB is the default; Cache Storage is allowed only if Task 1 proves a
+clearer lifecycle). Every record is keyed by an unguessable `jobId`, has a byte count and
+creation time, and is deleted in `finally`, on timeout and by stale-job cleanup at
+startup. The store defines per-file, per-job and total quotas and turns quota failures
+into readable errors.
+
+Static WASM, fonts and `atlcli.typ` load directly from packaged extension URLs inside the
+offscreen context. They are initialized once and never copied through runtime messages.
+
+### 2.3 Compiler lifecycle
+
+The offscreen document is a lifecycle host. A locally bundled Dedicated Worker owns the
+compiler and mutable virtual filesystem.
+
+States: `closed → initializing → ready → running → resetting → ready`; any fatal init,
+timeout or compiler failure transitions through `failed → closed` before retry.
+
+Rules:
+
+- Compiler initialization is single-flight.
+- Compile jobs are FIFO with exactly one active job per worker until concurrency is
+  explicitly proven safe.
+- Fonts and compiler core initialize once; job sources and assets are mapped per job.
+- Job shadows are reset before a job and in `finally`; one export cannot observe files
+  from another export.
+- A 60-second timeout terminates the worker, rejects the job, clears cached readiness
+  state and creates a fresh worker for the next attempt. A Promise timeout alone is not
+  considered cancellation.
+- Idle teardown never closes an active or resetting job. Late responses are ignored by
+  `jobId` and their stored results are deleted.
+- Panel navigation or page changes invalidate the visible job without leaking its
+  eventual result into the newly loaded page.
+
+### 2.4 Network and privacy contract
+
+Allowed during export:
+
+- the active Atlassian tenant under `*.atlassian.net`;
+- `https://api.media.atlassian.com/*` for authenticated attachment redirects already
+  required by the working image pipeline.
+
+Disallowed:
+
+- compiler, WASM, font, template or package-registry downloads;
+- Typst default-font/default-package loaders that fetch remote assets;
+- external image hosts unless a later spec adds explicit host permissions.
+
+The compiler adapter disables default remote asset resolution and exposes only packaged
+fonts, template files and the current job VFS.
+
+---
+
+## 3. PDF content contract
+
+### 3.1 Preparation and serialization API
+
+The asynchronous preparation step resolves assets and renders diagrams; the serializer
+itself remains pure:
+
+```ts
+preparePdfDocument(
+  blocks: ExportBlock[],
+  context: PdfExportContext,
+  resolver: PdfAssetResolver,
+): Promise<PreparedPdfDocument>
+
+serializePdfDocument(
+  document: PreparedPdfDocument,
+  options: PdfSerializeOptions,
+): PdfSourceBundle
 ```
 
-- **Serialization (blocks → Typst source) happens in the panel** — pure string work,
-  fully unit-testable in bun without WASM.
-- **Only the compile runs offscreen.** Message protocol (002's `messages.ts`) gains
-  `compile-typst { files: Map<path, bytes>, mainPath }` → `{ ok, pdf } | { ok: false,
-  diagnostics }`. Large payloads: images/fonts passed as ArrayBuffers (structured clone;
-  measure — if cloning ~10 MB payloads is slow, switch to a Blob-URL handoff, noted as
-  fallback).
-- Offscreen doc initializes the typst.ts compiler once and caches it (font parsing is the
-  expensive part); idle-timeout teardown after N minutes.
-- **Fonts and WASM ship inside the extension** (no CDN at runtime — the privacy story
-  "only `*.atlassian.net`" must hold; use the packaged compiler module, not
-  `all-in-one-lite`'s CDN loading).
+`PdfSourceBundle` contains `main.typ`, deterministic job-local asset names, a structured
+source map and preparation notes. It is an internal value written to the job store, not
+a runtime-message payload.
 
-### 2.2 Typst template (`assets/typst/atlcli.typ`)
+Both `ExportBlock` and `InlineNode` mappings are exhaustive TypeScript switches with a
+`never` guard. Adding a model variant must fail typecheck until its PDF behavior is
+chosen.
 
-Single entry `#show: atlcli-doc.with(meta: (…))` providing: cover page, `outline()`,
-heading numbering, running header via heading query, footer page numbers, `callout()`
-(per the EXPORT-QUALITY §4 reference implementation), `status-badge()`, code block
-styling, table defaults (`table.header` repeat), image figure with optional caption,
-document metadata (title/author → PDF metadata, required for UA-1).
+### 3.2 Normative block mapping
 
-### 2.3 Block serializer
-
-`typstSerialize(blocks: ExportBlock[], opts): { main: string, assets: AssetRef[] }` in the
-extension (or `packages/confluence` if it stays dependency-free — preferred, keeps it
-under the isomorphism gate and testable).
-
-Normative mappings:
-
-| ExportBlock | Typst |
+| `ExportBlock` | Typst behavior |
 |---|---|
-| heading(n) | `#heading(level: n)[…]` (template numbers + bookmarks) |
-| callout(kind, title) | `#callout(kind: …, title: …)[…]` |
-| codeBlock(lang) | ` ```lang … ``` ` (native highlighting) |
-| table (colspan/rowspan) | `#table` with `table.cell(colspan:, rowspan:)` |
-| image(attachment) | `#figure(image("images/<n>.<ext>"), caption: alt?)` + **alt text** (UA-1 requires it; fall back to filename) |
-| mermaid code block | beautiful-mermaid SVG → `image("images/dN.svg")` (vector) |
-| statusBadge | `#status-badge(color:)[TEXT]` |
-| link | `#link(url)[text]` |
-| unknown macro | omitted + report line (never raw storage XML in output) |
+| heading | semantic `heading`; document-wide promotion of the shallowest source heading to level 1, matching the established DOCX fixture behavior |
+| paragraph | semantic paragraph with serialized inline children |
+| callout | semantic content inside a styled `callout` container; title and kind preserved |
+| codeBlock | safe raw-code representation with language metadata and native highlighting |
+| ordered/unordered/task list | semantic nested `enum`/`list`; checked state rendered visibly and announced in text |
+| table | semantic `table`; spans preserved where valid, leading complete header rows emitted as `table.header` |
+| image attachment | semantic figure/image using resolved job asset; caption and alternative description remain separate |
+| image external | skipped with a stable report note unless already available through an approved resolver |
+| blockquote | semantic quote styling without flattening child content |
+| divider | thematic visual separator with no misleading text |
+| unknown | omitted or readable text fallback according to the shared export policy; never raw storage XML |
 
-Escaping is a first-class concern: Typst markup characters (`#`, `*`, `_`, `@`, `<`, `[`,
-`$`, `\``) in Confluence text must be escaped — dedicated escape function with a
-character-table test (this is the classic injection-bug source in markup generators).
+Table policy additionally defines mixed header cells, invalid span grids, repeated
+headers, very wide tables and rows crossing page boundaries. Invalid grids degrade to a
+readable table or linearized content with a report note; they never create invalid Typst.
 
-### 2.4 Error/diagnostics model
+### 3.3 Normative inline mapping
 
-Typst diagnostics (source spans) map back to a block index via line markers
-(`// blk:<i>` comments emitted by the serializer) → panel shows "failed at: <block type>
-'<heading text>'…" instead of raw Typst spans. Compile timeout (60 s hard) → readable
-error + offscreen teardown.
+| `InlineNode` | Typst behavior |
+|---|---|
+| text | literal content with bold, italic, underline, strike, code and supported color marks composed deterministically |
+| link | external, page, attachment and anchor targets resolved separately; unsafe or unresolved schemes become text plus a note |
+| mention | visible display name; link only when the model contains an approved target |
+| status | styled inline badge preserving label and color category |
+| lineBreak | explicit line break |
+
+Internal heading labels are deterministic and collision-safe. Duplicate or punctuation-
+only headings receive stable suffixes derived from document order. TOC entries, outline
+bookmarks and internal links use the same promoted hierarchy and label registry.
+
+### 3.4 Escaping and hostile input
+
+There is no universal escape helper. The serializer defines separate, unit-tested
+encoders for:
+
+- Typst content;
+- string literals and URLs;
+- labels/identifiers;
+- raw code bodies.
+
+Raw-code fences are chosen longer than every matching backtick run in the source, or use
+an equivalently safe function form. Hostile fixtures cover Typst punctuation, embedded
+fences, Unicode, RTL text, long unbroken strings, malicious-looking URLs and content that
+resembles template calls. The acceptance test compiles the result and confirms the text
+is represented literally.
+
+### 3.5 Semantic template and accessibility
+
+`atlcli.typ` supplies cover, outline, heading numbering, running header, footer, callout
+styling, status styling, code styling, table defaults and figure styling through semantic
+Typst elements and show rules. Styling must not replace headings, paragraphs, lists,
+tables or figures with layout-only boxes.
+
+Document language, title, author and a caller-supplied export timestamp are set before
+content. Tests inject locale and time; production supplies the current user and clock.
+
+Caption and alternative description are distinct:
+
+- meaningful source alt text is attached to the image;
+- a filename is only a technical fallback in standard tagged mode and produces a report
+  warning;
+- the PDF/UA-1 reference mode fails when meaningful alternative text is required but
+  unavailable;
+- Mermaid source code is not automatically treated as a useful description. Missing
+  diagram descriptions are reported and block the UA reference mode;
+- decorative treatment requires an explicit semantic decision, not an empty string by
+  accident.
+
+### 3.6 PDF profiles and claims
+
+- **Standard mode:** tagged PDF using the pinned compiler's default tagging support.
+- **UA reference mode:** explicitly requests PDF/UA-1 only if Task 1 proves that the
+  pinned browser compiler API exposes it.
+- Compiler success is necessary but not sufficient for a PDF/UA claim. The archived
+  reference requires an external validator report and a manual accessibility checklist.
+- This spec makes no PDF/A or archival-conformance claim.
+
+If the pinned browser compiler cannot select PDF/UA-1, standard tagged export continues,
+and UA mode becomes a clearly blocked follow-up. Vendoring or forking the compiler is a
+new scope decision rather than an implicit Task 1 workaround.
 
 ---
 
-## 3. Task breakdown
+## 4. Asset pipeline
 
-### Task 1 — typst.ts vendored + offscreen compile round-trip
+The PDF path reuses/generalizes the authenticated resolver proven by DOCX and 005:
 
-- [ ] `@myriaddreamin/typst.ts` (+ web compiler WASM) bundled into the extension **without runtime CDN access**; build script copies WASM + font assets into `dist/`
-- [ ] `compile-typst` message implemented; a hardcoded "hello world" .typ compiles to a valid PDF end-to-end (panel button in debug section) — extends 002's WASM smoke into the real thing
-- [ ] Compiler instance cached across compiles (second compile measurably faster — timed assertion in manual check, logged)
-- [ ] Compile error (syntactically broken .typ) returns diagnostics, panel shows readable failure; 60 s timeout enforced
-- [ ] Bundle-size figure recorded (WASM + fonts) in this file — input for store-packaging sanity later
+- page ID plus attachment filename resolve to the canonical Confluence download URL;
+- redirects to Atlassian Media preserve the established credential policy;
+- fetches have bounded concurrency, cancellation, deduplication and deterministic order;
+- each response is checked for status, declared MIME, magic bytes and size;
+- corrupt, missing or unsupported files generate one stable note and no empty VFS file;
+- deterministic collision-free VFS names do not expose tenant URLs or credentials;
+- repeated references reuse one stored asset;
+- per-file and total byte caps fail or skip according to an explicit policy;
+- SVG remains vector after sanitation; raster formats retain original bytes when safe;
+- `@atlcli/diagram` is the only Mermaid renderer. Supported diagrams become sanitized
+  vector SVG; unsupported diagrams remain readable code with a note.
 
-### Task 2 — Fonts
-
-- [ ] Inter (400/500/600) + JetBrains Mono (400/700) bundled as **pinned files with recorded release versions** (version + source URL + checksum noted in `assets/fonts/README.md`)
-- [ ] Compiler configured to use only the bundled fonts; a compile referencing a non-bundled font **fails loudly** rather than silently substituting (test with a deliberately wrong font name) — no local-font fallback exists in WASM, and none is added
-- [ ] **Full character sets bundled for Phase 1** (incl. Latin Extended for umlauts etc.); subsetting is an explicit later optimization, not done now
-- [ ] Font licenses (OFL) copied into `apps/extension/assets/fonts/`
-- [ ] PDF output embeds the fonts (verify via PDF inspection in Task 6)
-
-### Task 3 — atlcli Typst template
-
-- [ ] `atlcli.typ` per §2.2: cover, TOC, numbered headings, running header, page-number footer, callout/status/code/table/figure helpers
-- [ ] Compiles standalone with a demo document (checked into `assets/typst/demo.typ`) — the template's own regression fixture
-- [ ] Document metadata (title/author/date) lands in PDF metadata
-
-### Task 4 — Serializer
-
-- [ ] `typstSerialize` implements the §2.3 table; unit tests per block type (string-level assertions, no WASM needed)
-- [ ] Escape function with full character-table test + a hostile fixture (page text containing Typst syntax) — pinning test that output compiles and renders the text literally
-- [ ] Image assets: attachment blobs → vfs paths; SVG passes through as vector; alt-text rule applied
-- [ ] Mermaid: beautiful-mermaid for the 6 supported types → SVG asset; unsupported types → code block + report (tests for both routes)
-- [ ] `// blk:<i>` markers emitted; diagnostic-to-block mapping unit-tested
-
-### Task 5 — Panel flow
-
-- [ ] "Export as PDF" on the loaded page: fetch images (session auth — mock-test credentials), serialize, compile, download `"<page-title>.pdf"`
-- [ ] Progress states (fetching assets → compiling → done) rendered; panel responsive during compile (compile is offscreen)
-- [ ] Export report: duration, image count, skipped/unsupported items — same report surface as 004
-- [ ] Full-pipeline test with the shared 004 fixture: blocks → typst source snapshot; compile smoke where runnable (see §4 note)
-
-### Task 6 — Quality proofs + manual E2E **[E2E: user]**
-
-Joint session (space `DOCSY`, same feature-zoo test page as 004, delete after):
-
-- [ ] Export the test page: cover, TOC **with correct page numbers**, bookmarks panel populated, internal TOC links click-navigate
-- [ ] Callouts, status badges, tables (repeated header across a page break), nested lists render correctly
-- [ ] Code block shows native syntax highlighting; a mermaid flowchart appears as crisp vector (zoom to 400% — no rasterization)
-- [ ] Images embedded and positioned sanely; fonts embedded (PDF properties / `pdffonts` if available)
-- [ ] **Tagged-PDF reference:** export validated as tagged (Acrobat/veraPDF or PAC if available; minimum: Typst UA-1 export mode succeeds, which validates strictly) — the reference PDF is archived in this spec dir
-- [ ] Duration for the ~2,000-word page recorded (input to 006; WASM path is the slower one — this is the number that matters)
+The compiler adapter maps binary files and registers fonts through the exact API of the
+pinned compiler version. Merely placing TTF files in a VFS is not accepted as proof that
+the compiler uses them.
 
 ---
 
-## 4. Test plan
+## 5. Diagnostics, report and UI contract
 
-- **Unit (fast, no WASM):** serializer per block type, escaping table, diagnostics mapping, template-demo source snapshot.
-- **Integration:** panel flow with mocked compile responses; image-fetch credential assertions.
-- **Compile-level:** if typst.ts runs under bun in CI (Node path is officially supported — probe early in Task 1), add a CI job compiling the demo doc + one fixture; otherwise compile checks are manual-E2E only and the serializer snapshots carry CI weight. Record which way it went here.
-- **Manual E2E (Task 6):** visual quality, tagged-PDF validation, performance number.
+### 5.1 Diagnostics
 
-## 5. Definition of done
+Serializer source mapping records generated file, start/end lines and a structured block
+path such as `blocks[4].table.rows[2].cells[1].children[0]`. Full compiler diagnostics
+(severity, path, range and message) map through it.
 
-- Tasks 1–6 checked; reference Tagged PDF archived in the spec dir.
-- Whole repo green incl. `check:browser` (serializer isomorphic if placed in packages/).
-- No runtime network access except `*.atlassian.net` during export (verified in 006's network-log check, pre-checked here in Task 6).
-- Compile of the E2E page < 10 s target met or the measured number + analysis documented for 006's verdict.
+Diagnostics originating in `atlcli.typ`, the compiler or a generated asset remain
+separate from content diagnostics. The panel shows a concise user-facing error and keeps
+the detailed diagnostic in the report/debug view.
 
-## 6. Risks and open questions
+### 5.2 PDF report
 
-1. **typst.ts API stability / PDF export surface** — the browser PDF path is less "advertised" than SVG/canvas (research §1b). Task 1 is deliberately first and minimal: if PDF bytes can't be produced reliably in the offscreen doc, escalate before any template work (fallback ladder: compile in a Web Worker inside the panel; server/bridge is out of scope for the PoC).
-2. **WASM + fonts bundle size** (likely 10–30 MB). Fine for load-unpacked PoC; store packaging limits arrive later — recorded, not solved, here.
-3. **Compile performance on big pages** — WASM is the slow path per typst.ts docs. The 006 budget check decides whether "good enough"; incremental-compile features of typst.ts are the known lever if not.
-4. **UA-1 strictness can fail exports** (Typst refuses on violations, e.g. missing alt text). Default export mode stays plain tagged PDF; UA-1 is the *reference* proof. Alt-text fallback rule (§2.3) keeps the reference viable.
-5. **Structured-clone payload cost** for image-heavy pages — measured in Task 5; Blob-URL handoff is the prepared fallback.
-6. **`table.cell` rowspan edge cases** mirror 004's merged-cell reef; same policy: basic merges correct, deep nesting degrades with a report line.
+`PdfExportReport` is PDF-specific and maps to a small shared presentation model rather
+than reusing the DOCX template report type directly. It includes:
+
+- page identity, filename and selected PDF profile;
+- compiler wrapper, WASM/Typst engine and template versions;
+- fetch, preparation, queue, compile, download and total durations;
+- embedded, deduplicated, skipped and failed images;
+- rendered and degraded diagrams;
+- warning/note counts with stable ordering;
+- page count, embedded-font result, tagging result and validator result when available;
+- timeout, cancellation and cleanup outcome.
+
+### 5.3 Panel and download flow
+
+- PDF receives its own export action outside the DOCX template-upload controls.
+- Phases: `preparing → fetching assets → queued → compiling → validating → downloading → done`.
+- Busy, cancel, timeout, retry and stale-page states are explicit.
+- The download sink is generalized to accept MIME type and extension; PDF uses
+  `application/pdf` and the established filename sanitizer with a parameterized suffix.
+- The report shown after completion is tied to the source page and `jobId`.
+
+---
+
+## 6. Task breakdown
+
+### Task 0 — Refresh contracts and shared assets
+
+- [ ] Add `@atlcli/pdf` with browser-safe package boundaries and explicit exports.
+- [ ] Establish one canonical font source and keep DOCX tests/output green after the
+  asset-path change.
+- [ ] Pin wrapper, web compiler/WASM, embedded Typst engine, diagram renderer, template
+  and fonts; record source URL, version, checksum and license.
+- [ ] Update `NOTICE` and ensure licenses ship in the extension artifact.
+- [ ] Add the decisions in §2 and §3 to code-facing types before integration work.
+
+### Task 1 — Browser compiler feasibility gate
+
+- [ ] In the built WXT extension, initialize the exact pinned compiler and produce a
+  valid hello-world PDF from packaged WASM with network access denied.
+- [ ] Prove font registration with Inter and JetBrains Mono and prove that an unknown
+  font fails rather than silently resolving from the environment.
+- [ ] Record whether and how the browser API selects tagged default and PDF/UA-1 output.
+  If UA selection is unavailable, record the follow-up boundary before template work.
+- [ ] Return a complete syntax diagnostic from a broken source.
+- [ ] Record compressed/uncompressed artifact size and cold/warm initialization time.
+- [ ] Add a load-unpacked Chromium smoke test; source snapshots alone do not satisfy this
+  gate.
+
+### Task 2 — Job store and compiler lifecycle
+
+- [ ] Implement JSON-only control messages and job-scoped binary storage per §2.2.
+- [ ] Enforce quotas, startup cleanup, `finally` cleanup and inaccessible/expired-job
+  behavior.
+- [ ] Implement the worker state machine, FIFO queue, single-flight initialization,
+  timeout termination, retry and idle-close rules from §2.3.
+- [ ] Test a payload above 10 MB, quota failure, two concurrent requests, navigation
+  invalidation, late completion, init failure/retry and a failed job between two
+  successful jobs.
+- [ ] Prove that job B cannot read job A's sources or assets.
+
+### Task 3 — Semantic template
+
+- [ ] Implement `atlcli.typ` following §3.5 with cover, TOC, numbered headings, running
+  header, footer, semantic callout/status/code/table/figure styling and metadata.
+- [ ] Add a standalone demo document and deterministic injected metadata/clock.
+- [ ] Test heading promotion, duplicate labels, outline/bookmarks, internal links,
+  repeated table headers and multi-page layout.
+- [ ] Keep default tagged and UA reference modes explicit and separate.
+
+### Task 4 — Preparation and exhaustive serializer
+
+- [ ] Implement both APIs from §3.1 in `@atlcli/pdf`.
+- [ ] Cover every `ExportBlock` and `InlineNode` variant with exhaustive switches and at
+  least one test, including nesting combinations.
+- [ ] Implement the context-specific encoders and hostile compile fixture from §3.4.
+- [ ] Emit structured source-map entries and map nested compiler diagnostics.
+- [ ] Render Mermaid only through `@atlcli/diagram`; test supported, unsupported and
+  renderer-failure paths.
+- [ ] Snapshot source only as a readable supplement; successful real compilation is the
+  correctness gate.
+
+### Task 5 — Authenticated asset integration
+
+- [ ] Reuse/generalize the working DOCX session resolver and canonical attachment path.
+- [ ] Implement redirect, cancellation, concurrency, byte limits, deduplication, content
+  validation, deterministic naming and failure notes from §4.
+- [ ] Test raster images, sanitized SVG, missing/corrupt assets, duplicate references,
+  external URLs, redirects and total-size exhaustion.
+- [ ] Verify the compiler performs no runtime requests outside the two allowed Atlassian
+  host classes.
+
+### Task 6 — Panel, report and download
+
+- [ ] Add the separate **Export as PDF** action with the phase and stale-page behavior in
+  §5.3.
+- [ ] Add `PdfExportReport` and the shared report presentation mapping.
+- [ ] Generalize the download adapter and download a sanitized `<page-title>.pdf` with
+  `application/pdf`.
+- [ ] Resolve cover metadata explicitly: page title, space name/key, current exporter,
+  document version, locale and injected export time.
+- [ ] Test busy, cancel, timeout, retry, error, success and navigation-during-export UI
+  states.
+
+### Task 7 — Automated PDF verification
+
+- [ ] CI compiles the demo and shared feature-zoo source through the real compiler. If
+  Bun cannot host the compiler, run the built offscreen path in Chromium; compile testing
+  never becomes manual-only.
+- [ ] Pin a PDF inspector and assert valid parse, page count, metadata, outline,
+  internal/external links, embedded fonts and tag presence.
+- [ ] Run the same fixed input twice after cold and warm initialization. Require
+  byte-identical output, or document and normalize specific compiler-owned volatile
+  fields before asserting structural identity.
+- [ ] Extend the extension-output check to require expected WASM, fonts, template,
+  licenses and hashes and to reject remote loader URLs.
+- [ ] Run repo tests, typecheck, `check:browser`, extension build/output checks and the
+  new Chromium smoke.
+
+### Task 8 — Quality proof and manual E2E **[E2E: user]**
+
+Use the standing DOCSY feature-zoo page retained by 004. Do not delete or materially
+mutate it in this spec; final cleanup belongs to 008.
+
+- [ ] Cover, TOC page numbers, outline/bookmarks and internal TOC links are correct.
+- [ ] Promoted headings, callouts, badges, nested lists, tasks, blockquotes and dividers
+  remain semantically and visually clear.
+- [ ] Tables repeat headers and remain readable across page breaks; merges degrade only
+  according to the documented policy.
+- [ ] Code highlights correctly and Mermaid remains crisp at 400% zoom.
+- [ ] Attachments embed through the real authenticated/redirect flow; missing assets
+  produce readable notes.
+- [ ] Fonts are embedded and only the pinned families are used.
+- [ ] Standard output is confirmed tagged.
+- [ ] If UA reference mode passed Task 1, archive the anonymized PDF, external validator
+  report and manual checklist for reading order, outline, links, tables, language and alt
+  descriptions. Compiler success alone does not pass this item.
+- [ ] Record cold compile, warm compile, total duration, peak memory and PDF size for the
+  approximately 2,000-word fixture.
+
+### Task 9 — Documentation and handoff
+
+- [ ] Update `src/content/docs/confluence/export.md` with the PDF UI path, support matrix,
+  tagged-versus-UA explanation, network/privacy contract, limits, fallbacks and
+  troubleshooting.
+- [ ] Record exact compiler/assets matrix and bundle-size result in this spec.
+- [ ] Update `008-export-poc-validation` to consume output from 007 and use the corrected
+  Atlassian plus Media network allowlist.
+- [ ] Hand performance and quality evidence to 008; do not make the final DOCX-versus-PDF
+  product verdict here.
+
+---
+
+## 7. Test matrix
+
+### Unit
+
+- Every block and inline variant, nesting, heading promotion and duplicate labels.
+- Context-specific escaping, code fences, unsafe links and Unicode/RTL fixtures.
+- Source mapping for nested table/list/callout diagnostics.
+- Stable report notes and deterministic asset naming.
+
+### Integration
+
+- Authenticated asset resolution, Atlassian Media redirect and credential policy.
+- Job store quotas, cleanup and isolation.
+- Queue, cancellation, worker timeout/restart and idle lifecycle.
+- Panel phases, stale navigation, report mapping and generic download sink.
+
+### Built-runtime and compile
+
+- Load-unpacked Chromium smoke against the built extension.
+- Cold/warm real compilation and broken-source diagnostics.
+- No compiler/font/CDN/package-network access.
+- Packaged WASM/font/template/license/hash verification.
+- PDF structural inspection and deterministic repeat compile.
+
+### Manual E2E and accessibility
+
+- Visual and semantic review of the standing feature-zoo fixture.
+- Performance and memory capture.
+- External PDF/UA validator plus manual checklist for the optional reference mode.
+
+---
+
+## 8. Definition of done
+
+- Tasks 0–9 are complete and all mandatory gates are automated except the named visual
+  and accessibility checks.
+- The built Chrome extension exports the standing page to a valid, tagged PDF without
+  blocking the panel.
+- No export job leaks VFS state, stored bytes or results into another job or page.
+- Runtime network access is limited to the active Atlassian tenant and the established
+  Atlassian Media redirect host; compiler and presentation assets are fully local.
+- The generated PDF passes structural inspection, embeds only the pinned fonts and
+  preserves the supported `ExportBlock`/`InlineNode` contract.
+- Fixed-input repeatability is proven under the documented determinism definition.
+- PDF/UA-1 is claimed only when the pinned compiler exposes the profile and the archived
+  result passes independent validation plus manual review.
+- Cold/warm performance, peak memory, output size and bundle size are recorded for 008.
+- Repository tests, typecheck, browser/isomorphism checks, extension build and built
+  runtime smoke are green.
+- User documentation and the 008 handoff are updated in the same change set.
+
+---
+
+## 9. Risks and escalation points
+
+1. **Browser PDF-standard API:** Task 1 may prove tagged output but not PDF/UA-1
+   selection. Standard export remains viable; a compiler fork or version change requires
+   a separate scope decision.
+2. **WASM and font size:** record the actual shipped size early. Optimization or
+   subsetting follows only after correctness and licensing are proven.
+3. **Long-running WASM:** hard cancellation requires worker termination and clean
+   reinitialization; a rejected Promise is not sufficient.
+4. **Large jobs and browser quota:** explicit limits and readable failure are required;
+   silently dropping assets is not acceptable.
+5. **Table pagination and spans:** complex grids may require a documented degradation
+   rather than visually incorrect output.
+6. **Meaningful alternative text:** technical fallbacks can keep standard export useful
+   but cannot establish accessibility quality or UA conformance.
 
 ### Decisions log
 
-- **F1 — serializer location**: ❓ open (proposal: `packages/confluence` next to the walker, isomorphism-gated).
-- **F2 — bundled font set**: ✅ (Björn, 2026-07-14; refined 2026-07-15) Inter 400/500/600 + JetBrains Mono 400/700 (OFL), files and versions pinned, no local-font fallback, full charsets in Phase 1 (subsetting later); no serif face in the PoC — template designed sans-only.
+- **F1 — serializer location:** ✅ `packages/pdf` / `@atlcli/pdf`; host-neutral and
+  browser-safe. Extension owns only browser adapters and compiler hosting.
+- **F2 — bundled font set:** ✅ Inter 400/500/600 + JetBrains Mono 400/700, full Phase 1
+  character sets, exact files/versions/checksums/licenses pinned, no system fallback.
+- **F3 — binary transport:** ✅ JSON control messages plus job-scoped same-origin binary
+  storage; no `Map`/`ArrayBuffer` payloads through runtime messaging.
+- **F4 — compiler concurrency:** ✅ one active compile per worker with FIFO queue until a
+  later benchmark proves safe parallelism.
+- **F5 — PDF profiles:** ✅ tagged standard mode; separately selected and independently
+  validated PDF/UA-1 reference mode; no PDF/A claim.
+- **F6 — heading hierarchy:** ✅ promote the shallowest document heading to level 1,
+  preserving relative depth and using the same hierarchy for visual headings, TOC,
+  outline and anchors.
+- **F7 — shared fixture:** ✅ retain the standing 004 feature-zoo page through 007;
+  cleanup remains in 008.

--- a/specs/008-export-poc-validation/PLAN.md
+++ b/specs/008-export-poc-validation/PLAN.md
@@ -28,7 +28,8 @@ better?"):
 2. **Correctness:** callouts, tables, code and embedded images correct in the output.
 3. **Performance:** typical page (~2,000 words, ~5 images) exports in **< 10 s**, no
    local install, no token configuration.
-4. **Privacy:** network log during export shows exclusively `*.atlassian.net` calls.
+4. **Privacy:** network log during export shows exclusively the active
+   `*.atlassian.net` tenant and authenticated redirects to `api.media.atlassian.com`.
 
 ### Goals
 
@@ -87,8 +88,9 @@ better?"):
   median of 3 runs, warm compiler for PDF runs 2–3 (cold-start noted separately).
   Machine + Chrome version recorded.
 - Network: DevTools network log (panel + offscreen contexts!) captured for one full DOCX
-  and one full PDF export; every request host listed. Any non-`*.atlassian.net` request =
-  criterion 4 **fail** (extension-internal `chrome-extension://` resources excluded).
+  and one full PDF export; every request host listed. Any request outside the active
+  `*.atlassian.net` tenant and `api.media.atlassian.com` = criterion 4 **fail**
+  (extension-internal `chrome-extension://` resources excluded).
 - Visual comparison: printed/PDF'd side-by-side, per-item checklist (§2.3), each item
   `match / minor deviation / major deviation` with screenshot evidence for deviations.
 
@@ -140,7 +142,9 @@ Rows 2, 3 (🏆 expected: Typst-computed page numbers), 4, 7, 8, 9, 11, 12, 13, 
 ### Task 5 — Privacy (criterion 4)
 
 - [ ] Network logs captured for one DOCX and one PDF export (all extension contexts)
-- [ ] Host inventory in `RESULTS.md`: only `*.atlassian.net` (+ `chrome-extension://`) — explicitly confirming no CDN font/WASM loads (005's bundling promise)
+- [ ] Host inventory in `RESULTS.md`: only the active `*.atlassian.net` tenant,
+  `api.media.atlassian.com` attachment redirects and `chrome-extension://` — explicitly
+  confirming no CDN font/WASM loads
 - [ ] Repeated in a network-throttled run to catch lazy loaders that only fire under specific conditions
 
 ### Task 6 — RESULTS.md + Phase-2 handoff

--- a/src/content/docs/confluence/export.md
+++ b/src/content/docs/confluence/export.md
@@ -1,11 +1,60 @@
 ---
-title: "DOCX Export"
-description: "DOCX Export - atlcli documentation"
+title: "DOCX and PDF Export"
+description: "Export Confluence pages to Word or tagged PDF"
 ---
 
-# DOCX Export
+# DOCX and PDF Export
 
-Export Confluence pages to Microsoft Word (DOCX) format using customizable templates.
+Export Confluence pages to Microsoft Word (DOCX) with customizable templates, or use
+the browser extension to create a tagged PDF with the built-in atlcli document design.
+
+## On this page
+
+- [Browser extension: PDF export](#browser-extension-pdf-export)
+- [CLI: DOCX quick start](#quick-start)
+- [Rendering engines](#rendering-engines)
+- [Templates](#templates)
+- [Table of contents](#table-of-contents)
+- [Template variables](#template-variables)
+- [Troubleshooting](#troubleshooting)
+
+## Browser extension: PDF export
+
+The PDF path is additive: **Export to Word** and its template upload continue to work as
+before. On a loaded Confluence page, select **Export to PDF**. The extension prepares
+attachments and diagrams, compiles the page in a background worker, validates the result,
+and downloads `<page-title>.pdf`.
+
+The completion report separates preparation, compilation, and download time. Preparation
+includes authenticated attachment fetching, so image-heavy pages can be distinguished from
+a slow compiler without enabling debug logging.
+
+PDF currently uses one built-in standard design. It includes a cover, computed table of
+contents, promoted heading hierarchy, running header, page-number footer, callouts, status
+badges, syntax-highlighted code, tables, images and vector Mermaid diagrams. Custom PDF
+template upload is not available yet.
+
+### PDF support and limits
+
+| Area | Behavior |
+|------|----------|
+| PDF profile | Tagged PDF; no PDF/UA or PDF/A conformance claim |
+| Fonts | Bundled Source Serif 4, Source Sans 3 and Source Code Pro; no system-font or CDN dependency |
+| Attachments | PNG, JPEG, GIF, WebP and safe SVG; 25 MB per file, 50 MB total |
+| External images | Not fetched; exported as a readable fallback with a report note |
+| Mermaid | Supported diagrams remain vector SVG; failures become readable source code |
+| Job storage | 64 MB per input/output and 128 MB total temporary browser storage |
+| Compiler timeout | 60 seconds; the compiler worker is terminated and recreated |
+
+The extension validates image magic bytes, rejects active or externally loaded SVG content,
+and validates that the compiled PDF has pages, tags and embedded fonts before download.
+Compilation, the template and fonts are fully local. Network requests during PDF export are
+limited to the active `*.atlassian.net` tenant and authenticated attachment redirects to
+`api.media.atlassian.com`.
+
+The generated PDF is tagged by default, but tagged output is not the same as certified
+PDF/UA. The pinned browser compiler does not expose PDF/UA-1 profile selection, so atlcli does
+not make that claim.
 
 ## Prerequisites
 
@@ -276,3 +325,4 @@ embedding.
 - [Attachments](attachments.md) - Managing page attachments for export
 - [Templates](templates.md) - Page templates (different from export templates)
 - [DOCX Export Engine](../reference/docx-engine.md) - The reusable `@atlcli/docx` engine behind `--engine ts`
+- [PDF Export Engine](../reference/pdf-engine.md) - Browser compiler, assets and verification

--- a/src/content/docs/reference/pdf-engine.md
+++ b/src/content/docs/reference/pdf-engine.md
@@ -1,0 +1,99 @@
+---
+title: "PDF Export Engine"
+description: "Architecture, pinned runtime and verification for the browser PDF exporter"
+---
+
+# PDF Export Engine (`@atlcli/pdf`)
+
+`packages/pdf` is the browser-safe preparation and Typst serialization layer used by the
+atlcli extension. It consumes the same structured Confluence `ExportBlock[]` tree as the
+working Word exporter. Browser integration - authentication, IndexedDB jobs, worker lifecycle
+and download - stays in `apps/extension`.
+
+## Built-in document design
+
+The standard template is a brand-neutral editorial A4 design. It bundles Source Serif 4 for
+flowing body copy, Source Sans 3 for headings, tables, metadata and other structural text, and
+Source Code Pro for code. Body copy uses 10 pt text, a relaxed 0.74 em leading value, and 10 pt
+paragraph spacing. Heading levels use progressively larger separation so a heading remains
+visually attached to the content it introduces while sections are easy to scan.
+
+The Editorial Indigo cover uses a warm paper tone, a Source Serif title and a left-aligned
+metadata rail. It is followed by the table of contents and does not display a page number.
+The running header preserves the page title and space key above a fine horizontal rule;
+the centered footer contains the page number. An automatically generated document-integrity
+page closes every export with the document title, version, export date, final page count and a
+clickable link to `atlcli.sh`; it does not repeat the running header. Unordered list levels use an en dash, filled
+bullet and open bullet; ordered levels use `1.`, `a)` and `i.`. Task lists use standalone
+checkbox markers without an additional bullet. Tables preserve meaningful authored column
+widths. Equal default widths may be replaced by a
+conservative content-aware ratio when one narrative column is substantially longer than the
+remaining short status columns. Complex tables and balanced prose tables remain unchanged.
+
+## Runtime matrix
+
+| Component | Pinned value | Verification |
+|-----------|--------------|--------------|
+| Web compiler wrapper | `@myriaddreamin/typst-ts-web-compiler` 0.7.0 | Exact package version and Bun patch |
+| Embedded Typst engine | 0.14.2 | PDF `Creator` metadata and compiler fixture |
+| Compiler WASM | SHA-256 `1fc968438a672366dfec39c96c842c26ed29caff4eb1bcaab19a6c60867de5fd` | Build inventory gate |
+| Source Sans 3 Regular / Italic / SemiBold / Bold | Adobe commit and SHA-256 values pinned in `ensure-fonts.ts` | Build fetch and inventory gates |
+| Source Serif 4 Regular / Italic / SemiBold / Bold | Adobe commit and SHA-256 values pinned in `ensure-fonts.ts` | Build fetch and inventory gates |
+| Source Code Pro Regular / Bold | Adobe commit and SHA-256 values pinned in `ensure-fonts.ts` | Build fetch and inventory gates |
+
+The production extension artifact includes the 28.3 MB compiler WASM, ten static font files
+and their shipped license texts. The build gate fails
+if any runtime asset is absent, the WASM is unexpectedly small, or generated JavaScript
+contains a known Manifest V3-incompatible dynamic-code constructor.
+
+The TTF binaries are not stored in Git. `bun run build`, extension development, extension
+typechecking and the PDF fixture first run `fonts:ensure`. It downloads missing files from
+immutable Adobe commit URLs into the gitignored `packages/pdf/.fonts/` cache and installs a
+file only after its SHA-256 value matches the manifest. A valid cache performs no network
+request. OFL license texts remain tracked and ship in the extension. PDF export itself never
+contacts Adobe, Google Fonts, Fontsource or another font service.
+
+## Export flow
+
+1. Convert Confluence storage to exhaustive `ExportBlock[]` values.
+2. Resolve approved attachments with the active Atlassian session and render Mermaid through
+   `@atlcli/diagram`.
+3. Serialize deterministic `main.typ`, the pinned template, assets and nested source mappings.
+4. Store the binary job in IndexedDB and send only `{ jobId }` control messages.
+5. Compile FIFO in a dedicated worker hosted by the offscreen extension document.
+6. Validate pages, tag structure and embedded font programs, then download as `application/pdf`.
+7. Delete the job in `finally`; startup cleanup removes records older than 24 hours.
+
+The completion report shows total time together with preparation, compilation, and download
+time. Preparation includes attachment resolution and Mermaid rendering, which makes network-
+or asset-heavy exports distinguishable from compiler time.
+
+Cancellation terminates an active compiler worker. A 60-second timeout also terminates it, so
+the next attempt starts in a clean compiler and virtual filesystem rather than merely rejecting
+an unresolved promise.
+
+## Verification fixture
+
+Run the deterministic feature fixture locally:
+
+```bash
+bun run --cwd apps/extension pdf:fixture
+pdfinfo tmp/pdfs/pdf-export-feature-zoo.pdf
+pdftoppm -png tmp/pdfs/pdf-export-feature-zoo.pdf tmp/pdfs/pdf-export-feature-zoo
+```
+
+The fixed fixture produces an A4 document with title and author metadata, outline,
+internal TOC links, semantic tags, embedded font programs, highlighted code and a native
+vector Mermaid diagram. A warm repeat compile is required to be byte-identical.
+
+## Known profile boundary
+
+Standard export requires tagged output and rejects an untagged result. The pinned compiler does
+not expose a PDF/UA-1 selector. Therefore the engine deliberately makes no PDF/UA or PDF/A claim;
+adding either profile requires a separately validated implementation and independent conformance
+evidence.
+
+## Related topics
+
+- [DOCX and PDF Export](../confluence/export.md)
+- [DOCX Export Engine](docx-engine.md)

--- a/turbo.json
+++ b/turbo.json
@@ -16,6 +16,7 @@
         "packages/jira/src/**/*.ts",
         "packages/core/src/**/*.ts",
         "packages/docx/src/**/*.ts",
+        "packages/pdf/src/**/*.ts",
         "packages/diagram/src/**/*.ts"
       ]
     }


### PR DESCRIPTION
## Summary

- adds PDF export alongside the existing Word export in the Chrome extension
- compiles locally in the browser with a pinned Typst/WASM runtime, worker isolation, IndexedDB-backed jobs, cancellation and timeout recovery
- serializes Confluence content into semantic Typst with images, Mermaid diagrams, tables, lists, callouts, links, code blocks and source-mapped diagnostics
- ships a brand-neutral Editorial Indigo default design with bundled Source fonts, cover, table of contents, running header, page numbers and a document-integrity closing page
- pins font downloads by immutable source revision and SHA-256 while keeping TTF binaries out of Git
- extends the browser-output gate, tests, specs and user-facing documentation

## Why

PDF is the next export level after DOCX. The implementation keeps Word export unchanged while providing a fast, deterministic and privacy-preserving PDF path without an external rendering service.

## Validation

- `bun test` — 1769 passed, 0 failed
- `bun run typecheck`
- `bun run build`
- `bun run check:extension-output`
- deterministic feature fixture: tagged A4 PDF, outline and embedded fonts
- manual exports of a dense page with five images and a Mermaid page with six diagrams
- verified the closing-page `https://atlcli.sh/` URL as a real PDF annotation

## Out of scope

The custom PDF-template editor concept is intentionally excluded. Its UX specification remains local for a separate follow-up PR after the UI design is ready.
