### PR TITLE
feat(export): extend ExportBlock model for phase-1 content features (spec 001, sync point 0)

### DIFF
--- a/packages/confluence/src/export-blocks.test.ts
+++ b/packages/confluence/src/export-blocks.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import {
+  macroParamText,
   storageToBlocks,
   type ExportBlock,
   type InlineNode,
+  type MacroParameter,
 } from "./export-blocks.js";
 
 /** Convenience: parse and return only the blocks. */
@@ -382,7 +384,11 @@ describe("storageToBlocks — unknown macros", () => {
     const { blocks: b, notes } = storageToBlocks(
       '<ac:structured-macro ac:name="drawio"><ac:parameter ac:name="diagramName">x</ac:parameter></ac:structured-macro>'
     );
-    expect(b).toEqual([{ type: "unknown", macroName: "drawio" }]);
+    // Lossless capture: the block keeps its (lowercased-name) parameter, and the
+    // note/no-raw-XML invariant is unchanged.
+    expect(b).toEqual([
+      { type: "unknown", macroName: "drawio", params: [{ name: "diagramname", text: "x" }] },
+    ]);
     expect(notes).toEqual([
       { level: "warning", code: "unknown-macro", message: expect.any(String), macroName: "drawio" },
     ]);
@@ -394,6 +400,261 @@ describe("storageToBlocks — unknown macros", () => {
     const { blocks: b, notes } = storageToBlocks('<ac:structured-macro ac:name="jira"/>');
     expect(b).toEqual([{ type: "unknown", macroName: "jira" }]);
     expect(notes[0]).toMatchObject({ level: "info", code: "macro-not-rendered", macroName: "jira" });
+  });
+});
+
+describe("storageToBlocks — lossless unknown macros", () => {
+  /** Convenience: parse and return the first block as an enriched unknown block. */
+  function unknownBlock(storage: string): Extract<ExportBlock, { type: "unknown" }> {
+    return blocks(storage)[0] as Extract<ExportBlock, { type: "unknown" }>;
+  }
+
+  test("captures macroId + plain-text parameters; no body fields when there is no body", () => {
+    const block = unknownBlock(
+      '<ac:structured-macro ac:name="drawio" ac:macro-id="mid-42">' +
+        '<ac:parameter ac:name="diagramName">Architecture</ac:parameter>' +
+        '<ac:parameter ac:name="width">640</ac:parameter>' +
+        "</ac:structured-macro>"
+    );
+    expect(block).toEqual({
+      type: "unknown",
+      macroName: "drawio",
+      macroId: "mid-42",
+      params: [
+        { name: "diagramname", text: "Architecture" },
+        { name: "width", text: "640" },
+      ],
+    });
+    // No rich-text/plain-text body → those fields are absent entirely.
+    expect(block.body).toBeUndefined();
+    expect(block.plainBody).toBeUndefined();
+    expect(block.bodyNotes).toBeUndefined();
+  });
+
+  test("captures an ri:page reference as a page MacroParamRef", () => {
+    const block = unknownBlock(
+      '<ac:structured-macro ac:name="include">' +
+        '<ac:parameter ac:name="page"><ri:page ri:content-id="12345" ri:content-title="Spec" ri:space-key="DOCSY"/></ac:parameter>' +
+        "</ac:structured-macro>"
+    );
+    expect(block.params).toEqual([
+      {
+        name: "page",
+        refs: [{ kind: "page", contentId: "12345", contentTitle: "Spec", spaceKey: "DOCSY" }],
+      },
+    ]);
+  });
+
+  test("captures an ri:attachment reference", () => {
+    const block = unknownBlock(
+      '<ac:structured-macro ac:name="multimedia">' +
+        '<ac:parameter ac:name="name"><ri:attachment ri:filename="demo.mp4"/></ac:parameter>' +
+        "</ac:structured-macro>"
+    );
+    expect(block.params).toEqual([
+      { name: "name", refs: [{ kind: "attachment", filename: "demo.mp4" }] },
+    ]);
+  });
+
+  test("captures an ri:url reference", () => {
+    const block = unknownBlock(
+      '<ac:structured-macro ac:name="widget">' +
+        '<ac:parameter ac:name="url"><ri:url ri:value="https://x.test/w"/></ac:parameter>' +
+        "</ac:structured-macro>"
+    );
+    expect(block.params).toEqual([
+      { name: "url", refs: [{ kind: "url", value: "https://x.test/w" }] },
+    ]);
+  });
+
+  test("captures an ri:user reference", () => {
+    const block = unknownBlock(
+      '<ac:structured-macro ac:name="blog-posts">' +
+        '<ac:parameter ac:name="author"><ri:user ri:account-id="acc-9"/></ac:parameter>' +
+        "</ac:structured-macro>"
+    );
+    expect(block.params).toEqual([
+      { name: "author", refs: [{ kind: "user", accountId: "acc-9" }] },
+    ]);
+  });
+
+  test("captures MULTIPLE sibling ri:space refs under one parameter (blog-posts spaces)", () => {
+    const block = unknownBlock(
+      '<ac:structured-macro ac:name="blog-posts">' +
+        '<ac:parameter ac:name="spaces"><ri:space ri:space-key="DOCSY"/><ri:space ri:space-key="ENG"/></ac:parameter>' +
+        "</ac:structured-macro>"
+    );
+    expect(block.params).toEqual([
+      {
+        name: "spaces",
+        refs: [
+          { kind: "space", spaceKey: "DOCSY" },
+          { kind: "space", spaceKey: "ENG" },
+        ],
+      },
+    ]);
+  });
+
+  test("captures an unnamed parameter with name: \"\" (include/excerpt-include shape)", () => {
+    const block = unknownBlock(
+      '<ac:structured-macro ac:name="excerpt-include">' +
+        '<ac:parameter ac:name=""><ri:page ri:content-id="999"/></ac:parameter>' +
+        "</ac:structured-macro>"
+    );
+    expect(block.params).toEqual([
+      { name: "", refs: [{ kind: "page", contentId: "999" }] },
+    ]);
+  });
+
+  test("keeps case-colliding duplicate parameter names as ordered array entries", () => {
+    const block = unknownBlock(
+      '<ac:structured-macro ac:name="drawio">' +
+        '<ac:parameter ac:name="Foo">first</ac:parameter>' +
+        '<ac:parameter ac:name="foo">second</ac:parameter>' +
+        "</ac:structured-macro>"
+    );
+    expect(block.params).toEqual([
+      { name: "foo", text: "first" },
+      { name: "foo", text: "second" },
+    ]);
+  });
+
+  test("trims leading/trailing whitespace in parameter text (mirrors macroParam)", () => {
+    const block = unknownBlock(
+      '<ac:structured-macro ac:name="drawio">' +
+        '<ac:parameter ac:name="title">   spaced value   </ac:parameter>' +
+        "</ac:structured-macro>"
+    );
+    expect(block.params).toEqual([{ name: "title", text: "spaced value" }]);
+  });
+
+  test("walks a rich-text-body; nested-macro note stays OUT of the top-level report", () => {
+    const { blocks: b, notes } = storageToBlocks(
+      '<ac:structured-macro ac:name="drawio"><ac:rich-text-body>' +
+        "<p>intro</p>" +
+        '<ac:structured-macro ac:name="jira"/>' +
+        "</ac:rich-text-body></ac:structured-macro>"
+    );
+    const block = b[0] as Extract<ExportBlock, { type: "unknown" }>;
+    expect(block.body).toEqual([
+      { type: "paragraph", content: [{ type: "text", text: "intro" }] },
+      { type: "unknown", macroName: "jira" },
+    ]);
+    // The top-level report has ONLY the outer macro's note — the nested
+    // jira note was collected by the scratch ctx, not merged upward.
+    expect(notes).toEqual([
+      { level: "warning", code: "unknown-macro", message: expect.any(String), macroName: "drawio" },
+    ]);
+    // ...and it survives on the block as bodyNotes.
+    expect(block.bodyNotes).toEqual([
+      { level: "info", code: "macro-not-rendered", message: expect.any(String), macroName: "jira" },
+    ]);
+  });
+
+  test("preserves a scratch-walk note that walkImage would otherwise drop (bodyNotes)", () => {
+    const { blocks: b, notes } = storageToBlocks(
+      '<ac:structured-macro ac:name="drawio"><ac:rich-text-body>' +
+        "<p>text</p>" +
+        "<ac:image></ac:image>" +
+        "</ac:rich-text-body></ac:structured-macro>"
+    );
+    const block = b[0] as Extract<ExportBlock, { type: "unknown" }>;
+    // The unresolvable image is dropped from body (as walkImage always does)...
+    expect(block.body).toEqual([{ type: "paragraph", content: [{ type: "text", text: "text" }] }]);
+    // ...but the observation is preserved on the block, not discarded.
+    expect(block.bodyNotes).toEqual([
+      { level: "warning", code: "image-unresolved", message: expect.any(String) },
+    ]);
+    // The top-level report never sees it.
+    expect(notes.some((n) => n.code === "image-unresolved")).toBe(false);
+    expect(notes).toEqual([
+      { level: "warning", code: "unknown-macro", message: expect.any(String), macroName: "drawio" },
+    ]);
+  });
+
+  test("captures a plain-text-body verbatim (CDATA)", () => {
+    const block = unknownBlock(
+      '<ac:structured-macro ac:name="drawio"><ac:plain-text-body><![CDATA[a < b && c > d]]></ac:plain-text-body></ac:structured-macro>'
+    );
+    expect(block.plainBody).toBe("a < b && c > d");
+    expect(block.body).toBeUndefined();
+  });
+
+  test("backward-compat pin: a bare macro is just { type, macroName }", () => {
+    const block = unknownBlock('<ac:structured-macro ac:name="x"/>');
+    expect(block).toEqual({ type: "unknown", macroName: "x" });
+  });
+});
+
+describe("macroParamText", () => {
+  const params: MacroParameter[] = [
+    { name: "jqlquery", text: "project = ATL" },
+    { name: "page", refs: [{ kind: "page", contentId: "1" }] },
+    { name: "dup", text: "first" },
+    { name: "dup", text: "second" },
+  ];
+
+  test("returns a matching parameter's text case-insensitively", () => {
+    expect(macroParamText(params, "jqlQuery")).toBe("project = ATL");
+  });
+
+  test("returns undefined for a ref-only parameter", () => {
+    expect(macroParamText(params, "page")).toBeUndefined();
+  });
+
+  test("returns undefined for an absent parameter or absent params", () => {
+    expect(macroParamText(params, "missing")).toBeUndefined();
+    expect(macroParamText(undefined, "jqlQuery")).toBeUndefined();
+  });
+
+  test("returns the FIRST match when duplicate names exist", () => {
+    expect(macroParamText(params, "dup")).toBe("first");
+  });
+});
+
+describe("storageToBlocks — options", () => {
+  test("exporter option has no semantic effect yet (deep-equal to no-options)", () => {
+    const xml =
+      '<h2>Mixed</h2><p>text with a <a href="https://x.test">link</a></p>' +
+      '<ac:structured-macro ac:name="drawio" ac:macro-id="m1"><ac:parameter ac:name="k">v</ac:parameter>' +
+      "<ac:rich-text-body><p>body</p></ac:rich-text-body></ac:structured-macro>";
+    expect(storageToBlocks(xml, { exporter: "pdf" })).toEqual(storageToBlocks(xml));
+    expect(storageToBlocks(xml, { exporter: "word" })).toEqual(storageToBlocks(xml));
+  });
+});
+
+describe("ExportBlock — compile-shape", () => {
+  test("the new/extended variants type-check as an ExportBlock[] literal", () => {
+    const doc: ExportBlock[] = [
+      { type: "pageBreak" },
+      {
+        type: "orientation",
+        landscape: true,
+        content: [{ type: "paragraph", content: [{ type: "text", text: "wide" }] }],
+      },
+      { type: "anchor", name: "sec-1" },
+      { type: "codeBlock", code: "x=1", caption: { kind: "code", content: [{ type: "text", text: "Listing 1" }] } },
+      {
+        type: "table",
+        rows: [],
+        caption: { kind: "table", content: [{ type: "text", text: "Table 1" }] },
+      },
+      {
+        type: "image",
+        source: { kind: "external", url: "https://x.test/i.png" },
+        caption: { kind: "figure", content: [{ type: "text", text: "Figure 1" }] },
+      },
+      { type: "heading", level: 2, content: [{ type: "text", text: "H" }], explicitAnchor: "h-anchor" },
+    ];
+    expect(doc.map((b) => b.type)).toEqual([
+      "pageBreak",
+      "orientation",
+      "anchor",
+      "codeBlock",
+      "table",
+      "image",
+      "heading",
+    ]);
   });
 });
 

--- a/packages/confluence/src/export-blocks.ts
+++ b/packages/confluence/src/export-blocks.ts
@@ -95,22 +95,118 @@ export type ImageSource =
 /** Confluence callout kinds plus the generic titled panel. */
 export type CalloutKind = "info" | "note" | "warning" | "tip" | "panel";
 
+/** What a {@link Caption} labels — drives the serializer's numbering prefix (Figure/Table/…). */
+export type CaptionKind = "figure" | "table" | "code" | "equation";
+
+/**
+ * A caption attached to a captionable block (figure/table/code/equation). Its
+ * `content` is typed inline nodes so a mention inside a caption resolves the
+ * same way as anywhere else (see `resolve-mentions.ts`). No walker emits a
+ * caption yet — that arrives with `scroll-title` (T1.4).
+ */
+export interface Caption {
+  kind: CaptionKind;
+  content: InlineNode[];
+}
+
+/**
+ * A structured reference captured from a macro parameter's `ri:*` child
+ * element (never raw XML — a typed projection of the five reference shapes
+ * the markdown→storage converter and hand-authored storage both emit:
+ * `ri:page`, `ri:attachment`, `ri:url`, `ri:user`, `ri:space`).
+ */
+export type MacroParamRef =
+  | { kind: "page"; contentId?: string; contentTitle?: string; spaceKey?: string; anchor?: string }
+  | { kind: "attachment"; filename: string }
+  | { kind: "url"; value: string }
+  | { kind: "user"; accountId: string }
+  | { kind: "space"; spaceKey: string };
+
+/**
+ * One `<ac:parameter>`. `name` is the lowercased `ac:name` attribute — the
+ * empty string for the unnamed first parameter some macros use (e.g.
+ * `include`/`excerpt-include`'s page ref, `markdown.ts:333`). `text` holds
+ * trimmed text content when present (today's `elementText` semantics);
+ * `refs` holds every `ri:*` child in document order — most parameters have
+ * at most one, but `spaces` (`blog-posts`) can carry several sibling
+ * `ri:space` refs under a single parameter. A parameter can have `text`,
+ * `refs`, both (mixed content), or neither (empty parameter).
+ */
+export interface MacroParameter {
+  name: string;
+  text?: string;
+  refs?: MacroParamRef[];
+}
+
+/**
+ * Case-insensitive convenience lookup for a parameter's plain-text value only
+ * (mirrors the internal `macroParam` helper). Returns `undefined` for
+ * ref-only or absent parameters — callers that need `ri:*` data read `refs`
+ * directly. When duplicate names exist, the first match wins.
+ */
+export function macroParamText(
+  params: MacroParameter[] | undefined,
+  name: string
+): string | undefined {
+  if (!params) return undefined;
+  const target = name.toLowerCase();
+  for (const p of params) {
+    if (p.name.toLowerCase() === target) return p.text;
+  }
+  return undefined;
+}
+
 /**
  * A block-level element. Discriminated on `type`. This is the unit both the
  * DOCX and Typst serializers iterate.
+ *
+ * The `pageBreak`, `orientation` and `anchor` variants are fed by the
+ * `scroll-pagebreak`/`scroll-landscape`/`scroll-bookmark` walker features
+ * (T1.4); until the engines learn real rendering (T1.3/T1.5) both serializers
+ * render them as no-ops (`pageBreak`/`anchor` → nothing, `orientation` →
+ * its `content` children rendered transparently, never dropped).
  */
 export type ExportBlock =
-  | { type: "heading"; level: 1 | 2 | 3 | 4 | 5 | 6; content: InlineNode[] }
+  | { type: "heading"; level: 1 | 2 | 3 | 4 | 5 | 6; content: InlineNode[]; explicitAnchor?: string }
   | { type: "paragraph"; content: InlineNode[] }
-  | { type: "codeBlock"; language?: string; code: string }
+  | { type: "codeBlock"; language?: string; code: string; caption?: Caption }
   | { type: "callout"; kind: CalloutKind; title?: string; content: ExportBlock[] }
   | { type: "list"; ordered: boolean; items: ListItem[] }
-  | { type: "table"; rows: TableRow[]; columnWidths?: number[] }
-  | { type: "image"; source: ImageSource; alt?: string; width?: number; height?: number }
+  | { type: "table"; rows: TableRow[]; columnWidths?: number[]; caption?: Caption }
+  | { type: "image"; source: ImageSource; alt?: string; width?: number; height?: number; caption?: Caption }
   | { type: "blockquote"; content: ExportBlock[] }
   | { type: "divider" }
-  /** An unrecognized macro. Never carries raw XML; the macro name is enough for a report line. */
-  | { type: "unknown"; macroName: string };
+  /** A hard page break (`scroll-pagebreak`). Engines render nothing until T1.3/T1.5. */
+  | { type: "pageBreak" }
+  /**
+   * A page-orientation region (`scroll-landscape`). `content` is walked
+   * recursively; engines render the children transparently (no real
+   * orientation switch) until T1.5, so no content is ever lost.
+   */
+  | { type: "orientation"; landscape: boolean; content: ExportBlock[] }
+  /** A named in-page anchor / bookmark (`scroll-bookmark`). No nested content. */
+  | { type: "anchor"; name: string }
+  /**
+   * An unrecognized macro. Never carries raw XML — the captured parameters and
+   * body are structured data (typed refs + walked blocks), not passthrough. All
+   * enrichment fields are optional so the block stays backward-compatible with
+   * `{ type: "unknown", macroName }`.
+   */
+  | { type: "unknown"; macroName: string;
+      /** Every `<ac:parameter>`, in document order, losslessly typed. */
+      params?: MacroParameter[];
+      /** `<ac:rich-text-body>`, recursively walked. */
+      body?: ExportBlock[];
+      /** `<ac:plain-text-body>` text, verbatim. */
+      plainBody?: string;
+      /** The `ac:macro-id` attribute. */
+      macroId?: string;
+      /**
+       * Notes the scratch walk of `body` produced but did NOT merge into the
+       * top-level report — preserved on the block for a later consumer (Lane E,
+       * T1.7) to promote rather than silently discarded.
+       */
+      bodyNotes?: ExportNote[] };
 
 /** A non-fatal observation surfaced in the export report (never thrown). */
 export interface ExportNote {
@@ -125,6 +221,15 @@ export interface ExportNote {
 export interface StorageToBlocksResult {
   blocks: ExportBlock[];
   notes: ExportNote[];
+}
+
+/** Options for {@link storageToBlocks}. */
+export interface StorageToBlocksOptions {
+  /**
+   * Exporter identity for `scroll-only` / `scroll-ignore` scoping. Consumed
+   * from T1.4 on — no behavioral effect yet.
+   */
+  exporter?: "pdf" | "word";
 }
 
 // ---------------------------------------------------------------------------
@@ -275,8 +380,27 @@ function parseAttributes(source: string): Record<string, string> {
 // Walker
 // ---------------------------------------------------------------------------
 
+/**
+ * Walk context threaded through the whole storage→blocks traversal. Beyond the
+ * note sink it carries the {@link StorageToBlocksOptions.exporter} identity for
+ * exporter-scoped decisions (T1.4). A scratch walk replaces ONLY the note sink;
+ * it inherits every other field via {@link forkWalkCtx}.
+ */
 interface WalkCtx {
   notes: ExportNote[];
+  /** Exporter identity (from options); undefined for hosts that don't set it. */
+  exporter?: "pdf" | "word";
+}
+
+/**
+ * Build a scratch {@link WalkCtx} that reuses every field of `ctx` but swaps in
+ * a fresh note sink. The ONLY sanctioned way to construct a scratch context —
+ * a hand-built `{ notes: [] }` literal would silently drop `exporter` (and any
+ * field added to `WalkCtx` later), producing exporter-blind decisions inside
+ * whatever body it walks.
+ */
+function forkWalkCtx(ctx: WalkCtx, notes: ExportNote[]): WalkCtx {
+  return { ...ctx, notes };
 }
 
 const HEADING_TAGS: Record<string, 1 | 2 | 3 | 4 | 5 | 6> = {
@@ -325,10 +449,14 @@ const TRANSPARENT_BLOCK_TAGS = new Set([
  * Convert a Confluence storage fragment to the intermediate export model.
  *
  * @param storage - Confluence storage-format XML (a fragment, not a full doc).
+ * @param options - Optional exporter identity ({@link StorageToBlocksOptions}).
  * @returns The block tree plus any {@link ExportNote}s for the export report.
  */
-export function storageToBlocks(storage: string): StorageToBlocksResult {
-  const ctx: WalkCtx = { notes: [] };
+export function storageToBlocks(
+  storage: string,
+  options?: StorageToBlocksOptions
+): StorageToBlocksResult {
+  const ctx: WalkCtx = { notes: [], exporter: options?.exporter };
   const nodes = parseXml(storage);
   const blocks = walkBlocks(nodes, ctx);
   return { blocks, notes: ctx.notes };
@@ -393,7 +521,12 @@ function walkBlocks(nodes: XmlNode[], ctx: WalkCtx): ExportBlock[] {
   return out;
 }
 
-/** A `status` structured-macro is the only inline-level macro. */
+/**
+ * A `status` structured-macro is the only inline-level macro.
+ *
+ * Seam for Lane C (T1.4): the `scroll-only-inline`/`scroll-ignore-inline`
+ * exporter-scoped inline handling lands here, not in T0.
+ */
 function isInlineMacro(node: XmlElement): boolean {
   return node.name === "ac:structured-macro" && (node.attrs["ac:name"] ?? "").toLowerCase() === "status";
 }
@@ -706,7 +839,99 @@ function walkMacro(el: XmlElement, ctx: WalkCtx): ExportBlock[] {
       : `Unknown macro "${macroName}" was emitted as a placeholder (no raw XML passthrough).`,
     macroName,
   });
-  return [{ type: "unknown", macroName: macroName || "unknown" }];
+
+  // Lossless capture: keep parameters (typed, ordered), the plain-text body,
+  // the recursively-walked rich-text body, and the macro id — so any future
+  // renderer (Lane E) can act on the macro instead of only its name.
+  const block: Extract<ExportBlock, { type: "unknown" }> = {
+    type: "unknown",
+    macroName: macroName || "unknown",
+  };
+
+  const params = captureMacroParams(el);
+  if (params.length > 0) block.params = params;
+
+  const plainBodyEl = childByName(el, "ac:plain-text-body");
+  if (plainBodyEl) block.plainBody = elementText(plainBodyEl);
+
+  const bodyEl = childByName(el, "ac:rich-text-body");
+  if (bodyEl) {
+    const scratchNotes: ExportNote[] = [];
+    const body = walkBlocks(bodyEl.children, forkWalkCtx(ctx, scratchNotes));
+    if (body.length > 0) block.body = body;
+    // Keep the scratch observations on the block (never merged into ctx.notes,
+    // so the top-level report stays byte-identical) rather than discarding them.
+    if (scratchNotes.length > 0) block.bodyNotes = scratchNotes;
+  }
+
+  const macroId = el.attrs["ac:macro-id"];
+  if (macroId !== undefined) block.macroId = macroId;
+
+  return [block];
+}
+
+/** The `ri:*` child names {@link captureMacroParams} recognizes as references. */
+function captureMacroRef(el: XmlElement): MacroParamRef | undefined {
+  switch (el.name) {
+    case "ri:page": {
+      const ref: Extract<MacroParamRef, { kind: "page" }> = { kind: "page" };
+      const contentId = el.attrs["ri:content-id"];
+      const contentTitle = el.attrs["ri:content-title"];
+      const spaceKey = el.attrs["ri:space-key"];
+      if (contentId) ref.contentId = contentId;
+      if (contentTitle) ref.contentTitle = contentTitle;
+      if (spaceKey) ref.spaceKey = spaceKey;
+      return ref;
+    }
+    case "ri:attachment": {
+      const filename = el.attrs["ri:filename"];
+      return filename ? { kind: "attachment", filename } : undefined;
+    }
+    case "ri:url": {
+      const value = el.attrs["ri:value"];
+      return value ? { kind: "url", value } : undefined;
+    }
+    case "ri:user": {
+      const accountId = el.attrs["ri:account-id"] ?? el.attrs["ri:userkey"];
+      return accountId ? { kind: "user", accountId } : undefined;
+    }
+    case "ri:space": {
+      const spaceKey = el.attrs["ri:space-key"];
+      return spaceKey ? { kind: "space", spaceKey } : undefined;
+    }
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Capture every `<ac:parameter>` of a macro as a {@link MacroParameter}. `text`
+ * is trimmed text content (when non-empty); `refs` is one typed reference per
+ * recognized `ri:*` element child (in document order, multiple allowed).
+ * Unrecognized `ri:*` names are skipped rather than misclassified. A parameter
+ * with neither text nor refs is omitted entirely.
+ *
+ * `elementText` is deliberately NOT the sole read path: it returns `""` for an
+ * element-only parameter (e.g. `<ac:parameter><ri:page .../></ac:parameter>`),
+ * which would drop the reference silently.
+ */
+function captureMacroParams(macro: XmlElement): MacroParameter[] {
+  const params: MacroParameter[] = [];
+  for (const p of childrenByName(macro, "ac:parameter")) {
+    const name = (p.attrs["ac:name"] ?? "").toLowerCase();
+    const text = elementText(p).trim();
+    const refs: MacroParamRef[] = [];
+    for (const child of p.children) {
+      if (child.type !== "element") continue;
+      const ref = captureMacroRef(child);
+      if (ref) refs.push(ref);
+    }
+    const param: MacroParameter = { name };
+    if (text) param.text = text;
+    if (refs.length > 0) param.refs = refs;
+    if (param.text !== undefined || param.refs !== undefined) params.push(param);
+  }
+  return params;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/confluence/src/resolve-mentions.test.ts
+++ b/packages/confluence/src/resolve-mentions.test.ts
@@ -82,4 +82,67 @@ describe("resolveExportMentions", () => {
       throw new Error("lookup unavailable");
     })).rejects.toThrow("lookup unavailable");
   });
+
+  it("resolves a mention nested inside an orientation region", async () => {
+    const blocks: ExportBlock[] = [{
+      type: "orientation",
+      landscape: true,
+      content: [{ type: "paragraph", content: [{ type: "mention", accountId: "a" }] }],
+    }];
+    let requested: string[] = [];
+    const result = await resolveExportMentions(blocks, async (ids) => {
+      requested = ids;
+      return new Map([["a", "Ada"]]);
+    });
+    expect(requested).toEqual(["a"]);
+    expect(result.unresolved).toBe(0);
+    expect(JSON.stringify(result.blocks)).toContain('"displayName":"Ada"');
+  });
+
+  it("resolves a mention inside a caption on codeBlock, image and table", async () => {
+    const caption = (accountId: string) => ({
+      kind: "figure" as const,
+      content: [{ type: "mention" as const, accountId }],
+    });
+    const blocks: ExportBlock[] = [
+      { type: "codeBlock", code: "x=1", caption: { ...caption("a"), kind: "code" } },
+      { type: "image", source: { kind: "external", url: "https://x.test/i.png" }, caption: caption("b") },
+      { type: "table", rows: [], caption: { ...caption("c"), kind: "table" } },
+    ];
+    let requested: string[] = [];
+    const result = await resolveExportMentions(blocks, async (ids) => {
+      requested = ids;
+      return new Map([["a", "Ada"], ["b", "Bo"], ["c", "Cy"]]);
+    });
+    expect(requested.sort()).toEqual(["a", "b", "c"]);
+    expect(result.unresolved).toBe(0);
+    const json = JSON.stringify(result.blocks);
+    expect(json).toContain('"displayName":"Ada"');
+    expect(json).toContain('"displayName":"Bo"');
+    expect(json).toContain('"displayName":"Cy"');
+  });
+
+  it("does NOT traverse unknown.body — deferred to Lane E (T1.7)", async () => {
+    const blocks: ExportBlock[] = [{
+      type: "unknown",
+      macroName: "drawio",
+      body: [{ type: "paragraph", content: [{ type: "mention", accountId: "a" }] }],
+    }];
+    let calls = 0;
+    const result = await resolveExportMentions(blocks, async () => {
+      calls += 1;
+      return new Map([["a", "Ada"]]);
+    });
+    // The mention buried in unknown.body is neither collected nor resolved.
+    expect(calls).toBe(0);
+    expect(result.unresolved).toBe(0);
+    expect(result.blocks).toEqual(blocks);
+    expect(JSON.stringify(result.blocks)).not.toContain("Ada");
+  });
+
+  it("leaves a bare unknown block (no body) untouched", async () => {
+    const blocks: ExportBlock[] = [{ type: "unknown", macroName: "drawio" }];
+    const result = await resolveExportMentions(blocks, async () => new Map());
+    expect(result).toEqual({ blocks, unresolved: 0 });
+  });
 });

--- a/packages/confluence/src/resolve-mentions.ts
+++ b/packages/confluence/src/resolve-mentions.ts
@@ -1,4 +1,4 @@
-import type { ExportBlock, InlineNode } from "./export-blocks.js";
+import type { Caption, ExportBlock, InlineNode } from "./export-blocks.js";
 
 export interface ExportMentionResolution {
   blocks: ExportBlock[];
@@ -31,6 +31,9 @@ function collectUnresolvedMentionIds(blocks: ExportBlock[]): string[] {
         case "blockquote":
           visitBlocks(block.content);
           break;
+        case "orientation":
+          visitBlocks(block.content);
+          break;
         case "list":
           for (const item of block.items) visitBlocks(item.content);
           break;
@@ -38,6 +41,11 @@ function collectUnresolvedMentionIds(blocks: ExportBlock[]): string[] {
           for (const row of block.rows) {
             for (const cell of row.cells) visitBlocks(cell.content);
           }
+          if (block.caption) visitInline(block.caption.content);
+          break;
+        case "codeBlock":
+        case "image":
+          if (block.caption) visitInline(block.caption.content);
           break;
       }
     }
@@ -64,6 +72,11 @@ function resolveBlockMentions(
   blocks: ExportBlock[],
   displayNames: ReadonlyMap<string, string | null>
 ): ExportBlock[] {
+  const resolveCaption = (caption: Caption): Caption => ({
+    ...caption,
+    content: resolveInlineMentions(caption.content, displayNames),
+  });
+
   return blocks.map((block): ExportBlock => {
     switch (block.type) {
       case "heading":
@@ -71,6 +84,8 @@ function resolveBlockMentions(
         return { ...block, content: resolveInlineMentions(block.content, displayNames) };
       case "callout":
       case "blockquote":
+        return { ...block, content: resolveBlockMentions(block.content, displayNames) };
+      case "orientation":
         return { ...block, content: resolveBlockMentions(block.content, displayNames) };
       case "list":
         return {
@@ -90,7 +105,16 @@ function resolveBlockMentions(
               content: resolveBlockMentions(cell.content, displayNames),
             })),
           })),
+          ...(block.caption ? { caption: resolveCaption(block.caption) } : {}),
         };
+      case "codeBlock":
+      case "image":
+        return block.caption ? { ...block, caption: resolveCaption(block.caption) } : block;
+      // NOTE: `unknown.body` is deliberately NOT traversed here. It is populated
+      // unconditionally by the walker but nothing renders it yet; resolving
+      // mentions inside it would make the extension's PDF path issue live user
+      // lookups for invisible content. Traversal belongs with Lane E (T1.7),
+      // once a macro renderer turns that body into visible output.
       default:
         return block;
     }

--- a/packages/docx/src/export.ts
+++ b/packages/docx/src/export.ts
@@ -232,7 +232,7 @@ export async function exportDocx(input: ExportInput): Promise<ExportResult> {
   //    (and images aren't disabled), the serializer's image seam embeds each
   //    image into THIS zip (media + rel + content type) before render — the
   //    rendered rawxml body then references relationships that already exist.
-  const { blocks, notes: walkNotes } = storageToBlocks(input.details.storage ?? "");
+  const { blocks, notes: walkNotes } = storageToBlocks(input.details.storage ?? "", { exporter: "word" });
   const styleNames = parseStyleNames(zip.file("word/styles.xml")?.asText() ?? "");
   // One embedder per export owns the unique-id counters for images AND
   // diagrams (spec 005a: "unique element ids reused from 005 — no collisions

--- a/packages/docx/src/serialize.test.ts
+++ b/packages/docx/src/serialize.test.ts
@@ -506,3 +506,81 @@ describe("serializeBlocks — callouts, code, tables, images", () => {
     expect(xml).toContain("1."); // ordered nested marker
   });
 });
+
+describe("serializeBlocks — new ExportBlock variants (T0 no-op renderings)", () => {
+  it("renders pageBreak/anchor as zero XML and orientation as its children bare", async () => {
+    const body: ExportBlock[] = [
+      { type: "paragraph", content: [{ type: "text", text: "before" }] },
+      { type: "paragraph", content: [{ type: "text", text: "inside region" }] },
+      { type: "paragraph", content: [{ type: "text", text: "after" }] },
+    ];
+    // The reference document without any new blocks.
+    const plain = await serializeBlocks(body, { styleNames: noStyles });
+
+    // The same content wrapped/surrounded with the new no-op blocks.
+    const withNew: ExportBlock[] = [
+      { type: "paragraph", content: [{ type: "text", text: "before" }] },
+      { type: "pageBreak" },
+      { type: "anchor", name: "sec" },
+      {
+        type: "orientation",
+        landscape: true,
+        content: [{ type: "paragraph", content: [{ type: "text", text: "inside region" }] }],
+      },
+      { type: "paragraph", content: [{ type: "text", text: "after" }] },
+    ];
+    const withNo = await serializeBlocks(withNew, { styleNames: noStyles });
+
+    // pageBreak + anchor contribute nothing, orientation renders its child
+    // transparently → output is byte-identical to the plain document.
+    expect(withNo.xml).toBe(plain.xml);
+    expect(withNo.notes).toEqual([]);
+  });
+
+  it("promotes headings nested inside an orientation region (computeHeadingOffset)", async () => {
+    const blocks: ExportBlock[] = [
+      {
+        type: "orientation",
+        landscape: true,
+        content: [{ type: "heading", level: 2, content: [{ type: "text", text: "Wide section" }] }],
+      },
+    ];
+    const { xml } = await serializeBlocks(blocks, { styleNames: noStyles });
+    // The lone H2 (inside the region) is the shallowest heading → promoted to
+    // Heading 1. Without the orientation recursion in minHeadingLevel it would
+    // stay Heading2.
+    expect(xml).toContain('<w:pStyle w:val="Heading1"/>');
+    expect(xml).toContain("Wide section");
+  });
+
+  it("prefetches an image and a mermaid diagram nested inside an orientation region", async () => {
+    const imagePrefetched: string[] = [];
+    const diagramPrefetched: string[] = [];
+    const blocks: ExportBlock[] = [
+      {
+        type: "orientation",
+        landscape: false,
+        content: [
+          { type: "image", source: { kind: "attachment", filename: "nested.png" }, alt: "n" },
+          { type: "codeBlock", language: "mermaid", code: "graph TD\n A-->B" },
+        ],
+      },
+    ];
+    await serializeBlocks(blocks, {
+      styleNames: noStyles,
+      images: {
+        embed: async () => ({ ok: false, reason: "unused" }),
+        prefetch: (block) =>
+          imagePrefetched.push(block.source.kind === "attachment" ? block.source.filename : block.source.url),
+      },
+      diagrams: {
+        embed: async () => ({ ok: false, route: "failed", reason: "unused" }),
+        prefetch: (block) => diagramPrefetched.push(block.code),
+      },
+    });
+    // Both nested-block prefetch hooks fired — the prefetchBlocks walk descended
+    // into the orientation region.
+    expect(imagePrefetched).toEqual(["nested.png"]);
+    expect(diagramPrefetched).toEqual(["graph TD\n A-->B"]);
+  });
+});

--- a/packages/docx/src/serialize.ts
+++ b/packages/docx/src/serialize.ts
@@ -255,6 +255,7 @@ function minHeadingLevel(blocks: ExportBlock[]): number {
         break;
       case "callout":
       case "blockquote":
+      case "orientation":
         min = Math.min(min, minHeadingLevel(block.content));
         break;
       case "list":
@@ -305,6 +306,7 @@ function prefetchBlocks(blocks: ExportBlock[], ctx: SerializeContext): void {
         }
         case "callout":
         case "blockquote":
+        case "orientation":
           walk(block.content);
           break;
         case "list":
@@ -430,6 +432,19 @@ async function serializeBlock(
 
     case "unknown":
       return paragraph(run(`[${block.macroName} macro not rendered]`, { italic: true, color: "97A0AF" }));
+
+    // No-op renderings (T0.2): today's walker never emits these; real rendering
+    // lands in T1.3/T1.5. Silent no-ops keep output and report byte-identical.
+    case "pageBreak":
+      return "";
+
+    case "anchor":
+      return "";
+
+    case "orientation":
+      // Transparent passthrough — children render exactly as if the region
+      // wrapper did not exist, so no content is lost before T1.5.
+      return serializeChildren(block.content, ctx, notes, depth);
 
     default: {
       const _exhaustive: never = block;

--- a/packages/pdf/src/prepare.test.ts
+++ b/packages/pdf/src/prepare.test.ts
@@ -53,6 +53,52 @@ describe("PDF asset preparation", () => {
     expect(prepared.notes[0]?.message).toContain("declared media type");
   });
 
+  it("resolves an image nested inside an orientation region", async () => {
+    const blocks: ExportBlock[] = [
+      {
+        type: "orientation",
+        landscape: true,
+        content: [
+          { type: "image", source: { kind: "attachment", filename: "wide.png" }, alt: "Wide" },
+        ],
+      },
+    ];
+    const prepared = await preparePdfDocument(blocks, {
+      resolve: async () => ({ bytes: pngBytes(), mediaType: "image/png" }),
+    });
+    expect(prepared.assets).toHaveLength(1);
+    const region = prepared.blocks[0] as { type: "orientation"; content: Array<{ type: string; assetPath?: string }> };
+    expect(region.type).toBe("orientation");
+    expect(region.content[0]).toMatchObject({ type: "image", assetPath: prepared.assets[0]!.path });
+  });
+
+  it("carries caption fields through preparation on table/codeBlock/image", async () => {
+    const blocks: ExportBlock[] = [
+      { type: "codeBlock", code: "x=1", caption: { kind: "code", content: [{ type: "text", text: "Listing 1" }] } },
+      { type: "table", rows: [], caption: { kind: "table", content: [{ type: "text", text: "Table 1" }] } },
+      {
+        type: "image",
+        source: { kind: "attachment", filename: "fig.png" },
+        caption: { kind: "figure", content: [{ type: "text", text: "Figure 1" }] },
+      },
+    ];
+    const prepared = await preparePdfDocument(blocks, {
+      resolve: async () => ({ bytes: pngBytes(), mediaType: "image/png" }),
+    });
+    expect((prepared.blocks[0] as { caption?: unknown }).caption).toEqual({
+      kind: "code",
+      content: [{ type: "text", text: "Listing 1" }],
+    });
+    expect((prepared.blocks[1] as { caption?: unknown }).caption).toEqual({
+      kind: "table",
+      content: [{ type: "text", text: "Table 1" }],
+    });
+    expect((prepared.blocks[2] as { caption?: unknown }).caption).toEqual({
+      kind: "figure",
+      content: [{ type: "text", text: "Figure 1" }],
+    });
+  });
+
   it("bounds parallel attachment resolution and preserves deterministic order", async () => {
     let active = 0;
     let peak = 0;

--- a/packages/pdf/src/prepare.ts
+++ b/packages/pdf/src/prepare.ts
@@ -197,6 +197,8 @@ export async function preparePdfDocument(
             return { ...block, content: await walk(block.content) };
           case "blockquote":
             return { ...block, content: await walk(block.content) };
+          case "orientation":
+            return { ...block, content: await walk(block.content) };
           case "list":
             return {
               ...block,
@@ -233,6 +235,7 @@ export async function preparePdfDocument(
                 width: block.width,
                 height: block.height,
                 fallbackLabel,
+                caption: block.caption,
               };
             } catch (error) {
               notes.push({
@@ -240,7 +243,7 @@ export async function preparePdfDocument(
                 code: "pdf-image-skipped",
                 message: `${fallbackLabel} was not embedded: ${error instanceof Error ? error.message : String(error)}`,
               });
-              return { type: "image", alt: block.alt, fallbackLabel };
+              return { type: "image", alt: block.alt, fallbackLabel, caption: block.caption };
             }
           }
           case "codeBlock": {
@@ -252,7 +255,7 @@ export async function preparePdfDocument(
                 { bytes, mediaType: "image/svg+xml", filename: "diagram.svg" },
                 "diagram"
               );
-              return { type: "diagram", assetPath, source: block.code };
+              return { type: "diagram", assetPath, source: block.code, caption: block.caption };
             }
             notes.push({
               level: rendered.kind === "unsupported" ? "info" : "warning",
@@ -271,6 +274,8 @@ export async function preparePdfDocument(
           case "paragraph":
           case "divider":
           case "unknown":
+          case "pageBreak":
+          case "anchor":
             return block;
           default: {
             const exhaustive: never = block;

--- a/packages/pdf/src/run-export.test.ts
+++ b/packages/pdf/src/run-export.test.ts
@@ -55,6 +55,30 @@ describe("neutral runPdfExport", () => {
     expect(emitted).toBe(0);
   });
 
+  it("counts an image nested inside an orientation region (embeddedImages)", async () => {
+    const png = new Uint8Array([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+      0, 0, 0, 13, 0x49, 0x48, 0x44, 0x52,
+      0, 0, 0, 1, 0, 0, 0, 1,
+    ]);
+    const regionBlocks: ExportBlock[] = [
+      {
+        type: "orientation",
+        landscape: true,
+        content: [{ type: "image", source: { kind: "attachment", filename: "wide.png" }, alt: "Wide" }],
+      },
+    ];
+    const report = await runPdfExport(
+      { blocks: regionBlocks, metadata, filename: "Test.pdf" },
+      {
+        assets: { resolve: async () => ({ bytes: png, mediaType: "image/png" }) },
+        compiler: { compile: async () => ({ pdf: validPdf, diagnostics: [], compilerVersion: "test" }) },
+        output: { emit: async () => {} },
+      }
+    );
+    expect(report.embeddedImages).toBe(1);
+  });
+
   it("lets abort win after a late compiler result", async () => {
     const controller = new AbortController();
     let emitted = 0;

--- a/packages/pdf/src/run-export.ts
+++ b/packages/pdf/src/run-export.ts
@@ -85,6 +85,7 @@ function countPrepared(blocks: PreparedPdfBlock[]): { images: number; diagrams: 
           break;
         case "callout":
         case "blockquote":
+        case "orientation":
           walk(block.content);
           break;
         case "list":

--- a/packages/pdf/src/serialize.test.ts
+++ b/packages/pdf/src/serialize.test.ts
@@ -673,3 +673,93 @@ describe("PDF preparation and serialization", () => {
     ).toBe(second!.blockPath);
   });
 });
+
+describe("PDF serialize — new ExportBlock variants (T0 no-op renderings)", () => {
+  const strip = (main: string): string =>
+    main.replace(/\/\* atlcli:(?:start|end):[^*]+ \*\//g, "");
+
+  // "Semantic" = the non-empty content lines are identical. Byte-identity is
+  // unreachable by design: writeMapped wraps EVERY block (including the empty
+  // pageBreak/anchor) in path-bearing comment markers, and array-index shifts
+  // change sibling paths even when content is unchanged (see the Engines note).
+  const contentLines = (main: string): string =>
+    strip(main)
+      .split("\n")
+      .filter((line) => line.trim() !== "")
+      .join("\n");
+
+  it("renders pageBreak/anchor/orientation with no semantic change to main.typ", async () => {
+    const reference: ExportBlock[] = [
+      { type: "heading", level: 2, content: [{ type: "text", text: "Section" }] },
+      { type: "paragraph", content: [{ type: "text", text: "before" }] },
+      { type: "paragraph", content: [{ type: "text", text: "inside" }] },
+      { type: "paragraph", content: [{ type: "text", text: "after" }] },
+    ];
+    const withNew: ExportBlock[] = [
+      { type: "heading", level: 2, content: [{ type: "text", text: "Section" }] },
+      { type: "paragraph", content: [{ type: "text", text: "before" }] },
+      { type: "pageBreak" },
+      { type: "anchor", name: "bm" },
+      {
+        type: "orientation",
+        landscape: true,
+        content: [{ type: "paragraph", content: [{ type: "text", text: "inside" }] }],
+      },
+      { type: "paragraph", content: [{ type: "text", text: "after" }] },
+    ];
+    const resolver = { resolve: async () => { throw new Error("unused"); } };
+    const refBundle = serializePdfDocument(await preparePdfDocument(reference, resolver), { metadata });
+    const newBundle = serializePdfDocument(await preparePdfDocument(withNew, resolver), { metadata });
+
+    // Semantic identity: content lines match once the comment markers are gone.
+    expect(contentLines(newBundle.main)).toBe(contentLines(refBundle.main));
+    // No new notes (no pdf-unknown-block, nothing) from the no-op blocks.
+    expect(newBundle.notes).toEqual([]);
+  });
+
+  it("gives pageBreak and anchor their own zero-width sourceMap entries", async () => {
+    const blocks: ExportBlock[] = [
+      { type: "paragraph", content: [{ type: "text", text: "x" }] },
+      { type: "pageBreak" },
+      { type: "anchor", name: "bm" },
+    ];
+    const bundle = serializePdfDocument(
+      await preparePdfDocument(blocks, { resolve: async () => { throw new Error("unused"); } }),
+      { metadata }
+    );
+    for (const blockType of ["pageBreak", "anchor"] as const) {
+      const entry = bundle.sourceMap.find((e) => e.blockType === blockType);
+      expect(entry).toBeDefined();
+      // Zero-width: the wrapped value is empty, so start position == end position.
+      expect(entry!.startLine).toBe(entry!.endLine);
+      expect(entry!.startColumn).toBe(entry!.endColumn);
+    }
+  });
+
+  it("sees a heading nested inside an orientation region (promotion + label link)", async () => {
+    const blocks: ExportBlock[] = [
+      {
+        type: "orientation",
+        landscape: true,
+        content: [{ type: "heading", level: 2, content: [{ type: "text", text: "Wide Section" }] }],
+      },
+      {
+        type: "paragraph",
+        content: [
+          { type: "link", target: { kind: "anchor", anchor: "Wide Section" }, content: [{ type: "text", text: "jump" }] },
+        ],
+      },
+    ];
+    const bundle = serializePdfDocument(
+      await preparePdfDocument(blocks, { resolve: async () => { throw new Error("unused"); } }),
+      { metadata }
+    );
+    // minHeadingLevel recursed into the region → the lone H2 promotes to level 1.
+    expect(bundle.main).toContain("#heading(level: 1, outlined: true)");
+    // collectHeadingLabels recursed into the region → the internal link resolves
+    // to the heading's <wide-section> label instead of degrading to plain text.
+    expect(bundle.main).toContain("<wide-section>");
+    expect(bundle.main).toContain("#link(<wide-section>)");
+    expect(bundle.notes.some((n) => n.code === "pdf-link-unresolved")).toBe(false);
+  });
+});

--- a/packages/pdf/src/serialize.ts
+++ b/packages/pdf/src/serialize.ts
@@ -130,6 +130,7 @@ function blocksPlainText(blocks: PreparedPdfBlock[]): string {
           return block.code;
         case "callout":
         case "blockquote":
+        case "orientation":
           return blocksPlainText(block.content);
         case "list":
           return block.items.map((item) => blocksPlainText(item.content)).join(" ");
@@ -145,6 +146,9 @@ function blocksPlainText(blocks: PreparedPdfBlock[]): string {
           return "";
         case "unknown":
           return block.macroName;
+        case "pageBreak":
+        case "anchor":
+          return "";
         default: {
           const exhaustive: never = block;
           return exhaustive;
@@ -470,6 +474,7 @@ function minHeadingLevel(blocks: PreparedPdfBlock[]): number {
         break;
       case "callout":
       case "blockquote":
+      case "orientation":
         min = Math.min(min, minHeadingLevel(block.content));
         break;
       case "list":
@@ -502,6 +507,7 @@ function collectHeadingLabels(blocks: PreparedPdfBlock[]): Map<string, string> {
         }
         case "callout":
         case "blockquote":
+        case "orientation":
           walk(block.content);
           break;
         case "list":
@@ -801,6 +807,19 @@ function serializeBlock(
         macroName: block.macroName,
       });
       value = "";
+      break;
+    // No-op renderings (T0.2): the walker never emits these yet; real rendering
+    // lands in T1.5. `writeMapped` still wraps them (source-map precedent).
+    case "pageBreak":
+      value = "";
+      break;
+    case "anchor":
+      value = "";
+      break;
+    case "orientation":
+      // Transparent — no `#set page(flipped:)` yet (T1.5); children serialize
+      // exactly as if the region wrapper were absent, so nothing is lost.
+      value = serializeBlocks(block.content, writer, `${path}.content`, context);
       break;
     default: {
       const exhaustive: never = block;

--- a/packages/pdf/src/types.ts
+++ b/packages/pdf/src/types.ts
@@ -1,4 +1,4 @@
-import type { ExportBlock, ExportNote, InlineNode, LinkTarget } from "@atlcli/confluence";
+import type { Caption, ExportBlock, ExportNote, InlineNode, LinkTarget } from "@atlcli/confluence";
 
 export interface PdfExportMetadata {
   title: string;
@@ -34,18 +34,20 @@ export interface PreparedPdfAsset {
 }
 
 export type PreparedPdfBlock =
-  | Exclude<ExportBlock, { type: "callout" | "list" | "table" | "image" | "blockquote" | "codeBlock" }>
+  | Exclude<ExportBlock, { type: "callout" | "list" | "table" | "image" | "blockquote" | "codeBlock" | "orientation" }>
   | { type: "callout"; kind: Extract<ExportBlock, { type: "callout" }>["kind"]; title?: string; content: PreparedPdfBlock[] }
   | { type: "list"; ordered: boolean; items: Array<{ content: PreparedPdfBlock[]; checked?: boolean }> }
   | {
       type: "table";
       rows: Array<{ cells: Array<{ header: boolean; colspan: number; rowspan: number; backgroundColor?: string; content: PreparedPdfBlock[] }> }>;
       columnWidths?: number[];
+      caption?: Caption;
     }
-  | { type: "image"; assetPath?: string; alt?: string; width?: number; height?: number; fallbackLabel: string }
+  | { type: "image"; assetPath?: string; alt?: string; width?: number; height?: number; fallbackLabel: string; caption?: Caption }
   | { type: "blockquote"; content: PreparedPdfBlock[] }
-  | { type: "codeBlock"; language?: string; code: string }
-  | { type: "diagram"; assetPath: string; alt?: string; source: string };
+  | { type: "codeBlock"; language?: string; code: string; caption?: Caption }
+  | { type: "diagram"; assetPath: string; alt?: string; source: string; caption?: Caption }
+  | { type: "orientation"; landscape: boolean; content: PreparedPdfBlock[] };
 
 export interface PreparedPdfDocument {
   blocks: PreparedPdfBlock[];

--- a/specs/export-expansion/001-exportblock-model/PLAN.md
+++ b/specs/export-expansion/001-exportblock-model/PLAN.md
@@ -2,8 +2,24 @@
 
 Reference: UMSETZUNGSPLAN T0.1/T0.2 · BASELINE-DESIGN cluster C/E (prerequisites)
 
-Status: Plan. Owner: one developer/agent, serial — this is the single
-non-parallelizable foundation. Everything in Phase 1 (lanes A, C, E, G and the
+Status: **Erledigt** (implementiert 2026-07-19, Branch
+`claude/exportblock-model-subagents-82d71f`, Commits `e7e693b` +
+`061e361`; Review: approve, keine Defekte). Typecheck grün, 1905 Tests
+grün, DOCX-Golden ohne Recapture, E2E gegen DOCSY inkl. verifiziertem
+Cleanup (Seite 1124565000 gelöscht, 404 bestätigt). Beide offenen
+Fragen wurden gemäß Empfehlung entschieden: `heading.explicitAnchor?`
+ist mit drin, `{ exporter: "word" }` ist in `packages/docx/src/export.ts`
+verdrahtet. Zwei dokumentierte E2E-Abweichungen: die Zoo-Seite wurde per
+Storage-Representation-Update statt Markdown-Passthrough befüllt (der
+Converter escapte die rohen Makros; Endzustand identisch), und die Makros
+erscheinen im ts-Engine-Report als `notes` statt `unsupportedNames`
+(Python-Engine-Konzept; Vorher/Nachher-Parität war der Prüfpunkt und ist
+erfüllt). Der Cross-Plan-Follow-up an 004-macro-renderer (Adoption der
+`MacroParameter[]`-Form, `bodyNotes`-Promotion, `unknown.body`-Mention-
+Resolution) ist erledigt: Commit `43136b4`.
+
+Ursprünglicher Plan-Kopf: Owner: one developer/agent, serial — this is the
+single non-parallelizable foundation. Everything in Phase 1 (lanes A, C, E, G and the
 engine parts of D/P/K) depends on this landing first, in **one PR**, so that
 `packages/confluence/src/export-blocks.ts` is touched exactly once before the
 lanes fork.
@@ -174,34 +190,34 @@ Every task is sized for one reviewable commit inside the single T0 PR.
 
 ### Model (@atlcli/confluence)
 
-- [ ] Add `CaptionKind` and `Caption` to
+- [x] Add `CaptionKind` and `Caption` to
       `packages/confluence/src/export-blocks.ts`, exported next to
       `InlineNode`/`LinkTarget` (model section, around line 90–113).
-- [ ] Extend the `codeBlock`, `table` and `image` variants of `ExportBlock`
+- [x] Extend the `codeBlock`, `table` and `image` variants of `ExportBlock`
       (`export-blocks.ts:102`) with `caption?: Caption`. No walker emits a
       caption yet (that is T1.4, `scroll-title`).
-- [ ] Add the three new variants to `ExportBlock`: `{ type: "pageBreak" }`,
+- [x] Add the three new variants to `ExportBlock`: `{ type: "pageBreak" }`,
       `{ type: "orientation"; landscape: boolean; content: ExportBlock[] }`,
       `{ type: "anchor"; name: string }`. Update the doc comment on the union
       to state which walker features feed them (T1.4) and that engines render
       them as no-ops until T1.3/T1.5.
-- [ ] Add `MacroParamRef`, `MacroParameter` and the `macroParamText()`
+- [x] Add `MacroParamRef`, `MacroParameter` and the `macroParamText()`
       convenience export to `export-blocks.ts`, next to `Caption` (model
       section). `macroParamText` is a straight lift of the existing
       case-insensitive lookup loop in `macroParam` (`:458`), just reading
       `.text` instead of `elementText(p)`.
-- [ ] Enrich the `unknown` variant (`export-blocks.ts:113`) with
+- [x] Enrich the `unknown` variant (`export-blocks.ts:113`) with
       `params?: MacroParameter[]`, `body?`, `plainBody?`, `macroId?`,
       `bodyNotes?: ExportNote[]` as sketched above; update its doc comment
       ("never carries raw XML" still holds — parameters and a walked body
       are structured data, not passthrough XML).
-- [ ] Add `StorageToBlocksOptions` (with `exporter?: "pdf" | "word"`) and
+- [x] Add `StorageToBlocksOptions` (with `exporter?: "pdf" | "word"`) and
       change `storageToBlocks(storage)` (`export-blocks.ts:330`) to
       `storageToBlocks(storage, options?)`. Thread `exporter` into `WalkCtx`
       (`export-blocks.ts:278`) as an optional field. **No behavioral use yet**
       — semantics arrive with `scroll-only`/`scroll-ignore` in T1.4. Existing
       call sites keep compiling (optional parameter).
-- [ ] Add a `forkWalkCtx(ctx: WalkCtx, notes: ExportNote[]): WalkCtx` helper
+- [x] Add a `forkWalkCtx(ctx: WalkCtx, notes: ExportNote[]): WalkCtx` helper
       next to `WalkCtx` (`export-blocks.ts:278`) that returns
       `{ ...ctx, notes }`. Every current and future scratch walk (today: only
       the `unknown.body` capture below) must go through this helper instead
@@ -212,7 +228,7 @@ Every task is sized for one reviewable commit inside the single T0 PR.
       whichever lane discovers the gap. Document the invariant on `WalkCtx`'s
       doc comment: "a scratch walk replaces only the note sink; it inherits
       every other field via `forkWalkCtx`."
-- [ ] Implement the lossless capture in the unknown-macro fallback of
+- [x] Implement the lossless capture in the unknown-macro fallback of
       `walkMacro` (`export-blocks.ts:698–710`):
       - `params`: iterate `childrenByName(el, "ac:parameter")` in document
         order; for each, `name` = lowercased `ac:name` attr (empty string
@@ -248,15 +264,15 @@ Every task is sized for one reviewable commit inside the single T0 PR.
       - `macroId`: `el.attrs["ac:macro-id"]` when present.
       - The existing note push (`macro-not-rendered` / `unknown-macro`,
         `:701–708`) stays byte-identical.
-- [ ] Pass the engine identity at the one call site an engine owns:
+- [x] Pass the engine identity at the one call site an engine owns:
       `packages/docx/src/export.ts:235` becomes
       `storageToBlocks(input.details.storage ?? "", { exporter: "word" })`.
       Pure plumbing — zero behavior until T1.4. (PDF hosts call
       `storageToBlocks` themselves and wire `{ exporter: "pdf" }` in Lane C.)
-- [ ] `isInlineMacro` (`export-blocks.ts:397`) is intentionally **not**
+- [x] `isInlineMacro` (`export-blocks.ts:397`) is intentionally **not**
       touched here — the `scroll-only-inline`/`scroll-ignore-inline` handling
       is T1.4. Leave a one-line pointer comment so Lane C finds the seam.
-- [ ] Extend the two non-exhaustive `switch (block.type)` walks in
+- [x] Extend the two non-exhaustive `switch (block.type)` walks in
       `packages/confluence/src/resolve-mentions.ts` —
       `collectUnresolvedMentionIds` (`:25`) and `resolveBlockMentions`
       (`:68`) — with a `case "orientation":` that recurses into
@@ -297,7 +313,7 @@ Every task is sized for one reviewable commit inside the single T0 PR.
 
 DOCX (`packages/docx/src/serialize.ts`):
 
-- [ ] Resolve the compile errors in the exhaustive `switch` of
+- [x] Resolve the compile errors in the exhaustive `switch` of
       `serializeBlock` (`serialize.ts:344–438`) with three new cases placed
       before the `never` default (`:434`):
       - `case "pageBreak": return "";`
@@ -307,20 +323,20 @@ DOCX (`packages/docx/src/serialize.ts`):
         children render exactly as if the region wrapper did not exist).
       No notes are pushed: today's walker never emits these blocks, so silent
       no-ops keep output and report byte-identical.
-- [ ] Extend the two non-exhaustive recursive walks so an `orientation`
+- [x] Extend the two non-exhaustive recursive walks so an `orientation`
       region's children are not skipped once T1.4 emits it:
       `minHeadingLevel` (`serialize.ts:249`, heading promotion must see
       headings inside regions) and `prefetchBlocks` (`serialize.ts:281`,
       images/diagrams inside regions must prefetch). Both get
       `case "orientation": … recurse into block.content …`.
-- [ ] `caption?` on `codeBlock`/`table`/`image` needs **no** DOCX change
+- [x] `caption?` on `codeBlock`/`table`/`image` needs **no** DOCX change
       (optional field, ignored by `serializeBlock`); confirm the `unknown`
       placeholder (`serialize.ts:431–432`) still renders from `macroName`
       only and ignores the enrichment fields.
 
 PDF (`packages/pdf/src/{types,prepare,serialize,run-export}.ts`):
 
-- [ ] `packages/pdf/src/types.ts` — extend `PreparedPdfBlock`
+- [x] `packages/pdf/src/types.ts` — extend `PreparedPdfBlock`
       (`types.ts:36`):
       - Add `"orientation"` to the `Exclude<…>` passthrough list and
         re-declare it with prepared children:
@@ -332,7 +348,7 @@ PDF (`packages/pdf/src/{types,prepare,serialize,run-export}.ts`):
         and the `image`/`diagram` variants gain `caption?: Caption`
         (import `Caption` as a type from `@atlcli/confluence`), so Lane C's
         rendering task never has to touch this file again.
-- [ ] `packages/pdf/src/prepare.ts` — extend the `walk` switch
+- [x] `packages/pdf/src/prepare.ts` — extend the `walk` switch
       (`prepare.ts:192–281`):
       - `case "orientation": return { ...block, content: await walk(block.content) };`
         (same shape as the `blockquote` arm, `:198`).
@@ -343,7 +359,7 @@ PDF (`packages/pdf/src/{types,prepare,serialize,run-export}.ts`):
         the `image` arm (`:229–236` and the failure arm `:243`) and the
         `diagram` arm (`:255`) copy `caption: block.caption`. (`table` and
         non-mermaid `codeBlock` spread `...block` and carry it for free.)
-- [ ] `packages/pdf/src/serialize.ts` — resolve the compile errors in
+- [x] `packages/pdf/src/serialize.ts` — resolve the compile errors in
       `serializeBlock` (`serialize.ts:639–811`) before the `never` default
       (`:805`):
       - `case "pageBreak": value = ""; break;`
@@ -365,13 +381,13 @@ PDF (`packages/pdf/src/{types,prepare,serialize,run-export}.ts`):
       block shifts every later sibling's array index, and therefore its
       `writeMapped` path/comment text, even though nothing about that
       sibling's own content changed) — assert semantic identity instead.
-- [ ] Extend the non-exhaustive recursive walks in the PDF engine with an
+- [x] Extend the non-exhaustive recursive walks in the PDF engine with an
       `orientation` recursion (and a `""` result for `pageBreak`/`anchor`
       where a value is required): `blocksPlainText` (`serialize.ts:122`),
       `minHeadingLevel` (`serialize.ts:464`), `collectHeadingLabels`
       (`serialize.ts:488`), and `countPrepared`
       (`packages/pdf/src/run-export.ts:74`).
-- [ ] Run `bun run typecheck` at the repo root — the `never` checks in both
+- [x] Run `bun run typecheck` at the repo root — the `never` checks in both
       engines are the completeness proof; typecheck green means no switch was
       missed.
 
@@ -389,7 +405,7 @@ instance (profile `mayflower`, space `DOCSY` — CLAUDE.md workflow rule).
 
 Unit — walker (`packages/confluence/src/export-blocks.test.ts`):
 
-- [ ] New `describe("storageToBlocks — lossless unknown macros")` with real
+- [x] New `describe("storageToBlocks — lossless unknown macros")` with real
       storage fixtures:
       - a `drawio`-style macro with `ac:macro-id`, several plain-text
         `<ac:parameter>`s and no body → `params` (as `{ name, text }`
@@ -428,29 +444,29 @@ Unit — walker (`packages/confluence/src/export-blocks.test.ts`):
       - a bare `<ac:structured-macro ac:name="x"/>` → block equals
         `{ type: "unknown", macroName: "x" }` with no extra fields
         (backward-compat pin).
-- [ ] `macroParamText()` unit tests: returns the `text` of a matching
+- [x] `macroParamText()` unit tests: returns the `text` of a matching
       parameter case-insensitively, `undefined` for a ref-only or absent
       parameter, and the first match when duplicate names exist (documents
       the convenience API's tie-breaking behavior for callers, e.g. 004's
       renderer registry, that only need simple string params).
-- [ ] Options test: `storageToBlocks(xml, { exporter: "pdf" })` and
+- [x] Options test: `storageToBlocks(xml, { exporter: "pdf" })` and
       `storageToBlocks(xml)` return deeply-equal results for a fixture with
       mixed content (pins "no semantics before T1.4").
-- [ ] Review the updated snapshot
+- [x] Review the updated snapshot
       (`packages/confluence/src/__snapshots__/export-blocks.test.ts.snap`):
       the only permitted diffs are **additive fields on `unknown` blocks**.
       Any other diff is a regression — reject it.
-- [ ] Compile-shape test constructing an `ExportBlock[]` literal containing
+- [x] Compile-shape test constructing an `ExportBlock[]` literal containing
       `pageBreak`, `orientation` (with children), `anchor`, and captioned
       `codeBlock`/`table`/`image` — pins the public type shape hosts rely on.
 
 Unit — mention resolution (`packages/confluence/src/resolve-mentions.test.ts`):
 
-- [ ] New test: an unresolved mention nested inside `{ type: "orientation",
+- [x] New test: an unresolved mention nested inside `{ type: "orientation",
       content: [...] }` is returned by `collectUnresolvedMentionIds` and gets
       its `displayName` filled by `resolveExportMentions` — regression for
       the new `orientation` recursion case.
-- [ ] New test: an unresolved mention inside a hand-built `caption?.content`
+- [x] New test: an unresolved mention inside a hand-built `caption?.content`
       on each of `codeBlock`, `image` and `table` (the walker does not emit
       captions until T1.4, so build the `ExportBlock[]` literal directly —
       same pattern as the compile-shape test above) is collected and
@@ -459,7 +475,7 @@ Unit — mention resolution (`packages/confluence/src/resolve-mentions.test.ts`)
       ship a caption-producing walker change that passes typecheck while
       silently leaving mentions unresolved in visible `scroll-title`
       captions, with no test anywhere catching it.
-- [ ] New **negative** test: an unresolved mention nested inside
+- [x] New **negative** test: an unresolved mention nested inside
       `{ type: "unknown", macroName, body: [...] }` is **not** returned by
       `collectUnresolvedMentionIds` and **not** touched by
       `resolveExportMentions` (`unresolved` count and returned `blocks` are
@@ -472,14 +488,14 @@ Unit — mention resolution (`packages/confluence/src/resolve-mentions.test.ts`)
 
 Unit — DOCX engine (`packages/docx/src/serialize.test.ts` + golden):
 
-- [ ] New test: serialize a document containing the three new blocks plus
+- [x] New test: serialize a document containing the three new blocks plus
       captioned image/table/codeBlock through `serializeBlocks` with a
       minimal `SerializeContext`; assert (a) `pageBreak`/`anchor` contribute
       zero XML — output equals the same document without them, (b)
       `orientation` output equals its children serialized bare, (c) headings
       inside an `orientation` region still drive promotion
       (`computeHeadingOffset` regression), (d) zero notes added.
-- [ ] New test: an `orientation` region containing an image and a mermaid
+- [x] New test: an `orientation` region containing an image and a mermaid
       `codeBlock` — assert `ctx.images?.prefetch`/`ctx.diagrams?.prefetch`
       are invoked for the nested blocks (spy/fake port, not a mock of an
       HTTP or Confluence client), regression for the `prefetchBlocks`
@@ -487,20 +503,20 @@ Unit — DOCX engine (`packages/docx/src/serialize.test.ts` + golden):
       change to `prefetchBlocks`'s switch could silently stop prefetching
       images/diagrams inside a region and nothing but a slower serial fetch
       at render time would reveal it.
-- [ ] Golden pin: `packages/docx/src/golden.test.ts` must pass **unchanged —
+- [x] Golden pin: `packages/docx/src/golden.test.ts` must pass **unchanged —
       no recapture of `golden-extension-export.json`**. This is the
       engine-level proof that T0 changed nothing observable (same role the
       golden played for the spec-006 extraction).
 
 Unit — PDF engine (`packages/pdf/src/{prepare,serialize}.test.ts`):
 
-- [ ] `prepare.test.ts`: prepare a document with an `orientation` region
+- [x] `prepare.test.ts`: prepare a document with an `orientation` region
       containing an attachment image (real bytes via the local
       `PdfAssetResolver` fixture pattern already used there — an in-memory
       resolver is a real implementation of the port, not an HTTP mock);
       assert the image inside the region is resolved into `assets` and
       `caption` fields survive `preparePdfDocument` on table/codeBlock/image.
-- [ ] `serialize.test.ts` (the PDF engine's golden-style suite — it pins
+- [x] `serialize.test.ts` (the PDF engine's golden-style suite — it pins
       `main.typ` content): assert a document with `pageBreak`/`anchor`/
       `orientation` produces `main.typ` **semantically identical** — equal
       after stripping every `/* atlcli:start:<path> */`/`/* atlcli:end:<path>
@@ -514,18 +530,18 @@ Unit — PDF engine (`packages/pdf/src/{prepare,serialize}.test.ts`):
       `unknown`-block precedent — this is intentional, not a leak, and keeps
       `mapPdfDiagnostics` able to attribute a future Typst error to the
       right block); no `pdf-unknown-block` or other new notes.
-- [ ] New test: a heading nested inside an `orientation` region — assert
+- [x] New test: a heading nested inside an `orientation` region — assert
       `minHeadingLevel`/`collectHeadingLabels` see it (heading-offset
       promotion and an internal link resolving to the label), regression for
       the `orientation` cases added to those two walks in Engines above (no
       exhaustiveness check protects them from silently skipping a new
       container).
-- [ ] `run-export.test.ts`: `countPrepared` counts an image inside an
+- [x] `run-export.test.ts`: `countPrepared` counts an image inside an
       `orientation` region (report `embeddedImages` regression).
 
 E2E — real Confluence (profile `mayflower`, space `DOCSY`):
 
-- [ ] Compute the title once, up front:
+- [x] Compute the title once, up front:
       `atlcli-e2e-exportblock-model-<epoch-seconds>` — the
       `atlcli-e2e-<feature>-<timestamp>` convention
       `specs/export-expansion/011-quality-gates/PLAN.md` establishes for all
@@ -537,7 +553,7 @@ E2E — real Confluence (profile `mayflower`, space `DOCSY`):
       parallel/repeated runs in the shared `DOCSY` space. Adopt 011's shared
       `makeE2eTitle`/cleanup helper once it exists instead of inlining the
       timestamp logic.
-- [ ] Create the test page containing the affected macros. Author
+- [x] Create the test page containing the affected macros. Author
       `/tmp/t0-zoo.md` with raw storage passthrough (the markdown→storage
       converter allows HTML/macro passthrough — `html: true` in
       `packages/confluence/src/markdown.ts:64`; verify the macros survive
@@ -553,7 +569,7 @@ E2E — real Confluence (profile `mayflower`, space `DOCSY`):
       `trap`) so the delete in the last bullet always runs, including on
       assertion failure; on a cleanup failure, print the page id prominently
       so it can be deleted manually.
-- [ ] Fetch the server-normalized storage and assert real capture — this is
+- [x] Fetch the server-normalized storage and assert real capture — this is
       the step that actually exercises `macroId`/`params`/`body` against a
       live Cloud instance, which the no-op export below cannot do (both
       no-op serializers ignore those fields by design — see Engines):
@@ -567,7 +583,7 @@ E2E — real Confluence (profile `mayflower`, space `DOCSY`):
       the walker's `MacroParamRef` recognition changes, not this test's
       shape), and `body` present for the `scroll-landscape` macro's
       rich-text body.
-- [ ] Export the page with the ts engine and assert **today's behavior**:
+- [x] Export the page with the ts engine and assert **today's behavior**:
       `bun run --cwd apps/cli src/index.ts wiki export <pageId> --engine ts -o /tmp/t0-zoo.docx --profile mayflower`
       — `apps/cli/src/commands/export.ts:873–890`'s `output()` call already
       emits the full JSON report to stdout by default, no extra flag needed;
@@ -590,7 +606,7 @@ E2E — real Confluence (profile `mayflower`, space `DOCSY`):
       is reproducible, not ad hoc. PDF has no CLI command until T3.1/T3.2 —
       the PDF no-op proof at sync point 0 is the unit/`main.typ` pin above;
       note this limitation in the PR description.
-- [ ] Cleanup (workflow rule, guaranteed by the `try/finally`/`trap` above):
+- [x] Cleanup (workflow rule, guaranteed by the `try/finally`/`trap` above):
       delete the test page —
       `bun run --cwd apps/cli src/index.ts wiki page delete --id <pageId> --confirm --profile mayflower`
       (`--confirm` or `--dry-run` is required by `page.ts`'s delete handler;
@@ -599,29 +615,29 @@ E2E — real Confluence (profile `mayflower`, space `DOCSY`):
 
 ## Definition of Done
 
-- [ ] `bun run typecheck` and `bun test` green at the repo root; both
+- [x] `bun run typecheck` and `bun test` green at the repo root; both
       engines' exhaustive `never` checks compile with the new variants
       handled.
-- [ ] `packages/docx/src/golden.test.ts` passes **without recapturing**
+- [x] `packages/docx/src/golden.test.ts` passes **without recapturing**
       `golden-extension-export.json`; PDF `serialize.test.ts` expectations
       pass without loosening existing assertions.
-- [ ] Walker snapshot diffs are limited to additive optional fields on
+- [x] Walker snapshot diffs are limited to additive optional fields on
       `unknown` blocks; `storageToBlocks(...).notes` output is proven
       unchanged by tests.
-- [ ] No new `ExportNote` codes, no changed note messages, no new public API
+- [x] No new `ExportNote` codes, no changed note messages, no new public API
       surface beyond: `Caption`, `CaptionKind`, `MacroParamRef`,
       `MacroParameter`, `macroParamText`, `StorageToBlocksOptions`, the
       new/extended `ExportBlock` variants, and the widened `storageToBlocks`
       signature — all exported through `index.ts` **and** `index.browser.ts`
       (existing `export *`).
-- [ ] Macro-parameter capture is verified lossless against every structured
+- [x] Macro-parameter capture is verified lossless against every structured
       reference shape `markdown.ts` actually produces (`ri:page`,
       `ri:attachment`, `ri:url`, `ri:user`, `ri:space`, including the
       multi-`ri:space` `spaces` parameter) plus unnamed parameters,
       duplicate/case-colliding names, and whitespace — no parameter is
       silently omitted because its value lived in element attributes rather
       than text.
-- [ ] `resolveExportMentions` (`packages/confluence/src/resolve-mentions.ts`)
+- [x] `resolveExportMentions` (`packages/confluence/src/resolve-mentions.ts`)
       resolves mentions nested inside `orientation.content` and inside
       `caption?.content` on `codeBlock`/`image`/`table`, proven by the new
       `resolve-mentions.test.ts` cases — every container type this repo's
@@ -630,15 +646,15 @@ E2E — real Confluence (profile `mayflower`, space `DOCSY`):
       which is deliberately deferred to Lane E (T1.7) and pinned by the new
       negative test — not a gap, a scoping decision recorded here and in
       Risks.
-- [ ] Scratch-walked notes for `unknown.body` are never permanently lost:
+- [x] Scratch-walked notes for `unknown.body` are never permanently lost:
       either they never occur (empty scratch walk) or they land in
       `bodyNotes` on the block — `storageToBlocks(...).notes` (the top-level
       report) still stays exactly as today, proven by the `bodyNotes`
       regression test.
-- [ ] `forkWalkCtx` is the only way a scratch `WalkCtx` is constructed
+- [x] `forkWalkCtx` is the only way a scratch `WalkCtx` is constructed
       anywhere in `export-blocks.ts` (no hand-built `{ notes: [] }` literal
       that would silently drop `exporter` or a future `WalkCtx` field).
-- [ ] E2E run against DOCSY performed under the
+- [x] E2E run against DOCSY performed under the
       `atlcli-e2e-exportblock-model-<timestamp>` naming convention with
       guaranteed cleanup (`try/finally`/`trap`); the E2E independently fetches
       real Cloud storage and asserts `macroId`/`params`/`body` capture (not
@@ -647,7 +663,7 @@ E2E — real Confluence (profile `mayflower`, space `DOCSY`):
       before/after CLI report diff is empty **after** the documented
       `durationMs`/`perf-timing`-note normalization; test page deleted and
       deletion verified.
-- [ ] One PR, conventional commit style
+- [x] One PR, conventional commit style
       (`feat(confluence): extend ExportBlock model …` +
       `feat(docx,pdf): compile no-op renderings …`), merged before any lane
       branch is cut; lanes rebase on it.

--- a/specs/export-expansion/004-macro-renderer/PLAN.md
+++ b/specs/export-expansion/004-macro-renderer/PLAN.md
@@ -10,11 +10,16 @@ Status: Plan, 2026-07-19. Part of the `export-expansion` series.
   (`MacroRendererRegistry` port + staged fallback chain), E1 (`export_view`/ADF
   fallback), E2 (Jira macro), E3 (draw.io/Gliffy preview PNG).
 - Code seams this plan builds on (verified):
-  - `packages/confluence/src/export-blocks.ts:113` — today's lossy
-    `{ type: "unknown"; macroName }` block; `walkMacro` at `:666` drops params
-    and body at `:698–:709`.
-  - `packages/docx/src/serialize.ts:431` and `packages/pdf/src/serialize.ts:796`
-    — current placeholder rendering of `unknown` blocks.
+  - `packages/confluence/src/export-blocks.ts:195` — the enriched
+    `{ type: "unknown" }` block spec 001 landed: `walkMacro` (`:800`) now
+    captures `params`/`body`/`plainBody`/`macroId` losslessly and parks the
+    scratch-walk notes of the body in `bodyNotes` (`:864`) instead of
+    discarding them — precisely so this lane can promote them (see the
+    `bodyNotes` task under T1.7). The walker's own note push
+    (`macro-not-rendered`/`unknown-macro`) is at `:836`.
+  - `packages/docx/src/serialize.ts:433` and `packages/pdf/src/serialize.ts:802`
+    — current placeholder rendering of `unknown` blocks (still `macroName`
+    only; 001 deliberately did not render the enrichment fields).
   - `packages/jira/src/client.ts:725` (`getIssue`) and `:855` (`search`, JQL via
     `POST /search/jql`) — the complete Jira API surface the CLI adapter needs.
   - `packages/confluence/src/client.ts:247` (`request` helper), `:512`
@@ -115,16 +120,21 @@ This spec delivers the pipeline that closes it:
 
 ## Dependencies (001)
 
-- **001 — ExportBlock model extension (T0.1/T0.2)** must be merged first. This
-  spec consumes the enriched `unknown` block it introduces in
-  `packages/confluence/src/export-blocks.ts`:
+- **001 — ExportBlock model extension (T0.1/T0.2)** must be merged first
+  (implemented 2026-07-19 on `claude/exportblock-model-subagents-82d71f`;
+  the shape below is the **as-built** one, verified against
+  `packages/confluence/src/export-blocks.ts:195`, not a sketch). This
+  spec consumes the enriched `unknown` block it introduces:
 
   ```ts
   | { type: "unknown"; macroName: string;
       params?: MacroParameter[];         // every <ac:parameter>, ordered, losslessly typed
       body?: ExportBlock[];              // ac:rich-text-body, walked recursively
       plainBody?: string;                // ac:plain-text-body
-      macroId?: string }                 // ac:macro-id (for REST macro rendering)
+      macroId?: string;                  // ac:macro-id (for REST macro rendering)
+      bodyNotes?: ExportNote[] }         // notes from 001's scratch walk of `body`,
+                                         // parked on the block for THIS lane to
+                                         // promote (see T1.7 bodyNotes task)
   ```
 
   **Post-hardening correction:** 001's own hardening round replaced the
@@ -141,6 +151,15 @@ This spec delivers the pipeline that closes it:
   convenience export 001 also adds) **except** the `include`/`excerpt-include`
   page reference (E5 task), which reads `m.params`' unnamed parameter's
   `refs` directly, since that parameter carries a `ri:page` ref, not text.
+  001's landing also recorded **two further obligations it explicitly
+  deferred to this lane (T1.7)** — both now have owning tasks below:
+  (a) promoting `unknown.bodyNotes` into the export report once body content
+  becomes visible (001 Risks, "Scratch-ctx decision" — see the `bodyNotes`
+  task under "Registry & resolver pass"); (b) extending
+  `resolve-mentions.ts` to traverse `unknown.body`
+  (`packages/confluence/src/resolve-mentions.ts:113–116` carries the pointer
+  comment; 001's negative regression test pins the current non-traversal —
+  see the mention-resolution task under "Placeholder floor keeps content").
   Without `params`/`macroId` no renderer can act; without the compiling no-op
   renderings (T0.2) the engines are not green. This is the only ordered landing
   in the hot file `export-blocks.ts` that Lane E waits for (T1.1 → T1.4 → T1.8
@@ -561,7 +580,7 @@ See T1.10 task and Risks.
 
 **Report/UX — exactly one terminal outcome per macro instance.** The walker
 already emits `unknown-macro`/`macro-not-rendered` for every unresolved macro
-during `storageToBlocks` (`packages/confluence/src/export-blocks.ts:698–709`),
+during `storageToBlocks` (`packages/confluence/src/export-blocks.ts:836`),
 *before* the resolver ever runs. Left alone, a macro the resolver successfully
 renders would show up in the report as both "not rendered" and
 "rendered via …" — confusing and wrong. `resolveMacroBlocks` therefore takes
@@ -571,10 +590,10 @@ walker's original note for that exact instance and appends exactly one new
 note — `rendered-via`, `degraded`, or `skipped-by-config`.
 
 **Matching is positional, not by `macroId`** — `ExportNote`
-(`packages/confluence/src/export-blocks.ts:114–121`) has no `macroId` field
-today, and spec 001 deliberately adds none ("Report-identical",
-`001-exportblock-model/PLAN.md:87`); `walkMacro` writes only `macroName`
-(`export-blocks.ts:705–709`), which is not unique across instances. The only
+(`packages/confluence/src/export-blocks.ts:212`) has no `macroId` field
+today, and spec 001 deliberately added none ("Report-identical",
+`001-exportblock-model/PLAN.md:94`); `walkMacro` writes only `macroName`
+(`export-blocks.ts:836`), which is not unique across instances. The only
 reliable correlation is emission order: `walkMacro` pushes exactly one
 `unknown-macro`/`macro-not-rendered` note per `unknown` block, in the same
 pre-order sequence the blocks themselves appear in. `resolveMacroBlocks`
@@ -699,12 +718,35 @@ macros in the registry are.
       `macro-degraded`, `macro-skipped-by-config` that **replace** (not
       "alongside", per outcome ownership above) the walker's
       `unknown-macro`/`macro-not-rendered` notes from
-      `packages/confluence/src/export-blocks.ts:698` for every macro
+      `packages/confluence/src/export-blocks.ts:836` for every macro
       instance the resolver actually touches; macros the resolver never
       reaches (e.g. `env.macros` unset) keep today's walker notes unchanged.
       These three codes populate `ExportNote.source` using the `source`
       field 003-content-features introduces on `ExportNote` (see
       `003-content-features/PLAN.md`, Walker tasks), once that field lands.
+- [ ] **`unknown.bodyNotes` promotion (deferred from 001)**: 001's walker
+      parks the notes produced while scratch-walking an `unknown` macro's
+      rich-text body in `bodyNotes` on the block
+      (`packages/confluence/src/export-blocks.ts:207,:864`) instead of the
+      top-level report — deliberately, so that report stays byte-identical
+      while nothing renders the body, and so *this* resolver can promote
+      them once something does. `resolveMacroBlocks` owns them now, exactly
+      once per instance: when the instance's terminal outcome makes the
+      preserved `body` visible — the stage-4 placeholder floor below, or a
+      renderer whose `{ kind: "blocks" }` output derives from `m.body`
+      (scroll-tablelayout, excerpt, the transparent passthroughs) — append
+      `bodyNotes` to the returned `notes` right after the instance's
+      terminal note; when the body is superseded wholesale by port-fetched
+      content (Jira table, `export_view` HTML), drop them with the body they
+      described (they annotate content that no longer appears — keeping
+      them would report problems in invisible content). Never merge them
+      twice, never keep a `bodyNotes` note whose content is visible without
+      surfacing it. This resolves 001's open revisit note ("`bodyNotes` may
+      fold into the resolver's note model"): the field stays on the model;
+      the resolver is its only consumer. Test in `resolve.test.ts`: an
+      `unknown` block with `bodyNotes` that falls through to the placeholder
+      floor surfaces them in the result `notes`; the same block resolved by
+      a port-backed renderer does not.
 
 ### TOC renderer (E5 — pure, no-IO reference renderer)
 
@@ -894,13 +936,13 @@ here and reused by every E4/E5 renderer below.
       `multiexcerpt-macro`/`multiexcerpt` body with a new
       `extractMacroBody(storage, macroNames, name)` helper (reuses the XML
       tokenizer `export-blocks.ts` already exports — never regex-parse
-      markup, `export-blocks.ts:170`), then `deps.storageToBlocks(fragment,
+      markup, `parseXml`, `export-blocks.ts:280`), then `deps.storageToBlocks(fragment,
       { walkContext: { depth: ctx.depth + 1 } })` and return `{ kind:
       "blocks", blocks, notes }`. No fragment found → `{ kind: "skip" }`.
       Definition-side `multiexcerpt-macro`/`multiexcerpt` (the macro on the
       page that *defines* the excerpt, not the include) renders its body
       transparently — same one-line treatment as `expand` in the walker
-      (`export-blocks.ts:693`); this half needs a `walkMacro` addition, so
+      (`export-blocks.ts:826`); this half needs a `walkMacro` addition, so
       land it alongside spec 001's other walker changes or as its own
       additive hunk in `export-blocks.ts` (see Dependencies — hot file).
 - [ ] `packages/export-macros/src/table-layout.ts` —
@@ -909,7 +951,7 @@ here and reused by every E4/E5 renderer below.
       transparent body wrapper, no port): no `m.body` → `{ kind: "skip" }`.
       Parse `macroParamText(m.params, "widths")` (comma-separated) and apply to every `table`
       block found at the top level of `m.body` via the existing
-      `columnWidths` field (`export-blocks.ts:108`; PDF already honors it,
+      `columnWidths` field (`export-blocks.ts:175`; PDF already honors it,
       G3/`006-word-quality` documents the DOCX gap — this renderer does not
       duplicate that work, it only sets the field). Unparseable/absent
       widths → pass `m.body` through unchanged with an info note ("widths not
@@ -1101,7 +1143,7 @@ here and reused by every E4/E5 renderer below.
       `ExternalAssetPolicy`/`ExternalAssetFetcher`, an optional
       `externalAssets` field on `MacroExportContext`. Add the additive
       `trust?: "page" | "export-view"` field to `ImageSource`'s external
-      variant (`packages/confluence/src/export-blocks.ts:91`), `AssetRef`
+      variant (`packages/confluence/src/export-blocks.ts:93`), `AssetRef`
       (`packages/docx/src/env.ts:26–38`), and `PdfAssetRef`
       (`packages/pdf/src/types.ts:14–28`); thread it from
       `htmlToExportBlocks` through to both asset seams. CLI host wiring's
@@ -1133,7 +1175,24 @@ Spec 001 deliberately keeps stage-4 rendering byte-identical to today
 yet. This plan is what actually uses them, since "never silently drop" is
 this spec's invariant, not 001's.
 
-- [ ] `packages/docx/src/serialize.ts` (`case "unknown"`, line 431): when
+- [ ] **Mention resolution for `unknown.body` (deferred from 001)**:
+      `packages/confluence/src/resolve-mentions.ts` deliberately does not
+      traverse `unknown.body` today (pointer comment at
+      `resolve-mentions.ts:113–116`; pinned by 001's negative test in
+      `resolve-mentions.test.ts`), because nothing rendered that body and
+      traversing it would have made the extension's PDF path — which calls
+      `resolveExportMentions` unconditionally
+      (`apps/extension/utils/pdf/run-export.ts:165`) — issue live
+      `getUsersBulk` lookups for invisible content. The moment this section
+      makes the body visible, that reasoning inverts: the **same PR** that
+      lands the placeholder-floor body rendering must add a
+      `case "unknown":` recursing into `block.body` to both
+      `collectUnresolvedMentionIds` and `resolveBlockMentions`, flip 001's
+      negative test into a positive regression test, and remove the pointer
+      comment — otherwise a mention inside a rendered macro body ships as a
+      raw technical `accountId` in visible output (exactly the silent-drop
+      class 001's plan documents).
+- [ ] `packages/docx/src/serialize.ts` (`case "unknown"`, line 433): when
       `block.body` is present, render the existing placeholder line followed
       by the body's blocks serialized through the normal `serializeChildren`
       path (recursive, so a table/list/nested-unknown-macro inside an
@@ -1141,7 +1200,7 @@ this spec's invariant, not 001's.
       present, render it as a `codeBlock`-styled paragraph. Cap recursion
       depth and total rendered length (reuse the resolver's depth guard
       shape) so a pathological macro body can't blow up a single page.
-- [ ] `packages/pdf/src/serialize.ts` (`case "unknown"`, line 796): same
+- [ ] `packages/pdf/src/serialize.ts` (`case "unknown"`, line 802): same
       treatment — today it emits nothing but a report note; render the
       preserved body/plain-body content instead of silently omitting it.
 - [ ] Tests: unresolved unknown macro with a table in `body`, with a list,
@@ -1328,6 +1387,12 @@ real instance.
   "network-free" — the page body and its page-authored attachments still
   fetch over the network; the guarantee is "no additional
   Jira/export_view/attachment-lookup calls".
+- Both obligations 001 deferred to this lane are closed: `unknown.bodyNotes`
+  are promoted into the report exactly when the body content they describe
+  becomes visible (and dropped when it is superseded — `resolve.test.ts`
+  covers both directions), and `resolve-mentions.ts` traverses `unknown.body`
+  in the same PR that renders it, with 001's negative test flipped to a
+  positive one and the pointer comment removed.
 - Per-port circuit breaker verified: a rate-limited port stops receiving
   further calls for the rest of the export instead of every remaining macro
   independently exhausting the same limit.


### PR DESCRIPTION
## What

Implements [specs/export-expansion/001-exportblock-model/PLAN.md](specs/export-expansion/001-exportblock-model/PLAN.md) — the single non-parallelizable foundation (sync point 0) of the export-expansion Phase 1. No user-visible feature ships here; behavior is byte-identical to today.

**Model (`@atlcli/confluence`, `export-blocks.ts`):**
- New types `CaptionKind`, `Caption`, `MacroParamRef`, `MacroParameter`, `macroParamText()`, `StorageToBlocksOptions` (with `exporter?: "pdf" | "word"`)
- New `ExportBlock` variants: `pageBreak`, `orientation` (with children), `anchor`; `caption?` on `codeBlock`/`table`/`image`; `heading.explicitAnchor?` (plan's open-question recommendation, adopted)
- Lossless `unknown`-macro capture: `params` (ordered, typed `ri:*` refs — not a lossy `Record<string, string>`), `body` (scratch-walked via new `forkWalkCtx`, notes parked in `bodyNotes` instead of the top-level report), `plainBody`, `macroId`
- `resolve-mentions.ts` traverses `orientation.content` and caption content; deliberately **not** `unknown.body` (pointer comment + negative regression test — deferred to Lane E/T1.7)

**Engines (no-op renderings):**
- DOCX: `pageBreak`/`anchor` → nothing, `orientation` → transparent passthrough; `minHeadingLevel`/`prefetchBlocks` recurse into regions; `{ exporter: "word" }` wired in `export.ts`
- PDF: `types.ts`/`prepare.ts`/`serialize.ts` arms incl. caption carry-through; `blocksPlainText`/`minHeadingLevel`/`collectHeadingLabels`/`countPrepared` recursion
- Both exhaustive `never` switches compile — the completeness proof

**Specs:**
- 004-macro-renderer aligned with the as-built model (`bodyNotes` snippet + promotion task, `unknown.body` mention-resolution task, refreshed line refs)
- 001 marked done, all 49 checkboxes checked

## Verification

- `bun run typecheck` green; `bun test`: **1905 pass / 0 fail** (119 files)
- DOCX golden passes **without recapturing** `golden-extension-export.json`; walker snapshot unchanged
- Top-level `storageToBlocks(...).notes` proven byte-identical (scratch notes → `bodyNotes`, regression-tested); no new `ExportNote` codes
- Implementation reviewed by a second independent pass: approve, no defects
- **E2E** (profile `mayflower`, space `DOCSY`): macro-zoo page `atlcli-e2e-exportblock-model-1784484359` — live Cloud storage asserted `macroId`/`params` (incl. surviving `ri:page` ref)/`body` capture; DOCX report diff vs. a `git stash` main baseline on the same live page **empty** after documented normalization (drop `durationMs`/timing note/output path, sort lists); page deleted, 404 verified

## Reviewer notes

- Two documented E2E deviations: the zoo page was authored via storage-representation update (the markdown converter escapes raw macro passthrough), and the ts-engine report surfaces macros as `notes`, not `unsupportedNames` (a python-engine concept) — before/after parity was the actual check and holds
- PDF has no CLI export command at this sync point; its no-op proof is the unit-level `main.typ` semantic-identity test (source-map comment markers make byte-identity unreachable by design)
- `MacroParamRef.page.anchor?` is typed but never populated here — matches the plan's sketch; the anchor lives on `<ac:link>`, not `<ri:page>`, in real storage

🤖 Generated with [Claude Code](https://claude.com/claude-code)