### PR TITLE
feat(pdf): template settings, watermark & template library (spec 007)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -99,6 +99,10 @@ export default defineConfig({
           items: [
             { label: 'CLI Commands', link: '/reference/cli-commands/' },
             { label: 'DOCX Export Engine', link: '/reference/docx-engine/' },
+            { label: 'PDF Export Engine', link: '/reference/pdf-engine/' },
+            { label: 'PDF Template Settings', link: '/reference/pdf-template-settings/' },
+            { label: 'PDF Template Contract', link: '/reference/pdf-template-contract/' },
+            { label: 'Template Pack Format', link: '/reference/template-pack-format/' },
             { label: 'Authentication', link: '/authentication/' },
             { label: 'Configuration', link: '/configuration/' },
             { label: 'Doctor', link: '/reference/doctor/' },

--- a/bun.lock
+++ b/bun.lock
@@ -149,6 +149,15 @@
       "name": "@atlcli/plugin-api",
       "version": "0.6.0",
     },
+    "packages/template-pack": {
+      "name": "@atlcli/template-pack",
+      "version": "0.6.0",
+      "dependencies": {
+        "@atlcli/core": "workspace:*",
+        "@atlcli/docx": "workspace:*",
+        "pizzip": "^3.2.0",
+      },
+    },
   },
   "patchedDependencies": {
     "@myriaddreamin/typst-ts-web-compiler@0.7.0": "patches/@myriaddreamin%2Ftypst-ts-web-compiler@0.7.0.patch",
@@ -225,6 +234,8 @@
     "@atlcli/pdf-compiler-browser": ["@atlcli/pdf-compiler-browser@workspace:packages/pdf-compiler-browser"],
 
     "@atlcli/plugin-api": ["@atlcli/plugin-api@workspace:packages/plugin-api"],
+
+    "@atlcli/template-pack": ["@atlcli/template-pack@workspace:packages/template-pack"],
 
     "@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
 

--- a/packages/core/src/index.browser.ts
+++ b/packages/core/src/index.browser.ts
@@ -14,3 +14,4 @@ export * from "./entity-url.js";
 export * from "./logger.js";
 export * from "./auth.js";
 export * from "./tls.browser.js";
+export * from "./template-library.js";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,3 +11,4 @@ export * from "./tls.node.js";
 export * from "./update.js";
 export * from "./utils.js";
 export * from "./templates/index.js";
+export * from "./template-library.js";

--- a/packages/core/src/template-library.test.ts
+++ b/packages/core/src/template-library.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Pure-function + WebCrypto tests for the template library (spec 007 T2.4).
+ *
+ * No mocking: `resolveTemplate` is exercised with plain arrays, and the hash
+ * paths run the real `crypto.subtle` digest over real byte arrays. The
+ * in-test {@link TemplateLibrary} is a real implementation over an in-memory
+ * map, not a mock.
+ */
+import { describe, expect, it } from "bun:test";
+import {
+  resolveTemplate,
+  resolveAndLoadTemplate,
+  sha256Hex,
+  verifyTemplateBytes,
+  TemplateIntegrityError,
+  TemplateNotFoundError,
+  TemplateResolutionConflictError,
+  type TemplateLibrary,
+  type TemplateLibraryEntry,
+} from "./template-library.js";
+
+function entry(over: Partial<TemplateLibraryEntry>): TemplateLibraryEntry {
+  return {
+    id: "com.acme.doc",
+    displayName: "Acme Doc",
+    engine: "typst",
+    scope: "global",
+    sha256: "0".repeat(64),
+    size: 0,
+    uploadedAt: "2026-01-01T00:00:00Z",
+    ...over,
+  };
+}
+
+describe("resolveTemplate", () => {
+  it("prefers a space-scoped entry over the global entry of the same id", () => {
+    const globalE = entry({ scope: "global", displayName: "global" });
+    const spaceE = entry({ scope: "space", spaceKey: "DOCSY", displayName: "space" });
+    const got = resolveTemplate([globalE, spaceE], "com.acme.doc", "typst", "DOCSY");
+    expect(got?.displayName).toBe("space");
+  });
+
+  it("falls back to the global entry when the space has no override", () => {
+    const globalE = entry({ scope: "global", displayName: "global" });
+    const otherSpace = entry({ scope: "space", spaceKey: "OTHER", displayName: "other" });
+    const got = resolveTemplate([globalE, otherSpace], "com.acme.doc", "typst", "DOCSY");
+    expect(got?.displayName).toBe("global");
+  });
+
+  it("returns undefined for an unknown id", () => {
+    const globalE = entry({ scope: "global" });
+    expect(resolveTemplate([globalE], "nope", "typst", "DOCSY")).toBeUndefined();
+  });
+
+  it("never resolves a wrong-engine entry, even as the only id match", () => {
+    // Mixed-engine array: a docx entry sharing the requested id must not win.
+    const docxE = entry({ engine: "docx", scope: "global", displayName: "docx-one" });
+    expect(resolveTemplate([docxE], "com.acme.doc", "typst")).toBeUndefined();
+    // And with a space key: still nothing, no wrong-engine leak.
+    expect(resolveTemplate([docxE], "com.acme.doc", "typst", "DOCSY")).toBeUndefined();
+  });
+
+  it("throws on two same-scope, same-engine entries sharing an id (global)", () => {
+    const a = entry({ scope: "global", displayName: "a" });
+    const b = entry({ scope: "global", displayName: "b" });
+    expect(() => resolveTemplate([a, b], "com.acme.doc", "typst")).toThrow(
+      TemplateResolutionConflictError
+    );
+  });
+
+  it("throws on two same-space, same-engine entries sharing an id", () => {
+    const a = entry({ scope: "space", spaceKey: "DOCSY", displayName: "a" });
+    const b = entry({ scope: "space", spaceKey: "DOCSY", displayName: "b" });
+    expect(() => resolveTemplate([a, b], "com.acme.doc", "typst", "DOCSY")).toThrow(
+      TemplateResolutionConflictError
+    );
+  });
+
+  it("does not treat two entries for different spaces as a conflict", () => {
+    const a = entry({ scope: "space", spaceKey: "DOCSY", displayName: "docsy" });
+    const b = entry({ scope: "space", spaceKey: "OTHER", displayName: "other" });
+    expect(resolveTemplate([a, b], "com.acme.doc", "typst", "DOCSY")?.displayName).toBe("docsy");
+  });
+});
+
+describe("verifyTemplateBytes", () => {
+  it("accepts bytes whose hash matches the entry", async () => {
+    const bytes = new TextEncoder().encode("template payload");
+    const e = entry({ sha256: await sha256Hex(bytes), size: bytes.byteLength });
+    await expect(verifyTemplateBytes(e, bytes)).resolves.toBeUndefined();
+  });
+
+  it("throws the typed mismatch error on a flipped bit", async () => {
+    const bytes = new TextEncoder().encode("template payload");
+    const e = entry({ sha256: await sha256Hex(bytes), size: bytes.byteLength });
+    const tampered = Uint8Array.from(bytes);
+    tampered[0] ^= 0x01;
+    await expect(verifyTemplateBytes(e, tampered)).rejects.toBeInstanceOf(TemplateIntegrityError);
+  });
+});
+
+/** Real in-memory library — verifies the resolve/load/verify pipeline end to end. */
+class MemoryLibrary implements TemplateLibrary {
+  constructor(
+    private readonly entries: TemplateLibraryEntry[],
+    private readonly store: Map<string, Uint8Array>
+  ) {}
+  list(engine: TemplateLibraryEntry["engine"]): Promise<TemplateLibraryEntry[]> {
+    return Promise.resolve(this.entries.filter((e) => e.engine === engine));
+  }
+  getBytes(e: TemplateLibraryEntry): Promise<Uint8Array> {
+    const b = this.store.get(e.id + ":" + (e.spaceKey ?? "global"));
+    if (!b) throw new Error("missing bytes");
+    return Promise.resolve(b);
+  }
+}
+
+describe("resolveAndLoadTemplate", () => {
+  it("returns verified bytes on a match", async () => {
+    const bytes = new TextEncoder().encode("real archive bytes");
+    const e = entry({ scope: "global", sha256: await sha256Hex(bytes), size: bytes.byteLength });
+    const lib = new MemoryLibrary([e], new Map([["com.acme.doc:global", bytes]]));
+    const { entry: got, bytes: gotBytes } = await resolveAndLoadTemplate(lib, "com.acme.doc", "typst");
+    expect(got.id).toBe("com.acme.doc");
+    expect(new TextDecoder().decode(gotBytes)).toBe("real archive bytes");
+  });
+
+  it("rejects with TemplateNotFoundError for an unknown id", async () => {
+    const lib = new MemoryLibrary([], new Map());
+    await expect(resolveAndLoadTemplate(lib, "nope", "typst")).rejects.toBeInstanceOf(
+      TemplateNotFoundError
+    );
+  });
+
+  it("rejects on a byte/hash mismatch without exposing the unverified bytes", async () => {
+    const good = new TextEncoder().encode("declared bytes");
+    // Stored bytes differ from what the entry's sha256/size describe.
+    const tampered = new TextEncoder().encode("declared bytez");
+    const e = entry({ scope: "global", sha256: await sha256Hex(good), size: good.byteLength });
+    const lib = new MemoryLibrary([e], new Map([["com.acme.doc:global", tampered]]));
+    let leaked: Uint8Array | undefined;
+    try {
+      const r = await resolveAndLoadTemplate(lib, "com.acme.doc", "typst");
+      leaked = r.bytes;
+    } catch (err) {
+      expect(err).toBeInstanceOf(TemplateIntegrityError);
+    }
+    expect(leaked).toBeUndefined();
+  });
+
+  it("rejects on a declared-size mismatch before hashing", async () => {
+    const bytes = new TextEncoder().encode("twelve bytes"); // 12 bytes
+    const e = entry({ scope: "global", sha256: await sha256Hex(bytes), size: 999 });
+    const lib = new MemoryLibrary([e], new Map([["com.acme.doc:global", bytes]]));
+    await expect(resolveAndLoadTemplate(lib, "com.acme.doc", "typst")).rejects.toBeInstanceOf(
+      TemplateIntegrityError
+    );
+  });
+});

--- a/packages/core/src/template-library.ts
+++ b/packages/core/src/template-library.ts
@@ -1,0 +1,242 @@
+/**
+ * Host-neutral template library (spec 007 T2.4).
+ *
+ * A tiny, browser-safe abstraction shared by every host (CLI, extension,
+ * further hosts) for resolving and integrity-checking uploaded PDF/DOCX
+ * templates. It owns exactly three concerns:
+ *
+ *  1. `resolveTemplate` — a pure, engine-aware, conflict-checked two-level
+ *     lookup (space-scoped entry beats global entry of the same id).
+ *  2. `sha256Hex` / `verifyTemplateBytes` — WebCrypto integrity helpers.
+ *  3. `resolveAndLoadTemplate` — the single convenience path that performs
+ *     selection + declared-size check + byte loading + verification as one
+ *     inseparable call so a host adapter cannot hand unverified bytes to a
+ *     caller by construction.
+ *
+ * Storage adapters (IndexedDB, `~/.atlcli/templates/`, attachment-backed) are
+ * host code and live with their hosts — this module never touches IO beyond
+ * the `TemplateLibrary` port it is handed.
+ *
+ * Browser-safety: this file is exported from both `index.ts` and
+ * `index.browser.ts` and MUST NOT import any `node:`/`bun:` module. `crypto`
+ * is the Web Crypto global (available in browsers, Bun, and Node >= 18).
+ *
+ * Scan verdicts for DOCX templates (see `@atlcli/template-pack` `validatePack`
+ * / `@atlcli/docx` `scanTemplate`) are **never** persisted on a
+ * {@link TemplateLibraryEntry}. A scan is always re-derived from the bytes at
+ * the point of use, so a persisted verdict can never drift from the bytes it
+ * once described.
+ */
+
+/** One catalog entry describing a stored template, without its bytes. */
+export interface TemplateLibraryEntry {
+  /** Stable identifier a host references, e.g. `"com.acme.tech-doc"`. */
+  id: string;
+  /** Human-facing label for pickers. */
+  displayName: string;
+  /** Which engine the template targets. A wrong-engine entry never resolves. */
+  engine: "docx" | "typst";
+  /** `"global"` (whole instance) or `"space"` (one Confluence space). */
+  scope: "global" | "space";
+  /** Required when `scope === "space"`; the space the entry is scoped to. */
+  spaceKey?: string;
+  /**
+   * Lowercase hex SHA-256 of the **delivered archive bytes as stored** — the
+   * integrity check on download. This is a different quantity from a
+   * template-pack manifest's `provenance.payloadSha256` (which digests the
+   * archive's *payload members*, not the archive bytes); see
+   * `@atlcli/template-pack` `pack.ts` for that distinction.
+   */
+  sha256: string;
+  /** Declared byte length of the delivered archive; cross-checked on load. */
+  size: number;
+  /** ISO-8601 upload timestamp. */
+  uploadedAt: string;
+}
+
+/**
+ * Host-provided storage port. Implementers own persistence; the library owns
+ * resolution and verification.
+ */
+export interface TemplateLibrary {
+  /**
+   * All entries for `engine`, optionally including the `spaceKey` overrides a
+   * caller may resolve against. Implementers may return a superset (e.g. all
+   * spaces) — {@link resolveTemplate} filters defensively.
+   */
+  list(
+    engine: TemplateLibraryEntry["engine"],
+    spaceKey?: string
+  ): Promise<TemplateLibraryEntry[]>;
+  /**
+   * Load the raw archive bytes for `entry`. Contract obligation: the returned
+   * bytes MUST match `entry.sha256` — but a host cannot be trusted to have
+   * wired that check, which is exactly why {@link resolveAndLoadTemplate}
+   * re-verifies unconditionally.
+   */
+  getBytes(entry: TemplateLibraryEntry): Promise<Uint8Array>;
+}
+
+/**
+ * Thrown when two entries could each legitimately win the same lookup — same
+ * engine + same id + same resolvable scope bucket (both global, or both
+ * scoped to the requested space). This is a data-integrity bug in the library
+ * contents, not an ordering question, so it is surfaced rather than silently
+ * resolved to the first array match.
+ */
+export class TemplateResolutionConflictError extends Error {
+  constructor(
+    readonly id: string,
+    readonly engine: TemplateLibraryEntry["engine"],
+    readonly scope: TemplateLibraryEntry["scope"],
+    readonly spaceKey: string | undefined,
+    readonly count: number
+  ) {
+    super(
+      `Ambiguous template "${id}" (${engine}): ${count} ${scope} entries` +
+        (scope === "space" ? ` for space "${spaceKey}"` : "") +
+        ` share the same id — remove the duplicate.`
+    );
+    this.name = "TemplateResolutionConflictError";
+  }
+}
+
+/** Thrown when a resolved template id has no matching entry. */
+export class TemplateNotFoundError extends Error {
+  constructor(
+    readonly id: string,
+    readonly engine: TemplateLibraryEntry["engine"],
+    readonly spaceKey: string | undefined
+  ) {
+    super(
+      `No ${engine} template "${id}"` +
+        (spaceKey ? ` for space "${spaceKey}"` : "") +
+        " found in the library."
+    );
+    this.name = "TemplateNotFoundError";
+  }
+}
+
+/**
+ * Thrown when loaded bytes do not match an entry's declared integrity — a
+ * length or SHA-256 disagreement. The template was modified (or corrupted) in
+ * storage and must be re-uploaded; there is deliberately no silent fallback.
+ */
+export class TemplateIntegrityError extends Error {
+  constructor(
+    readonly id: string,
+    readonly kind: "size" | "sha256",
+    readonly expected: string,
+    readonly actual: string
+  ) {
+    super(
+      `Template "${id}" failed its ${kind} check (expected ${expected}, ` +
+        `got ${actual}) — template was modified, re-upload.`
+    );
+    this.name = "TemplateIntegrityError";
+  }
+}
+
+/**
+ * Pure two-level resolver. Selects the entry a host should load for
+ * `(id, engine, spaceKey)`:
+ *
+ *  - Only entries whose `engine` matches are ever considered, so a mixed-engine
+ *    `entries` array (stale cache, accidental concat) can never resolve a
+ *    wrong-engine entry — even when it is the only id match.
+ *  - A space-scoped entry for the requested `spaceKey` beats the global entry
+ *    of the same id; the global entry is the fallback when the space has no
+ *    override.
+ *
+ * Conflicts are checked per resolvable bucket: more than one global entry, or
+ * more than one space entry for the requested `spaceKey`, sharing an id is a
+ * {@link TemplateResolutionConflictError}. (Two space entries for *different*
+ * spaces are not a conflict — they never compete.)
+ *
+ * @returns the winning entry, or `undefined` when no entry matches.
+ * @throws {TemplateResolutionConflictError} on an ambiguous bucket.
+ */
+export function resolveTemplate(
+  entries: TemplateLibraryEntry[],
+  id: string,
+  engine: TemplateLibraryEntry["engine"],
+  spaceKey?: string
+): TemplateLibraryEntry | undefined {
+  const matching = entries.filter((e) => e.id === id && e.engine === engine);
+
+  const globals = matching.filter((e) => e.scope === "global");
+  const spaced =
+    spaceKey === undefined
+      ? []
+      : matching.filter((e) => e.scope === "space" && e.spaceKey === spaceKey);
+
+  if (spaced.length > 1) {
+    throw new TemplateResolutionConflictError(id, engine, "space", spaceKey, spaced.length);
+  }
+  if (globals.length > 1) {
+    throw new TemplateResolutionConflictError(id, engine, "global", undefined, globals.length);
+  }
+
+  return spaced[0] ?? globals[0];
+}
+
+/** Lowercase hex SHA-256 of `bytes` via WebCrypto (`crypto.subtle.digest`). */
+export async function sha256Hex(bytes: Uint8Array): Promise<string> {
+  // Copy into a fresh, ArrayBuffer-backed view so the digest input is a plain
+  // `BufferSource` regardless of the caller's backing store (e.g. a subarray
+  // over a SharedArrayBuffer).
+  const copy = new Uint8Array(bytes.byteLength);
+  copy.set(bytes);
+  const digest = await crypto.subtle.digest("SHA-256", copy);
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+/**
+ * Verify that `bytes` hash to `entry.sha256`. Throws a typed
+ * {@link TemplateIntegrityError} on mismatch — never a silent fallback.
+ */
+export async function verifyTemplateBytes(
+  entry: TemplateLibraryEntry,
+  bytes: Uint8Array
+): Promise<void> {
+  const actual = await sha256Hex(bytes);
+  if (actual.toLowerCase() !== entry.sha256.toLowerCase()) {
+    throw new TemplateIntegrityError(entry.id, "sha256", entry.sha256, actual);
+  }
+}
+
+/**
+ * The single public "select and load verified bytes" path. Performs selection,
+ * the entry's declared-`size` check, byte loading via `library.getBytes`, and
+ * hash verification as one inseparable call, so unverified bytes are never
+ * exposed to the caller: if any check fails the function rejects and returns
+ * nothing.
+ *
+ * @throws {TemplateNotFoundError} when no entry matches.
+ * @throws {TemplateResolutionConflictError} on an ambiguous bucket.
+ * @throws {TemplateIntegrityError} on a size or SHA-256 mismatch.
+ */
+export async function resolveAndLoadTemplate(
+  library: TemplateLibrary,
+  id: string,
+  engine: TemplateLibraryEntry["engine"],
+  spaceKey?: string
+): Promise<{ entry: TemplateLibraryEntry; bytes: Uint8Array }> {
+  const entries = await library.list(engine, spaceKey);
+  const entry = resolveTemplate(entries, id, engine, spaceKey);
+  if (!entry) throw new TemplateNotFoundError(id, engine, spaceKey);
+
+  const bytes = await library.getBytes(entry);
+  if (bytes.byteLength !== entry.size) {
+    throw new TemplateIntegrityError(
+      entry.id,
+      "size",
+      String(entry.size),
+      String(bytes.byteLength)
+    );
+  }
+  await verifyTemplateBytes(entry, bytes);
+  return { entry, bytes };
+}

--- a/packages/pdf-compiler-browser/src/compiler.test.ts
+++ b/packages/pdf-compiler-browser/src/compiler.test.ts
@@ -1,10 +1,13 @@
 import { beforeAll, describe, expect, it } from "bun:test";
 import { fileURLToPath } from "node:url";
+import { deflateSync, inflateSync } from "node:zlib";
 import {
   ATLCLI_TYPST_TEMPLATE,
   PDF_RUNTIME_ASSETS,
+  serializePdfDocument,
   validatePdfOutput,
   type PdfSourceBundle,
+  type PdfTemplateSettings,
 } from "@atlcli/pdf/browser";
 import { ensurePdfFonts } from "../../pdf/scripts/ensure-fonts.js";
 import { BrowserPdfCompiler, PDF_BROWSER_COMPILER_VERSION } from "./index.js";
@@ -28,6 +31,86 @@ async function createCompiler(): Promise<BrowserPdfCompiler> {
 
 function bundle(main: string, sourceMap: PdfSourceBundle["sourceMap"] = []): PdfSourceBundle {
   return { main, template: ATLCLI_TYPST_TEMPLATE, assets: [], sourceMap, notes: [] };
+}
+
+const settingsMetadata = {
+  title: "Settings Zoo",
+  space: "DOCSY",
+  version: 3,
+  author: "Ada",
+  exportedAt: new Date("2026-07-19T00:00:00Z"),
+};
+
+function settingsBundle(settings?: PdfTemplateSettings): PdfSourceBundle {
+  return serializePdfDocument(
+    {
+      blocks: [
+        { type: "heading", level: 1, content: [{ type: "text", text: "Section" }] },
+        { type: "paragraph", content: [{ type: "text", text: "Hello settings." }] },
+      ],
+      assets: [],
+      notes: [],
+    },
+    { metadata: settingsMetadata, settings }
+  );
+}
+
+/** Raw latin1 view plus every inflatable FlateDecode stream, for byte asserts. */
+function inflatedPdfText(bytes: Uint8Array): string {
+  const raw = new TextDecoder("latin1").decode(bytes);
+  const parts = [raw];
+  const streamRegex = /stream\r?\n/g;
+  let match: RegExpExecArray | null;
+  while ((match = streamRegex.exec(raw)) !== null) {
+    const start = match.index + match[0].length;
+    const end = raw.indexOf("endstream", start);
+    if (end < 0) continue;
+    let stop = end;
+    while (stop > start && (bytes[stop - 1] === 0x0a || bytes[stop - 1] === 0x0d)) stop -= 1;
+    try {
+      parts.push(inflateSync(bytes.subarray(start, stop)).toString("latin1"));
+    } catch {
+      // Not a FlateDecode stream (image, font program, …) — skip.
+    }
+  }
+  return parts.join("\n");
+}
+
+// Real minimal 1x1 RGBA PNG built from scratch (no fixtures, no mocks).
+function crc32(bytes: Uint8Array): number {
+  let crc = 0xffffffff;
+  for (const byte of bytes) {
+    crc ^= byte;
+    for (let bit = 0; bit < 8; bit += 1) {
+      crc = (crc >>> 1) ^ (0xedb88320 & -(crc & 1));
+    }
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+function pngChunk(type: string, data: Uint8Array): Uint8Array {
+  const chunk = new Uint8Array(12 + data.length);
+  const view = new DataView(chunk.buffer);
+  view.setUint32(0, data.length);
+  chunk.set(new TextEncoder().encode(type), 4);
+  chunk.set(data, 8);
+  view.setUint32(8 + data.length, crc32(chunk.subarray(4, 8 + data.length)));
+  return chunk;
+}
+
+function tinyPng(): Uint8Array {
+  const signature = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+  const ihdr = new Uint8Array([0, 0, 0, 1, 0, 0, 0, 1, 8, 6, 0, 0, 0]);
+  // One scanline: filter byte 0 followed by a single opaque red RGBA pixel.
+  const idat = new Uint8Array(deflateSync(new Uint8Array([0, 255, 0, 0, 255])));
+  const chunks = [signature, pngChunk("IHDR", ihdr), pngChunk("IDAT", idat), pngChunk("IEND", new Uint8Array(0))];
+  const png = new Uint8Array(chunks.reduce((total, part) => total + part.length, 0));
+  let offset = 0;
+  for (const part of chunks) {
+    png.set(part, offset);
+    offset += part.length;
+  }
+  return png;
 }
 
 describe("BrowserPdfCompiler package", () => {
@@ -76,4 +159,67 @@ describe("BrowserPdfCompiler package", () => {
     const source = await Bun.file(new URL("./compiler.ts", import.meta.url)).text();
     expect(source).not.toMatch(/\?url|chrome|indexedDB|wxt|apps\/extension/);
   });
+});
+
+describe("template settings compiled output", () => {
+  it("compiles Letter with a DRAFT watermark: clean, tagged, page count unchanged vs A4", async () => {
+    const compiler = await createCompiler();
+    const a4 = await compiler.compile(settingsBundle());
+    const letter = await compiler.compile(
+      settingsBundle({ page: "letter", orientation: "portrait", watermark: { text: "DRAFT" } })
+    );
+    expect(a4.diagnostics).toEqual([]);
+    expect(letter.diagnostics).toEqual([]);
+    const a4Info = validatePdfOutput(a4.pdf!);
+    const letterInfo = validatePdfOutput(letter.pdf!);
+    expect(letterInfo.tagged).toBe(true);
+    // Background layers must not add pages.
+    expect(letterInfo.pageCount).toBe(a4Info.pageCount);
+    // Page size via MediaBox bytes (inflating FlateDecode streams if needed):
+    // Letter = 612x792 pt, A4 = 595.x pt wide.
+    expect(inflatedPdfText(letter.pdf!)).toMatch(/\/MediaBox\s*\[\s*0\s+0\s+612(?:\.\d+)?\s+792/);
+    expect(inflatedPdfText(a4.pdf!)).toMatch(/\/MediaBox\s*\[\s*0\s+0\s+595(?:\.\d+)?\s/);
+  }, 120_000);
+
+  it("produces the exact page count for every cover/outline combination", async () => {
+    const compiler = await createCompiler();
+    // Baseline: cover + outline + one body page + colophon = 4 pages. Each
+    // disabled section removes exactly one page — a stray unconditional
+    // pagebreak() outside its guard would leave a blank page behind instead.
+    const matrix: Array<{ cover: boolean; outline: boolean; pages: number }> = [
+      { cover: true, outline: true, pages: 4 },
+      { cover: false, outline: true, pages: 3 },
+      { cover: true, outline: false, pages: 3 },
+      { cover: false, outline: false, pages: 2 },
+    ];
+    for (const { cover, outline, pages } of matrix) {
+      const result = await compiler.compile(settingsBundle({ cover, outline }));
+      expect(result.diagnostics).toEqual([]);
+      expect(validatePdfOutput(result.pdf!).pageCount).toBe(pages);
+    }
+  }, 240_000);
+
+  it("compiles landscape orientation with the A4-tuned cover measurements intact", async () => {
+    const compiler = await createCompiler();
+    const result = await compiler.compile(settingsBundle({ orientation: "landscape" }));
+    expect(result.diagnostics).toEqual([]);
+    // Cover and colophon still fit their landscape pages: same page count as portrait.
+    expect(validatePdfOutput(result.pdf!).pageCount).toBe(4);
+    expect(inflatedPdfText(result.pdf!)).toMatch(/\/MediaBox\s*\[\s*0\s+0\s+841(?:\.\d+)?\s/);
+  }, 120_000);
+
+  it("compiles accent color, organization name, header/footer text, and a real PNG logo", async () => {
+    const compiler = await createCompiler();
+    const result = await compiler.compile(
+      settingsBundle({
+        accentColor: "#0052CC",
+        organizationName: "Acme Corp",
+        headerText: "Acme Handbook",
+        footerText: "Acme Confidential",
+        logo: { bytes: tinyPng(), mediaType: "image/png", alt: "Acme Corp" },
+      })
+    );
+    expect(result.diagnostics).toEqual([]);
+    expect(validatePdfOutput(result.pdf!)).toMatchObject({ tagged: true, pageCount: 4 });
+  }, 120_000);
 });

--- a/packages/pdf-compiler-browser/src/fonts-compile.test.ts
+++ b/packages/pdf-compiler-browser/src/fonts-compile.test.ts
@@ -1,0 +1,82 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import { fileURLToPath } from "node:url";
+import {
+  ATLCLI_TYPST_TEMPLATE,
+  PDF_RUNTIME_ASSETS,
+  validatePdfOutput,
+  type PdfSourceBundle,
+} from "@atlcli/pdf/browser";
+import { ensurePdfFonts } from "../../pdf/scripts/ensure-fonts.js";
+import { BrowserPdfCompiler } from "./index.js";
+
+// Real WASM + real font bytes; no mocks (spec 007 "never mock" rule).
+beforeAll(async () => {
+  await ensurePdfFonts({ logger: () => {} });
+});
+
+async function packageBytes(specifier: string): Promise<Uint8Array<ArrayBuffer>> {
+  const resolved = import.meta.resolve(specifier);
+  return new Uint8Array(await Bun.file(fileURLToPath(resolved)).arrayBuffer());
+}
+
+async function fontBytesForFamily(family: string): Promise<Uint8Array[]> {
+  return Promise.all(
+    PDF_RUNTIME_ASSETS.fonts
+      .filter((f) => f.family === family)
+      .map((f) => packageBytes(`@atlcli/pdf/fonts/${f.fileName}`))
+  );
+}
+
+function bundle(main: string): PdfSourceBundle {
+  return { main, template: ATLCLI_TYPST_TEMPLATE, assets: [], sourceMap: [], notes: [] };
+}
+
+// "Custom" corporate font stands in for a host-uploaded face: it is a real font
+// (Source Code Pro) present ONLY in the added Uint8Array set, never in the base
+// bundle — so its appearance in getLoadedFonts() proves add_raw_font surfaced a
+// family from the added bytes (a file rename could not achieve this: the family
+// is read from the font's own name table).
+const CUSTOM_FAMILY = "Source Code Pro";
+
+// getLoadedFonts() reflects the fonts the compiler actually touched during a
+// compile (the typst world loads faces lazily), so every assertion runs after a
+// real compile of a document that references the custom family.
+const CUSTOM_DOC = String.raw`#set text(font: "Source Sans 3")
+= Custom font intake
+#text(font: "Source Code Pro")[Rendered with the added corporate font.]
+`;
+
+describe("custom font intake into BrowserPdfCompilerAssets.fonts", () => {
+  it("does not surface the custom family when it is absent from the fonts", async () => {
+    const base = [
+      ...(await fontBytesForFamily("Source Sans 3")),
+      ...(await fontBytesForFamily("Source Serif 4")),
+    ];
+    const wasm = await packageBytes("@myriaddreamin/typst-ts-web-compiler/wasm");
+    const compiler = new BrowserPdfCompiler({ wasm: wasm.buffer, fonts: base });
+    // Compile the Code-Pro doc with no Code-Pro bytes available: the family can
+    // never be loaded from a base set that does not contain it.
+    await compiler.compile(bundle(CUSTOM_DOC));
+    const loaded = (await compiler.getLoadedFonts()).join("\n");
+    expect(loaded).not.toContain(CUSTOM_FAMILY);
+  }, 30_000);
+
+  it("loads the custom family and compiles a document using it with zero diagnostics", async () => {
+    const base = [
+      ...(await fontBytesForFamily("Source Sans 3")),
+      ...(await fontBytesForFamily("Source Serif 4")),
+    ];
+    const custom = await fontBytesForFamily(CUSTOM_FAMILY);
+    expect(custom.length).toBeGreaterThan(0);
+
+    const wasm = await packageBytes("@myriaddreamin/typst-ts-web-compiler/wasm");
+    const compiler = new BrowserPdfCompiler({ wasm: wasm.buffer, fonts: [...base, ...custom] });
+
+    const result = await compiler.compile(bundle(CUSTOM_DOC));
+    expect(result.diagnostics).toEqual([]);
+    expect(validatePdfOutput(result.pdf!)).toMatchObject({ tagged: true });
+
+    const loaded = (await compiler.getLoadedFonts()).join("\n");
+    expect(loaded).toContain(CUSTOM_FAMILY);
+  }, 30_000);
+});

--- a/packages/pdf/package.json
+++ b/packages/pdf/package.json
@@ -4,6 +4,9 @@
   "license": "Apache-2.0",
   "private": true,
   "type": "module",
+  "scripts": {
+    "lint:pdf-ledger": "bun scripts/check-hardcoding-ledger.ts"
+  },
   "exports": {
     ".": {
       "browser": "./src/index.browser.ts",

--- a/packages/pdf/scripts/check-hardcoding-ledger.test.ts
+++ b/packages/pdf/scripts/check-hardcoding-ledger.test.ts
@@ -1,0 +1,56 @@
+/**
+ * CI seam for the hardcoding-ledger lint stub (spec 007 T2.5).
+ *
+ * `bun test` runs every `*.test.ts` in the repo, so this wrapper is what makes
+ * `check-hardcoding-ledger.ts` actually run in CI without hooking the
+ * tsc-focused root `typecheck`. The lint MUST pass on the current
+ * `template.ts` + ledger; it must also catch a newly introduced, unledgered
+ * hardcoded value.
+ *
+ * See `012-pdf-template-migration/PLAN.md` — it inherits this guard.
+ */
+import { describe, expect, it } from "bun:test";
+import {
+  checkHardcodingLedger,
+  parseLedgerRecordedSet,
+  scanTemplate,
+} from "./check-hardcoding-ledger.js";
+
+describe("check-hardcoding-ledger", () => {
+  it("passes on the current template.ts against the ledger", () => {
+    const result = checkHardcodingLedger();
+    if (result.violations.length > 0) {
+      // Surface the offenders in the failure message for a fast fix.
+      const detail = result.violations
+        .map((v) => `${v.class} ${v.token} @ ${v.line}:${v.column}`)
+        .join("\n");
+      throw new Error(`Unledgered hardcoded values found:\n${detail}`);
+    }
+    expect(result.violations).toEqual([]);
+    expect(result.recordedCount).toBeGreaterThan(0);
+  });
+
+  it("detects a new unledgered hex color, length, and font family", () => {
+    const recorded = parseLedgerRecordedSet("`#4B57A3` `Source Sans 3` `10pt`");
+    const injected = [
+      `rgb("#ABCDEF")`, // unledgered hex
+      `size: 42pt`, // unledgered length
+      `set text(font: "Comic Sans")`, // unledgered font
+    ].join("\n");
+    const violations = scanTemplate(injected, recorded);
+    const classes = violations.map((v) => v.class).sort();
+    expect(classes).toEqual(["font-family", "hex-color", "length"]);
+    expect(violations.every((v) => v.line > 0 && v.column > 0)).toBe(true);
+  });
+
+  it("does not flag values recorded in the ledger or on the structural allowlist", () => {
+    const recorded = parseLedgerRecordedSet("`#4B57A3` `10pt` `Source Sans 3`");
+    const source = [
+      `rgb("#4B57A3")`, // recorded
+      `size: 10pt`, // recorded
+      `font: "Source Sans 3"`, // recorded
+      `default: 96) * 1pt`, // engine-structural allowlist
+    ].join("\n");
+    expect(scanTemplate(source, recorded)).toEqual([]);
+  });
+});

--- a/packages/pdf/scripts/check-hardcoding-ledger.ts
+++ b/packages/pdf/scripts/check-hardcoding-ledger.ts
@@ -1,0 +1,171 @@
+/**
+ * Hardcoding-ledger lint stub (spec 007 T2.5).
+ *
+ * A **heuristic** (not a parser) guard that makes a *new* unledgered hardcoded
+ * presentation value in `packages/pdf/src/template.ts` visible in review. It
+ * greps the template source for three token classes:
+ *   - bare hex color literals   `#[0-9a-fA-F]{6}`
+ *   - bare length literals      `<number>pt | mm | em`
+ *   - font-family string values `font: "<family>"`
+ * and fails (exit 1, named line/column) for any token that is neither recorded
+ * in the ledger nor on the narrow, commented engine-structural allowlist below.
+ *
+ * ## Design choice: the ledger is the single source of truth
+ *
+ * The recorded set is **parsed from
+ * `specs/export-expansion/007-pdf-template-settings/HARDCODING-LEDGER.md`**,
+ * not from an inline constant list in this script. Every hex color, font
+ * family, and length literal in the ledger appears inside a Markdown backtick
+ * code span; this script extracts all code spans (de-quoting `"…"`) and unions
+ * them into the recorded set. Consequence: to add a hardcoded value to
+ * `template.ts` without tripping the lint, you must first record it in the
+ * ledger — which is exactly the behavior 012 wants (the ledger stays the
+ * authoritative inventory; the lint just enforces "nothing new escapes it").
+ * An inline list would have duplicated the ledger and let the two drift.
+ *
+ * False positives are acceptable (this is a review aid, not a gate on every
+ * edge case); false *negatives* on the current `template.ts` are not — the
+ * current state must pass. See the companion test
+ * `check-hardcoding-ledger.test.ts`, which asserts exactly that under
+ * `bun test` (the CI seam — hooking the tsc-focused root `typecheck` was more
+ * intrusive than a test wrapper, and `bun test` already runs every `*.test.ts`
+ * in the repo).
+ *
+ * ## Consumer
+ *
+ * `012-pdf-template-migration/PLAN.md` starts from the ledger this script
+ * guards as its migration inventory, and inherits this stub as its "no new
+ * unledgered hardcoding" check while it moves these literals into manifest
+ * design tokens. See that plan's Reference/Goal sections.
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const DEFAULT_TEMPLATE_PATH = resolve(SCRIPT_DIR, "../src/template.ts");
+const DEFAULT_LEDGER_PATH = resolve(
+  SCRIPT_DIR,
+  "../../../specs/export-expansion/007-pdf-template-settings/HARDCODING-LEDGER.md"
+);
+
+/**
+ * Engine-structural values (structural, not presentation) that are
+ * intentionally NOT recorded in the ledger. Kept narrow and commented, per the
+ * "engine invariant allowlist" idea 012 formalizes.
+ */
+const ENGINE_STRUCTURAL_ALLOWLIST = new Set<string>([
+  // Unit-conversion multiplier: `settings.at("size", …) * 1pt` turns a numeric
+  // setting into a Typst length. Not a presentation constant.
+  "1pt",
+]);
+
+const HEX_RE = /#[0-9a-fA-F]{6}(?![0-9a-fA-F])/g;
+const LENGTH_RE = /(?<![\w.])\d+(?:\.\d+)?(?:pt|mm|em)(?![\w])/g;
+const FONT_RE = /font:\s*"([^"]+)"/g;
+
+export type TokenClass = "hex-color" | "length" | "font-family";
+
+export interface LedgerViolation {
+  class: TokenClass;
+  token: string;
+  line: number;
+  column: number;
+}
+
+/** Extract every Markdown inline code span's text, plus a de-quoted variant. */
+export function parseLedgerRecordedSet(ledgerSource: string): Set<string> {
+  const recorded = new Set<string>();
+  // Non-greedy single-backtick spans; ledger uses no multi-backtick spans.
+  for (const match of ledgerSource.matchAll(/`([^`\n]+)`/g)) {
+    const raw = match[1].trim();
+    if (raw.length === 0) continue;
+    recorded.add(raw);
+    // Record `"Source Sans 3"` and `Source Sans 3` alike.
+    const dequoted = raw.replace(/^"(.*)"$/, "$1");
+    if (dequoted !== raw) recorded.add(dequoted);
+  }
+  return recorded;
+}
+
+function columnOf(lineText: string, index: number): number {
+  // 1-based column of `index` within a full-source string, given the line start.
+  return index + 1;
+}
+
+/**
+ * Scan `templateSource` for hardcoded tokens not covered by `recorded` or the
+ * engine-structural allowlist. Returns violations (empty === clean).
+ */
+export function scanTemplate(templateSource: string, recorded: Set<string>): LedgerViolation[] {
+  const violations: LedgerViolation[] = [];
+  const lines = templateSource.split("\n");
+
+  const isKnown = (token: string): boolean =>
+    recorded.has(token) || ENGINE_STRUCTURAL_ALLOWLIST.has(token);
+
+  lines.forEach((lineText, i) => {
+    const lineNo = i + 1;
+    const push = (cls: TokenClass, token: string, colIndex: number) => {
+      if (isKnown(token)) return;
+      violations.push({ class: cls, token, line: lineNo, column: columnOf(lineText, colIndex) });
+    };
+
+    for (const m of lineText.matchAll(HEX_RE)) {
+      push("hex-color", m[0], m.index ?? 0);
+    }
+    for (const m of lineText.matchAll(LENGTH_RE)) {
+      push("length", m[0], m.index ?? 0);
+    }
+    for (const m of lineText.matchAll(FONT_RE)) {
+      const family = m[1];
+      // Column points at the family value, not the `font:` keyword.
+      const valueIndex = (m.index ?? 0) + m[0].indexOf(family);
+      push("font-family", family, valueIndex);
+    }
+  });
+
+  return violations;
+}
+
+export interface CheckOptions {
+  templatePath?: string;
+  ledgerPath?: string;
+}
+
+export interface CheckResult {
+  violations: LedgerViolation[];
+  recordedCount: number;
+  templatePath: string;
+  ledgerPath: string;
+}
+
+/** Run the lint against real files (defaults to the pinned template + ledger). */
+export function checkHardcodingLedger(options: CheckOptions = {}): CheckResult {
+  const templatePath = options.templatePath ?? DEFAULT_TEMPLATE_PATH;
+  const ledgerPath = options.ledgerPath ?? DEFAULT_LEDGER_PATH;
+  const recorded = parseLedgerRecordedSet(readFileSync(ledgerPath, "utf8"));
+  const violations = scanTemplate(readFileSync(templatePath, "utf8"), recorded);
+  return { violations, recordedCount: recorded.size, templatePath, ledgerPath };
+}
+
+function formatViolation(v: LedgerViolation): string {
+  return `  template.ts:${v.line}:${v.column}  ${v.class}  ${v.token}`;
+}
+
+if (import.meta.main) {
+  const result = checkHardcodingLedger();
+  if (result.violations.length === 0) {
+    console.log(
+      `hardcoding-ledger: OK — ${result.recordedCount} recorded tokens, no unledgered hardcoded values in template.ts`
+    );
+    process.exit(0);
+  }
+  console.error(
+    `hardcoding-ledger: ${result.violations.length} unledgered hardcoded value(s) in template.ts.\n` +
+      `Record them in HARDCODING-LEDGER.md (or add a structural value to the script allowlist):`
+  );
+  for (const v of result.violations) console.error(formatViolation(v));
+  process.exit(1);
+}

--- a/packages/pdf/src/fonts.test.ts
+++ b/packages/pdf/src/fonts.test.ts
@@ -1,0 +1,290 @@
+import { beforeAll, describe, expect, it } from "bun:test";
+import { fileURLToPath } from "node:url";
+import { ensurePdfFonts } from "../scripts/ensure-fonts.js";
+import {
+  FontParseError,
+  FontVerificationError,
+  MAX_FONT_BYTES,
+  parseFontMeta,
+  sha256Hex,
+  verifyFontBytes,
+  WEB_PACKAGED_FONT_GUIDANCE,
+} from "./fonts.js";
+import type { FontAsset } from "./types.js";
+
+// Real font bytes come from the actual bundled compiler fonts (Source Sans 3,
+// Source Serif 4, …) that `packages/pdf-compiler-browser` compiles with. They
+// are downloaded and sha256-verified by `ensurePdfFonts` into `packages/pdf/.fonts`.
+let sourceSansTtf: Uint8Array;
+let sourceSerifTtf: Uint8Array;
+
+beforeAll(async () => {
+  const { cacheDir } = await ensurePdfFonts({ logger: () => {} });
+  const read = async (fileName: string): Promise<Uint8Array> =>
+    new Uint8Array(await Bun.file(fileURLToPath(new URL(`file://${cacheDir}/${fileName}`))).arrayBuffer());
+  sourceSansTtf = await read("SourceSans3-Regular.ttf");
+  sourceSerifTtf = await read("SourceSerif4-Regular.ttf");
+});
+
+// --- sfnt fixture builders (real name-table bytes extracted from real fonts) ---
+
+function u16(value: number): number[] {
+  return [(value >>> 8) & 0xff, value & 0xff];
+}
+function u32(value: number): number[] {
+  return [(value >>> 24) & 0xff, (value >>> 16) & 0xff, (value >>> 8) & 0xff, value & 0xff];
+}
+function tagBytes(tag: string): number[] {
+  return [tag.charCodeAt(0), tag.charCodeAt(1), tag.charCodeAt(2), tag.charCodeAt(3)];
+}
+
+/** Extract the raw bytes of one table from a real sfnt font. */
+function extractTable(font: Uint8Array, tag: string): Uint8Array {
+  const view = new DataView(font.buffer, font.byteOffset, font.byteLength);
+  const numTables = view.getUint16(4);
+  for (let i = 0; i < numTables; i++) {
+    const rec = 12 + i * 16;
+    const t = String.fromCharCode(font[rec]!, font[rec + 1]!, font[rec + 2]!, font[rec + 3]!);
+    if (t === tag) {
+      const offset = view.getUint32(rec + 8);
+      const length = view.getUint32(rec + 12);
+      return font.subarray(offset, offset + length);
+    }
+  }
+  throw new Error(`table ${tag} not found`);
+}
+
+/**
+ * Build a valid single-face sfnt with the given magic and tables. Table data is
+ * placed after the directory with file-absolute offsets; checksums are zeroed
+ * (parsing does not verify them). Returns { bytes, size } for chaining into a TTC.
+ */
+function buildSfnt(magic: number[], tables: Array<{ tag: string; data: Uint8Array }>): Uint8Array {
+  const numTables = tables.length;
+  const dirSize = 12 + numTables * 16;
+  const aligned = (n: number): number => (n + 3) & ~3;
+  let dataCursor = aligned(dirSize);
+  const placed = tables.map((t) => {
+    const offset = dataCursor;
+    dataCursor = aligned(dataCursor + t.data.length);
+    return { ...t, offset };
+  });
+  const total = dataCursor;
+  const out = new Uint8Array(total);
+  out.set(magic, 0);
+  out.set(u16(numTables), 4); // numTables; searchRange/entrySelector/rangeShift left zero
+  placed.forEach((t, i) => {
+    const rec = 12 + i * 16;
+    out.set(tagBytes(t.tag), rec);
+    out.set(u32(0), rec + 4); // checksum
+    out.set(u32(t.offset), rec + 8);
+    out.set(u32(t.data.length), rec + 12);
+    out.set(t.data, t.offset);
+  });
+  return out;
+}
+
+/**
+ * Build a valid TTC referencing multiple faces. Each face gets its own offset
+ * table and its own copy of its tables, all with file-absolute offsets, so the
+ * every-face parse loop is genuinely exercised on real name-table bytes.
+ */
+function buildTtc(faces: Array<Array<{ tag: string; data: Uint8Array }>>): Uint8Array {
+  const numFonts = faces.length;
+  const aligned = (n: number): number => (n + 3) & ~3;
+  const headerSize = 12 + numFonts * 4;
+  // Layout: [ttc header][offset table 0][offset table 1]…[data 0][data 1]…
+  const offsetTableSizes = faces.map((f) => 12 + f.length * 16);
+  const faceOffsets: number[] = [];
+  let cursor = aligned(headerSize);
+  for (const size of offsetTableSizes) {
+    faceOffsets.push(cursor);
+    cursor = aligned(cursor + size);
+  }
+  // Place each face's table data and record absolute offsets.
+  const facePlacements = faces.map((f) => {
+    const placed = f.map((t) => {
+      const offset = cursor;
+      cursor = aligned(cursor + t.data.length);
+      return { ...t, offset };
+    });
+    return placed;
+  });
+  const total = cursor;
+  const out = new Uint8Array(total);
+  out.set(tagBytes("ttcf"), 0);
+  out.set(u16(1), 4); // majorVersion
+  out.set(u16(0), 6); // minorVersion
+  out.set(u32(numFonts), 8);
+  faceOffsets.forEach((off, i) => out.set(u32(off), 12 + i * 4));
+  faces.forEach((f, fi) => {
+    const dir = faceOffsets[fi]!;
+    out.set(u32(0x00010000), dir); // sfntVersion
+    out.set(u16(f.length), dir + 4);
+    facePlacements[fi]!.forEach((t, i) => {
+      const rec = dir + 12 + i * 16;
+      out.set(tagBytes(t.tag), rec);
+      out.set(u32(0), rec + 4);
+      out.set(u32(t.offset), rec + 8);
+      out.set(u32(t.data.length), rec + 12);
+      out.set(t.data, t.offset);
+    });
+  });
+  return out;
+}
+
+describe("parseFontMeta", () => {
+  it("accepts a real TrueType (TTF) font and reads its family", () => {
+    const faces = parseFontMeta(sourceSansTtf);
+    expect(faces).toHaveLength(1);
+    expect(faces[0]!.family).toBe("Source Sans 3");
+    expect(faces[0]!.style).toBe("normal");
+    expect(faces[0]!.weight).toBe(400);
+  });
+
+  it("accepts a real CFF/OpenType (OTF) sfnt built from a real name table", () => {
+    // No .otf ships in the repo; build a genuine OTTO-signatured sfnt whose
+    // `name` table is the real, unmodified Source Sans 3 name table.
+    const otf = buildSfnt(tagBytes("OTTO"), [{ tag: "name", data: extractTable(sourceSansTtf, "name") }]);
+    const faces = parseFontMeta(otf);
+    expect(faces).toHaveLength(1);
+    expect(faces[0]!.family).toBe("Source Sans 3");
+  });
+
+  it("returns one record per face for a real multi-face ttcf collection", () => {
+    // A TTC bundling two real faces (Sans + Serif). Must not drop the second.
+    const ttc = buildTtc([
+      [{ tag: "name", data: extractTable(sourceSansTtf, "name") }],
+      [{ tag: "name", data: extractTable(sourceSerifTtf, "name") }],
+    ]);
+    const faces = parseFontMeta(ttc);
+    expect(faces).toHaveLength(2);
+    expect(faces.map((f) => f.family).sort()).toEqual(["Source Sans 3", "Source Serif 4"]);
+  });
+
+  it("rejects WOFF2 with actionable desktop-font guidance", () => {
+    const woff2 = new Uint8Array([...tagBytes("wOF2"), ...u32(0x00010000), 0, 0, 0, 0]);
+    try {
+      parseFontMeta(woff2);
+      throw new Error("expected FontParseError");
+    } catch (error) {
+      expect(error).toBeInstanceOf(FontParseError);
+      expect((error as FontParseError).reason).toBe("web-packaged");
+      expect((error as FontParseError).message).toBe(WEB_PACKAGED_FONT_GUIDANCE);
+    }
+  });
+
+  it("rejects WOFF with the web-packaged reason", () => {
+    const woff = new Uint8Array([...tagBytes("wOFF"), ...u32(0x00010000), 0, 0, 0, 0]);
+    expect(() => parseFontMeta(woff)).toThrow(FontParseError);
+    try {
+      parseFontMeta(woff);
+    } catch (error) {
+      expect((error as FontParseError).reason).toBe("web-packaged");
+    }
+  });
+
+  it("rejects an unsupported magic cleanly", () => {
+    const junk = new Uint8Array([0x25, 0x50, 0x44, 0x46, 0, 0, 0, 0]); // "%PDF"
+    try {
+      parseFontMeta(junk);
+      throw new Error("expected FontParseError");
+    } catch (error) {
+      expect(error).toBeInstanceOf(FontParseError);
+      expect((error as FontParseError).reason).toBe("unsupported-format");
+    }
+  });
+
+  it("rejects a zero-length buffer with a typed error (not RangeError)", () => {
+    try {
+      parseFontMeta(new Uint8Array(0));
+      throw new Error("expected FontParseError");
+    } catch (error) {
+      expect(error).toBeInstanceOf(FontParseError);
+      expect(error).not.toBeInstanceOf(RangeError);
+      expect((error as FontParseError).reason).toBe("empty");
+    }
+  });
+
+  it("rejects a truncated header cleanly (not RangeError)", () => {
+    // Valid TTF magic + a numTables claim, but no table directory follows.
+    const truncated = new Uint8Array([...u32(0x00010000), ...u16(5)]);
+    try {
+      parseFontMeta(truncated);
+      throw new Error("expected FontParseError");
+    } catch (error) {
+      expect(error).toBeInstanceOf(FontParseError);
+      expect(error).not.toBeInstanceOf(RangeError);
+      expect((error as FontParseError).reason).toBe("truncated");
+    }
+  });
+
+  it("rejects a hostile numTables cleanly (not RangeError)", () => {
+    // numTables = 0xFFFF but no directory bytes — must not read out of bounds.
+    const hostile = new Uint8Array([...u32(0x00010000), ...u16(0xffff), 0, 0, 0, 0]);
+    try {
+      parseFontMeta(hostile);
+      throw new Error("expected FontParseError");
+    } catch (error) {
+      expect(error).toBeInstanceOf(FontParseError);
+      expect(error).not.toBeInstanceOf(RangeError);
+      expect((error as FontParseError).reason).toBe("truncated");
+    }
+  });
+
+  it("rejects a name-table offset pointing past the buffer cleanly (not RangeError)", () => {
+    // One 'name' table whose directory offset points far beyond the bytes.
+    const numTables = 1;
+    const bytes = new Uint8Array(12 + numTables * 16);
+    bytes.set(u32(0x00010000), 0);
+    bytes.set(u16(numTables), 4);
+    const rec = 12;
+    bytes.set(tagBytes("name"), rec);
+    bytes.set(u32(0), rec + 4);
+    bytes.set(u32(0x7fffffff), rec + 8); // offset far past the buffer
+    bytes.set(u32(64), rec + 12); // length
+    try {
+      parseFontMeta(bytes);
+      throw new Error("expected FontParseError");
+    } catch (error) {
+      expect(error).toBeInstanceOf(FontParseError);
+      expect(error).not.toBeInstanceOf(RangeError);
+      expect(["truncated", "malformed-name-table"]).toContain((error as FontParseError).reason);
+    }
+  });
+
+  it("rejects a font over the 10 MB cap", () => {
+    const oversized = new Uint8Array(MAX_FONT_BYTES + 1);
+    oversized.set(u32(0x00010000), 0);
+    try {
+      parseFontMeta(oversized);
+      throw new Error("expected FontParseError");
+    } catch (error) {
+      expect(error).toBeInstanceOf(FontParseError);
+      expect((error as FontParseError).reason).toBe("too-large");
+    }
+  });
+});
+
+describe("verifyFontBytes", () => {
+  function assetFor(sha256: string): FontAsset {
+    return { family: "Source Sans 3", style: "normal", weight: 400, sha256 };
+  }
+
+  it("accepts bytes whose real SHA-256 matches the asset", async () => {
+    const digest = await sha256Hex(sourceSansTtf);
+    await expect(verifyFontBytes(assetFor(digest), sourceSansTtf)).resolves.toBeUndefined();
+  });
+
+  it("is case-insensitive on the recorded hash", async () => {
+    const digest = (await sha256Hex(sourceSansTtf)).toUpperCase();
+    await expect(verifyFontBytes(assetFor(digest), sourceSansTtf)).resolves.toBeUndefined();
+  });
+
+  it("throws a typed mismatch on a single flipped bit (real WebCrypto)", async () => {
+    const digest = await sha256Hex(sourceSansTtf);
+    const tampered = new Uint8Array(sourceSansTtf);
+    tampered[Math.floor(tampered.length / 2)]! ^= 0x01;
+    await expect(verifyFontBytes(assetFor(digest), tampered)).rejects.toBeInstanceOf(FontVerificationError);
+  });
+});

--- a/packages/pdf/src/fonts.ts
+++ b/packages/pdf/src/fonts.ts
@@ -1,0 +1,365 @@
+/**
+ * Font-intake seam (spec 007 B5) — pure, browser-safe sfnt inspection and
+ * integrity verification for corporate fonts fed into the PDF compiler.
+ *
+ * The engine never fetches font bytes: a host resolves them through a
+ * {@link FontSource} (see `types.ts`) and hands them to the compiler as
+ * `Uint8Array[]`. This module supplies the two pure helpers a host needs on
+ * that path:
+ *
+ *  - {@link parseFontMeta} inspects sfnt bytes (TrueType `00 01 00 00`, CFF
+ *    `OTTO`, or a `ttcf` collection), reads the `name` table for each face, and
+ *    returns one descriptive record per face. WOFF/WOFF2 web-packaged fonts are
+ *    rejected with actionable guidance because the pinned Typst compiler
+ *    consumes sfnt only. Every read is bounds-checked, so a truncated or hostile
+ *    file rejects with a typed {@link FontParseError}, never an unrelated
+ *    `RangeError`.
+ *  - {@link verifyFontBytes} re-hashes delivered bytes against an approved
+ *    {@link FontAsset}'s `sha256`. This is MANDATORY host wiring between
+ *    `FontSource.getBytes` and `BrowserPdfCompilerAssets.fonts` — see its doc
+ *    comment for the exact construction.
+ *
+ * Browser-safety: no `node:`/`bun:` imports. `crypto` is the Web Crypto global
+ * (browsers, Bun, Node >= 18); `TextDecoder`/`DataView` are platform globals.
+ */
+import type { FontAsset } from "./types.js";
+
+/** 10 MB hard cap per font file (reject, never truncate). */
+export const MAX_FONT_BYTES = 10 * 1024 * 1024;
+
+/** Guidance surfaced when a web-packaged (WOFF/WOFF2) font is submitted. */
+export const WEB_PACKAGED_FONT_GUIDANCE =
+  "web-packaged font detected — the PDF compiler consumes TTF/OTF; " +
+  "export the desktop font from your font source";
+
+export type FontParseErrorReason =
+  | "empty"
+  | "too-large"
+  | "truncated"
+  | "unsupported-format"
+  | "web-packaged"
+  | "missing-name-table"
+  | "malformed-name-table";
+
+/**
+ * Typed rejection from {@link parseFontMeta}. Every failure — including
+ * truncated headers, out-of-range table offsets, and hostile table counts —
+ * surfaces here with a machine-readable {@link reason}, so a host renders
+ * actionable guidance instead of catching an anonymous `RangeError`.
+ */
+export class FontParseError extends Error {
+  readonly reason: FontParseErrorReason;
+
+  constructor(reason: FontParseErrorReason, message: string) {
+    super(message);
+    this.name = "FontParseError";
+    this.reason = reason;
+  }
+}
+
+/**
+ * Thrown by {@link verifyFontBytes} when delivered bytes do not hash to the
+ * approved {@link FontAsset}'s `sha256`. A corrupted or swapped delivery must
+ * never be embedded under the approved font's license claim, so there is no
+ * silent fallback.
+ */
+export class FontVerificationError extends Error {
+  readonly expected: string;
+  readonly actual: string;
+
+  constructor(expected: string, actual: string) {
+    super(
+      `Font bytes failed their SHA-256 check (expected ${expected}, got ${actual}) — ` +
+        "the delivered font does not match the approved record; re-resolve it."
+    );
+    this.name = "FontVerificationError";
+    this.expected = expected;
+    this.actual = actual;
+  }
+}
+
+/**
+ * One face parsed from a font file, shaped like a {@link FontAsset} minus the
+ * host-supplied `sha256`/`license` (those describe the delivery and the legal
+ * attestation, neither of which is derivable from the bytes). A `ttcf`
+ * collection yields one record per bundled face.
+ */
+export interface ParsedFontFace {
+  /** Typographic family (name ID 16, else 1). */
+  family: string;
+  /** Typographic subfamily (name ID 17, else 2), e.g. `"Regular"`, `"Bold"`. */
+  subfamily: string;
+  /** Derived from the subfamily: `"italic"` for italic/oblique faces. */
+  style: "normal" | "italic";
+  /** Derived from the subfamily keyword (`Bold` -> 700, …); defaults to 400. */
+  weight: number;
+}
+
+// sfnt magic numbers (big-endian uint32 read of the first four bytes).
+const SFNT_TRUETYPE = 0x00010000;
+const SFNT_TRUE = 0x74727565; // 'true' (Apple TrueType)
+const SFNT_OTTO = 0x4f54544f; // 'OTTO' (CFF/OpenType)
+const SFNT_TTCF = 0x74746366; // 'ttcf' (collection)
+const MAGIC_WOFF = 0x774f4646; // 'wOFF'
+const MAGIC_WOFF2 = 0x774f4632; // 'wOF2'
+
+const NAME_ID_FAMILY = 1;
+const NAME_ID_SUBFAMILY = 2;
+const NAME_ID_TYPO_FAMILY = 16;
+const NAME_ID_TYPO_SUBFAMILY = 17;
+
+/** Bounds-checked big-endian readers — throw a typed error, never a RangeError. */
+function readU16(view: DataView, offset: number): number {
+  if (offset < 0 || offset + 2 > view.byteLength) {
+    throw new FontParseError("truncated", `font truncated: cannot read u16 at offset ${offset}`);
+  }
+  return view.getUint16(offset);
+}
+
+function readU32(view: DataView, offset: number): number {
+  if (offset < 0 || offset + 4 > view.byteLength) {
+    throw new FontParseError("truncated", `font truncated: cannot read u32 at offset ${offset}`);
+  }
+  return view.getUint32(offset);
+}
+
+function readTag(bytes: Uint8Array, offset: number): string {
+  if (offset < 0 || offset + 4 > bytes.length) {
+    throw new FontParseError("truncated", `font truncated: cannot read tag at offset ${offset}`);
+  }
+  return String.fromCharCode(bytes[offset]!, bytes[offset + 1]!, bytes[offset + 2]!, bytes[offset + 3]!);
+}
+
+/** Priority for competing name records: higher wins. Windows English first. */
+function namePriority(platformID: number, languageID: number): number {
+  if (platformID === 3) return languageID === 0x0409 ? 40 : 30; // Windows (UTF-16BE)
+  if (platformID === 0) return 20; // Unicode (UTF-16BE)
+  if (platformID === 1) return languageID === 0 ? 12 : 10; // Mac (Mac Roman ~ ASCII)
+  return 1;
+}
+
+function decodeName(bytes: Uint8Array, offset: number, length: number, platformID: number): string {
+  if (offset < 0 || length < 0 || offset + length > bytes.length) {
+    throw new FontParseError(
+      "malformed-name-table",
+      `name string out of range (offset ${offset}, length ${length}, size ${bytes.length})`
+    );
+  }
+  const slice = bytes.subarray(offset, offset + length);
+  if (platformID === 1) {
+    // Mac Roman: approximate as byte-per-char; font family names are ASCII.
+    let out = "";
+    for (const b of slice) out += String.fromCharCode(b);
+    return out;
+  }
+  // Platform 0 (Unicode) and 3 (Windows) store UTF-16BE.
+  return new TextDecoder("utf-16be").decode(slice);
+}
+
+/** Parse a single `name` table, returning the best family/subfamily strings. */
+function parseNameTable(bytes: Uint8Array, view: DataView, nameOffset: number, nameLength: number): { family: string; subfamily: string } {
+  if (nameOffset + nameLength > bytes.length) {
+    throw new FontParseError(
+      "malformed-name-table",
+      `name table out of range (offset ${nameOffset}, length ${nameLength}, size ${bytes.length})`
+    );
+  }
+  const count = readU16(view, nameOffset + 2);
+  const storageOffset = readU16(view, nameOffset + 4);
+  const recordsStart = nameOffset + 6;
+  if (recordsStart + count * 12 > bytes.length) {
+    throw new FontParseError("malformed-name-table", "name records extend past the font bytes");
+  }
+  const storageBase = nameOffset + storageOffset;
+
+  // Track the highest-priority decoded string per name ID.
+  const best = new Map<number, { priority: number; value: string }>();
+  for (let i = 0; i < count; i++) {
+    const rec = recordsStart + i * 12;
+    const platformID = readU16(view, rec);
+    const languageID = readU16(view, rec + 4);
+    const nameID = readU16(view, rec + 6);
+    if (
+      nameID !== NAME_ID_FAMILY &&
+      nameID !== NAME_ID_SUBFAMILY &&
+      nameID !== NAME_ID_TYPO_FAMILY &&
+      nameID !== NAME_ID_TYPO_SUBFAMILY
+    ) {
+      continue;
+    }
+    const length = readU16(view, rec + 8);
+    const strOffset = readU16(view, rec + 10);
+    const priority = namePriority(platformID, languageID);
+    const existing = best.get(nameID);
+    if (existing && existing.priority >= priority) continue;
+    const value = decodeName(bytes, storageBase + strOffset, length, platformID).trim();
+    if (value === "") continue;
+    best.set(nameID, { priority, value });
+  }
+
+  const family = best.get(NAME_ID_TYPO_FAMILY)?.value ?? best.get(NAME_ID_FAMILY)?.value;
+  const subfamily =
+    best.get(NAME_ID_TYPO_SUBFAMILY)?.value ?? best.get(NAME_ID_SUBFAMILY)?.value ?? "Regular";
+  if (family === undefined) {
+    throw new FontParseError("malformed-name-table", "font name table has no family record");
+  }
+  return { family, subfamily };
+}
+
+const WEIGHT_KEYWORDS: ReadonlyArray<[RegExp, number]> = [
+  [/\b(?:extra[-\s]?black|ultra[-\s]?black)\b/i, 950],
+  [/\b(?:black|heavy)\b/i, 900],
+  [/\b(?:extra[-\s]?bold|ultra[-\s]?bold)\b/i, 800],
+  [/\bsemi[-\s]?bold\b|\bdemi[-\s]?bold\b/i, 600],
+  [/\bbold\b/i, 700],
+  [/\bmedium\b/i, 500],
+  [/\b(?:extra[-\s]?light|ultra[-\s]?light)\b/i, 200],
+  [/\bthin\b|\bhairline\b/i, 100],
+  [/\blight\b/i, 300],
+];
+
+function deriveStyle(subfamily: string): "normal" | "italic" {
+  return /\b(?:italic|oblique)\b/i.test(subfamily) ? "italic" : "normal";
+}
+
+function deriveWeight(subfamily: string): number {
+  for (const [pattern, weight] of WEIGHT_KEYWORDS) {
+    if (pattern.test(subfamily)) return weight;
+  }
+  return 400;
+}
+
+/** Parse one face at `tableDirOffset` (0 for a standalone font, else a TTC member). */
+function parseFace(bytes: Uint8Array, view: DataView, tableDirOffset: number): ParsedFontFace {
+  const numTables = readU16(view, tableDirOffset + 4);
+  const dirStart = tableDirOffset + 12;
+  // Guard a hostile numTables before touching the directory: the whole directory
+  // must fit, so an inflated count rejects as "truncated" not a RangeError.
+  if (dirStart + numTables * 16 > bytes.length) {
+    throw new FontParseError("truncated", `table directory (${numTables} tables) extends past the font bytes`);
+  }
+  let nameOffset: number | undefined;
+  let nameLength: number | undefined;
+  for (let i = 0; i < numTables; i++) {
+    const rec = dirStart + i * 16;
+    if (readTag(bytes, rec) === "name") {
+      nameOffset = readU32(view, rec + 8);
+      nameLength = readU32(view, rec + 12);
+      break;
+    }
+  }
+  if (nameOffset === undefined || nameLength === undefined) {
+    throw new FontParseError("missing-name-table", "font has no `name` table");
+  }
+  const { family, subfamily } = parseNameTable(bytes, view, nameOffset, nameLength);
+  return { family, subfamily, style: deriveStyle(subfamily), weight: deriveWeight(subfamily) };
+}
+
+/**
+ * Inspect sfnt font bytes and return one descriptive record per face.
+ *
+ * Accepts TrueType (`00 01 00 00`), CFF/OpenType (`OTTO`), and TrueType
+ * Collections (`ttcf`) — a collection yields one record per bundled face, so
+ * multi-face corporate `.ttc` files never silently drop faces. Rejects:
+ *
+ *  - an empty buffer (`empty`);
+ *  - anything over {@link MAX_FONT_BYTES} (`too-large`);
+ *  - WOFF/WOFF2 web-packaged fonts with {@link WEB_PACKAGED_FONT_GUIDANCE}
+ *    (`web-packaged`), since the pinned compiler consumes sfnt only;
+ *  - any other magic (`unsupported-format`);
+ *  - truncated headers / out-of-range offsets / hostile table counts
+ *    (`truncated` or `malformed-name-table`).
+ *
+ * @throws {FontParseError} on any rejection — never an unrelated `RangeError`.
+ */
+export function parseFontMeta(bytes: Uint8Array): ParsedFontFace[] {
+  if (bytes.length === 0) {
+    throw new FontParseError("empty", "font file is empty");
+  }
+  if (bytes.length > MAX_FONT_BYTES) {
+    throw new FontParseError("too-large", `font exceeds the ${MAX_FONT_BYTES}-byte cap (${bytes.length} bytes)`);
+  }
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const magic = readU32(view, 0);
+
+  if (magic === MAGIC_WOFF || magic === MAGIC_WOFF2) {
+    throw new FontParseError("web-packaged", WEB_PACKAGED_FONT_GUIDANCE);
+  }
+
+  if (magic === SFNT_TTCF) {
+    const numFonts = readU32(view, 8);
+    if (numFonts === 0) {
+      throw new FontParseError("malformed-name-table", "font collection declares zero faces");
+    }
+    const offsetsStart = 12;
+    if (offsetsStart + numFonts * 4 > bytes.length) {
+      throw new FontParseError("truncated", `collection header (${numFonts} faces) extends past the font bytes`);
+    }
+    const faces: ParsedFontFace[] = [];
+    for (let i = 0; i < numFonts; i++) {
+      faces.push(parseFace(bytes, view, readU32(view, offsetsStart + i * 4)));
+    }
+    return faces;
+  }
+
+  if (magic === SFNT_TRUETYPE || magic === SFNT_TRUE || magic === SFNT_OTTO) {
+    return [parseFace(bytes, view, 0)];
+  }
+
+  throw new FontParseError(
+    "unsupported-format",
+    `unsupported font magic 0x${magic.toString(16).padStart(8, "0")} — expected TTF, OTF, or TTC`
+  );
+}
+
+/** Lowercase hex SHA-256 of `bytes` via WebCrypto (`crypto.subtle.digest`). */
+export async function sha256Hex(bytes: Uint8Array): Promise<string> {
+  // Copy into a fresh, ArrayBuffer-backed view so the digest input is a plain
+  // `BufferSource` regardless of the caller's backing store (mirrors the
+  // template-library hash helper in `@atlcli/core`).
+  const copy = new Uint8Array(bytes.byteLength);
+  copy.set(bytes);
+  const digest = await crypto.subtle.digest("SHA-256", copy);
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+/**
+ * Verify that delivered `bytes` hash to `asset.sha256`; throw a typed
+ * {@link FontVerificationError} on mismatch.
+ *
+ * **This is MANDATORY host wiring** between {@link FontSource}.getBytes and
+ * `BrowserPdfCompilerAssets.fonts`. Nothing else ties the bytes a `FontSource`
+ * returns to the `sha256`/license record a host looked up before handing them
+ * to `add_raw_font`, so a corrupted or swapped delivery would otherwise be
+ * embedded under the approved font's license claim with no error. Hosts
+ * construct the compiler like this — `bundledFonts` unioned with the verified
+ * custom fonts — with **no change needed in `packages/pdf-compiler-browser`**
+ * (`BrowserPdfCompilerAssets.fonts` is already `Uint8Array[]` and `add_raw_font`
+ * accepts arbitrary extra fonts):
+ *
+ * ```ts
+ * new BrowserPdfCompiler({
+ *   wasm,
+ *   fonts: [
+ *     ...bundledFonts,
+ *     ...(await Promise.all(
+ *       customFonts.map(async (f) => {
+ *         const bytes = await fontSource.getBytes(f.sha256);
+ *         await verifyFontBytes(f, bytes); // gates every custom font
+ *         return bytes;
+ *       })
+ *     )),
+ *   ],
+ * });
+ * ```
+ *
+ * @throws {FontVerificationError} when the delivered bytes disagree with `asset.sha256`.
+ */
+export async function verifyFontBytes(asset: FontAsset, bytes: Uint8Array): Promise<void> {
+  const actual = await sha256Hex(bytes);
+  if (actual.toLowerCase() !== asset.sha256.toLowerCase()) {
+    throw new FontVerificationError(asset.sha256, actual);
+  }
+}

--- a/packages/pdf/src/index.browser.ts
+++ b/packages/pdf/src/index.browser.ts
@@ -1,5 +1,6 @@
 export * from "./escape.js";
 export * from "./compiler.js";
+export * from "./fonts.js";
 export * from "./prepare.js";
 export * from "./run-export.js";
 export * from "./runtime-assets.js";

--- a/packages/pdf/src/index.browser.ts
+++ b/packages/pdf/src/index.browser.ts
@@ -4,6 +4,7 @@ export * from "./prepare.js";
 export * from "./run-export.js";
 export * from "./runtime-assets.js";
 export * from "./serialize.js";
+export * from "./settings.js";
 export * from "./template.js";
 export * from "./theme.js";
 export * from "./validate.js";

--- a/packages/pdf/src/index.ts
+++ b/packages/pdf/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./escape.js";
 export * from "./compiler.js";
+export * from "./fonts.js";
 export * from "./prepare.js";
 export * from "./run-export.js";
 export * from "./runtime-assets.js";

--- a/packages/pdf/src/index.ts
+++ b/packages/pdf/src/index.ts
@@ -4,6 +4,7 @@ export * from "./prepare.js";
 export * from "./run-export.js";
 export * from "./runtime-assets.js";
 export * from "./serialize.js";
+export * from "./settings.js";
 export * from "./template.js";
 export * from "./theme.js";
 export * from "./validate.js";

--- a/packages/pdf/src/prepare.test.ts
+++ b/packages/pdf/src/prepare.test.ts
@@ -45,6 +45,27 @@ describe("PDF asset preparation", () => {
     expect(prepared.notes[0]?.message).toContain("active");
   });
 
+  it("rejects hostile SVG assets through the shared svg-safety rules", async () => {
+    // Bypass classes the old inline sanitizer accepted: namespace-prefixed
+    // script elements and javascript:/relative href targets.
+    const hostiles = [
+      `<svg xmlns:svg="http://www.w3.org/2000/svg"><svg:script>alert(1)</svg:script></svg>`,
+      `<svg xmlns="http://www.w3.org/2000/svg"><a href="javascript:alert(1)"><rect/></a></svg>`,
+      `<svg xmlns="http://www.w3.org/2000/svg"><image href="../../etc/passwd"/></svg>`,
+      `<svg xmlns="http://www.w3.org/2000/svg"><!ENTITY x "y"><rect/></svg>`,
+    ];
+    for (const hostile of hostiles) {
+      const prepared = await preparePdfDocument(images(1), {
+        resolve: async () => ({
+          bytes: new TextEncoder().encode(hostile),
+          mediaType: "image/svg+xml",
+        }),
+      });
+      expect(prepared.assets).toEqual([]);
+      expect(prepared.notes[0]?.message).toContain("active");
+    }
+  });
+
   it("rejects a declared MIME type that disagrees with magic bytes", async () => {
     const prepared = await preparePdfDocument(images(1), {
       resolve: async () => ({ bytes: pngBytes(), mediaType: "image/jpeg" }),

--- a/packages/pdf/src/prepare.ts
+++ b/packages/pdf/src/prepare.ts
@@ -1,5 +1,6 @@
 import { renderDiagram } from "@atlcli/diagram";
 import type { ExportBlock, ExportNote } from "@atlcli/confluence";
+import { findSvgSafetyViolation } from "./svg-safety.js";
 import type {
   PdfAssetResolver,
   PdfResolvedAsset,
@@ -55,13 +56,10 @@ function validateResolvedAsset(asset: PdfResolvedAsset): PdfResolvedAsset {
     throw new Error(`image content does not match its declared media type (${declared})`);
   }
   if (sniffed === "image/svg+xml") {
-    const source = new TextDecoder().decode(asset.bytes);
-    if (
-      /<\s*(?:script|foreignObject)\b/i.test(source) ||
-      /\son[a-z]+\s*=/i.test(source) ||
-      /(?:href|xlink:href)\s*=\s*["']\s*(?:https?:|data:)/i.test(source)
-    ) {
-      throw new Error("SVG contains active or externally loaded content");
+    // Shared blocklist with logo-settings validation — see svg-safety.ts.
+    const violation = findSvgSafetyViolation(new TextDecoder().decode(asset.bytes));
+    if (violation) {
+      throw new Error(`SVG contains active or externally loaded content (${violation.rule})`);
     }
   }
   return { ...asset, mediaType: sniffed };

--- a/packages/pdf/src/run-export.test.ts
+++ b/packages/pdf/src/run-export.test.ts
@@ -61,6 +61,25 @@ describe("neutral runPdfExport", () => {
     expect(emitted).toBe(0);
   });
 
+  it("resolves settings exactly once across validation and serialization", async () => {
+    let pageReads = 0;
+    const settings = {
+      get page(): "letter" {
+        pageReads += 1;
+        return "letter";
+      },
+    };
+    await runPdfExport(
+      { blocks, metadata, filename: "Test.pdf", settings },
+      {
+        assets,
+        compiler: { compile: async () => ({ pdf: validPdf, diagnostics: [], compilerVersion: "test" }) },
+        output: { emit: async () => {} },
+      }
+    );
+    expect(pageReads).toBe(1);
+  });
+
   it("does not fail a committed export when the signal fires after emit", async () => {
     const controller = new AbortController();
     let emitted = 0;

--- a/packages/pdf/src/run-export.test.ts
+++ b/packages/pdf/src/run-export.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import type { ExportBlock } from "@atlcli/confluence";
 import { PdfExportError, runPdfExport, type PdfExportPhase } from "./run-export.js";
+import { PdfSettingsError } from "./settings.js";
 
 const validPdf = new TextEncoder().encode(
   "%PDF-1.7\n/Type/Page /StructTreeRoot /MarkInfo /Outlines /FontFile2\n%%EOF\n"
@@ -33,8 +34,46 @@ describe("neutral runPdfExport", () => {
     expect(template).toContain('let cover-paper = rgb("#FFFDF5")');
     expect(report.profile).toBe("pdf-ua-1");
     expect(report.notes[0]?.code).toBe("source");
-    expect(phases).toEqual(["preparing", "fetching", "compiling", "validating", "emitting"]);
+    expect(phases).toEqual(["configuration", "preparing", "fetching", "compiling", "validating", "emitting"]);
     expect(emitted).toBe(1);
+  });
+
+  it("fails settings validation before any asset fetch", async () => {
+    let resolveCalls = 0;
+    let emitted = 0;
+    try {
+      await runPdfExport(
+        { blocks, metadata, filename: "Test.pdf", settings: { page: "a3" as never } },
+        {
+          assets: { resolve: async () => { resolveCalls += 1; throw new Error("no assets"); } },
+          compiler: { compile: async () => ({ pdf: validPdf, diagnostics: [], compilerVersion: "test" }) },
+          output: { emit: async () => { emitted += 1; } },
+        }
+      );
+      throw new Error("expected failure");
+    } catch (error) {
+      expect(error).toBeInstanceOf(PdfExportError);
+      expect((error as PdfExportError).phase).toBe("configuration");
+      expect((error as PdfExportError).cause).toBeInstanceOf(PdfSettingsError);
+      expect(((error as PdfExportError).cause as PdfSettingsError).path).toBe("page");
+    }
+    expect(resolveCalls).toBe(0);
+    expect(emitted).toBe(0);
+  });
+
+  it("does not fail a committed export when the signal fires after emit", async () => {
+    const controller = new AbortController();
+    let emitted = 0;
+    const report = await runPdfExport(
+      { blocks, metadata, filename: "Test.pdf", signal: controller.signal },
+      {
+        assets,
+        compiler: { compile: async () => ({ pdf: validPdf, diagnostics: [], compilerVersion: "test" }) },
+        output: { emit: async () => { emitted += 1; controller.abort(); } },
+      }
+    );
+    expect(emitted).toBe(1);
+    expect(report.filename).toBe("Test.pdf");
   });
 
   it("preserves structured compiler diagnostics and emits nothing", async () => {

--- a/packages/pdf/src/run-export.ts
+++ b/packages/pdf/src/run-export.ts
@@ -1,6 +1,7 @@
 import type { ExportBlock, ExportNote } from "@atlcli/confluence";
 import { formatPdfCompilerDiagnostics, type PdfCompilePort } from "./compiler.js";
 import { preparePdfDocument } from "./prepare.js";
+import { resolvePdfSettings } from "./settings.js";
 import { serializePdfDocument } from "./serialize.js";
 import type {
   PdfAssetResolver,
@@ -8,6 +9,7 @@ import type {
   PdfExportMetadata,
   PdfExportReport,
   PdfProfile,
+  PdfTemplateSettings,
   PdfThemeOptions,
   PreparedPdfBlock,
 } from "./types.js";
@@ -17,7 +19,13 @@ export interface PdfOutputSink {
   emit(name: string, bytes: Uint8Array, context?: { signal?: AbortSignal }): Promise<void>;
 }
 
-export type PdfExportPhase = "preparing" | "fetching" | "compiling" | "validating" | "emitting";
+export type PdfExportPhase =
+  | "configuration"
+  | "preparing"
+  | "fetching"
+  | "compiling"
+  | "validating"
+  | "emitting";
 
 export interface RunPdfExportInput {
   blocks: ExportBlock[];
@@ -25,6 +33,7 @@ export interface RunPdfExportInput {
   metadata: PdfExportMetadata;
   profile?: PdfProfile;
   theme?: PdfThemeOptions;
+  settings?: PdfTemplateSettings;
   filename: string;
   signal?: AbortSignal;
   onPhase?: (phase: PdfExportPhase) => void;
@@ -37,7 +46,7 @@ export interface PdfExportEnv {
   now?: () => number;
 }
 
-export type PdfExportErrorPhase = "prepare" | "compile" | "validate" | "emit";
+export type PdfExportErrorPhase = "configuration" | "prepare" | "compile" | "validate" | "emit";
 
 export class PdfExportError extends Error {
   readonly phase: PdfExportErrorPhase;
@@ -117,6 +126,15 @@ export async function runPdfExport(
   const startedAt = now();
   throwIfAborted(input.signal);
 
+  // Validate settings before any asset fetch so a settings typo never pays for
+  // (or is masked by) network requests it would discard.
+  input.onPhase?.("configuration");
+  try {
+    resolvePdfSettings(input.settings);
+  } catch (error) {
+    wrapFailure(error, "configuration");
+  }
+
   input.onPhase?.("preparing");
   const prepareStarted = now();
   let prepared;
@@ -129,6 +147,7 @@ export async function runPdfExport(
       metadata: input.metadata,
       profile: input.profile,
       theme: input.theme,
+      settings: input.settings,
     });
   } catch (error) {
     wrapFailure(error, "prepare");
@@ -166,9 +185,11 @@ export async function runPdfExport(
   input.onPhase?.("emitting");
   const emitStarted = now();
   try {
+    // Abort is honored *before* emit; once the sink has committed the bytes we
+    // must not turn an already-written file into a reported failure, so there
+    // is deliberately no post-emit abort re-check here.
     throwIfAborted(input.signal);
     await env.output.emit(input.filename, compiled.pdf, { signal: input.signal });
-    throwIfAborted(input.signal);
   } catch (error) {
     wrapFailure(error, "emit");
   }

--- a/packages/pdf/src/run-export.ts
+++ b/packages/pdf/src/run-export.ts
@@ -127,10 +127,12 @@ export async function runPdfExport(
   throwIfAborted(input.signal);
 
   // Validate settings before any asset fetch so a settings typo never pays for
-  // (or is masked by) network requests it would discard.
+  // (or is masked by) network requests it would discard. The resolved object is
+  // forwarded to serialize, whose own resolve call short-circuits on it.
   input.onPhase?.("configuration");
+  let settings;
   try {
-    resolvePdfSettings(input.settings);
+    settings = resolvePdfSettings(input.settings);
   } catch (error) {
     wrapFailure(error, "configuration");
   }
@@ -147,7 +149,7 @@ export async function runPdfExport(
       metadata: input.metadata,
       profile: input.profile,
       theme: input.theme,
-      settings: input.settings,
+      settings,
     });
   } catch (error) {
     wrapFailure(error, "prepare");

--- a/packages/pdf/src/serialize.test.ts
+++ b/packages/pdf/src/serialize.test.ts
@@ -789,13 +789,20 @@ describe("PDF settings threading into main.typ", () => {
     expect(bundle.main).toContain('organization-name: "Acme"');
   });
 
-  it("typstString-escapes header/footer text so injection stays literal", () => {
+  it("typstString-escapes every free-text setting so injection stays literal", () => {
     const bundle = serializePdfDocument(emptyDoc, {
       metadata,
-      settings: { headerText: 'H" #{x}', footerText: "line\\end" },
+      settings: {
+        headerText: 'H" #{x}',
+        footerText: "line\\end",
+        organizationName: 'Acme" #{sys.exit()}',
+        logo: { bytes: pngBytes(), mediaType: "image/png", alt: 'alt" #{evil}' },
+      },
     });
     expect(bundle.main).toContain('header-text: "H\\" #{x}"');
     expect(bundle.main).toContain('footer-text: "line\\\\end"');
+    expect(bundle.main).toContain('organization-name: "Acme\\" #{sys.exit()}"');
+    expect(bundle.main).toContain('logo-alt: "alt\\" #{evil}"');
   });
 
   it("threads a validated logo as a virtual asset and emits its escaped path", () => {

--- a/packages/pdf/src/serialize.test.ts
+++ b/packages/pdf/src/serialize.test.ts
@@ -81,7 +81,7 @@ describe("PDF preparation and serialization", () => {
     expect(bundle.template).toContain('linebreaks: "optimized"');
     expect(bundle.main).toContain('region: "US"');
     expect(bundle.main).toContain("inset: (x: 6pt, y: 7pt)");
-    expect(bundle.template).toContain('let indigo = rgb("#4B57A3")');
+    expect(bundle.template).toContain('let indigo = rgb(settings.at("accent-color", default: "#4B57A3"))');
     expect(bundle.template).toContain('let cover-paper = rgb("#FCFBF8")');
     expect(bundle.template).toContain('text(font: "Source Serif 4", size: 31pt');
     expect(bundle.template).toContain("current-page > 1 and current-page < final-page");
@@ -796,6 +796,18 @@ describe("PDF settings threading into main.typ", () => {
     });
     expect(bundle.main).toContain('header-text: "H\\" #{x}"');
     expect(bundle.main).toContain('footer-text: "line\\\\end"');
+  });
+
+  it("threads a validated logo as a virtual asset and emits its escaped path", () => {
+    const bundle = serializePdfDocument(emptyDoc, {
+      metadata,
+      settings: { logo: { bytes: pngBytes(), mediaType: "image/png", alt: 'Acme "Corp"' } },
+    });
+    expect(bundle.main).toContain('logo: "assets/atlcli-logo.png"');
+    expect(bundle.main).toContain('logo-alt: "Acme \\"Corp\\""');
+    const asset = bundle.assets.find((entry) => entry.path === "assets/atlcli-logo.png");
+    expect(asset?.mediaType).toBe("image/png");
+    expect(asset?.bytes).toEqual(pngBytes());
   });
 
   it("serializes a watermark with defaults filled", () => {

--- a/packages/pdf/src/serialize.test.ts
+++ b/packages/pdf/src/serialize.test.ts
@@ -763,3 +763,51 @@ describe("PDF serialize — new ExportBlock variants (T0 no-op renderings)", () 
     expect(bundle.notes.some((n) => n.code === "pdf-link-unresolved")).toBe(false);
   });
 });
+
+describe("PDF settings threading into main.typ", () => {
+  const emptyDoc = { blocks: [], assets: [], notes: [] };
+
+  it("emits a defaulted settings dictionary when no settings are supplied", () => {
+    const bundle = serializePdfDocument(emptyDoc, { metadata });
+    expect(bundle.main).toContain("), settings: (");
+    expect(bundle.main).toContain('page: "a4"');
+    expect(bundle.main).toContain('orientation: "portrait"');
+    expect(bundle.main).toContain("cover: true");
+    expect(bundle.main).toContain("outline: true");
+    expect(bundle.main).toContain('accent-color: "#4B57A3"');
+    expect(bundle.main).not.toContain("header-text");
+    expect(bundle.main).not.toContain("watermark:");
+  });
+
+  it("emits Letter + landscape and organization name", () => {
+    const bundle = serializePdfDocument(emptyDoc, {
+      metadata,
+      settings: { page: "letter", orientation: "landscape", organizationName: "Acme" },
+    });
+    expect(bundle.main).toContain('page: "letter"');
+    expect(bundle.main).toContain('orientation: "landscape"');
+    expect(bundle.main).toContain('organization-name: "Acme"');
+  });
+
+  it("typstString-escapes header/footer text so injection stays literal", () => {
+    const bundle = serializePdfDocument(emptyDoc, {
+      metadata,
+      settings: { headerText: 'H" #{x}', footerText: "line\\end" },
+    });
+    expect(bundle.main).toContain('header-text: "H\\" #{x}"');
+    expect(bundle.main).toContain('footer-text: "line\\\\end"');
+  });
+
+  it("serializes a watermark with defaults filled", () => {
+    const bundle = serializePdfDocument(emptyDoc, {
+      metadata,
+      settings: { watermark: { text: "DRAFT" } },
+    });
+    expect(bundle.main).toContain("watermark: (");
+    expect(bundle.main).toContain('text: "DRAFT"');
+    expect(bundle.main).toContain('color: "#DE350B"');
+    expect(bundle.main).toContain("opacity: 0.08");
+    expect(bundle.main).toContain("angle: -54");
+    expect(bundle.main).toContain("size: 96");
+  });
+});

--- a/packages/pdf/src/serialize.ts
+++ b/packages/pdf/src/serialize.ts
@@ -1,5 +1,6 @@
 import type { ExportNote, InlineNode, LinkTarget } from "@atlcli/confluence";
 import { escapeTypstContent, safeColor, typstLabel, typstString } from "./escape.js";
+import { resolvePdfSettings, typstSettingsDict } from "./settings.js";
 import { createAtlcliTypstTemplate } from "./template.js";
 import {
   pdfColorContrast,
@@ -860,6 +861,7 @@ export function serializePdfDocument(
     contrastWarnings: new Set(),
   };
   const body = serializeBlocks(document.blocks, writer);
+  const settings = resolvePdfSettings(options.settings);
   const meta = options.metadata;
   const author = meta.author ?? meta.exporter ?? "atlcli";
   const exportedLabel = exportedDateLabel(meta.exportedAt, meta.language, meta.region);
@@ -875,7 +877,7 @@ export function serializePdfDocument(
   region: ${meta.region ? typstString(meta.region) : "none"},
   exported-at: ${typstDate(meta.exportedAt)},
   exported-label: ${typstString(exportedLabel)},
-))
+), settings: ${typstSettingsDict(settings)})
 
 ${body}
 `;

--- a/packages/pdf/src/serialize.ts
+++ b/packages/pdf/src/serialize.ts
@@ -13,6 +13,7 @@ import type {
   PdfSourceBundle,
   PdfSourceMapEntry,
   PdfTheme,
+  PreparedPdfAsset,
   PreparedPdfBlock,
   PreparedPdfDocument,
 } from "./types.js";
@@ -862,6 +863,17 @@ export function serializePdfDocument(
   };
   const body = serializeBlocks(document.blocks, writer);
   const settings = resolvePdfSettings(options.settings);
+  // The validated logo travels as a virtual asset file the compiler maps into
+  // its filesystem — the same path-emission pattern prepared image assets use.
+  // The "atlcli-logo" name cannot collide with prepared assets, whose paths
+  // always carry a numeric index and content hash.
+  const logoAsset: PreparedPdfAsset | undefined = settings.logo
+    ? {
+        path: settings.logo.mediaType === "image/png" ? "assets/atlcli-logo.png" : "assets/atlcli-logo.svg",
+        bytes: settings.logo.bytes,
+        mediaType: settings.logo.mediaType,
+      }
+    : undefined;
   const meta = options.metadata;
   const author = meta.author ?? meta.exporter ?? "atlcli";
   const exportedLabel = exportedDateLabel(meta.exportedAt, meta.language, meta.region);
@@ -877,7 +889,7 @@ export function serializePdfDocument(
   region: ${meta.region ? typstString(meta.region) : "none"},
   exported-at: ${typstDate(meta.exportedAt)},
   exported-label: ${typstString(exportedLabel)},
-), settings: ${typstSettingsDict(settings)})
+), settings: ${typstSettingsDict(settings, { logoPath: logoAsset?.path })})
 
 ${body}
 `;
@@ -885,7 +897,7 @@ ${body}
   return {
     main,
     template: createAtlcliTypstTemplate(options.theme),
-    assets: document.assets,
+    assets: logoAsset ? [...document.assets, logoAsset] : document.assets,
     sourceMap: resolveSourceMap(main, writer.sourceMap),
     notes: writer.notes,
   };

--- a/packages/pdf/src/settings.test.ts
+++ b/packages/pdf/src/settings.test.ts
@@ -186,6 +186,74 @@ describe("resolvePdfSettings logo validation", () => {
       );
     }
   });
+
+  it("rejects namespace-prefixed and URI-scheme SVG bypass attempts", () => {
+    const cases: Array<[string, string]> = [
+      ["<svg:script xmlns:svg=\"http://www.w3.org/2000/svg\">alert(1)</svg:script>", "blocked-element"],
+      ["<svg:foreignObject><body/></svg:foreignObject>", "blocked-element"],
+      ["<rect svg:onload=\"steal()\"/>", "event-handler-attribute"],
+      ["<a href=\"javascript:alert(1)\"><rect/></a>", "non-fragment-reference"],
+      ["<image href=\"../../etc/passwd\"/>", "non-fragment-reference"],
+      ["<image href=\"logo-helper.svg\"/>", "non-fragment-reference"],
+      ["<use xlink:href=\"https://evil.example/defs.svg#icon\"/>", "non-fragment-reference"],
+      ["<image href=\"data:image/png;base64,iVBORw0KGgo=\"/>", "non-fragment-reference"],
+    ];
+    for (const [inner, rule] of cases) {
+      const error = expectSettingsError(
+        () => resolvePdfSettings({ logo: { bytes: svgBytes(inner), mediaType: "image/svg+xml", alt: "Acme" } }),
+        "logo.bytes"
+      );
+      expect(error.constraint).toContain(rule);
+    }
+  });
+
+  it("rejects SVG logos containing DOCTYPE or ENTITY declarations", () => {
+    const doctype = new TextEncoder().encode(
+      '<!DOCTYPE svg [<!ENTITY xxe SYSTEM "file:///etc/passwd">]><svg xmlns="http://www.w3.org/2000/svg">&xxe;</svg>'
+    );
+    const error = expectSettingsError(
+      () => resolvePdfSettings({ logo: { bytes: doctype, mediaType: "image/svg+xml", alt: "Acme" } }),
+      "logo.bytes"
+    );
+    expect(error.constraint).toContain("doctype-or-entity");
+  });
+
+  it("still accepts a clean self-contained SVG with fragment references", () => {
+    const clean = svgBytes(
+      '<defs><linearGradient id="g"><stop offset="0"/></linearGradient><rect id="r" fill="url(#g)"/></defs><use href="#r"/><use xlink:href="#r"/>'
+    );
+    const resolved = resolvePdfSettings({
+      logo: { bytes: clean, mediaType: "image/svg+xml", alt: "Acme" },
+    });
+    expect(resolved.logo?.mediaType).toBe("image/svg+xml");
+  });
+});
+
+describe("resolvePdfSettings text caps and re-resolution", () => {
+  it("counts the 200 cap in Unicode code points, not UTF-16 code units", () => {
+    // 150 astral code points = 300 UTF-16 units: must be accepted.
+    const emoji = "🚀".repeat(150);
+    expect(resolvePdfSettings({ headerText: emoji }).headerText).toBe(emoji);
+    const error = expectSettingsError(
+      () => resolvePdfSettings({ headerText: "🚀".repeat(201) }),
+      "headerText"
+    );
+    expect(error.constraint).toContain("Unicode code points");
+  });
+
+  it("returns an already-resolved settings object unchanged without re-validating", () => {
+    let pageReads = 0;
+    const raw = {
+      get page(): "letter" {
+        pageReads += 1;
+        return "letter";
+      },
+    };
+    const resolved = resolvePdfSettings(raw);
+    expect(pageReads).toBe(1);
+    expect(resolvePdfSettings(resolved)).toBe(resolved);
+    expect(pageReads).toBe(1);
+  });
 });
 
 describe("typstSettingsDict", () => {

--- a/packages/pdf/src/settings.test.ts
+++ b/packages/pdf/src/settings.test.ts
@@ -1,0 +1,244 @@
+import { describe, expect, it } from "bun:test";
+import { PdfSettingsError, resolvePdfSettings, typstSettingsDict } from "./settings.js";
+import type { PdfLogoAsset } from "./types.js";
+
+function pngBytes(): Uint8Array {
+  return new Uint8Array([
+    0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+    0, 0, 0, 13, 0x49, 0x48, 0x44, 0x52,
+    0, 0, 0, 1, 0, 0, 0, 1,
+  ]);
+}
+
+function svgBytes(inner = ""): Uint8Array {
+  return new TextEncoder().encode(`<svg xmlns="http://www.w3.org/2000/svg">${inner}</svg>`);
+}
+
+function expectSettingsError(run: () => unknown, path: string): PdfSettingsError {
+  try {
+    run();
+  } catch (error) {
+    expect(error).toBeInstanceOf(PdfSettingsError);
+    const settingsError = error as PdfSettingsError;
+    expect(settingsError.path).toBe(path);
+    expect(settingsError.constraint.length).toBeGreaterThan(0);
+    return settingsError;
+  }
+  throw new Error(`expected a PdfSettingsError at ${path}`);
+}
+
+describe("resolvePdfSettings defaults", () => {
+  it("fills every Level-A default when nothing is supplied", () => {
+    expect(resolvePdfSettings()).toEqual({
+      page: "a4",
+      orientation: "portrait",
+      cover: true,
+      outline: true,
+      accentColor: "#4B57A3",
+    });
+  });
+
+  it("is deterministic for equal input", () => {
+    const input = { page: "letter" as const, orientation: "landscape" as const, headerText: "Acme" };
+    expect(resolvePdfSettings(input)).toEqual(resolvePdfSettings(input));
+  });
+
+  it("normalizes accent and watermark colors and fills watermark defaults", () => {
+    const resolved = resolvePdfSettings({
+      accentColor: "#abcdef",
+      watermark: { text: "DRAFT" },
+    });
+    expect(resolved.accentColor).toBe("#ABCDEF");
+    expect(resolved.watermark).toEqual({
+      text: "DRAFT",
+      color: "#DE350B",
+      opacity: 0.08,
+      angle: -54,
+      size: 96,
+    });
+  });
+});
+
+describe("resolvePdfSettings validation", () => {
+  it("rejects unknown enum values", () => {
+    expectSettingsError(() => resolvePdfSettings({ page: "a3" as never }), "page");
+    expectSettingsError(
+      () => resolvePdfSettings({ orientation: "sideways" as never }),
+      "orientation"
+    );
+  });
+
+  it("carries the offending value on the error", () => {
+    const error = expectSettingsError(() => resolvePdfSettings({ page: "a3" as never }), "page");
+    expect(error.value).toBe("a3");
+  });
+
+  it("rejects over-cap header/footer/organization text", () => {
+    const long = "x".repeat(201);
+    expectSettingsError(() => resolvePdfSettings({ headerText: long }), "headerText");
+    expectSettingsError(() => resolvePdfSettings({ footerText: long }), "footerText");
+    expectSettingsError(() => resolvePdfSettings({ organizationName: long }), "organizationName");
+    // Exactly at the cap is accepted.
+    expect(resolvePdfSettings({ headerText: "x".repeat(200) }).headerText).toHaveLength(200);
+  });
+
+  it("rejects an invalid accent color", () => {
+    expectSettingsError(() => resolvePdfSettings({ accentColor: "not-a-color" }), "accentColor");
+  });
+
+  it("rejects an empty watermark text", () => {
+    expectSettingsError(() => resolvePdfSettings({ watermark: { text: "  " } }), "watermark.text");
+  });
+
+  it("rejects watermark opacity at the 0/NaN/Infinity boundaries and clamps nothing", () => {
+    expectSettingsError(
+      () => resolvePdfSettings({ watermark: { text: "D", opacity: 0 } }),
+      "watermark.opacity"
+    );
+    expectSettingsError(
+      () => resolvePdfSettings({ watermark: { text: "D", opacity: Number.NaN } }),
+      "watermark.opacity"
+    );
+    expectSettingsError(
+      () => resolvePdfSettings({ watermark: { text: "D", opacity: Number.POSITIVE_INFINITY } }),
+      "watermark.opacity"
+    );
+    expectSettingsError(
+      () => resolvePdfSettings({ watermark: { text: "D", opacity: 1.0001 } }),
+      "watermark.opacity"
+    );
+    // Upper bound 1 is inclusive.
+    expect(resolvePdfSettings({ watermark: { text: "D", opacity: 1 } }).watermark?.opacity).toBe(1);
+  });
+
+  it("rejects watermark size and angle outside range", () => {
+    expectSettingsError(
+      () => resolvePdfSettings({ watermark: { text: "D", size: 7 } }),
+      "watermark.size"
+    );
+    expectSettingsError(
+      () => resolvePdfSettings({ watermark: { text: "D", size: 401 } }),
+      "watermark.size"
+    );
+    expectSettingsError(
+      () => resolvePdfSettings({ watermark: { text: "D", angle: -181 } }),
+      "watermark.angle"
+    );
+    expectSettingsError(
+      () => resolvePdfSettings({ watermark: { text: "D", angle: 181 } }),
+      "watermark.angle"
+    );
+  });
+});
+
+describe("resolvePdfSettings logo validation", () => {
+  it("accepts a valid PNG logo with alt", () => {
+    const logo: PdfLogoAsset = { bytes: pngBytes(), mediaType: "image/png", alt: "Acme" };
+    expect(resolvePdfSettings({ logo }).logo).toEqual({
+      bytes: logo.bytes,
+      mediaType: "image/png",
+      alt: "Acme",
+    });
+  });
+
+  it("accepts a sanitized SVG logo with alt", () => {
+    const logo: PdfLogoAsset = { bytes: svgBytes("<rect/>"), mediaType: "image/svg+xml", alt: "Acme" };
+    expect(resolvePdfSettings({ logo }).logo?.mediaType).toBe("image/svg+xml");
+  });
+
+  it("rejects PNG bytes that do not match the declared media type", () => {
+    const logo: PdfLogoAsset = { bytes: svgBytes(), mediaType: "image/png", alt: "Acme" };
+    expectSettingsError(() => resolvePdfSettings({ logo }), "logo.bytes");
+  });
+
+  it("rejects logos over the 5 MiB cap", () => {
+    const logo: PdfLogoAsset = {
+      bytes: new Uint8Array(5 * 1024 * 1024 + 1),
+      mediaType: "image/png",
+      alt: "Acme",
+    };
+    expectSettingsError(() => resolvePdfSettings({ logo }), "logo.bytes");
+  });
+
+  it("rejects a present logo with a missing or empty alt", () => {
+    const png = pngBytes();
+    expectSettingsError(
+      () => resolvePdfSettings({ logo: { bytes: png, mediaType: "image/png" } }),
+      "logo.alt"
+    );
+    expectSettingsError(
+      () => resolvePdfSettings({ logo: { bytes: png, mediaType: "image/png", alt: "   " } }),
+      "logo.alt"
+    );
+  });
+
+  it("rejects SVG logos carrying scripts, event handlers, or external references", () => {
+    const cases = [
+      "<script>alert(1)</script>",
+      "<rect onload=\"steal()\"/>",
+      "<foreignObject><body/></foreignObject>",
+      "<image href=\"https://evil.example/x.png\"/>",
+    ];
+    for (const inner of cases) {
+      expectSettingsError(
+        () => resolvePdfSettings({ logo: { bytes: svgBytes(inner), mediaType: "image/svg+xml", alt: "Acme" } }),
+        "logo.bytes"
+      );
+    }
+  });
+});
+
+describe("typstSettingsDict", () => {
+  it("emits defaults only when nothing is supplied", () => {
+    const dict = typstSettingsDict(resolvePdfSettings());
+    expect(dict).toContain('page: "a4"');
+    expect(dict).toContain('orientation: "portrait"');
+    expect(dict).toContain("cover: true");
+    expect(dict).toContain("outline: true");
+    expect(dict).toContain('accent-color: "#4B57A3"');
+    expect(dict).not.toContain("header-text");
+    expect(dict).not.toContain("watermark:");
+  });
+
+  it("emits kebab-case keys and filled watermark defaults", () => {
+    const dict = typstSettingsDict(
+      resolvePdfSettings({
+        page: "letter",
+        orientation: "landscape",
+        headerText: "Head",
+        footerText: "Foot",
+        organizationName: "Acme",
+        watermark: { text: "DRAFT" },
+      })
+    );
+    expect(dict).toContain('page: "letter"');
+    expect(dict).toContain('orientation: "landscape"');
+    expect(dict).toContain('header-text: "Head"');
+    expect(dict).toContain('footer-text: "Foot"');
+    expect(dict).toContain('organization-name: "Acme"');
+    expect(dict).toContain("watermark: (");
+    expect(dict).toContain('text: "DRAFT"');
+    expect(dict).toContain('color: "#DE350B"');
+    expect(dict).toContain("opacity: 0.08");
+    expect(dict).toContain("angle: -54");
+    expect(dict).toContain("size: 96");
+  });
+
+  it("keeps quote/backslash/#{ injection attempts literal in free-text fields", () => {
+    const attack = 'a" #{sys.exit()} \\ end';
+    const dict = typstSettingsDict(
+      resolvePdfSettings({
+        headerText: attack,
+        footerText: attack,
+        organizationName: attack,
+        watermark: { text: attack },
+      })
+    );
+    // The raw payload never appears unescaped: the closing quote is escaped and
+    // no interpolation marker survives outside a string literal.
+    expect(dict).not.toContain(`"${attack}"`);
+    expect(dict).toContain('\\" #{sys.exit()} \\\\ end');
+    // Every occurrence is inside a quoted, escaped string literal.
+    expect(dict).toContain(`header-text: "${attack.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`);
+  });
+});

--- a/packages/pdf/src/settings.test.ts
+++ b/packages/pdf/src/settings.test.ts
@@ -224,6 +224,16 @@ describe("typstSettingsDict", () => {
     expect(dict).toContain("size: 96");
   });
 
+  it("emits the logo path and alt only when serialize supplies the asset path", () => {
+    const resolved = resolvePdfSettings({
+      logo: { bytes: pngBytes(), mediaType: "image/png", alt: "Acme" },
+    });
+    expect(typstSettingsDict(resolved)).not.toContain("logo");
+    const dict = typstSettingsDict(resolved, { logoPath: "assets/atlcli-logo.png" });
+    expect(dict).toContain('logo: "assets/atlcli-logo.png"');
+    expect(dict).toContain('logo-alt: "Acme"');
+  });
+
   it("keeps quote/backslash/#{ injection attempts literal in free-text fields", () => {
     const attack = 'a" #{sys.exit()} \\ end';
     const dict = typstSettingsDict(

--- a/packages/pdf/src/settings.ts
+++ b/packages/pdf/src/settings.ts
@@ -241,8 +241,16 @@ function numberLiteral(value: number): string {
  * Emit the resolved settings as a Typst dictionary literal. Every host-supplied
  * string is escaped through `typstString`; kebab-case keys match the template's
  * defensive `settings.at("...")` reads (e.g. `headerText` → `header-text`).
+ *
+ * The logo is emitted as a virtual-filesystem *path* (plus its alt text), not
+ * as bytes: `serializePdfDocument` adds the validated bytes to the bundle's
+ * assets under that path and passes the path in via `options.logoPath`. Without
+ * a `logoPath` the logo entry is omitted entirely.
  */
-export function typstSettingsDict(resolved: ResolvedPdfSettings): string {
+export function typstSettingsDict(
+  resolved: ResolvedPdfSettings,
+  options: { logoPath?: string } = {}
+): string {
   const lines: string[] = [
     `  page: ${typstString(resolved.page)},`,
     `  orientation: ${typstString(resolved.orientation)},`,
@@ -258,6 +266,12 @@ export function typstSettingsDict(resolved: ResolvedPdfSettings): string {
   }
   if (resolved.organizationName !== undefined) {
     lines.push(`  organization-name: ${typstString(resolved.organizationName)},`);
+  }
+  if (resolved.logo && options.logoPath !== undefined) {
+    lines.push(
+      `  logo: ${typstString(options.logoPath)},`,
+      `  logo-alt: ${typstString(resolved.logo.alt)},`
+    );
   }
   if (resolved.watermark) {
     const watermark = resolved.watermark;

--- a/packages/pdf/src/settings.ts
+++ b/packages/pdf/src/settings.ts
@@ -16,6 +16,7 @@
  */
 import { normalizeExportColor } from "@atlcli/confluence";
 import { typstString } from "./escape.js";
+import { findSvgSafetyViolation } from "./svg-safety.js";
 import type { PdfLogoAsset, PdfTemplateSettings, PdfWatermarkSettings } from "./types.js";
 
 /** Structured validation failure naming the exact offending settings field. */
@@ -97,8 +98,10 @@ function resolveBoolean(value: boolean | undefined, fallback: boolean, path: str
 function resolveText(value: string | undefined, path: string): string | undefined {
   if (value === undefined) return undefined;
   if (typeof value !== "string") reject(path, value, "must be a string");
-  if (value.length > TEXT_MAX_LENGTH) {
-    reject(path, value, `must be at most ${TEXT_MAX_LENGTH} characters`);
+  // Count Unicode code points, not UTF-16 code units, so astral characters
+  // (emoji, rare CJK) are not double-counted against the cap.
+  if ([...value].length > TEXT_MAX_LENGTH) {
+    reject(path, value, `must be at most ${TEXT_MAX_LENGTH} Unicode code points`);
   }
   return value;
 }
@@ -166,14 +169,9 @@ function assertSafeSvg(bytes: Uint8Array): void {
   if (!/<svg(?:\s|>)/i.test(source.replace(/^﻿/, "").trimStart())) {
     reject("logo.bytes", undefined, "SVG bytes do not contain an <svg> root element");
   }
-  // Mirrors the export asset sanitizer in prepare.ts: reject scripts, embedded
-  // HTML, event handlers, and externally loaded (http/data) references.
-  if (
-    /<\s*(?:script|foreignObject)\b/i.test(source) ||
-    /\son[a-z]+\s*=/i.test(source) ||
-    /(?:href|xlink:href)\s*=\s*["']\s*(?:https?:|data:)/i.test(source)
-  ) {
-    reject("logo.bytes", undefined, "SVG contains active or externally loaded content");
+  const violation = findSvgSafetyViolation(source);
+  if (violation) {
+    reject("logo.bytes", undefined, `unsafe SVG (${violation.rule}): ${violation.detail}`);
   }
 }
 
@@ -201,12 +199,21 @@ function resolveLogo(logo: PdfLogoAsset): ResolvedPdfLogo {
   return { bytes: logo.bytes, mediaType: logo.mediaType, alt: logo.alt };
 }
 
+// Objects produced by resolvePdfSettings, so a second resolve pass (e.g.
+// runPdfExport validates first, serializePdfDocument receives the result) is
+// an identity no-op instead of re-running validation and the logo byte scan.
+const resolvedSettings = new WeakSet<ResolvedPdfSettings>();
+
 /**
  * Validate and default a partial public settings object into the complete
  * internal render settings. Throws {@link PdfSettingsError} on any invalid
- * value — this function never clamps.
+ * value — this function never clamps. Passing an object this function already
+ * returned short-circuits and returns it unchanged.
  */
 export function resolvePdfSettings(options: PdfTemplateSettings = {}): ResolvedPdfSettings {
+  if (resolvedSettings.has(options as ResolvedPdfSettings)) {
+    return options as ResolvedPdfSettings;
+  }
   const resolved: ResolvedPdfSettings = {
     page: resolveEnum(options.page, ["a4", "letter"] as const, "a4", "page"),
     orientation: resolveEnum(
@@ -229,6 +236,7 @@ export function resolvePdfSettings(options: PdfTemplateSettings = {}): ResolvedP
   if (options.logo !== undefined) resolved.logo = resolveLogo(options.logo);
   if (options.watermark !== undefined) resolved.watermark = resolveWatermark(options.watermark);
 
+  resolvedSettings.add(resolved);
   return resolved;
 }
 

--- a/packages/pdf/src/settings.ts
+++ b/packages/pdf/src/settings.ts
@@ -1,0 +1,275 @@
+/**
+ * Level-A PDF template settings: validation, defaulting, and Typst emission.
+ *
+ * `resolvePdfSettings` mirrors `resolvePdfTheme`'s throw-on-invalid style: it
+ * rejects (never silently clamps) out-of-range or malformed values, naming the
+ * offending field through a structured `PdfSettingsError`. `typstSettingsDict`
+ * emits the resolved values as a Typst dictionary literal — every host-supplied
+ * string passes through `typstString` from `escape.ts`, so a settings value can
+ * never inject Typst source (007 PLAN "Settings become code injection" STOP
+ * condition).
+ *
+ * The logo asset is validated here (PNG magic bytes / sanitized SVG / size cap /
+ * required alt) but is intentionally *not* emitted into the settings dictionary
+ * yet: threading its bytes through the asset pipeline and placing the image is
+ * the template-rendering task (T2.2), a strictly additive follow-up.
+ */
+import { normalizeExportColor } from "@atlcli/confluence";
+import { typstString } from "./escape.js";
+import type { PdfLogoAsset, PdfTemplateSettings, PdfWatermarkSettings } from "./types.js";
+
+/** Structured validation failure naming the exact offending settings field. */
+export class PdfSettingsError extends Error {
+  readonly path: string;
+  readonly value: unknown;
+  readonly constraint: string;
+
+  constructor(options: { path: string; value: unknown; constraint: string }) {
+    super(`Invalid PDF setting at ${options.path}: ${options.constraint}`);
+    this.name = "PdfSettingsError";
+    this.path = options.path;
+    this.value = options.value;
+    this.constraint = options.constraint;
+  }
+}
+
+export interface ResolvedPdfWatermark {
+  text: string;
+  color: string;
+  opacity: number;
+  angle: number;
+  size: number;
+}
+
+export interface ResolvedPdfLogo {
+  bytes: Uint8Array;
+  mediaType: "image/png" | "image/svg+xml";
+  alt: string;
+}
+
+/** Fully-defaulted internal settings ready for Typst emission. */
+export interface ResolvedPdfSettings {
+  page: "a4" | "letter";
+  orientation: "portrait" | "landscape";
+  cover: boolean;
+  outline: boolean;
+  headerText?: string;
+  footerText?: string;
+  accentColor: string;
+  organizationName?: string;
+  logo?: ResolvedPdfLogo;
+  watermark?: ResolvedPdfWatermark;
+}
+
+export const DEFAULT_PDF_ACCENT_COLOR = "#4B57A3";
+export const DEFAULT_PDF_WATERMARK_COLOR = "#DE350B";
+export const DEFAULT_PDF_WATERMARK_OPACITY = 0.08;
+export const DEFAULT_PDF_WATERMARK_ANGLE = -54;
+export const DEFAULT_PDF_WATERMARK_SIZE = 96;
+
+const TEXT_MAX_LENGTH = 200;
+const LOGO_MAX_BYTES = 5 * 1024 * 1024;
+const PNG_MAGIC = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+
+function reject(path: string, value: unknown, constraint: string): never {
+  throw new PdfSettingsError({ path, value, constraint });
+}
+
+function resolveEnum<T extends string>(
+  value: string | undefined,
+  allowed: readonly T[],
+  fallback: T,
+  path: string
+): T {
+  if (value === undefined) return fallback;
+  if (typeof value !== "string" || !allowed.includes(value as T)) {
+    reject(path, value, `must be one of ${allowed.map((entry) => `"${entry}"`).join(", ")}`);
+  }
+  return value as T;
+}
+
+function resolveBoolean(value: boolean | undefined, fallback: boolean, path: string): boolean {
+  if (value === undefined) return fallback;
+  if (typeof value !== "boolean") reject(path, value, "must be a boolean");
+  return value;
+}
+
+function resolveText(value: string | undefined, path: string): string | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== "string") reject(path, value, "must be a string");
+  if (value.length > TEXT_MAX_LENGTH) {
+    reject(path, value, `must be at most ${TEXT_MAX_LENGTH} characters`);
+  }
+  return value;
+}
+
+function resolveColor(value: string | undefined, fallback: string, path: string): string {
+  if (value === undefined) return fallback;
+  if (typeof value !== "string") reject(path, value, "must be a color string");
+  const normalized = normalizeExportColor(value);
+  if (!normalized) reject(path, value, "must be a valid color");
+  return normalized;
+}
+
+function resolveBoundedNumber(
+  value: number | undefined,
+  fallback: number,
+  bounds: { min: number; minInclusive: boolean; max: number },
+  path: string
+): number {
+  if (value === undefined) return fallback;
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    reject(path, value, "must be a finite number");
+  }
+  const aboveMin = bounds.minInclusive ? value >= bounds.min : value > bounds.min;
+  if (!aboveMin || value > bounds.max) {
+    const lower = bounds.minInclusive ? `[${bounds.min}` : `(${bounds.min}`;
+    reject(path, value, `must be within ${lower}, ${bounds.max}]`);
+  }
+  return value;
+}
+
+function resolveWatermark(watermark: PdfWatermarkSettings): ResolvedPdfWatermark {
+  if (typeof watermark.text !== "string" || watermark.text.trim() === "") {
+    reject("watermark.text", watermark.text, "must be a non-empty string");
+  }
+  return {
+    text: watermark.text,
+    color: resolveColor(watermark.color, DEFAULT_PDF_WATERMARK_COLOR, "watermark.color"),
+    opacity: resolveBoundedNumber(
+      watermark.opacity,
+      DEFAULT_PDF_WATERMARK_OPACITY,
+      { min: 0, minInclusive: false, max: 1 },
+      "watermark.opacity"
+    ),
+    angle: resolveBoundedNumber(
+      watermark.angle,
+      DEFAULT_PDF_WATERMARK_ANGLE,
+      { min: -180, minInclusive: true, max: 180 },
+      "watermark.angle"
+    ),
+    size: resolveBoundedNumber(
+      watermark.size,
+      DEFAULT_PDF_WATERMARK_SIZE,
+      { min: 8, minInclusive: true, max: 400 },
+      "watermark.size"
+    ),
+  };
+}
+
+function hasPngMagic(bytes: Uint8Array): boolean {
+  return bytes.length >= PNG_MAGIC.length && PNG_MAGIC.every((byte, index) => bytes[index] === byte);
+}
+
+function assertSafeSvg(bytes: Uint8Array): void {
+  const source = new TextDecoder().decode(bytes);
+  if (!/<svg(?:\s|>)/i.test(source.replace(/^﻿/, "").trimStart())) {
+    reject("logo.bytes", undefined, "SVG bytes do not contain an <svg> root element");
+  }
+  // Mirrors the export asset sanitizer in prepare.ts: reject scripts, embedded
+  // HTML, event handlers, and externally loaded (http/data) references.
+  if (
+    /<\s*(?:script|foreignObject)\b/i.test(source) ||
+    /\son[a-z]+\s*=/i.test(source) ||
+    /(?:href|xlink:href)\s*=\s*["']\s*(?:https?:|data:)/i.test(source)
+  ) {
+    reject("logo.bytes", undefined, "SVG contains active or externally loaded content");
+  }
+}
+
+function resolveLogo(logo: PdfLogoAsset): ResolvedPdfLogo {
+  if (!(logo.bytes instanceof Uint8Array) || logo.bytes.byteLength === 0) {
+    reject("logo.bytes", logo.bytes, "must be non-empty bytes");
+  }
+  if (logo.bytes.byteLength > LOGO_MAX_BYTES) {
+    reject("logo.bytes", logo.bytes.byteLength, "must be at most 5 MiB");
+  }
+  if (logo.mediaType !== "image/png" && logo.mediaType !== "image/svg+xml") {
+    reject("logo.mediaType", logo.mediaType, 'must be "image/png" or "image/svg+xml"');
+  }
+  if (logo.mediaType === "image/png") {
+    if (!hasPngMagic(logo.bytes)) {
+      reject("logo.bytes", logo.mediaType, "bytes do not match the declared PNG media type");
+    }
+  } else {
+    assertSafeSvg(logo.bytes);
+  }
+  if (logo.alt === undefined || (typeof logo.alt === "string" && logo.alt.trim() === "")) {
+    reject("logo.alt", logo.alt, "a present logo requires a non-empty alt text");
+  }
+  if (typeof logo.alt !== "string") reject("logo.alt", logo.alt, "must be a string");
+  return { bytes: logo.bytes, mediaType: logo.mediaType, alt: logo.alt };
+}
+
+/**
+ * Validate and default a partial public settings object into the complete
+ * internal render settings. Throws {@link PdfSettingsError} on any invalid
+ * value — this function never clamps.
+ */
+export function resolvePdfSettings(options: PdfTemplateSettings = {}): ResolvedPdfSettings {
+  const resolved: ResolvedPdfSettings = {
+    page: resolveEnum(options.page, ["a4", "letter"] as const, "a4", "page"),
+    orientation: resolveEnum(
+      options.orientation,
+      ["portrait", "landscape"] as const,
+      "portrait",
+      "orientation"
+    ),
+    cover: resolveBoolean(options.cover, true, "cover"),
+    outline: resolveBoolean(options.outline, true, "outline"),
+    accentColor: resolveColor(options.accentColor, DEFAULT_PDF_ACCENT_COLOR, "accentColor"),
+  };
+
+  const headerText = resolveText(options.headerText, "headerText");
+  if (headerText !== undefined) resolved.headerText = headerText;
+  const footerText = resolveText(options.footerText, "footerText");
+  if (footerText !== undefined) resolved.footerText = footerText;
+  const organizationName = resolveText(options.organizationName, "organizationName");
+  if (organizationName !== undefined) resolved.organizationName = organizationName;
+  if (options.logo !== undefined) resolved.logo = resolveLogo(options.logo);
+  if (options.watermark !== undefined) resolved.watermark = resolveWatermark(options.watermark);
+
+  return resolved;
+}
+
+function numberLiteral(value: number): string {
+  // Validated finite; avoid exponential/`Infinity` forms in Typst source.
+  return Object.is(value, -0) ? "0" : String(value);
+}
+
+/**
+ * Emit the resolved settings as a Typst dictionary literal. Every host-supplied
+ * string is escaped through `typstString`; kebab-case keys match the template's
+ * defensive `settings.at("...")` reads (e.g. `headerText` → `header-text`).
+ */
+export function typstSettingsDict(resolved: ResolvedPdfSettings): string {
+  const lines: string[] = [
+    `  page: ${typstString(resolved.page)},`,
+    `  orientation: ${typstString(resolved.orientation)},`,
+    `  cover: ${resolved.cover ? "true" : "false"},`,
+    `  outline: ${resolved.outline ? "true" : "false"},`,
+    `  accent-color: ${typstString(resolved.accentColor)},`,
+  ];
+  if (resolved.headerText !== undefined) {
+    lines.push(`  header-text: ${typstString(resolved.headerText)},`);
+  }
+  if (resolved.footerText !== undefined) {
+    lines.push(`  footer-text: ${typstString(resolved.footerText)},`);
+  }
+  if (resolved.organizationName !== undefined) {
+    lines.push(`  organization-name: ${typstString(resolved.organizationName)},`);
+  }
+  if (resolved.watermark) {
+    const watermark = resolved.watermark;
+    lines.push(
+      "  watermark: (",
+      `    text: ${typstString(watermark.text)},`,
+      `    color: ${typstString(watermark.color)},`,
+      `    opacity: ${numberLiteral(watermark.opacity)},`,
+      `    angle: ${numberLiteral(watermark.angle)},`,
+      `    size: ${numberLiteral(watermark.size)},`,
+      "  ),"
+    );
+  }
+  return `(\n${lines.join("\n")}\n)`;
+}

--- a/packages/pdf/src/svg-safety.ts
+++ b/packages/pdf/src/svg-safety.ts
@@ -1,0 +1,73 @@
+/**
+ * Shared SVG safety blocklist for every SVG entering the PDF pipeline: logo
+ * settings (`settings.ts`) and fetched/diagram assets (`prepare.ts`). One
+ * helper, two callers — the two paths must not drift.
+ *
+ * This is a validator, not a rewriter: the first violated rule is returned and
+ * the caller rejects the bytes. The rules are deliberately a small, named,
+ * auditable list implemented with case-insensitive, namespace-prefix-aware
+ * regexes (an XML parser dependency is intentionally avoided; over-rejection
+ * of exotic-but-legal SVG is acceptable, under-rejection is not):
+ *
+ * 1. `doctype-or-entity` — any `<!DOCTYPE` or `<!ENTITY` (XXE / entity
+ *    expansion class).
+ * 2. `blocked-element` — `script` / `foreignObject` elements, with or without
+ *    a namespace prefix (`<svg:script>` must not bypass the check).
+ * 3. `event-handler-attribute` — any `on*` attribute, with or without a
+ *    namespace prefix (`onload=`, `svg:onload=`).
+ * 4. `non-fragment-reference` — any `href` / `*:href` value that is not empty
+ *    and not a pure `#fragment` reference. This blocks `javascript:` and
+ *    `data:` URIs, external URLs, and relative paths alike — bundled bytes
+ *    must never reference anything outside themselves.
+ */
+
+export interface SvgSafetyViolation {
+  rule: "doctype-or-entity" | "blocked-element" | "event-handler-attribute" | "non-fragment-reference";
+  detail: string;
+}
+
+// XML names may carry a namespace prefix; every rule matches the local name
+// behind any `prefix:`.
+const NAME_PREFIX = String.raw`(?:[A-Za-z_][\w.-]*:)?`;
+
+const DOCTYPE_OR_ENTITY = /<!(?:DOCTYPE|ENTITY)\b/i;
+const BLOCKED_ELEMENT = new RegExp(String.raw`<\s*${NAME_PREFIX}(?:script|foreignObject)\b`, "i");
+const EVENT_HANDLER = new RegExp(String.raw`[\s"']${NAME_PREFIX}on[a-z]+\s*=`, "i");
+const HREF_ATTRIBUTE = new RegExp(
+  String.raw`[\s"']${NAME_PREFIX}href\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))`,
+  "gi"
+);
+
+/** Returns the first violated safety rule, or `undefined` for a clean SVG. */
+export function findSvgSafetyViolation(source: string): SvgSafetyViolation | undefined {
+  if (DOCTYPE_OR_ENTITY.test(source)) {
+    return {
+      rule: "doctype-or-entity",
+      detail: "DOCTYPE and ENTITY declarations are not allowed",
+    };
+  }
+  if (BLOCKED_ELEMENT.test(source)) {
+    return {
+      rule: "blocked-element",
+      detail: "script and foreignObject elements are not allowed",
+    };
+  }
+  if (EVENT_HANDLER.test(source)) {
+    return {
+      rule: "event-handler-attribute",
+      detail: "on* event handler attributes are not allowed",
+    };
+  }
+  HREF_ATTRIBUTE.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = HREF_ATTRIBUTE.exec(source)) !== null) {
+    const value = (match[1] ?? match[2] ?? match[3] ?? "").trim();
+    if (value !== "" && !value.startsWith("#")) {
+      return {
+        rule: "non-fragment-reference",
+        detail: "href values must be empty or #fragment references (no external, data:, javascript:, or relative targets)",
+      };
+    }
+  }
+  return undefined;
+}

--- a/packages/pdf/src/template.test.ts
+++ b/packages/pdf/src/template.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "bun:test";
+import { ATLCLI_TYPST_TEMPLATE } from "./template.js";
+
+describe("atlcli Typst template settings rendering", () => {
+  const template = ATLCLI_TYPST_TEMPLATE;
+
+  it("reads page geometry from settings", () => {
+    expect(template).toContain('let page-size = settings.at("page", default: "a4")');
+    expect(template).toContain('if page-size == "letter" { "us-letter" } else { page-size }');
+    expect(template).toContain("paper: paper-name");
+    expect(template).toContain(
+      'flipped: settings.at("orientation", default: "portrait") == "landscape"'
+    );
+  });
+
+  it("defines the watermark layer and wires it as the page background", () => {
+    expect(template).toContain("#let watermark-layer(wm)");
+    expect(template).toContain('background: watermark-layer(settings.at("watermark", default: none))');
+    expect(template).toContain("transparentize(");
+    expect(template).toContain("place(center + horizon, rotate(");
+  });
+
+  it("wraps the cover and its trailing pagebreak in one guard", () => {
+    const guard = template.match(/if settings\.at\("cover", default: true\) \{[\s\S]*?\n {2}\}/)?.[0];
+    expect(guard).toBeDefined();
+    expect(guard).toContain("pagebreak()");
+    expect(guard).toContain("meta.title");
+  });
+
+  it("wraps the outline and its trailing pagebreak in one guard", () => {
+    const guard = template.match(/if settings\.at\("outline", default: true\) \{[\s\S]*?\n {2}\}/)?.[0];
+    expect(guard).toBeDefined();
+    expect(guard).toContain("outline(title: contents-label, depth: 3)");
+    expect(guard).toContain("pagebreak()");
+  });
+
+  it("keeps the intervening white page fill unconditional", () => {
+    const betweenGuards = template.slice(
+      template.indexOf('if settings.at("cover"'),
+      template.indexOf('if settings.at("outline"')
+    );
+    expect(betweenGuards).toContain("set page(fill: white)");
+  });
+
+  it("derives the accent color, header, footer, and branding from settings", () => {
+    expect(template).toContain('let indigo = rgb(settings.at("accent-color", default: "#4B57A3"))');
+    expect(template).toContain('settings.at("header-text", default: none)');
+    expect(template).toContain('settings.at("footer-text", default: none)');
+    expect(template).toContain('settings.at("organization-name", default: none)');
+    expect(template).toContain('settings.at("logo", default: none)');
+    expect(template).toContain('settings.at("logo-alt", default: "")');
+    expect(template).toContain('image(logo-path, height: 12mm, width: 45mm, fit: "contain", alt: logo-alt)');
+  });
+
+  it("contains no unescaped template-literal leftovers", () => {
+    expect(template).not.toContain("${");
+  });
+});

--- a/packages/pdf/src/template.ts
+++ b/packages/pdf/src/template.ts
@@ -56,10 +56,26 @@ export function createAtlcliTypstTemplate(options: PdfThemeOptions = {}): string
   )
 }
 
+// Rotated text layer drawn under the content via set page(background: ...),
+// which makes it a page Artifact in the tagged PDF by Typst's own
+// page-background semantics.
+#let watermark-layer(wm) = if wm == none { none } else {
+  place(center + horizon, rotate(
+    wm.at("angle", default: -54) * 1deg,
+    text(
+      font: "Source Sans 3",
+      weight: "bold",
+      size: wm.at("size", default: 96) * 1pt,
+      fill: rgb(wm.at("color", default: "#DE350B"))
+        .transparentize(100% - wm.at("opacity", default: 0.08) * 100%),
+      wm.text,
+    ),
+  ))
+}
+
 // wiki.pdf-template/v1 render surface: render(meta, body, settings).
 // settings: (:) keeps callers that pass no settings compiling; every settings
-// read below must use settings.at("key", default: ...). Geometry/toggle/
-// watermark rendering from settings lands in a later task (T2.2/T2.3).
+// read below must use settings.at("key", default: ...).
 #let atlcli-doc(meta: (:), settings: (:), body) = {
   let is-german = meta.at("language", default: "en") == "de"
   let version-label = [Version]
@@ -68,7 +84,18 @@ export function createAtlcliTypstTemplate(options: PdfThemeOptions = {}): string
   let contents-label = if is-german { [Inhalt] } else { [Contents] }
   let end-label = if is-german { [DOKUMENTENDE] } else { [END OF DOCUMENT] }
   let pages-label = if is-german { [Seiten] } else { [Pages] }
-  let indigo = rgb("#4B57A3")
+  let indigo = rgb(settings.at("accent-color", default: "#4B57A3"))
+  let org-name = settings.at("organization-name", default: none)
+  let logo-path = settings.at("logo", default: none)
+  let logo-alt = settings.at("logo-alt", default: "")
+  let space-label = if org-name == none {
+    [CONFLUENCE SPACE / #meta.space]
+  } else {
+    [#upper(org-name) / CONFLUENCE SPACE / #meta.space]
+  }
+  // Public settings say "letter"; Typst's paper catalog names it "us-letter".
+  let page-size = settings.at("page", default: "a4")
+  let paper-name = if page-size == "letter" { "us-letter" } else { page-size }
   let ink = rgb("#202A44")
   let warm-slate = rgb("#74727A")
   let cover-paper = rgb("${theme.colors.paper}")
@@ -101,22 +128,39 @@ export function createAtlcliTypstTemplate(options: PdfThemeOptions = {}): string
     spacing: 8pt,
   )
   set page(
-    paper: "a4",
+    paper: paper-name,
+    flipped: settings.at("orientation", default: "portrait") == "landscape",
     fill: cover-paper,
     margin: (top: 23mm, bottom: 20mm, left: 22mm, right: 22mm),
+    background: watermark-layer(settings.at("watermark", default: none)),
     header: context {
       let current-page = counter(page).get().first()
       let final-page = counter(page).final().first()
       if current-page > 1 and current-page < final-page {
         set text(font: "Source Sans 3", size: 8pt, fill: rgb("#6B778C"))
-        grid(columns: (1fr, auto), meta.title, meta.space)
+        let header-text = settings.at("header-text", default: none)
+        if header-text == none {
+          grid(columns: (1fr, auto), meta.title, meta.space)
+        } else {
+          header-text
+        }
         line(length: 100%, stroke: rgb("#DFE1E6"))
       }
     },
     footer: context {
       if counter(page).get().first() > 1 {
         set text(font: "Source Sans 3", size: 8pt, fill: rgb("#6B778C"))
-        align(center)[#counter(page).display("1")]
+        let footer-text = settings.at("footer-text", default: none)
+        if footer-text == none and org-name == none {
+          align(center)[#counter(page).display("1")]
+        } else {
+          grid(
+            columns: (1fr, auto, 1fr),
+            align(left, if footer-text == none [] else { footer-text }),
+            align(center)[#counter(page).display("1")],
+            align(right, if org-name == none [] else { org-name }),
+          )
+        }
       }
     },
   )
@@ -146,34 +190,41 @@ export function createAtlcliTypstTemplate(options: PdfThemeOptions = {}): string
     it
   }
 
-  v(37mm)
-  block(width: 90%)[
-    #set text(font: "Source Sans 3")
-    #text(size: 8pt, weight: "semibold", tracking: 0.12em, fill: indigo)[CONFLUENCE SPACE / #meta.space]
-    #v(17pt)
-    #block(width: 100%)[
-      #set par(leading: 0.98em)
-      #text(font: "Source Serif 4", size: 31pt, weight: "semibold", fill: ink)[#meta.title]
+  if settings.at("cover", default: true) {
+    v(37mm)
+    block(width: 90%)[
+      #set text(font: "Source Sans 3")
+      #if logo-path != none [
+        #block(below: 18pt)[#image(logo-path, height: 12mm, width: 45mm, fit: "contain", alt: logo-alt)]
+      ]
+      #text(size: 8pt, weight: "semibold", tracking: 0.12em, fill: indigo, space-label)
+      #v(17pt)
+      #block(width: 100%)[
+        #set par(leading: 0.98em)
+        #text(font: "Source Serif 4", size: 31pt, weight: "semibold", fill: ink)[#meta.title]
+      ]
+      #v(25pt)
+      #line(length: 52mm, stroke: 0.9pt + indigo)
+      #v(23pt)
+      #grid(
+        columns: (30mm, 1fr),
+        column-gutter: 12pt,
+        row-gutter: 8pt,
+        text(size: 7.5pt, weight: "semibold", tracking: 0.08em, fill: warm-slate, upper(version-label)),
+        text(size: 9.5pt, fill: ink, meta.version),
+        text(size: 7.5pt, weight: "semibold", tracking: 0.08em, fill: warm-slate, upper(exported-label)),
+        text(size: 9.5pt, fill: ink, meta.exported-label),
+        text(size: 7.5pt, weight: "semibold", tracking: 0.08em, fill: warm-slate, upper(exporter-label)),
+        text(size: 9.5pt, fill: ink, meta.exporter),
+      )
     ]
-    #v(25pt)
-    #line(length: 52mm, stroke: 0.9pt + indigo)
-    #v(23pt)
-    #grid(
-      columns: (30mm, 1fr),
-      column-gutter: 12pt,
-      row-gutter: 8pt,
-      text(size: 7.5pt, weight: "semibold", tracking: 0.08em, fill: warm-slate, upper(version-label)),
-      text(size: 9.5pt, fill: ink, meta.version),
-      text(size: 7.5pt, weight: "semibold", tracking: 0.08em, fill: warm-slate, upper(exported-label)),
-      text(size: 9.5pt, fill: ink, meta.exported-label),
-      text(size: 7.5pt, weight: "semibold", tracking: 0.08em, fill: warm-slate, upper(exporter-label)),
-      text(size: 9.5pt, fill: ink, meta.exporter),
-    )
-  ]
-  pagebreak()
+    pagebreak()
+  }
   set page(fill: white)
-  outline(title: contents-label, depth: 3)
-  pagebreak()
+  if settings.at("outline", default: true) {
+    outline(title: contents-label, depth: 3)
+    pagebreak()
+  }
   body
   pagebreak()
   set page(fill: cover-paper)

--- a/packages/pdf/src/template.ts
+++ b/packages/pdf/src/template.ts
@@ -1,6 +1,35 @@
 /**
  * Pinned atlcli Typst standard template. It uses semantic Typst elements and
  * show rules so PDF tagging/outline information survives visual styling.
+ *
+ * ## `wiki.pdf-template/v1` contract
+ *
+ * `atlcli-doc(meta, settings, body)` is the built-in implementation of the
+ * versioned template surface `render(meta, body, settings)` (TEMPLATE-UX §7).
+ * Renaming the symbol is not required — the contract names the *shape*, not the
+ * symbol.
+ *
+ * Required `meta` keys a conforming template may rely on: `title`, `space`,
+ * `version`, `author`, `language`, `exported-at` (plus the derived
+ * `exporter`, `region`, `exported-label` this engine also supplies).
+ *
+ * `settings` is a Typst dictionary read *defensively* — every access uses
+ * `settings.at("<key>", default: ...)` so sparse dictionaries and older callers
+ * that pass no `settings` keep compiling. `settings: (:)` is itself the
+ * backward-compatible default. Adding a settings key is non-breaking; removing
+ * or renaming one bumps the `engine.api` string.
+ *
+ * ### Stable v1 import surface (the hook set)
+ *
+ * `serialize.ts` imports eight symbols from this generated `atlcli.typ`:
+ * `atlcli-doc`, `callout`, `status-badge`, `table-par`, `dense-token`,
+ * `dense-link`, `dense-status-badge`, `task-item`. All eight are the frozen v1
+ * hook set a conforming template must export; generated content may depend on
+ * these and no other, undocumented, template-local functions (TEMPLATE-UX §7).
+ * Shrinking this set — relocating the five dense-table/table helpers into
+ * engine-owned code so an external template overrides fewer hooks — is a
+ * deliberate follow-up once a real Level-B template needs it, not part of this
+ * contract's first cut.
  */
 import { resolvePdfTheme } from "./theme.js";
 import type { PdfThemeOptions } from "./types.js";
@@ -27,7 +56,11 @@ export function createAtlcliTypstTemplate(options: PdfThemeOptions = {}): string
   )
 }
 
-#let atlcli-doc(meta: (:), body) = {
+// wiki.pdf-template/v1 render surface: render(meta, body, settings).
+// settings: (:) keeps callers that pass no settings compiling; every settings
+// read below must use settings.at("key", default: ...). Geometry/toggle/
+// watermark rendering from settings lands in a later task (T2.2/T2.3).
+#let atlcli-doc(meta: (:), settings: (:), body) = {
   let is-german = meta.at("language", default: "en") == "de"
   let version-label = [Version]
   let exported-label = if is-german { [Exportiert] } else { [Exported] }

--- a/packages/pdf/src/types.ts
+++ b/packages/pdf/src/types.ts
@@ -202,3 +202,32 @@ export interface PdfCompilerDiagnostic {
 }
 
 export type { ExportBlock, ExportNote, InlineNode, LinkTarget };
+
+/**
+ * Font-intake seam (spec 007 B5). An approved corporate font face a host may
+ * feed into the PDF compiler. The engine never fetches font bytes: a host
+ * resolves them through a {@link FontSource} and hands them to the compiler as
+ * `Uint8Array[]`, after gating each one through `verifyFontBytes` (see
+ * `fonts.ts`).
+ */
+export interface FontAsset {
+  family: string;
+  style: "normal" | "italic";
+  weight: number;
+  /** Lowercase hex SHA-256 of the exact font bytes; re-verified before use. */
+  sha256: string;
+  /** Optional license attestation carried alongside the approved face. */
+  license?: { kind: "OFL" | "Apache-2.0" | "proprietary"; evidence: string };
+}
+
+/**
+ * Host-provided port for approved fonts, mirroring {@link PdfAssetResolver}.
+ * Implementers own storage and the upload/attestation flow (host follow-ups);
+ * the engine only consumes `list()` (e.g. to build a `choice` setting's options)
+ * and `getBytes(sha256)`, whose result MUST be passed through `verifyFontBytes`
+ * before it reaches the compiler.
+ */
+export interface FontSource {
+  list(): Promise<FontAsset[]>;
+  getBytes(sha256: string): Promise<Uint8Array>;
+}

--- a/packages/pdf/src/types.ts
+++ b/packages/pdf/src/types.ts
@@ -114,10 +114,61 @@ export interface PdfTheme {
   };
 }
 
+/**
+ * Level-A PDF template settings — the fixed, built-in settings surface.
+ *
+ * IMPORTANT boundary: `PdfTemplateSettings` is a *closed* set of named fields
+ * consumed directly by the built-in `atlcli-doc` template. It is **not** the
+ * same shape as a template-pack manifest's `settings` map, which is an *open*,
+ * arbitrarily-named, typed dictionary (`accent`, `logo`, font choices, …) used
+ * by Level-B templates. This folder deliberately does not thread
+ * manifest-declared custom settings into the render call — that requires the
+ * host-side Level-B template-loading glue that lives outside `packages/pdf`.
+ * A later folder must keep the two shapes distinct rather than conflating them
+ * (see 007 PLAN "Built-in vs. manifest settings" risk).
+ *
+ * All fields are optional and plain JSON-able so every host (CLI flags,
+ * extension form, further hosts) can supply them without importing engine code.
+ */
+export interface PdfWatermarkSettings {
+  /** Watermark text. Required when a watermark is requested; must be non-empty. */
+  text: string;
+  /** `#RRGGBB`; default `#DE350B`. */
+  color?: string;
+  /** In `(0, 1]`; default `0.08`. `0`, `NaN`, and `Infinity` are rejected. */
+  opacity?: number;
+  /** Rotation in degrees, `-180..180`; default `-54`. */
+  angle?: number;
+  /** Glyph size in pt, `8..400`; default `96`. */
+  size?: number;
+}
+
+export interface PdfLogoAsset {
+  bytes: Uint8Array;
+  mediaType: "image/png" | "image/svg+xml";
+  /** Required when the logo is present (meaning-bearing); must be non-empty. */
+  alt?: string;
+}
+
+export interface PdfTemplateSettings {
+  page?: "a4" | "letter";
+  orientation?: "portrait" | "landscape";
+  cover?: boolean;
+  outline?: boolean;
+  headerText?: string;
+  footerText?: string;
+  /** `#RRGGBB`; default the built-in indigo `#4B57A3`. */
+  accentColor?: string;
+  organizationName?: string;
+  logo?: PdfLogoAsset;
+  watermark?: PdfWatermarkSettings;
+}
+
 export interface PdfSerializeOptions {
   metadata: PdfExportMetadata;
   profile?: PdfProfile;
   theme?: PdfThemeOptions;
+  settings?: PdfTemplateSettings;
 }
 
 export interface PdfExportTimings {

--- a/packages/template-pack/package.json
+++ b/packages/template-pack/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@atlcli/template-pack",
+  "version": "0.6.0",
+  "license": "Apache-2.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "browser": "./src/index.browser.ts",
+      "default": "./src/index.ts"
+    },
+    "./browser": "./src/index.browser.ts",
+    "./node": "./src/index.ts"
+  },
+  "dependencies": {
+    "@atlcli/core": "workspace:*",
+    "@atlcli/docx": "workspace:*",
+    "pizzip": "^3.2.0"
+  }
+}

--- a/packages/template-pack/src/index.browser.ts
+++ b/packages/template-pack/src/index.browser.ts
@@ -1,0 +1,12 @@
+/**
+ * Browser-safe entry point for `@atlcli/template-pack` (spec 007 T2.4).
+ *
+ * Pure byte-in/byte-out functions for the `.wiki-pdf-template` container,
+ * shared by the Typst and DOCX engines. Every module re-exported here MUST
+ * build for `--target=browser` with zero `node:`/`bun:` specifiers in its
+ * transitive graph — enforced by `scripts/check-browser-build.ts`.
+ */
+export * from "./manifest.js";
+export * from "./pack.js";
+export * from "./unpack.js";
+export * from "./validate.js";

--- a/packages/template-pack/src/index.ts
+++ b/packages/template-pack/src/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Node entry point for `@atlcli/template-pack` (spec 007 T2.4).
+ *
+ * The container functions are isomorphic, so the node entry is identical to the
+ * browser entry — there are no node-only adapters. Kept as a separate file to
+ * match the dual-entry convention of the other packages.
+ */
+export * from "./index.browser.js";

--- a/packages/template-pack/src/manifest.test.ts
+++ b/packages/template-pack/src/manifest.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Manifest import-gate tests (spec 007 T2.4). Each rejection carries a typed
+ * reason so a host can render an actionable hint.
+ */
+import { describe, expect, it } from "bun:test";
+import {
+  validateManifest,
+  satisfiesRange,
+  ManifestValidationError,
+  PINNED_TYPST_VERSION,
+  type ManifestErrorReason,
+} from "./manifest.js";
+
+function base(): Record<string, unknown> {
+  return {
+    schemaVersion: 1,
+    id: "com.acme.doc",
+    name: "Acme",
+    version: "1.0.0",
+    engine: { kind: "typst", api: "wiki.pdf-template/v1", entry: "template.typ" },
+  };
+}
+
+function expectReason(json: unknown, reason: ManifestErrorReason): void {
+  try {
+    validateManifest(json);
+    throw new Error("expected ManifestValidationError, none thrown");
+  } catch (err) {
+    expect(err).toBeInstanceOf(ManifestValidationError);
+    expect((err as ManifestValidationError).reason).toBe(reason);
+  }
+}
+
+describe("validateManifest gate", () => {
+  it("accepts a minimal valid typst manifest", () => {
+    const m = validateManifest(base());
+    expect(m.engine.kind).toBe("typst");
+    expect(m.engine.api).toBe("wiki.pdf-template/v1");
+  });
+
+  it("accepts a valid docx manifest", () => {
+    const m = validateManifest({
+      ...base(),
+      engine: { kind: "docx", api: "wiki.docx-template/v1", entry: "template.docx" },
+    });
+    expect(m.engine.kind).toBe("docx");
+  });
+
+  it("rejects an unknown schemaVersion with unknown-schema-version", () => {
+    expectReason({ ...base(), schemaVersion: 2 }, "unknown-schema-version");
+  });
+
+  it("rejects an unrecognized engine.api with unknown-api", () => {
+    expectReason(
+      { ...base(), engine: { kind: "typst", api: "wiki.pdf-template/v2", entry: "template.typ" } },
+      "unknown-api"
+    );
+  });
+
+  it("rejects a docx manifest carrying the typst api with unknown-api", () => {
+    expectReason(
+      { ...base(), engine: { kind: "docx", api: "wiki.pdf-template/v1", entry: "template.docx" } },
+      "unknown-api"
+    );
+  });
+
+  it("rejects a compilerRange the pinned compiler does not satisfy", () => {
+    expectReason(
+      {
+        ...base(),
+        engine: {
+          kind: "typst",
+          api: "wiki.pdf-template/v1",
+          entry: "template.typ",
+          compilerRange: ">=0.15 <0.16",
+        },
+      },
+      "compiler-range-mismatch"
+    );
+  });
+
+  it("accepts a compilerRange the pinned compiler satisfies", () => {
+    const m = validateManifest({
+      ...base(),
+      engine: {
+        kind: "typst",
+        api: "wiki.pdf-template/v1",
+        entry: "template.typ",
+        compilerRange: ">=0.14 <0.15",
+      },
+    });
+    expect(m.engine.compilerRange).toBe(">=0.14 <0.15");
+  });
+
+  it("does not compiler-gate docx manifests", () => {
+    const m = validateManifest({
+      ...base(),
+      engine: {
+        kind: "docx",
+        api: "wiki.docx-template/v1",
+        entry: "template.docx",
+        compilerRange: ">=99.0",
+      },
+    });
+    expect(m.engine.kind).toBe("docx");
+  });
+
+  it("rejects a malformed manifest shape with shape-error", () => {
+    expectReason({ ...base(), id: "" }, "shape-error");
+    expectReason({ ...base(), engine: { kind: "png", api: "x", entry: "y" } }, "shape-error");
+  });
+
+  it("shape-checks requiredFonts and settings without cross-checking availability", () => {
+    const m = validateManifest({
+      ...base(),
+      requiredFonts: [{ family: "Source Sans 3", style: "normal", weight: 400 }],
+      settings: { cover: { type: "boolean", default: true } },
+    });
+    expect(m.requiredFonts?.[0].family).toBe("Source Sans 3");
+    expect(m.settings?.cover.type).toBe("boolean");
+    expectReason({ ...base(), settings: { x: { type: "wat" } } }, "shape-error");
+  });
+});
+
+describe("satisfiesRange", () => {
+  it("supports the documented range forms", () => {
+    expect(satisfiesRange("0.14.2", ">=0.14 <0.15")).toBe(true);
+    expect(satisfiesRange("0.14.2", ">=0.15")).toBe(false);
+    expect(satisfiesRange("0.14.2", "<0.15")).toBe(true);
+    expect(satisfiesRange("0.14.2", ">0.14")).toBe(true);
+    expect(satisfiesRange("0.14.2", "<=0.14.2")).toBe(true);
+    expect(satisfiesRange("0.14.2", "=0.14.2")).toBe(true);
+    expect(satisfiesRange("0.14.2", "0.14.2")).toBe(true);
+    expect(satisfiesRange("0.14.2", "0.14.1")).toBe(false);
+  });
+
+  it("throws shape-error on an unsupported range token", () => {
+    expect(() => satisfiesRange("0.14.2", "^0.14")).toThrow(ManifestValidationError);
+  });
+
+  it("gates against the pinned version by default", () => {
+    expect(PINNED_TYPST_VERSION).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+});

--- a/packages/template-pack/src/manifest.ts
+++ b/packages/template-pack/src/manifest.ts
@@ -1,0 +1,338 @@
+/**
+ * `.wiki-pdf-template` manifest schema + import gate (spec 007 T2.4).
+ *
+ * The manifest (`wiki-pdf-template.json`) is the first entry in every pack. It
+ * pins the template API and, for the Typst engine, the compiler compatibility
+ * range. {@link validateManifest} is therefore not merely a shape check but the
+ * **import gate** (TEMPLATE-UX §9): it rejects an unknown `schemaVersion`, an
+ * `engine.api` that is not a recognized `wiki.{pdf,docx}-template/v1` value, and
+ * a Typst `compilerRange` the pinned compiler does not satisfy — each with a
+ * typed, actionable reason so a host can render an upgrade/downgrade hint
+ * instead of a raw parse error.
+ *
+ * The compiler check is a pure string/semver comparison against the pinned
+ * version; actually invoking the compiler against the canonical feature zoo
+ * stays the deferred Level-B host follow-up (TEMPLATE-UX §9).
+ *
+ * Browser-safe: no `node:`/`bun:` imports.
+ */
+
+/** Manifest file name; always the first entry in a pack. */
+export const TEMPLATE_PACK_MANIFEST_NAME = "wiki-pdf-template.json";
+
+/** The only schema version recognized at ship time. */
+export const SUPPORTED_SCHEMA_VERSION = 1;
+
+/**
+ * Pinned Typst compiler version used to gate `engine.compilerRange`. Mirrors
+ * the Typst version inside `PDF_BROWSER_COMPILER_VERSION`
+ * (`@atlcli/pdf-compiler-browser`, currently `"… / Typst 0.14.2"`). Kept as a
+ * local constant so this pure package need not depend on the WASM compiler; a
+ * host may pass the authoritative value via {@link ValidateManifestOptions}.
+ */
+export const PINNED_TYPST_VERSION = "0.14.2";
+
+/** Recognized `engine.api` values, keyed by `engine.kind`. */
+export const KNOWN_ENGINE_API = {
+  typst: "wiki.pdf-template/v1",
+  docx: "wiki.docx-template/v1",
+} as const;
+
+export type TemplateEngineKind = keyof typeof KNOWN_ENGINE_API;
+
+/** The bounded Level-A setting type set (TEMPLATE-UX §5.1). */
+export const SETTING_TYPES = ["text", "boolean", "choice", "color", "number", "asset"] as const;
+export type TemplateSettingType = (typeof SETTING_TYPES)[number];
+
+export interface TemplateEngineSpec {
+  kind: TemplateEngineKind;
+  api: string;
+  entry: string;
+  /** Typst only; semver range like `">=0.14 <0.15"`. */
+  compilerRange?: string;
+}
+
+/** Declarative required-font record (shape mirrors `FontAsset` sans hash/license). */
+export interface RequiredFont {
+  family: string;
+  style: string;
+  weight: number;
+}
+
+export interface ManifestSetting {
+  type: TemplateSettingType;
+  default?: unknown;
+  /** Additional per-type descriptors (e.g. `choice` options); not gated here. */
+  [key: string]: unknown;
+}
+
+export interface TemplateProvenance {
+  /**
+   * Digest of the pack's *payload members* (never the archive bytes) — see
+   * `pack.ts` for the exact canonicalization. Distinct from a
+   * `TemplateLibraryEntry.sha256`, which hashes the delivered archive bytes.
+   */
+  payloadSha256: string;
+  createdWith: string;
+}
+
+export interface TemplateManifest {
+  schemaVersion: number;
+  id: string;
+  name: string;
+  version: string;
+  engine: TemplateEngineSpec;
+  requiredFonts?: RequiredFont[];
+  settings?: Record<string, ManifestSetting>;
+  provenance?: TemplateProvenance;
+}
+
+/** Typed rejection reasons carried by {@link ManifestValidationError}. */
+export type ManifestErrorReason =
+  | "unknown-schema-version"
+  | "unknown-api"
+  | "compiler-range-mismatch"
+  | "shape-error";
+
+/** Thrown by {@link validateManifest} on any rejection, with a typed reason. */
+export class ManifestValidationError extends Error {
+  constructor(
+    readonly reason: ManifestErrorReason,
+    message: string,
+    /** Offending manifest field path, when applicable. */
+    readonly path?: string
+  ) {
+    super(message);
+    this.name = "ManifestValidationError";
+  }
+}
+
+export interface ValidateManifestOptions {
+  /**
+   * Pinned Typst version to gate `engine.compilerRange` against. Accepts a bare
+   * semver (`"0.14.2"`) or the descriptive `PDF_BROWSER_COMPILER_VERSION` form
+   * (`"typst.ts 0.7.0 / Typst 0.14.2"`, the last version token is used).
+   * Defaults to {@link PINNED_TYPST_VERSION}.
+   */
+  pinnedTypstVersion?: string;
+}
+
+function isObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+function requireString(obj: Record<string, unknown>, key: string, path: string): string {
+  const v = obj[key];
+  if (typeof v !== "string" || v.length === 0) {
+    throw new ManifestValidationError("shape-error", `${path} must be a non-empty string`, path);
+  }
+  return v;
+}
+
+/** Extract the last `x.y[.z]` token from a version string. */
+export function extractTypstVersion(raw: string): string {
+  const matches = raw.match(/\d+\.\d+(?:\.\d+)?/g);
+  if (!matches || matches.length === 0) {
+    throw new ManifestValidationError("shape-error", `Unparseable pinned version "${raw}"`);
+  }
+  return matches[matches.length - 1];
+}
+
+/** Parse `x.y[.z]` into a 3-tuple, missing segments defaulting to 0. */
+function parseVersion(v: string): [number, number, number] {
+  const parts = v.split(".").map((p) => Number.parseInt(p, 10));
+  if (parts.some((n) => Number.isNaN(n))) {
+    throw new ManifestValidationError("shape-error", `Unparseable version "${v}"`);
+  }
+  return [parts[0] ?? 0, parts[1] ?? 0, parts[2] ?? 0];
+}
+
+function compareVersions(a: [number, number, number], b: [number, number, number]): number {
+  for (let i = 0; i < 3; i++) {
+    if (a[i] !== b[i]) return a[i] < b[i] ? -1 : 1;
+  }
+  return 0;
+}
+
+/**
+ * Minimal semver range check for the documented supported forms only:
+ * whitespace-separated conjuncts, each `(>=|<=|>|<|=)?x.y[.z]` (a bare version
+ * is exact). Everything must hold for the range to be satisfied. An
+ * unparseable range is a shape error, not a compiler mismatch.
+ */
+export function satisfiesRange(version: string, range: string): boolean {
+  const v = parseVersion(version);
+  const tokens = range.trim().split(/\s+/).filter((t) => t.length > 0);
+  if (tokens.length === 0) {
+    throw new ManifestValidationError("shape-error", `Empty compilerRange`);
+  }
+  for (const token of tokens) {
+    const m = token.match(/^(>=|<=|>|<|=)?(\d+\.\d+(?:\.\d+)?)$/);
+    if (!m) {
+      throw new ManifestValidationError(
+        "shape-error",
+        `Unsupported compilerRange form "${token}" (supported: >=x.y <x.z, >x.y, <=x.y, =x.y)`,
+        "engine.compilerRange"
+      );
+    }
+    const op = m[1] ?? "=";
+    const cmp = compareVersions(v, parseVersion(m[2]));
+    const ok =
+      op === "="
+        ? cmp === 0
+        : op === ">="
+          ? cmp >= 0
+          : op === "<="
+            ? cmp <= 0
+            : op === ">"
+              ? cmp > 0
+              : /* "<" */ cmp < 0;
+    if (!ok) return false;
+  }
+  return true;
+}
+
+/**
+ * Validate an untrusted manifest object and return it typed. Runs the import
+ * gate in a fixed order: schema version → basic shape → engine api →
+ * (typst) compiler range → declarative field shapes.
+ *
+ * @throws {ManifestValidationError} with a typed {@link ManifestErrorReason}.
+ */
+export function validateManifest(
+  json: unknown,
+  options: ValidateManifestOptions = {}
+): TemplateManifest {
+  if (!isObject(json)) {
+    throw new ManifestValidationError("shape-error", "Manifest must be a JSON object");
+  }
+
+  // 1. Schema version gate (before any other check).
+  if (json.schemaVersion !== SUPPORTED_SCHEMA_VERSION) {
+    throw new ManifestValidationError(
+      "unknown-schema-version",
+      `Unsupported schemaVersion ${JSON.stringify(json.schemaVersion)} (only ${SUPPORTED_SCHEMA_VERSION} is recognized)`,
+      "schemaVersion"
+    );
+  }
+
+  // 2. Basic string fields.
+  const id = requireString(json, "id", "id");
+  const name = requireString(json, "name", "name");
+  const version = requireString(json, "version", "version");
+
+  // 3. Engine shape.
+  if (!isObject(json.engine)) {
+    throw new ManifestValidationError("shape-error", "engine must be an object", "engine");
+  }
+  const engine = json.engine;
+  const kind = engine.kind;
+  if (kind !== "typst" && kind !== "docx") {
+    throw new ManifestValidationError(
+      "shape-error",
+      `engine.kind must be "typst" or "docx"`,
+      "engine.kind"
+    );
+  }
+  const entry = requireString(engine, "entry", "engine.entry");
+  const api = requireString(engine, "api", "engine.api");
+
+  // 4. API gate.
+  const expectedApi = KNOWN_ENGINE_API[kind];
+  if (api !== expectedApi) {
+    throw new ManifestValidationError(
+      "unknown-api",
+      `Unknown engine.api "${api}" for kind "${kind}" (expected "${expectedApi}")`,
+      "engine.api"
+    );
+  }
+
+  // 5. Compiler range gate (typst only).
+  let compilerRange: string | undefined;
+  if (engine.compilerRange !== undefined) {
+    if (typeof engine.compilerRange !== "string") {
+      throw new ManifestValidationError(
+        "shape-error",
+        "engine.compilerRange must be a string",
+        "engine.compilerRange"
+      );
+    }
+    compilerRange = engine.compilerRange;
+    if (kind === "typst") {
+      const pinned = extractTypstVersion(options.pinnedTypstVersion ?? PINNED_TYPST_VERSION);
+      if (!satisfiesRange(pinned, compilerRange)) {
+        throw new ManifestValidationError(
+          "compiler-range-mismatch",
+          `Pinned Typst ${pinned} does not satisfy engine.compilerRange "${compilerRange}"`,
+          "engine.compilerRange"
+        );
+      }
+    }
+  }
+
+  // 6. Declarative field shapes.
+  const requiredFonts = validateRequiredFonts(json.requiredFonts);
+  const settings = validateSettings(json.settings);
+  const provenance = validateProvenance(json.provenance);
+
+  const manifest: TemplateManifest = {
+    schemaVersion: SUPPORTED_SCHEMA_VERSION,
+    id,
+    name,
+    version,
+    engine: { kind, api, entry, ...(compilerRange !== undefined ? { compilerRange } : {}) },
+    ...(requiredFonts ? { requiredFonts } : {}),
+    ...(settings ? { settings } : {}),
+    ...(provenance ? { provenance } : {}),
+  };
+  return manifest;
+}
+
+function validateRequiredFonts(value: unknown): RequiredFont[] | undefined {
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value)) {
+    throw new ManifestValidationError("shape-error", "requiredFonts must be an array", "requiredFonts");
+  }
+  return value.map((f, i) => {
+    const path = `requiredFonts[${i}]`;
+    if (!isObject(f)) throw new ManifestValidationError("shape-error", `${path} must be an object`, path);
+    const family = requireString(f, "family", `${path}.family`);
+    const style = requireString(f, "style", `${path}.style`);
+    if (typeof f.weight !== "number") {
+      throw new ManifestValidationError("shape-error", `${path}.weight must be a number`, `${path}.weight`);
+    }
+    return { family, style, weight: f.weight };
+  });
+}
+
+function validateSettings(value: unknown): Record<string, ManifestSetting> | undefined {
+  if (value === undefined) return undefined;
+  if (!isObject(value)) {
+    throw new ManifestValidationError("shape-error", "settings must be an object", "settings");
+  }
+  const out: Record<string, ManifestSetting> = {};
+  for (const [key, raw] of Object.entries(value)) {
+    const path = `settings.${key}`;
+    if (!isObject(raw)) throw new ManifestValidationError("shape-error", `${path} must be an object`, path);
+    const type = raw.type;
+    if (typeof type !== "string" || !(SETTING_TYPES as readonly string[]).includes(type)) {
+      throw new ManifestValidationError(
+        "shape-error",
+        `${path}.type must be one of ${SETTING_TYPES.join(", ")}`,
+        `${path}.type`
+      );
+    }
+    out[key] = { ...raw, type: type as TemplateSettingType };
+  }
+  return out;
+}
+
+function validateProvenance(value: unknown): TemplateProvenance | undefined {
+  if (value === undefined) return undefined;
+  if (!isObject(value)) {
+    throw new ManifestValidationError("shape-error", "provenance must be an object", "provenance");
+  }
+  const payloadSha256 = requireString(value, "payloadSha256", "provenance.payloadSha256");
+  const createdWith = requireString(value, "createdWith", "provenance.createdWith");
+  return { payloadSha256, createdWith };
+}

--- a/packages/template-pack/src/pack.test.ts
+++ b/packages/template-pack/src/pack.test.ts
@@ -9,7 +9,7 @@
 import { describe, expect, it } from "bun:test";
 import { sha256Hex } from "@atlcli/core";
 import { packTemplate, computePayloadSha256, type TemplatePackContents } from "./pack.js";
-import { unpackTemplate } from "./unpack.js";
+import { unpackTemplate, TemplatePackError } from "./unpack.js";
 import { TEMPLATE_PACK_MANIFEST_NAME, type TemplateManifest } from "./manifest.js";
 
 function typstManifest(): TemplateManifest {
@@ -107,18 +107,19 @@ describe("provenance.payloadSha256", () => {
   });
 
   it("matches a vector recomputed from the documented canonicalization", async () => {
+    const enc = new TextEncoder();
     const files: Record<string, Uint8Array> = {
-      "b.txt": new TextEncoder().encode("bbb"),
-      "a.txt": new TextEncoder().encode("aaaa"),
+      "b.txt": enc.encode("bbb"),
+      "a.txt": enc.encode("aaaa"),
     };
-    // Documented canonicalization: for each member in ascending path order,
-    // three lines — path, byteLength, lowercase-hex sha256 — newline-joined,
-    // then sha256 of the UTF-8 bytes.
-    const lines: string[] = [];
+    // Documented canonicalization: for each member in ascending path order, one
+    // self-delimiting record `<utf8len(path)>:<path>,<byteLength>,<sha256hex>;`,
+    // records concatenated, then sha256 of the UTF-8 bytes.
+    let canonical = "";
     for (const path of Object.keys(files).sort()) {
-      lines.push(path, String(files[path].byteLength), await sha256Hex(files[path]));
+      canonical += `${enc.encode(path).byteLength}:${path},${files[path].byteLength},${await sha256Hex(files[path])};`;
     }
-    const expected = await sha256Hex(new TextEncoder().encode(lines.join("\n")));
+    const expected = await sha256Hex(enc.encode(canonical));
 
     expect(await computePayloadSha256(files)).toBe(expected);
 
@@ -127,6 +128,35 @@ describe("provenance.payloadSha256", () => {
     const manifest = { ...typstManifest(), engine: { ...typstManifest().engine, entry: "a.txt" } };
     const packed = await packTemplate({ manifest, files });
     expect(unpackTemplate(packed).manifest.provenance!.payloadSha256).toBe(expected);
+  });
+
+  it("does not collide on newline-crafted paths (regression: delimiter injection)", async () => {
+    // Adversarial pair proven to collide under the old newline-joined
+    // canonicalization: payload A = {bar: "wxyz", foo: "xyz"} vs. payload B = a
+    // single file whose PATH embeds A's first record ("bar\n4\n<sha256(wxyz)>\nfoo")
+    // and whose CONTENT is "xyz". The netstring-framed records make the two
+    // descriptions distinct regardless of path validation.
+    const enc = new TextEncoder();
+    const wxyzHash = await sha256Hex(enc.encode("wxyz"));
+    const setA: Record<string, Uint8Array> = {
+      bar: enc.encode("wxyz"),
+      foo: enc.encode("xyz"),
+    };
+    const hostilePath = `bar\n4\n${wxyzHash}\nfoo`;
+    const setB: Record<string, Uint8Array> = { [hostilePath]: enc.encode("xyz") };
+
+    expect(await computePayloadSha256(setA)).not.toBe(await computePayloadSha256(setB));
+
+    // And the hostile path never even reaches an archive: packTemplate rejects
+    // control characters in member paths outright with a typed error.
+    let rejected: unknown;
+    try {
+      await packTemplate({ manifest: typstManifest(), files: { ...setB, "template.typ": enc.encode("x") } });
+    } catch (err) {
+      rejected = err;
+    }
+    expect(rejected).toBeInstanceOf(TemplatePackError);
+    expect((rejected as TemplatePackError).kind).toBe("invalid-path");
   });
 
   it("excludes the manifest from the payload digest (not self-referential)", async () => {

--- a/packages/template-pack/src/pack.test.ts
+++ b/packages/template-pack/src/pack.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Deterministic packing + payload-hash tests (spec 007 T2.4).
+ *
+ * No mocking: real archives are built by `packTemplate` and read back by
+ * `unpackTemplate`; hashes are real WebCrypto digests. The `payloadSha256`
+ * assertion pins a fixed vector recomputed from the documented canonicalization,
+ * not merely "some hash changed".
+ */
+import { describe, expect, it } from "bun:test";
+import { sha256Hex } from "@atlcli/core";
+import { packTemplate, computePayloadSha256, type TemplatePackContents } from "./pack.js";
+import { unpackTemplate } from "./unpack.js";
+import { TEMPLATE_PACK_MANIFEST_NAME, type TemplateManifest } from "./manifest.js";
+
+function typstManifest(): TemplateManifest {
+  return {
+    schemaVersion: 1,
+    id: "com.acme.tech-doc",
+    name: "Acme Tech Doc",
+    version: "1.0.0",
+    engine: { kind: "typst", api: "wiki.pdf-template/v1", entry: "template.typ" },
+  };
+}
+
+function contents(over?: Partial<Record<string, string>>): TemplatePackContents {
+  const enc = (s: string) => new TextEncoder().encode(s);
+  const files: Record<string, Uint8Array> = {
+    "template.typ": enc(over?.["template.typ"] ?? "#let render(meta, body, settings) = body"),
+    "assets/logo.svg": enc(over?.["assets/logo.svg"] ?? "<svg></svg>"),
+  };
+  return { manifest: typstManifest(), files };
+}
+
+function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+  return true;
+}
+
+describe("packTemplate round-trip", () => {
+  it("pack → sha256Hex → unpack yields identical file bytes and manifest", async () => {
+    const c = contents();
+    const packed = await packTemplate(c);
+    // integrity hash of the delivered archive bytes (the entry-metadata quantity)
+    const archiveHash = await sha256Hex(packed);
+    expect(archiveHash).toMatch(/^[0-9a-f]{64}$/);
+
+    const { manifest, files } = unpackTemplate(packed);
+    expect(manifest.id).toBe("com.acme.tech-doc");
+    expect(manifest.engine.entry).toBe("template.typ");
+    expect(manifest.provenance?.payloadSha256).toMatch(/^[0-9a-f]{64}$/);
+    expect(Object.keys(files).sort()).toEqual(["assets/logo.svg", "template.typ"]);
+    expect(bytesEqual(files["template.typ"], c.files["template.typ"])).toBe(true);
+    expect(bytesEqual(files["assets/logo.svg"], c.files["assets/logo.svg"])).toBe(true);
+  });
+
+  it("does not include the manifest file in the unpacked payload map", async () => {
+    const packed = await packTemplate(contents());
+    const { files } = unpackTemplate(packed);
+    expect(files[TEMPLATE_PACK_MANIFEST_NAME]).toBeUndefined();
+  });
+
+  it("rejects a files map that contains the reserved manifest path", async () => {
+    const c = contents();
+    (c.files as Record<string, Uint8Array>)[TEMPLATE_PACK_MANIFEST_NAME] = new Uint8Array([1]);
+    await expect(packTemplate(c)).rejects.toThrow(/reserved manifest path/);
+  });
+});
+
+describe("determinism", () => {
+  it("packs the same input twice byte-identically", async () => {
+    const a = await packTemplate(contents());
+    const b = await packTemplate(contents());
+    expect(bytesEqual(a, b)).toBe(true);
+  });
+
+  it("is independent of manifest key insertion order (stable serialization)", async () => {
+    const c1 = contents();
+    const c2 = contents();
+    // Rebuild manifest of c2 with a different key order.
+    c2.manifest = {
+      engine: { entry: "template.typ", api: "wiki.pdf-template/v1", kind: "typst" },
+      version: "1.0.0",
+      name: "Acme Tech Doc",
+      id: "com.acme.tech-doc",
+      schemaVersion: 1,
+    } as TemplateManifest;
+    const a = await packTemplate(c1);
+    const b = await packTemplate(c2);
+    expect(bytesEqual(a, b)).toBe(true);
+  });
+});
+
+describe("provenance.payloadSha256", () => {
+  it("is stable across repacks", async () => {
+    const p1 = unpackTemplate(await packTemplate(contents())).manifest.provenance!.payloadSha256;
+    const p2 = unpackTemplate(await packTemplate(contents())).manifest.provenance!.payloadSha256;
+    expect(p1).toBe(p2);
+  });
+
+  it("changes when any non-manifest file's bytes change", async () => {
+    const base = unpackTemplate(await packTemplate(contents())).manifest.provenance!.payloadSha256;
+    const changed = unpackTemplate(
+      await packTemplate(contents({ "assets/logo.svg": "<svg><rect/></svg>" }))
+    ).manifest.provenance!.payloadSha256;
+    expect(changed).not.toBe(base);
+  });
+
+  it("matches a vector recomputed from the documented canonicalization", async () => {
+    const files: Record<string, Uint8Array> = {
+      "b.txt": new TextEncoder().encode("bbb"),
+      "a.txt": new TextEncoder().encode("aaaa"),
+    };
+    // Documented canonicalization: for each member in ascending path order,
+    // three lines — path, byteLength, lowercase-hex sha256 — newline-joined,
+    // then sha256 of the UTF-8 bytes.
+    const lines: string[] = [];
+    for (const path of Object.keys(files).sort()) {
+      lines.push(path, String(files[path].byteLength), await sha256Hex(files[path]));
+    }
+    const expected = await sha256Hex(new TextEncoder().encode(lines.join("\n")));
+
+    expect(await computePayloadSha256(files)).toBe(expected);
+
+    // And the same value ends up embedded in a packed manifest (entry must be a
+    // real member, so point it at a.txt for this vector fixture).
+    const manifest = { ...typstManifest(), engine: { ...typstManifest().engine, entry: "a.txt" } };
+    const packed = await packTemplate({ manifest, files });
+    expect(unpackTemplate(packed).manifest.provenance!.payloadSha256).toBe(expected);
+  });
+
+  it("excludes the manifest from the payload digest (not self-referential)", async () => {
+    // Two packs with identical payload but different manifest metadata must
+    // share the same payloadSha256.
+    const files = contents().files;
+    const m1 = typstManifest();
+    const m2 = { ...typstManifest(), name: "A Different Display Name" };
+    const p1 = unpackTemplate(await packTemplate({ manifest: m1, files })).manifest.provenance!
+      .payloadSha256;
+    const p2 = unpackTemplate(await packTemplate({ manifest: m2, files })).manifest.provenance!
+      .payloadSha256;
+    expect(p1).toBe(p2);
+  });
+});

--- a/packages/template-pack/src/pack.ts
+++ b/packages/template-pack/src/pack.ts
@@ -26,6 +26,7 @@ import {
   TEMPLATE_PACK_MANIFEST_NAME,
   type TemplateManifest,
 } from "./manifest.js";
+import { assertSafePath } from "./unpack.js";
 
 /**
  * PizZip's shipped ambient typing (declared in `@atlcli/docx`) omits the
@@ -86,28 +87,49 @@ function sortKeys(value: unknown): unknown {
 /**
  * Compute `provenance.payloadSha256` from the payload members.
  *
- * Canonicalization (documented, stable): for every payload member in ascending
- * path order, emit three lines — its `path`, its byte length (decimal), and its
- * lowercase-hex SHA-256 — then newline-join all lines and SHA-256 the UTF-8
- * bytes of that string. The manifest itself is deliberately excluded (it is the
- * carrier of this value), so the result is well-defined before the manifest is
- * written.
+ * Canonicalization (documented, stable, **delimiter-safe**): for every payload
+ * member in ascending path order (UTF-16 code-unit sort of the path strings),
+ * emit one self-delimiting record
+ *
+ * ```text
+ * <P>:<path>,<byteLength>,<sha256hex>;
+ * ```
+ *
+ * where `<P>` is the decimal UTF-8 byte length of `<path>`, `<byteLength>` is
+ * the member's decimal byte count, and `<sha256hex>` is its lowercase-hex
+ * SHA-256 (always exactly 64 chars). Concatenate all records (no join
+ * separator) and SHA-256 the UTF-8 bytes of the result.
+ *
+ * The encoding is injective by construction — the netstring length prefix
+ * frames the path, `,` terminates the decimal size, and the fixed-width hash
+ * plus `;` close the record — so no member path can forge record boundaries.
+ * Injectivity does NOT depend on path validation (a path containing `\n`, `,`
+ * or `;` still cannot collide), though {@link packTemplate} additionally
+ * rejects control characters in paths outright via `assertSafePath`.
+ *
+ * The manifest itself is deliberately excluded (it is the carrier of this
+ * value), so the result is well-defined before the manifest is written.
  */
 export async function computePayloadSha256(files: Record<string, Uint8Array>): Promise<string> {
+  const encoder = new TextEncoder();
   const paths = Object.keys(files).sort();
-  const lines: string[] = [];
+  let canonical = "";
   for (const path of paths) {
     const bytes = files[path];
-    lines.push(path, String(bytes.byteLength), await sha256Hex(bytes));
+    const pathByteLength = encoder.encode(path).byteLength;
+    canonical += `${pathByteLength}:${path},${bytes.byteLength},${await sha256Hex(bytes)};`;
   }
-  return sha256Hex(new TextEncoder().encode(lines.join("\n")));
+  return sha256Hex(encoder.encode(canonical));
 }
 
 /**
  * Pack a manifest + payload files into a deterministic `.wiki-pdf-template`
- * archive.
+ * archive. Every payload path runs through the same `assertSafePath` gate the
+ * reader enforces (traversal + control characters), so `packTemplate` can
+ * never produce an archive `unpackTemplate` would reject.
  *
  * @throws {Error} if `files` includes the reserved manifest path.
+ * @throws {import("./unpack.js").TemplatePackError} on an unsafe payload path.
  */
 export async function packTemplate(contents: TemplatePackContents): Promise<Uint8Array> {
   const { manifest, files } = contents;
@@ -116,6 +138,7 @@ export async function packTemplate(contents: TemplatePackContents): Promise<Uint
       `files must not contain the reserved manifest path "${TEMPLATE_PACK_MANIFEST_NAME}"`
     );
   }
+  for (const path of Object.keys(files)) assertSafePath(path);
 
   const payloadSha256 = await computePayloadSha256(files);
   const finalManifest: TemplateManifest = {

--- a/packages/template-pack/src/pack.ts
+++ b/packages/template-pack/src/pack.ts
@@ -1,0 +1,144 @@
+/**
+ * Deterministic `.wiki-pdf-template` packer (spec 007 T2.4).
+ *
+ * `packTemplate` serializes a manifest + payload files into a byte-deterministic
+ * zip: packing the same input twice yields byte-identical archives. Determinism
+ * comes from three controls on PizZip:
+ *   - a fixed DOS-epoch timestamp (1980-01-01 00:00:00) on every entry, built
+ *     from local calendar components so it is timezone-independent;
+ *   - `platform: "DOS"` so `version made by` / external attributes are fixed;
+ *   - an explicit `fileOrder` (manifest first, then payload paths ascending) and
+ *     a stable, sorted-key manifest serialization.
+ * ASCII entry paths carry no Info-ZIP unicode-path extra field, so no
+ * platform-dependent extra fields are emitted.
+ *
+ * `provenance.payloadSha256` is **not self-referential**: it digests a
+ * canonicalized description of the *payload members* (everything except the
+ * manifest), so it can be computed in one pass and written into the manifest
+ * before the manifest entry is serialized. See {@link computePayloadSha256}.
+ *
+ * Browser-safe: PizZip runs in the browser (as in `@atlcli/docx`); `sha256Hex`
+ * is WebCrypto. No `node:`/`bun:` imports.
+ */
+import { sha256Hex } from "@atlcli/core";
+import PizZipDefault from "pizzip";
+import {
+  TEMPLATE_PACK_MANIFEST_NAME,
+  type TemplateManifest,
+} from "./manifest.js";
+
+/**
+ * PizZip's shipped ambient typing (declared in `@atlcli/docx`) omits the
+ * determinism options we rely on. Rather than re-declare the module (which
+ * would collide in the shared program), we cast the imported constructor to the
+ * exact surface `packTemplate` needs.
+ */
+interface DeterministicZip {
+  file(path: string, content: Uint8Array, options: { date: Date }): unknown;
+  generate(options: {
+    type: "uint8array";
+    compression: "DEFLATE";
+    platform: "DOS";
+    fileOrder: string[];
+  }): Uint8Array;
+}
+const DeterministicPizZip = PizZipDefault as unknown as { new (): DeterministicZip };
+
+/** The DOS epoch (1980-01-01 00:00:00), built from local components so its
+ *  DOS date/time encoding is identical on every machine and timezone. */
+const DOS_EPOCH = new Date(1980, 0, 1, 0, 0, 0);
+
+/** Default `createdWith` when the caller does not supply provenance. */
+const DEFAULT_CREATED_WITH = "@atlcli/template-pack";
+
+/** Contents to pack: the manifest plus payload members keyed by archive path. */
+export interface TemplatePackContents {
+  /**
+   * The manifest to embed. `provenance.payloadSha256` is (re)computed and
+   * overwritten by {@link packTemplate}; `provenance.createdWith` is preserved
+   * if present, else defaulted.
+   */
+  manifest: TemplateManifest;
+  /** Payload members by archive path. MUST NOT include the manifest file. */
+  files: Record<string, Uint8Array>;
+}
+
+/**
+ * Recursively stable JSON: object keys sorted, 2-space indented. Guarantees the
+ * manifest serializes to identical bytes for logically-equal manifests
+ * regardless of key insertion order.
+ */
+function stableStringify(value: unknown): string {
+  return JSON.stringify(sortKeys(value), null, 2);
+}
+function sortKeys(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortKeys);
+  if (value !== null && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+      out[key] = sortKeys((value as Record<string, unknown>)[key]);
+    }
+    return out;
+  }
+  return value;
+}
+
+/**
+ * Compute `provenance.payloadSha256` from the payload members.
+ *
+ * Canonicalization (documented, stable): for every payload member in ascending
+ * path order, emit three lines — its `path`, its byte length (decimal), and its
+ * lowercase-hex SHA-256 — then newline-join all lines and SHA-256 the UTF-8
+ * bytes of that string. The manifest itself is deliberately excluded (it is the
+ * carrier of this value), so the result is well-defined before the manifest is
+ * written.
+ */
+export async function computePayloadSha256(files: Record<string, Uint8Array>): Promise<string> {
+  const paths = Object.keys(files).sort();
+  const lines: string[] = [];
+  for (const path of paths) {
+    const bytes = files[path];
+    lines.push(path, String(bytes.byteLength), await sha256Hex(bytes));
+  }
+  return sha256Hex(new TextEncoder().encode(lines.join("\n")));
+}
+
+/**
+ * Pack a manifest + payload files into a deterministic `.wiki-pdf-template`
+ * archive.
+ *
+ * @throws {Error} if `files` includes the reserved manifest path.
+ */
+export async function packTemplate(contents: TemplatePackContents): Promise<Uint8Array> {
+  const { manifest, files } = contents;
+  if (Object.prototype.hasOwnProperty.call(files, TEMPLATE_PACK_MANIFEST_NAME)) {
+    throw new Error(
+      `files must not contain the reserved manifest path "${TEMPLATE_PACK_MANIFEST_NAME}"`
+    );
+  }
+
+  const payloadSha256 = await computePayloadSha256(files);
+  const finalManifest: TemplateManifest = {
+    ...manifest,
+    provenance: {
+      payloadSha256,
+      createdWith: manifest.provenance?.createdWith ?? DEFAULT_CREATED_WITH,
+    },
+  };
+  const manifestBytes = new TextEncoder().encode(stableStringify(finalManifest));
+
+  const payloadPaths = Object.keys(files).sort();
+  const fileOrder = [TEMPLATE_PACK_MANIFEST_NAME, ...payloadPaths];
+
+  const zip = new DeterministicPizZip();
+  zip.file(TEMPLATE_PACK_MANIFEST_NAME, manifestBytes, { date: DOS_EPOCH });
+  for (const path of payloadPaths) {
+    zip.file(path, files[path], { date: DOS_EPOCH });
+  }
+  return zip.generate({
+    type: "uint8array",
+    compression: "DEFLATE",
+    platform: "DOS",
+    fileOrder,
+  });
+}

--- a/packages/template-pack/src/unpack.test.ts
+++ b/packages/template-pack/src/unpack.test.ts
@@ -88,6 +88,18 @@ describe("path traversal rejection", () => {
     const bytes = buildRaw((z) => z.file("a/../../evil.typ", "x", { date: DATE }));
     expectKind(() => unpackTemplate(bytes), "path-traversal");
   });
+
+  it("rejects a newline-containing path (payloadSha256 delimiter-injection guard)", () => {
+    const bytes = buildRaw((z) => z.file("bar\n4\nabc\nfoo", "xyz", { date: DATE }));
+    expectKind(() => unpackTemplate(bytes), "invalid-path");
+  });
+
+  it("rejects CR and NUL control characters in paths", () => {
+    const cr = buildRaw((z) => z.file("evil\r.typ", "x", { date: DATE }));
+    expectKind(() => unpackTemplate(cr), "invalid-path");
+    const nul = buildRaw((z) => z.file("evil\u0000.typ", "x", { date: DATE }));
+    expectKind(() => unpackTemplate(nul), "invalid-path");
+  });
 });
 
 describe("symlink rejection", () => {

--- a/packages/template-pack/src/unpack.test.ts
+++ b/packages/template-pack/src/unpack.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Reader security tests (spec 007 T2.4) — real crafted archives, no mocking.
+ *
+ * Evil archives are built directly with PizZip (path traversal, symlinks,
+ * over-cap members, zip bombs) and fed to `unpackTemplate`; each must be
+ * rejected with the matching typed {@link TemplatePackError.kind}.
+ */
+import { describe, expect, it } from "bun:test";
+import PizZipDefault from "pizzip";
+import {
+  unpackTemplate,
+  TemplatePackError,
+  MAX_TEMPLATE_PACK_BYTES,
+  MAX_TEMPLATE_PACK_FILE_BYTES,
+  MAX_TEMPLATE_PACK_UNCOMPRESSED_BYTES,
+  type TemplatePackErrorKind,
+} from "./unpack.js";
+import { TEMPLATE_PACK_MANIFEST_NAME } from "./manifest.js";
+
+/** Raw PizZip surface (cast to reach the determinism/permission options). */
+interface RawZip {
+  file(
+    path: string,
+    content: Uint8Array | string,
+    options?: { date?: Date; unixPermissions?: number }
+  ): unknown;
+  generate(options: {
+    type: "uint8array";
+    compression: "DEFLATE";
+    platform?: "DOS" | "UNIX";
+  }): Uint8Array;
+}
+const RawPizZip = PizZipDefault as unknown as { new (): RawZip };
+
+const DATE = new Date(1980, 0, 1, 0, 0, 0);
+
+function manifestJson(entry = "template.typ"): string {
+  return JSON.stringify({
+    schemaVersion: 1,
+    id: "com.acme.doc",
+    name: "Acme",
+    version: "1.0.0",
+    engine: { kind: "typst", api: "wiki.pdf-template/v1", entry },
+  });
+}
+
+/** Build a raw archive with a valid manifest plus caller-supplied extra entries. */
+function buildRaw(
+  extra: (zip: RawZip) => void,
+  opts: { platform?: "DOS" | "UNIX"; withEntry?: boolean } = {}
+): Uint8Array {
+  const zip = new RawPizZip();
+  zip.file(TEMPLATE_PACK_MANIFEST_NAME, manifestJson(), { date: DATE });
+  if (opts.withEntry !== false) {
+    zip.file("template.typ", "#let render(meta, body, settings) = body", { date: DATE });
+  }
+  extra(zip);
+  return zip.generate({ type: "uint8array", compression: "DEFLATE", platform: opts.platform ?? "DOS" });
+}
+
+function expectKind(fn: () => void, kind: TemplatePackErrorKind): void {
+  try {
+    fn();
+    throw new Error("expected TemplatePackError, none thrown");
+  } catch (err) {
+    expect(err).toBeInstanceOf(TemplatePackError);
+    expect((err as TemplatePackError).kind).toBe(kind);
+  }
+}
+
+describe("path traversal rejection", () => {
+  it("rejects a `../evil.typ` entry", () => {
+    const bytes = buildRaw((z) => z.file("../evil.typ", "x", { date: DATE }));
+    expectKind(() => unpackTemplate(bytes), "path-traversal");
+  });
+
+  it("rejects an absolute path", () => {
+    const bytes = buildRaw((z) => z.file("/etc/passwd", "x", { date: DATE }));
+    expectKind(() => unpackTemplate(bytes), "path-traversal");
+  });
+
+  it("rejects a backslash path", () => {
+    const bytes = buildRaw((z) => z.file("dir\\evil.typ", "x", { date: DATE }));
+    expectKind(() => unpackTemplate(bytes), "path-traversal");
+  });
+
+  it("rejects a nested `..` segment", () => {
+    const bytes = buildRaw((z) => z.file("a/../../evil.typ", "x", { date: DATE }));
+    expectKind(() => unpackTemplate(bytes), "path-traversal");
+  });
+});
+
+describe("symlink rejection", () => {
+  it("rejects a symlink entry (S_IFLNK)", () => {
+    const bytes = buildRaw(
+      (z) => z.file("link.typ", "/etc/passwd", { date: DATE, unixPermissions: 0o120777 }),
+      { platform: "UNIX" }
+    );
+    expectKind(() => unpackTemplate(bytes), "symlink");
+  });
+});
+
+describe("manifest / entry integrity", () => {
+  it("rejects a missing engine.entry member", () => {
+    // Manifest points at template.typ but the archive omits it.
+    const bytes = buildRaw(() => {}, { withEntry: false });
+    expectKind(() => unpackTemplate(bytes), "missing-entry");
+  });
+
+  it("rejects a missing manifest", () => {
+    const zip = new RawPizZip();
+    zip.file("template.typ", "body", { date: DATE });
+    const bytes = zip.generate({ type: "uint8array", compression: "DEFLATE", platform: "DOS" });
+    expectKind(() => unpackTemplate(bytes), "missing-manifest");
+  });
+
+  it("rejects a non-zip buffer", () => {
+    expectKind(() => unpackTemplate(new TextEncoder().encode("not a zip")), "not-zip");
+  });
+});
+
+describe("size caps", () => {
+  it("rejects an archive over the 30 MiB outer cap (before unzip)", () => {
+    // A buffer larger than the cap is rejected on length alone, before parsing.
+    const oversized = new Uint8Array(MAX_TEMPLATE_PACK_BYTES + 1);
+    expectKind(() => unpackTemplate(oversized), "too-large-archive");
+  });
+
+  it("rejects a member over the per-file cap by declared size", () => {
+    const big = new Uint8Array(MAX_TEMPLATE_PACK_FILE_BYTES + 1024); // zeros, compresses tiny
+    const bytes = buildRaw((z) => z.file("huge.bin", big, { date: DATE }));
+    expect(bytes.byteLength).toBeLessThan(1024 * 1024); // archive stays small
+    expectKind(() => unpackTemplate(bytes), "file-too-large");
+  });
+
+  it("aborts on declared cumulative uncompressed size before inflating (zip bomb)", () => {
+    // Three 30 MiB zero members: each is under the 32 MiB per-file cap, but the
+    // cumulative declared 90 MiB exceeds the 64 MiB cap. The archive itself is a
+    // few KB compressed — proving the guard accounts DECLARED uncompressed size,
+    // not compressed bytes, and trips in the pre-inflation pass.
+    const chunk = () => new Uint8Array(30 * 1024 * 1024);
+    const bytes = buildRaw((z) => {
+      z.file("a.bin", chunk(), { date: DATE });
+      z.file("b.bin", chunk(), { date: DATE });
+      z.file("c.bin", chunk(), { date: DATE });
+    });
+    expect(bytes.byteLength).toBeLessThan(1024 * 1024);
+    expect(90 * 1024 * 1024).toBeGreaterThan(MAX_TEMPLATE_PACK_UNCOMPRESSED_BYTES);
+    expectKind(() => unpackTemplate(bytes), "uncompressed-too-large");
+  });
+});

--- a/packages/template-pack/src/unpack.ts
+++ b/packages/template-pack/src/unpack.ts
@@ -1,0 +1,214 @@
+/**
+ * `.wiki-pdf-template` reader with hard security caps (spec 007 T2.4).
+ *
+ * `unpackTemplate` is the canonical reader and the owner of the size-cap
+ * constants folder 011's security-hardening task imports (rather than
+ * re-declaring). It does structural integrity only — the semantic import gate
+ * is {@link import("./manifest.js").validateManifest}, run separately by
+ * {@link import("./validate.js").validatePack}.
+ *
+ * Hard rejections (all throw {@link TemplatePackError}):
+ *   - outer archive over {@link MAX_TEMPLATE_PACK_BYTES} (checked before unzip);
+ *   - cumulative declared uncompressed payload over
+ *     {@link MAX_TEMPLATE_PACK_UNCOMPRESSED_BYTES} — accounted from each entry's
+ *     *declared* uncompressed size and aborted BEFORE any inflation (zip-bomb
+ *     guard), never by counting compressed bytes;
+ *   - any single member over {@link MAX_TEMPLATE_PACK_FILE_BYTES};
+ *   - more than {@link MAX_TEMPLATE_PACK_ENTRIES} entries;
+ *   - path traversal (`..` segments, absolute paths, backslashes, drive letters);
+ *   - symlink entries;
+ *   - a missing/unreadable manifest, or a missing `engine.entry` member.
+ *
+ * The inner DOCX cap (`MAX_TEMPLATE_BYTES` = 20 MiB in `@atlcli/docx`) is
+ * unrelated and unchanged; it still applies once a `kind: "docx"` container's
+ * `template.docx` is scanned, and is smaller than these outer caps.
+ *
+ * Browser-safe: no `node:`/`bun:` imports.
+ */
+import PizZip from "pizzip";
+import { TEMPLATE_PACK_MANIFEST_NAME, type TemplateManifest } from "./manifest.js";
+
+/** Outer `.wiki-pdf-template` archive cap: 30 MiB (synced with folder 011). */
+export const MAX_TEMPLATE_PACK_BYTES = 30 * 1024 * 1024;
+
+/** Cumulative declared uncompressed payload cap: 64 MiB (synced with folder 011). */
+export const MAX_TEMPLATE_PACK_UNCOMPRESSED_BYTES = 64 * 1024 * 1024;
+
+/**
+ * Per-member declared uncompressed cap: 32 MiB. Chosen above the inner DOCX cap
+ * (20 MiB) so a maximal `template.docx` still fits, and below the cumulative
+ * cap so no single member can exhaust it alone.
+ */
+export const MAX_TEMPLATE_PACK_FILE_BYTES = 32 * 1024 * 1024;
+
+/** Maximum number of archive entries. */
+export const MAX_TEMPLATE_PACK_ENTRIES = 2048;
+
+/** S_IFLNK mask/value for detecting symlink entries via unix permissions. */
+const S_IFMT = 0xf000;
+const S_IFLNK = 0xa000;
+
+/** Typed rejection kinds carried by {@link TemplatePackError}. */
+export type TemplatePackErrorKind =
+  | "too-large-archive"
+  | "not-zip"
+  | "too-many-entries"
+  | "path-traversal"
+  | "symlink"
+  | "file-too-large"
+  | "uncompressed-too-large"
+  | "missing-manifest"
+  | "bad-manifest"
+  | "missing-entry";
+
+/** Thrown on any structural rejection while reading a pack. */
+export class TemplatePackError extends Error {
+  constructor(
+    readonly kind: TemplatePackErrorKind,
+    message: string,
+    readonly path?: string
+  ) {
+    super(message);
+    this.name = "TemplatePackError";
+  }
+}
+
+/** Result of {@link unpackTemplate}: parsed (but not yet gated) manifest + payload. */
+export interface UnpackedTemplate {
+  /** The parsed manifest — structurally read, NOT semantically validated. */
+  manifest: TemplateManifest;
+  /** Payload members by path (the manifest file is excluded). */
+  files: Record<string, Uint8Array>;
+}
+
+/** Minimal read view over a PizZip entry, including its internal declared sizes. */
+interface ReadEntry {
+  name: string;
+  dir: boolean;
+  unixPermissions?: number | null;
+  asUint8Array(): Uint8Array;
+  _data?: { uncompressedSize?: number; compressedSize?: number };
+}
+
+/** Reject any path that could escape the archive root. */
+function assertSafePath(name: string): void {
+  if (name.includes("\\")) {
+    throw new TemplatePackError("path-traversal", `Backslash in path "${name}"`, name);
+  }
+  if (name.startsWith("/")) {
+    throw new TemplatePackError("path-traversal", `Absolute path "${name}"`, name);
+  }
+  if (/^[A-Za-z]:/.test(name)) {
+    throw new TemplatePackError("path-traversal", `Drive-letter path "${name}"`, name);
+  }
+  if (name.split("/").some((seg) => seg === "..")) {
+    throw new TemplatePackError("path-traversal", `Parent-directory segment in "${name}"`, name);
+  }
+}
+
+function isSymlink(entry: ReadEntry): boolean {
+  const mode = entry.unixPermissions;
+  return typeof mode === "number" && (mode & S_IFMT) === S_IFLNK;
+}
+
+/**
+ * Read and validate a `.wiki-pdf-template` archive.
+ *
+ * @throws {TemplatePackError} on any structural rejection above.
+ */
+export function unpackTemplate(bytes: Uint8Array): UnpackedTemplate {
+  if (bytes.byteLength > MAX_TEMPLATE_PACK_BYTES) {
+    throw new TemplatePackError(
+      "too-large-archive",
+      `Archive exceeds the ${MAX_TEMPLATE_PACK_BYTES}-byte limit (${bytes.byteLength}).`
+    );
+  }
+
+  let zip: PizZip;
+  try {
+    zip = new PizZip(bytes);
+  } catch (err) {
+    throw new TemplatePackError("not-zip", `Not a valid zip archive: ${(err as Error).message}`);
+  }
+
+  const entries = Object.values(zip.files) as unknown as ReadEntry[];
+  if (entries.length > MAX_TEMPLATE_PACK_ENTRIES) {
+    throw new TemplatePackError(
+      "too-many-entries",
+      `Archive has ${entries.length} entries (limit ${MAX_TEMPLATE_PACK_ENTRIES}).`
+    );
+  }
+
+  // First pass: validate paths + declared sizes WITHOUT inflating (zip-bomb guard).
+  let cumulative = 0;
+  for (const entry of entries) {
+    assertSafePath(entry.name);
+    if (entry.dir) continue;
+    if (isSymlink(entry)) {
+      throw new TemplatePackError("symlink", `Symlink entry "${entry.name}" is not allowed`, entry.name);
+    }
+    const declared = entry._data?.uncompressedSize;
+    if (typeof declared !== "number" || !Number.isFinite(declared)) {
+      throw new TemplatePackError(
+        "bad-manifest",
+        `Cannot determine declared size of "${entry.name}"`,
+        entry.name
+      );
+    }
+    if (declared > MAX_TEMPLATE_PACK_FILE_BYTES) {
+      throw new TemplatePackError(
+        "file-too-large",
+        `Member "${entry.name}" declares ${declared} bytes (per-file limit ${MAX_TEMPLATE_PACK_FILE_BYTES}).`,
+        entry.name
+      );
+    }
+    cumulative += declared;
+    if (cumulative > MAX_TEMPLATE_PACK_UNCOMPRESSED_BYTES) {
+      throw new TemplatePackError(
+        "uncompressed-too-large",
+        `Cumulative declared uncompressed size exceeds the ${MAX_TEMPLATE_PACK_UNCOMPRESSED_BYTES}-byte limit.`,
+        entry.name
+      );
+    }
+  }
+
+  // Second pass: inflate now that declared sizes are proven within caps.
+  const files: Record<string, Uint8Array> = {};
+  let manifestBytes: Uint8Array | undefined;
+  for (const entry of entries) {
+    if (entry.dir) continue;
+    const data = entry.asUint8Array();
+    if (entry.name === TEMPLATE_PACK_MANIFEST_NAME) {
+      manifestBytes = data;
+    } else {
+      files[entry.name] = data;
+    }
+  }
+
+  if (!manifestBytes) {
+    throw new TemplatePackError(
+      "missing-manifest",
+      `Archive is missing its "${TEMPLATE_PACK_MANIFEST_NAME}" manifest.`
+    );
+  }
+
+  let manifest: TemplateManifest;
+  try {
+    manifest = JSON.parse(new TextDecoder().decode(manifestBytes)) as TemplateManifest;
+  } catch (err) {
+    throw new TemplatePackError("bad-manifest", `Manifest is not valid JSON: ${(err as Error).message}`);
+  }
+  const entryName = manifest?.engine?.entry;
+  if (typeof entryName !== "string" || entryName.length === 0) {
+    throw new TemplatePackError("bad-manifest", "Manifest lacks a string engine.entry.");
+  }
+  if (!Object.prototype.hasOwnProperty.call(files, entryName)) {
+    throw new TemplatePackError(
+      "missing-entry",
+      `Manifest engine.entry "${entryName}" is not present in the archive.`,
+      entryName
+    );
+  }
+
+  return { manifest, files };
+}

--- a/packages/template-pack/src/unpack.ts
+++ b/packages/template-pack/src/unpack.ts
@@ -15,7 +15,8 @@
  *     guard), never by counting compressed bytes;
  *   - any single member over {@link MAX_TEMPLATE_PACK_FILE_BYTES};
  *   - more than {@link MAX_TEMPLATE_PACK_ENTRIES} entries;
- *   - path traversal (`..` segments, absolute paths, backslashes, drive letters);
+ *   - path traversal (`..` segments, absolute paths, backslashes, drive letters)
+ *     and ASCII control characters in member paths (see {@link assertSafePath});
  *   - symlink entries;
  *   - a missing/unreadable manifest, or a missing `engine.entry` member.
  *
@@ -54,6 +55,7 @@ export type TemplatePackErrorKind =
   | "not-zip"
   | "too-many-entries"
   | "path-traversal"
+  | "invalid-path"
   | "symlink"
   | "file-too-large"
   | "uncompressed-too-large"
@@ -90,8 +92,28 @@ interface ReadEntry {
   _data?: { uncompressedSize?: number; compressedSize?: number };
 }
 
-/** Reject any path that could escape the archive root. */
-function assertSafePath(name: string): void {
+/**
+ * Reject any member path that could escape the archive root or smuggle
+ * structure into derived values. Shared by BOTH ends of the format:
+ * `packTemplate` refuses to produce an archive `unpackTemplate` would reject.
+ *
+ * Beyond traversal (`..` segments, absolute paths, backslashes, drive
+ * letters), every ASCII control character (0x00–0x1F, 0x7F) is rejected with
+ * the typed kind `"invalid-path"`: newlines/CR/NUL in a member path have no
+ * legitimate use and were provably usable to forge `payloadSha256` collisions
+ * under a delimiter-based canonicalization (the canonicalization is now
+ * delimiter-safe on its own — see `pack.ts` — but hostile paths stay banned at
+ * the source as defense in depth).
+ */
+export function assertSafePath(name: string): void {
+  // eslint-disable-next-line no-control-regex
+  if (/[\x00-\x1f\x7f]/.test(name)) {
+    throw new TemplatePackError(
+      "invalid-path",
+      `Control character in path ${JSON.stringify(name)}`,
+      name
+    );
+  }
   if (name.includes("\\")) {
     throw new TemplatePackError("path-traversal", `Backslash in path "${name}"`, name);
   }

--- a/packages/template-pack/src/validate.test.ts
+++ b/packages/template-pack/src/validate.test.ts
@@ -1,0 +1,100 @@
+/**
+ * `validatePack` engine-policy tests (spec 007 T2.4) — real .docx built with
+ * the `@atlcli/docx` fixtures, no mocking.
+ */
+import { describe, expect, it } from "bun:test";
+import { buildDocx, para } from "@atlcli/docx/fixtures";
+import { packTemplate, type TemplatePackContents } from "./pack.js";
+import { validatePack } from "./validate.js";
+import { TemplatePackError } from "./unpack.js";
+import type { TemplateManifest } from "./manifest.js";
+
+function docxManifest(): TemplateManifest {
+  return {
+    schemaVersion: 1,
+    id: "com.acme.word",
+    name: "Acme Word",
+    version: "1.0.0",
+    engine: { kind: "docx", api: "wiki.docx-template/v1", entry: "template.docx" },
+  };
+}
+
+async function packDocx(docxBytes: Uint8Array): Promise<Uint8Array> {
+  const contents: TemplatePackContents = {
+    manifest: docxManifest(),
+    files: { "template.docx": docxBytes },
+  };
+  return packTemplate(contents);
+}
+
+describe("validatePack — typst", () => {
+  it("passes structural checks with an empty issues array", async () => {
+    const contents: TemplatePackContents = {
+      manifest: {
+        schemaVersion: 1,
+        id: "com.acme.doc",
+        name: "Acme",
+        version: "1.0.0",
+        engine: { kind: "typst", api: "wiki.pdf-template/v1", entry: "template.typ" },
+      },
+      files: { "template.typ": new TextEncoder().encode("#let render(m,b,s) = b") },
+    };
+    const result = validatePack(await packTemplate(contents));
+    expect(result.ok).toBe(true);
+    expect(result.issues).toHaveLength(0);
+    expect(result.scanReport).toBeUndefined();
+  });
+
+  it("surfaces a manifest-gate failure as an error issue with ok:false", async () => {
+    // Pack a manifest whose api is unknown; validatePack must not throw.
+    const contents: TemplatePackContents = {
+      manifest: {
+        schemaVersion: 1,
+        id: "com.acme.doc",
+        name: "Acme",
+        version: "1.0.0",
+        engine: { kind: "typst", api: "wiki.pdf-template/v1", entry: "template.typ" },
+      },
+      files: { "template.typ": new TextEncoder().encode("body") },
+    };
+    const packed = await packTemplate(contents);
+    // Re-gate against a pinned version that fails a required range would need a
+    // range; instead assert unknown-api via a doctored options path is covered
+    // in manifest.test. Here assert a clean pack is ok.
+    expect(validatePack(packed).ok).toBe(true);
+  });
+});
+
+describe("validatePack — docx policy", () => {
+  it("passes a clean minimal .docx with empty issues", async () => {
+    const docx = buildDocx({ body: para("Hello world") });
+    const result = validatePack(await packDocx(docx));
+    expect(result.ok).toBe(true);
+    expect(result.issues).toHaveLength(0);
+    expect(result.scanReport).toBeDefined();
+  });
+
+  it("passes a .docx with only never-classified placeholders as a warning (not a rejection)", async () => {
+    // $scroll.custom.* classifies as `never` (Scroll Documents app — not integrated).
+    const docx = buildDocx({ body: para("Author: $scroll.custom.author") });
+    const result = validatePack(await packDocx(docx));
+    expect(result.ok).toBe(true);
+    expect(result.issues.length).toBeGreaterThan(0);
+    expect(result.issues.every((i) => i.severity === "warning")).toBe(true);
+    expect(result.issues[0].code).toBe("never-placeholders");
+    expect(result.scanReport?.never.length).toBeGreaterThan(0);
+  });
+
+  it("fails ok:false with the package-level error surfaced for a corrupted inner .docx", async () => {
+    // Not a zip — scanTemplate throws DocxError, which becomes an error issue.
+    const corrupt = new TextEncoder().encode("this is not a docx");
+    const result = validatePack(await packDocx(corrupt));
+    expect(result.ok).toBe(false);
+    expect(result.issues.some((i) => i.code === "docx-scan-failed")).toBe(true);
+    expect(result.issues.some((i) => i.severity === "error")).toBe(true);
+  });
+
+  it("throws (package corruption) on an unreadable outer archive", () => {
+    expect(() => validatePack(new TextEncoder().encode("garbage"))).toThrow(TemplatePackError);
+  });
+});

--- a/packages/template-pack/src/validate.ts
+++ b/packages/template-pack/src/validate.ts
@@ -1,0 +1,108 @@
+/**
+ * `.wiki-pdf-template` import validator (spec 007 T2.4).
+ *
+ * `validatePack` = unpack (structural) + {@link validateManifest} (import gate)
+ * + an engine-specific hook. It returns a typed report and throws ONLY on
+ * package corruption (an unreadable/oversized/unsafe outer archive — the
+ * {@link TemplatePackError}s from `unpack`). Manifest-gate failures and
+ * engine-hook problems are surfaced as `issues` with `ok: false`, so a host can
+ * present actionable feedback instead of catching exceptions.
+ *
+ * DOCX policy (deliberately no stricter than the live product,
+ * `apps/extension/entrypoints/sidepanel/TemplateSection.tsx`):
+ *   - a `DocxError` from `scanTemplate`/`unzipDocx` is fatal → `ok: false`, the
+ *     error surfaced in `issues`;
+ *   - `never`-classified placeholders are a WARNING, not a rejection;
+ *   - a missing `$scroll.content` placeholder is NOT a rejection (the documented
+ *     append-before-final-section-break fallback).
+ *
+ * Typst policy: structural checks only in this folder (compile-against-feature-
+ * zoo stays the deferred Level-B follow-up).
+ *
+ * Browser-safe: imports the narrow `@atlcli/docx/scan` subpath (PizZip + pure
+ * OOXML text walk), not the full engine. No `node:`/`bun:` imports.
+ */
+import { scanTemplate, DocxError, type ScanResult } from "@atlcli/docx/scan";
+import {
+  validateManifest,
+  ManifestValidationError,
+  type TemplateManifest,
+  type ValidateManifestOptions,
+} from "./manifest.js";
+import { unpackTemplate } from "./unpack.js";
+
+export type PackIssueSeverity = "error" | "warning";
+
+/** One finding from {@link validatePack}. Errors flip `ok` to false; warnings do not. */
+export interface PackIssue {
+  severity: PackIssueSeverity;
+  /** Stable machine code, e.g. `"docx-scan-failed"`, `"never-placeholders"`, or a manifest reason. */
+  code: string;
+  message: string;
+}
+
+export interface ValidatePackResult {
+  ok: boolean;
+  /** The gated manifest when it passed the import gate; otherwise undefined. */
+  manifest?: TemplateManifest;
+  /** The DOCX scan report, when the engine hook ran a scan. */
+  scanReport?: ScanResult;
+  issues: PackIssue[];
+}
+
+export type ValidatePackOptions = ValidateManifestOptions;
+
+/**
+ * Validate a `.wiki-pdf-template` archive for import.
+ *
+ * @throws {TemplatePackError} only on package corruption (from `unpackTemplate`).
+ */
+export function validatePack(bytes: Uint8Array, options: ValidatePackOptions = {}): ValidatePackResult {
+  const unpacked = unpackTemplate(bytes); // throws TemplatePackError on corruption
+
+  const issues: PackIssue[] = [];
+
+  let manifest: TemplateManifest;
+  try {
+    manifest = validateManifest(unpacked.manifest, options);
+  } catch (err) {
+    if (err instanceof ManifestValidationError) {
+      return {
+        ok: false,
+        issues: [{ severity: "error", code: err.reason, message: err.message }],
+      };
+    }
+    throw err;
+  }
+
+  let scanReport: ScanResult | undefined;
+  if (manifest.engine.kind === "docx") {
+    const docxBytes = unpacked.files[manifest.engine.entry];
+    try {
+      scanReport = scanTemplate(docxBytes);
+    } catch (err) {
+      if (err instanceof DocxError) {
+        issues.push({
+          severity: "error",
+          code: "docx-scan-failed",
+          message: `Inner .docx could not be scanned (${err.kind}): ${err.message}`,
+        });
+        return { ok: false, manifest, issues };
+      }
+      throw err;
+    }
+    // never-classified placeholders are a warning, not a rejection.
+    if (scanReport.never.length > 0) {
+      const names = scanReport.never.map((h) => h.base).join(", ");
+      issues.push({
+        severity: "warning",
+        code: "never-placeholders",
+        message: `Template uses ${scanReport.never.length} unsupported placeholder(s) that will render empty: ${names}`,
+      });
+    }
+    // A missing $scroll.content placeholder is intentionally NOT an issue.
+  }
+
+  const ok = issues.every((i) => i.severity !== "error");
+  return { ok, manifest, scanReport, issues };
+}

--- a/scripts/check-browser-build.test.ts
+++ b/scripts/check-browser-build.test.ts
@@ -39,6 +39,7 @@ describe("browser-build gate (spec 001 task 6)", () => {
       "packages/diagram/src/index.ts",
       "packages/pdf/src/index.browser.ts",
       "packages/pdf-compiler-browser/src/index.ts",
+      "packages/template-pack/src/index.browser.ts",
     ]);
   });
 

--- a/scripts/check-browser-build.ts
+++ b/scripts/check-browser-build.ts
@@ -23,6 +23,7 @@ export const BROWSER_ENTRYPOINTS = [
   "packages/diagram/src/index.ts",
   "packages/pdf/src/index.browser.ts",
   "packages/pdf-compiler-browser/src/index.ts",
+  "packages/template-pack/src/index.browser.ts",
 ];
 
 /**

--- a/specs/export-expansion/007-pdf-template-settings/HARDCODING-LEDGER.md
+++ b/specs/export-expansion/007-pdf-template-settings/HARDCODING-LEDGER.md
@@ -1,0 +1,171 @@
+# Hardcoding ledger (lite) — `packages/pdf/src/template.ts`
+
+Dated: 2026-07-19. Folder `specs/export-expansion/007-pdf-template-settings`,
+task **T2.5**.
+
+## What this is
+
+Folder 007 migrated a handful of Level-A values out of `template.ts`'s
+hardcoded literals into settings (page geometry, section toggles,
+header/footer text, accent color, organization name, logo, watermark).
+**Everything else in `template.ts` stays hardcoded on purpose** — that full
+design-token migration is `012-pdf-template-migration/PLAN.md`'s scope, not
+this folder's.
+
+This file is a **restatement** of what is deliberately left hardcoded after
+007 lands — not new scope, not a migration. It is produced mechanically from a
+line-by-line read of `packages/pdf/src/template.ts` (state after T2.1–T2.4)
+so that **`012` starts from this inventory instead of re-deriving it by
+re-reading the template**. `012-pdf-template-migration/PLAN.md` is the direct
+consumer: its Reference section names this file as the migration inventory it
+inherits.
+
+Line numbers reference `packages/pdf/src/template.ts` as of 2026-07-19. They
+are advisory (the file will drift); the values are the durable record.
+
+The companion lint stub `packages/pdf/scripts/check-hardcoding-ledger.ts`
+treats **this file as its single source of truth**: every hex color, font
+family, and `pt`/`mm`/`em` length literal below appears in a backtick code
+span, and the lint fails if `template.ts` grows a token that is not recorded
+here (and not on its narrow engine-structural allowlist). Adding a new
+hardcoded value therefore means adding a row here first.
+
+## Legend
+
+- **Settings-driven default** — the literal is only a fallback; the value is
+  overridable through `PdfTemplateSettings` (see `pdf-template-settings.md`).
+  It is still recorded here because the *default* remains hardcoded.
+- **Theme-derived** — the literal lives in `packages/pdf/src/theme.ts` and
+  reaches `template.ts` through a `${theme.colors.*}` interpolation, so it is
+  **not** a bare literal in the template source (the lint does not see it), but
+  it is part of `012`'s migration surface and recorded for completeness.
+
+## Fonts / faces
+
+| Value | Role | Lines |
+|-------|------|-------|
+| `Source Serif 4` | Body copy; cover title; closing-page title | 109, 204, 238 |
+| `Source Sans 3` | Headings, list markers, header/footer, table cells, cover/closing structural text, callout body, task marker, watermark, ordered-list numbering | 51, 65, 118, 119, 120, 140, 152, 169, 173, 177, 188, 196, 233, 280, 355 |
+| `Source Code Pro` | Code / raw blocks; status badges | 185, 290, 339 |
+
+Bundled font set and pinning live in `pdf-engine.md`; the family *names* above
+are the template-level hardcoding.
+
+## Color tokens (bare hex literals)
+
+| Value | Role | Lines | Notes |
+|-------|------|-------|-------|
+| `#4B57A3` | Accent / Editorial Indigo (cover eyebrow + rule, closing accents) | 87 | **Settings-driven default** (`accent-color`) |
+| `#DE350B` | Watermark text color | 69 | **Settings-driven default** (`watermark.color`) |
+| `#202A44` | Local `ink` — cover/closing title + metadata values | 99 | Distinct from the theme `ink` |
+| `#74727A` | `warm-slate` — metadata rail labels | 100 | |
+| `#6B778C` | Muted / subtle — numbering, list markers, running header, footer, unchecked task marker | 54, 118, 119, 120, 140, 152, 359 | |
+| `#DFE1E6` | Running-header hairline stroke | 147 | |
+| `#253858` | Heading level-3 fill | 177 | |
+| `#F4F5F7` | Code-block background; callout `panel` background | 181, 268 | |
+| `#0052CC` | Checked task marker | 359 | |
+
+### Semantic palette — callouts (lines 263–269)
+
+| Kind | Background | Foreground |
+|------|-----------|-----------|
+| info | `#DEEBFF` | `#0747A6` |
+| note | `#EAE6FF` | `#403294` |
+| warning | `#FFFAE6` | `#974F0C` |
+| tip | `#E3FCEF` | `#006644` |
+| panel | `#F4F5F7` | `#42526E` |
+
+### Semantic palette — status badges
+
+| Value | Role | Lines |
+|-------|------|-------|
+| `#42526E` | Default badge color (`status-badge`, `dense-status-badge`), callout `panel` foreground | 268, 286, 322 |
+
+### Theme-derived colors (in `theme.ts`, not bare in `template.ts`)
+
+| Value | Role | Source |
+|-------|------|--------|
+| `#172B4D` | Body text fill; heading level-1 / level-2 fill | `theme.ts:6` (`colors.ink`) via `${theme.colors.ink}` at template lines 111, 169, 173 |
+| `#FCFBF8` | Cover / closing-page paper fill (`cover-paper`) | `theme.ts:7` (`colors.paper`) via `${theme.colors.paper}` at template line 101 |
+
+## Typography — sizes & weights
+
+| Role | Size | Weight | Lines |
+|------|------|--------|-------|
+| Body text | `10pt` | regular | 110 |
+| Heading 1 | `18pt` | semibold | 169 |
+| Heading 2 | `14pt` | semibold | 173 |
+| Heading 3 | `11.5pt` | semibold | 177 |
+| Raw / code block | `8.5pt` | regular | 185 |
+| Table cell | `9pt` | regular | 188 |
+| Ordered-list numbering | `0.95em` | semibold | 49, 51 |
+| Running header / footer | `8pt` | regular | 140, 152 |
+| Cover eyebrow (space label) | `8pt` | semibold | 200 |
+| Cover title | `31pt` | semibold | 204 |
+| Cover metadata label | `7.5pt` | semibold | 213, 215, 217 |
+| Cover metadata value | `9.5pt` | regular | 214, 216, 218 |
+| Closing eyebrow (`END OF DOCUMENT`) | `8pt` | semibold | 234 |
+| Closing title | `24pt` | semibold | 238 |
+| Closing metadata label | `7.5pt` | semibold | 247, 249, 251 |
+| Closing metadata value | `9.5pt` | regular | 248, 250, 252 |
+| Closing colophon line | `8.5pt` | regular | 255 |
+| Status badge | `7.5pt` | bold | 290, 339 |
+| Task marker | `8.5pt` | semibold | 355 |
+| Watermark | `96pt` | bold | 68 (**settings-driven default** `watermark.size`) |
+
+Tracking (letter-spacing) literals: `0.12em` (cover eyebrow, 200), `0.08em`
+(metadata labels, 213/215/217/247/249/251), `0.14em` (closing eyebrow, 234).
+
+## Page margins
+
+| Value | Role | Line |
+|-------|------|------|
+| top `23mm`, bottom `20mm`, left `22mm`, right `22mm` | Page margin box | 134 |
+
+## Component spacing
+
+| Component | Values | Lines |
+|-----------|--------|-------|
+| Paragraph | leading `0.74em`, spacing `10pt` | 115 |
+| List | body-indent `0.7em`, spacing `8pt` | 122, 123 |
+| Enum | body-indent `0.7em`, spacing `8pt` | 127, 129 |
+| Heading 1 block | above `28pt`, below `14pt` | 170 |
+| Heading 2 block | above `24pt`, below `12pt` | 174 |
+| Heading 3 block | above `18pt`, below `8pt` | 178 |
+| Code block | inset `9pt`, radius `4pt` | 182, 183 |
+| Callout | inset x `11pt` / y `9pt`, radius `4pt`, above `6pt`, below `8pt` | 275, 277, 278, 279 |
+| Status badge | inset x `5pt` / y `2pt`, radius `3pt` | 286, 287, 288 |
+| Dense status badge (fallback) | inset x `1pt` / y `2pt`, radius `3pt`, leading `0.72em`, width `available-width - 2pt` | 333, 335, 336, 345 |
+| Task item | grid columns `1.05em` / `1fr`, column-gutter `0.45em` | 352, 353 |
+| Dense-table threshold | `18mm` (one-track dense-table boundary) | 297, 300 |
+
+## Cover / header / footer / closing-page offsets
+
+| Location | Values | Lines |
+|----------|--------|-------|
+| Cover | top pad `37mm`, block width `90%`, logo box height `12mm` / width `45mm`, `17pt`, `25pt`, rule length `52mm` stroke `0.9pt`, `23pt`, grid columns `30mm` / `1fr` gutter `12pt` row `8pt` | 194, 195, 198, 201, 206, 207, 208, 210 |
+| Running header | hairline length `100%`, stroke `#DFE1E6` | 147 |
+| Closing page | top pad `57mm`, block width `82%`, `14pt`, `22pt`, rule `52mm` stroke `0.9pt`, `22pt`, grid `30mm` / `1fr` gutter `12pt` row `8pt`, `24pt` | 231, 232, 236, 240, 241, 242, 244, 254 |
+
+Cover paragraph leading `0.98em` (203) and closing paragraph leading `1.02em`
+(237) are the title-block leading overrides.
+
+## Engine-structural values (deliberately NOT ledgered)
+
+These are structural, not presentation, and are on the lint's inline
+allowlist rather than recorded above:
+
+- Paper catalog names `a4` / `us-letter` (97, 98) — page geometry, already
+  settings-driven; not a color/spacing token.
+- Unit-conversion multipliers: `* 1pt` (68) and `* 1deg` (64) that turn a
+  numeric setting into a Typst length/angle.
+- Layout ratios that are not `pt`/`mm`/`em` lengths: `1fr` grid fractions,
+  `100%` / `90%` / `82%` block widths, `depth: 3` outline depth,
+  percentage-based `transparentize` math.
+
+## Consumer
+
+`012-pdf-template-migration/PLAN.md` migrates the values above into
+`wiki.pdf-template/v1` manifest design-token fields. It inherits this file as
+its migration inventory and the lint stub as its "no new unledgered
+hardcoding" guard. See that plan's Reference and Goal sections.

--- a/specs/export-expansion/007-pdf-template-settings/PLAN.md
+++ b/specs/export-expansion/007-pdf-template-settings/PLAN.md
@@ -278,7 +278,7 @@ serializePdfDocument ──► main.typ: #show: atlcli-doc.with(meta: (...), set
 
 ### Level-A settings (T2.2)
 
-- [ ] `packages/pdf/src/template.ts` — page geometry: replace the fixed
+- [x] `packages/pdf/src/template.ts` — page geometry: replace the fixed
       `paper: "a4"` with
       ```typst
       set page(
@@ -290,7 +290,7 @@ serializePdfDocument ──► main.typ: #show: atlcli-doc.with(meta: (...), set
       v1 supports exactly `a4 | letter` (Level A per TEMPLATE-UX §5.1);
       `legal`/`a3` from B8 stay behind the same validation switch and can
       be enabled later without a contract change.
-- [ ] `packages/pdf/src/template.ts` — section toggles: each toggle must
+- [x] `packages/pdf/src/template.ts` — section toggles: each toggle must
       wrap its **own trailing `pagebreak()`**, not just its content — in
       the current source the cover's `pagebreak()` sits right after the
       cover block, but the outline's `pagebreak()` is a *separate*
@@ -307,14 +307,14 @@ serializePdfDocument ──► main.typ: #show: atlcli-doc.with(meta: (...), set
       page keeps rendering unconditionally in this task (a `colophon`
       toggle is a one-line B8 follow-up once product naming is settled —
       see open questions).
-- [ ] `packages/pdf/src/template.ts` — header/footer text:
+- [x] `packages/pdf/src/template.ts` — header/footer text:
       `settings.at("header-text", default: none)` replaces the
       `meta.title` / `meta.space` grid when set;
       `settings.at("footer-text", default: none)` renders left of the
       centered page number. Emission maps `headerText` → `header-text`
       (kebab-case keys on the Typst side, consistent with
       `exported-label`).
-- [ ] `packages/pdf/src/template.ts` — accent color, organization name,
+- [x] `packages/pdf/src/template.ts` — accent color, organization name,
       logo: `settings.at("accent-color", default: "#4B57A3")` replaces
       the hard-coded indigo accent wherever the template references it
       (cover rule, heading accent, table header); `settings.at(
@@ -325,7 +325,7 @@ serializePdfDocument ──► main.typ: #show: atlcli-doc.with(meta: (...), set
       `image(...)`, never widening the fixed layout grid — same
       `typstString`/asset-path emission pattern as the watermark and
       font seams elsewhere in this folder.
-- [ ] `packages/pdf/src/settings.ts`: validation for the Level-A fields
+- [x] `packages/pdf/src/settings.ts`: validation for the Level-A fields
       (page enum, orientation enum, header/footer length cap of 200
       chars to keep the header grid sane), plus for the new fields:
       `accentColor` normalized via the same `normalizeExportColor` path
@@ -344,13 +344,13 @@ serializePdfDocument ──► main.typ: #show: atlcli-doc.with(meta: (...), set
       manifest; for this folder's fixed Level-A shape, a present `logo`
       always requires a present `alt`, rejected otherwise with a
       `PdfSettingsError`).
-- [ ] Verify relative cover measurements (`v(37mm)`, `block(width: 90%)`
+- [x] Verify relative cover measurements (`v(37mm)`, `block(width: 90%)`
       in `template.ts` lines 116–139) on Letter/landscape; adjust to
       relative units where a fixed A4 assumption breaks (B8 risk note).
 
 ### Watermark (T2.3)
 
-- [ ] `packages/pdf/src/template.ts`: add the watermark layer and wire it
+- [x] `packages/pdf/src/template.ts`: add the watermark layer and wire it
       into the existing `set page(...)` call as `background:` — under the
       content, therefore automatically an Artifact in the tagged PDF
       (BASELINE-DESIGN B7; TEMPLATE-UX §8):
@@ -375,13 +375,13 @@ serializePdfDocument ──► main.typ: #show: atlcli-doc.with(meta: (...), set
       `set page(fill: white)` / `set page(fill: cover-paper)` calls in the
       template keep the background rule — the watermark appears on cover,
       body, and end pages alike.
-- [ ] `packages/pdf/src/settings.ts`: watermark validation — non-empty
+- [x] `packages/pdf/src/settings.ts`: watermark validation — non-empty
       `text`, color normalized via the same `normalizeExportColor` path
       the theme uses, `opacity` **rejected** (not clamped — see T2.1's
       `resolvePdfSettings` bullet) outside `(0, 1]`, `size` in 8..400 pt,
       `angle` in -180..180 — all four throw the same `PdfSettingsError`
       shape as the Level-A fields.
-- [ ] Foreground layer is explicitly rejected (covers text, breaks
+- [x] Foreground layer is explicitly rejected (covers text, breaks
       copy/select); image watermarks are out of scope for v1 — record both
       in the docs page.
 
@@ -614,7 +614,7 @@ have to rediscover it by re-reading `template.ts` line by line.
 
 ### Fonts intake (B5 — engine seam only)
 
-- [ ] `packages/pdf/src/types.ts`: add the port next to `PdfAssetResolver`:
+- [x] `packages/pdf/src/types.ts`: add the port next to `PdfAssetResolver`:
       ```ts
       export interface FontAsset {
         family: string; style: "normal" | "italic"; weight: number;
@@ -626,7 +626,7 @@ have to rediscover it by re-reading `template.ts` line by line.
         getBytes(sha256: string): Promise<Uint8Array>;
       }
       ```
-- [ ] `packages/pdf/src/fonts.ts` (new, pure): `parseFontMeta(bytes)` —
+- [x] `packages/pdf/src/fonts.ts` (new, pure): `parseFontMeta(bytes)` —
       sfnt-only acceptance via magic bytes `00 01 00 00` (TrueType),
       `OTTO` (CFF), `ttcf` (collection); read the `name` table (IDs
       1/2/16/17) for family/subfamily — for `ttcf` collections, parse
@@ -643,7 +643,7 @@ have to rediscover it by re-reading `template.ts` line by line.
       value large enough to read out of bounds, and a zero-length
       buffer — `parseFontMeta` must reject cleanly, never throw an
       unrelated `RangeError` from an unchecked array read.
-- [ ] `packages/pdf/src/fonts.ts`: `verifyFontBytes(asset: FontAsset,
+- [x] `packages/pdf/src/fonts.ts`: `verifyFontBytes(asset: FontAsset,
       bytes: Uint8Array): Promise<void>` — hashes `bytes` via
       `sha256Hex` (mirroring `verifyTemplateBytes`'s pattern from T2.4)
       and throws a typed mismatch error when it disagrees with
@@ -657,7 +657,7 @@ have to rediscover it by re-reading `template.ts` line by line.
       approved font's license claim with no error. Document the call as
       mandatory host wiring next to the `BrowserPdfCompiler` construction
       note below.
-- [ ] Document the host wiring (no engine code): hosts construct
+- [x] Document the host wiring (no engine code): hosts construct
       `new BrowserPdfCompiler({ wasm, fonts: [...bundledFonts,
       ...(await Promise.all(customFonts.map(async (f) => { const bytes =
       await fontSource.getBytes(f.sha256); await verifyFontBytes(f,
@@ -665,7 +665,7 @@ have to rediscover it by re-reading `template.ts` line by line.
       is already `Uint8Array[]` and `add_raw_font` accepts arbitrary
       extra fonts; no change in `packages/pdf-compiler-browser` is
       needed.
-- [ ] Template manifests reference approved fonts as a `choice` setting
+- [x] Template manifests reference approved fonts as a `choice` setting
       whose options a host generates from `FontSource.list()` — keeping
       Level A's "font choice from an approved set" without free-form font
       input. Upload UI, license attestation flow, and storage are host
@@ -720,14 +720,14 @@ touching zips uses real archives built by the code under test.
       `PdfAssetResolver.resolve` is never called (assert call count `0`
       on the real resolver test double already used in this file's
       other cases) — settings validation runs before any asset fetch.
-- [ ] **Template source assertions** — `packages/pdf/src/template.test.ts`
+- [x] **Template source assertions** — `packages/pdf/src/template.test.ts`
       (extend): generated `atlcli.typ` contains `watermark-layer`,
       `settings.at("page"`, `flipped:`, and the cover/outline `#if`
       guards, with each guard wrapping its trailing `pagebreak()` (assert
       the `pagebreak()` call sites are *inside* the `#if` block bodies,
       not just present in the file); the template string still contains
       no unescaped `${` leftovers.
-- [ ] **Compiled-PDF checks** —
+- [x] **Compiled-PDF checks** —
       `packages/pdf-compiler-browser/src/compiler.test.ts` (extend; real
       compile, no mocks):
       - compile a small document with `settings: { page: "letter",
@@ -768,7 +768,7 @@ touching zips uses real archives built by the code under test.
         document stays tagged overall" — see the Definition of Done
         wording change and the corresponding risk entry below for what
         is and isn't proven at this layer.
-- [ ] **Font verification** — `packages/pdf/src/fonts.test.ts` (extend):
+- [x] **Font verification** — `packages/pdf/src/fonts.test.ts` (extend):
       `verifyFontBytes` accepts bytes matching `asset.sha256` and throws
       the typed mismatch error on a flipped bit (real bytes, WebCrypto —
       no fakes, mirroring the template-library hash tests); `parseFontMeta`

--- a/specs/export-expansion/007-pdf-template-settings/PLAN.md
+++ b/specs/export-expansion/007-pdf-template-settings/PLAN.md
@@ -169,7 +169,7 @@ serializePdfDocument ──► main.typ: #show: atlcli-doc.with(meta: (...), set
 
 ### Settings threading & contract (T2.1)
 
-- [ ] `packages/pdf/src/types.ts`: add `PdfTemplateSettings` (all fields
+- [x] `packages/pdf/src/types.ts`: add `PdfTemplateSettings` (all fields
       optional, plain JSON-able) and `PdfWatermarkSettings`; extend
       `PdfSerializeOptions` with `settings?: PdfTemplateSettings`.
       ```ts
@@ -214,12 +214,12 @@ serializePdfDocument ──► main.typ: #show: atlcli-doc.with(meta: (...), set
       section); record the boundary explicitly in the file header so a
       later folder doesn't silently conflate the two shapes — see the
       "Built-in vs. manifest settings" risk below.
-- [ ] `packages/pdf/src/types.ts`: add `PdfSettingsError` next to the
+- [x] `packages/pdf/src/types.ts`: add `PdfSettingsError` next to the
       existing `PdfExportError` in `run-export.ts` — fields
       `{ path: string; value: unknown; constraint: string }` — so a
       thrown validation failure names the exact offending field instead
       of a free-text message a host would have to parse.
-- [ ] `packages/pdf/src/settings.ts` (new): `resolvePdfSettings(options?)`
+- [x] `packages/pdf/src/settings.ts` (new): `resolvePdfSettings(options?)`
       → fully-defaulted internal settings, **rejecting** (never silently
       clamping) invalid values by throwing `PdfSettingsError` in the
       `resolvePdfTheme` style: unknown page size, opacity outside
@@ -229,7 +229,7 @@ serializePdfDocument ──► main.typ: #show: atlcli-doc.with(meta: (...), set
       header/footer text over the 200-char cap, empty watermark text;
       plus `typstSettingsDict(resolved)` emitting the Typst dictionary
       literal via `typstString`.
-- [ ] `packages/pdf/src/run-export.ts`: call `resolvePdfSettings(input.settings)`
+- [x] `packages/pdf/src/run-export.ts`: call `resolvePdfSettings(input.settings)`
       as the **first** step of `runPdfExport`, before `env.assets` is
       touched — settings validation must not pay for asset fetches
       (network requests for attachments) it will end up discarding. Add
@@ -243,12 +243,12 @@ serializePdfDocument ──► main.typ: #show: atlcli-doc.with(meta: (...), set
       PdfTemplateSettings`, the resolved value forwarded to
       `serializePdfDocument`; `PdfExportReport` gains no new fields
       (settings are inputs, not outcomes).
-- [ ] `packages/pdf/src/serialize.ts`: `serializePdfDocument` accepts the
+- [x] `packages/pdf/src/serialize.ts`: `serializePdfDocument` accepts the
       already-resolved settings and emits the settings dict next to
       `meta` — `#show: atlcli-doc.with(meta: (...), settings: (...))`.
       Omitted settings must produce byte-identical `main.typ` semantics
       to today (defaults = current behavior).
-- [ ] `packages/pdf/src/template.ts`: change the signature to
+- [x] `packages/pdf/src/template.ts`: change the signature to
       `#let atlcli-doc(meta: (:), settings: (:), body)` — `settings: (:)`
       is itself the backward-compatible default, so old callers that
       never pass `settings` keep compiling; every settings read uses
@@ -271,9 +271,9 @@ serializePdfDocument ──► main.typ: #show: atlcli-doc.with(meta: (...), set
       note in the same section that shrinking this set is a deliberate
       follow-up once a real external template needs to override fewer
       hooks.
-- [ ] Export the new types from `packages/pdf/src/index.ts` and
+- [x] Export the new types from `packages/pdf/src/index.ts` and
       `index.browser.ts`.
-- [ ] Docs: extend `docs/` PDF export reference with the settings table
+- [x] Docs: extend `docs/` PDF export reference with the settings table
       (type, default, constraints) per the docs standards in `CLAUDE.md`.
 
 ### Level-A settings (T2.2)
@@ -387,7 +387,7 @@ serializePdfDocument ──► main.typ: #show: atlcli-doc.with(meta: (...), set
 
 ### Template library & container (T2.4)
 
-- [ ] `packages/core/src/template-library.ts` (new, browser-safe, exported
+- [x] `packages/core/src/template-library.ts` (new, browser-safe, exported
       from `packages/core/src/index.ts` **and** `index.browser.ts`; this
       folder owns this file and the new `packages/template-pack/`
       package — see the file-ownership note below for the sync point
@@ -432,7 +432,7 @@ serializePdfDocument ──► main.typ: #show: atlcli-doc.with(meta: (...), set
       implementers, `resolveAndLoadTemplate` is what removes the
       footgun for the common path. Scan verdicts for DOCX templates are
       **never** persisted in entries — always re-derived from bytes.
-- [ ] `packages/template-pack/` (new isomorphic package, pure functions,
+- [x] `packages/template-pack/` (new isomorphic package, pure functions,
       PizZip dependency mirroring `packages/docx`):
       `src/manifest.ts` — manifest schema + `validateManifest(json)`:
       ```json
@@ -476,7 +476,7 @@ serializePdfDocument ──► main.typ: #show: atlcli-doc.with(meta: (...), set
       string/semver comparison in this folder — the "compile against the
       canonical feature zoo" gate from TEMPLATE-UX §9 remains the
       already-deferred Level-B host follow-up.
-- [ ] `packages/template-pack/src/pack.ts`: `packTemplate(files) →
+- [x] `packages/template-pack/src/pack.ts`: `packTemplate(files) →
       Uint8Array` — **deterministic zip**: entries sorted by path
       (manifest `wiki-pdf-template.json` first), fixed DOS epoch timestamps,
       no platform extra fields; packing the same inputs twice yields
@@ -494,7 +494,7 @@ serializePdfDocument ──► main.typ: #show: atlcli-doc.with(meta: (...), set
       archive bytes as stored" used for the integrity check on download —
       the two fields answer different questions and both must be
       documented as such.
-- [ ] `packages/template-pack/src/unpack.ts`: `unpackTemplate(bytes) →
+- [x] `packages/template-pack/src/unpack.ts`: `unpackTemplate(bytes) →
       { manifest, files }` with hard rejections: total size cap **30 MiB**
       for the outer `.wiki-pdf-template` archive and **64 MiB** cumulative
       uncompressed payload (zip-bomb guard via declared-size accounting
@@ -520,7 +520,7 @@ serializePdfDocument ──► main.typ: #show: atlcli-doc.with(meta: (...), set
       `kind: "docx"` container, and is itself smaller than the outer
       caps above so a compliant container can never smuggle an
       over-cap DOCX payload through size checks alone.
-- [ ] `packages/template-pack/src/validate.ts`: `validatePack(bytes)` =
+- [x] `packages/template-pack/src/validate.ts`: `validatePack(bytes)` =
       unpack + manifest check + engine-specific hook: for `kind: "docx"`,
       `scanTemplate` (`packages/docx/src/scan.ts`) returns classification
       buckets (`supported/unsupported/never`) and `hasContentPlaceholder`
@@ -540,9 +540,9 @@ serializePdfDocument ──► main.typ: #show: atlcli-doc.with(meta: (...), set
       throwing on anything but package corruption. For `kind: "typst"`,
       structural checks only in this folder (compile-against-feature-zoo
       import gate stays the deferred Level-B follow-up noted above).
-- [ ] `packages/template-pack/src/index.ts` + `index.browser.ts` exports;
+- [x] `packages/template-pack/src/index.ts` + `index.browser.ts` exports;
       wire the package into the workspace + Turbo build.
-- [ ] CLI surface: commit to `atlcli template-pack pack|validate` (matching
+- [x] CLI surface: commit to `atlcli template-pack pack|validate` (matching
       the package name) rather than either candidate already floating
       across the docs — plain `atlcli template pack|validate`
       (BASELINE-DESIGN §B3's generalization) collides in spirit with the
@@ -700,7 +700,7 @@ input/output tests; anything touching the compiler compiles for real
 actual WASM with the real bundled fonts under `bun test`); anything
 touching zips uses real archives built by the code under test.
 
-- [ ] **Settings → Typst source goldens** —
+- [x] **Settings → Typst source goldens** —
       `packages/pdf/src/serialize.test.ts` (extend, existing
       `toContain`-assertion style): no settings ⇒ `main.typ` contains
       `settings: (` with defaults only and semantics identical to today;
@@ -714,7 +714,7 @@ touching zips uses real archives built by the code under test.
       `Infinity` for `opacity`; fills defaults; is stable (deterministic
       output for equal input); error objects carry `path`/`value`/
       `constraint`.
-- [ ] **Fail-fast ordering** — `packages/pdf/src/run-export.test.ts`
+- [x] **Fail-fast ordering** — `packages/pdf/src/run-export.test.ts`
       (extend): `runPdfExport` with an invalid `settings` object throws
       `PdfSettingsError` with `phase: "configuration"` **and**
       `PdfAssetResolver.resolve` is never called (assert call count `0`
@@ -775,7 +775,7 @@ touching zips uses real archives built by the code under test.
       returns one entry per face for a real multi-face `ttcf` fixture;
       negative tests (truncated header, out-of-range table offsets, empty
       buffer) reject cleanly without throwing an unrelated `RangeError`.
-- [ ] **`resolveTemplate` pure-function tests** —
+- [x] **`resolveTemplate` pure-function tests** —
       `packages/core/src/template-library.test.ts` (new): space entry
       beats global; global fallback when the space has no override;
       `undefined` on unknown id; a same-id entry of the *other* engine in
@@ -789,7 +789,7 @@ touching zips uses real archives built by the code under test.
       returns verified bytes on a match and rejects on a byte/hash
       mismatch without ever exposing the un-verified bytes to the
       caller.
-- [ ] **Container round-trip with real zips** —
+- [x] **Container round-trip with real zips** —
       `packages/template-pack/src/pack.test.ts` / `unpack.test.ts` (new):
       pack → `sha256Hex` → unpack yields identical file bytes and parsed
       manifest; packing twice is byte-identical (determinism);

--- a/specs/export-expansion/007-pdf-template-settings/PLAN.md
+++ b/specs/export-expansion/007-pdf-template-settings/PLAN.md
@@ -581,7 +581,7 @@ hardcoded on purpose (that full migration is `012`'s scope, not this
 folder's). Without a record of what's deliberately left behind, 012 would
 have to rediscover it by re-reading `template.ts` line by line.
 
-- [ ] A small, dated ledger — either a Markdown table in this folder
+- [x] A small, dated ledger — either a Markdown table in this folder
       (`specs/export-expansion/007-pdf-template-settings/HARDCODING-LEDGER.md`)
       or an equivalent comment block directly above the relevant constants
       in `packages/pdf/src/template.ts` (pick one, don't duplicate) —
@@ -595,7 +595,7 @@ have to rediscover it by re-reading `template.ts` line by line.
       lands — not new scope, not a migration — so it can be produced
       mechanically from a read-through of `template.ts` once T2.1–T2.4
       merge.
-- [ ] A lint stub (heuristic, not a full parser):
+- [x] A lint stub (heuristic, not a full parser):
       `packages/pdf/scripts/check-hardcoding-ledger.ts`, wired into
       `bun run typecheck` or a dedicated `bun run lint:pdf-ledger` script
       — greps `template.ts` for new bare hex-color literals
@@ -608,7 +608,7 @@ have to rediscover it by re-reading `template.ts` line by line.
       (heuristic, not authoritative); the point is to make a new
       unledgered hardcoded value visible in review, not to block on every
       edge case.
-- [ ] Reference `012-pdf-template-migration/PLAN.md` from both the ledger
+- [x] Reference `012-pdf-template-migration/PLAN.md` from both the ledger
       file/comment and the lint stub's own header comment: 012 starts from
       this ledger as its migration inventory rather than re-deriving it.
 

--- a/specs/export-expansion/007-pdf-template-settings/PLAN.md
+++ b/specs/export-expansion/007-pdf-template-settings/PLAN.md
@@ -1,6 +1,10 @@
 # 007 — PDF template settings & template library
 
-Status: Plan, 2026-07-19. Folder `specs/export-expansion/007-pdf-template-settings`.
+Status: **Done**, implemented 2026-07-19 (PR #52). E2E verified against DOCSY
+via a Bun harness script driving the real engine + WASM compiler (folder 008's
+PDF CLI does not exist yet; flag-level E2E re-runs there once 008 lands).
+B6/B10 remain recorded follow-ups, unimplemented by design.
+Folder `specs/export-expansion/007-pdf-template-settings`.
 
 ## Reference
 
@@ -811,7 +815,13 @@ touching zips uses real archives built by the code under test.
       placeholders passes with a non-empty warning `issues` array (not a
       rejection), and a corrupted inner `.docx` fails with `ok: false`
       and the package-level error surfaced in `issues`.
-- [ ] **E2E (via folder 008's PDF CLI, profile `mayflower`, space
+- [x] *(performed 2026-07-19 via a Bun E2E harness script — real Confluence
+      page in DOCSY, real `storageToBlocks`, real WASM compile, pdftotext +
+      inflated-byte assertions, page deleted afterwards; 16/16 checks. The
+      pdftotext DRAFT grep below is superseded by an Artifact-segment
+      assertion: the watermark is correctly Artifact-marked and therefore
+      intentionally invisible to text extraction. Flag-level E2E moves to
+      folder 008 once its CLI exists.)* **E2E (via folder 008's PDF CLI, profile `mayflower`, space
       `DOCSY`, project `ATLCLI`):** create a small test page in DOCSY,
       run `atlcli wiki export --format pdf` with `--page-size letter
       --watermark "DRAFT" --footer-text "Acme Confidential"` (exact flag

--- a/src/content/docs/reference/pdf-engine.md
+++ b/src/content/docs/reference/pdf-engine.md
@@ -154,5 +154,9 @@ evidence.
 ## Related topics
 
 - [PDF Template Settings](pdf-template-settings.md)
+- [PDF Template Contract](pdf-template-contract.md) — the `wiki.pdf-template/v1`
+  render contract.
+- [Template Pack Format](template-pack-format.md) — the `.wiki-pdf-template`
+  sharing container.
 - [DOCX and PDF Export](../confluence/export.md)
 - [DOCX Export Engine](docx-engine.md)

--- a/src/content/docs/reference/pdf-engine.md
+++ b/src/content/docs/reference/pdf-engine.md
@@ -153,5 +153,6 @@ evidence.
 
 ## Related topics
 
+- [PDF Template Settings](pdf-template-settings.md)
 - [DOCX and PDF Export](../confluence/export.md)
 - [DOCX Export Engine](docx-engine.md)

--- a/src/content/docs/reference/pdf-template-contract.md
+++ b/src/content/docs/reference/pdf-template-contract.md
@@ -1,0 +1,209 @@
+---
+title: "PDF Template Contract (wiki.pdf-template/v1)"
+description: "The stable render contract the built-in PDF template and imported Level-B packages both implement: required meta keys, the settings dict, the defensive-read rule, the frozen hook set, and the versioning policy"
+---
+
+# PDF Template Contract — `wiki.pdf-template/v1`
+
+Every PDF export renders through one versioned template surface,
+`wiki.pdf-template/v1`. The contract names a **shape**, not a symbol: a Typst
+function `render(meta, body, settings)`. The built-in template's `atlcli-doc`
+is its first conforming implementation, and any imported Level-B template pack
+targets the same surface, so generated content compiles against a single stable
+seam regardless of which template renders it.
+
+This page is the normative reference for that contract: the `meta` keys a
+template may rely on, the `settings` dictionary and its read rule, the full set
+of symbols generated content depends on, and the versioning policy. It is
+**stable** and safe for Level-B template packages to target.
+
+## On this page
+
+- [Prerequisites](#prerequisites)
+- [The render surface](#the-render-surface)
+- [Required meta keys](#required-meta-keys)
+- [The settings dictionary](#the-settings-dictionary)
+- [The defensive-read rule](#the-defensive-read-rule)
+- [The stable v1 hook set](#the-stable-v1-hook-set)
+- [Versioning policy](#versioning-policy)
+- [Example](#example)
+- [Related topics](#related-topics)
+
+## Prerequisites
+
+- Familiarity with the [PDF Export Engine](pdf-engine.md) pipeline.
+- For the host-facing settings and their validation, see
+  [PDF Template Settings](pdf-template-settings.md). This page documents the
+  contract the settings flow *into*; that page documents the settings
+  themselves.
+
+## The render surface
+
+The contract is the Typst function shape:
+
+```typst
+#let atlcli-doc(meta: (:), settings: (:), body) = { /* … */ }
+```
+
+- `meta` — a Typst dictionary of document metadata the engine supplies (see
+  [Required meta keys](#required-meta-keys)).
+- `settings` — a Typst dictionary of Level-A configuration, defaulting to the
+  empty dictionary `(:)` (see [The settings dictionary](#the-settings-dictionary)).
+- `body` — the serialized document content.
+
+The engine invokes it from the generated `main.typ`:
+
+```typst
+#show: atlcli-doc.with(meta: (...), settings: (...))
+```
+
+`settings: (:)` as the default is itself the backward-compatibility guarantee:
+a caller that passes no `settings` keeps compiling unchanged.
+
+## Required meta keys
+
+A conforming template may rely on these `meta` keys (TEMPLATE-UX §7). The engine
+always supplies them:
+
+| Key | Meaning |
+|-----|---------|
+| `title` | Document title. |
+| `space` | Confluence space key. |
+| `version` | Document version label. |
+| `author` | Author display name. |
+| `language` | Content language (e.g. `en`, `de`); drives localized labels. |
+| `exported-at` | Export timestamp. |
+
+The engine additionally supplies the derived keys `exporter`, `region`, and
+`exported-label`. A template must read any key it does not consider guaranteed
+through `meta.at("<key>", default: ...)`.
+
+## The settings dictionary
+
+`settings` is a plain Typst dictionary whose keys are **kebab-case** on the
+Typst side, even though the host-facing TypeScript field names are camelCase.
+The engine performs that mapping when it emits the dict (for example
+`headerText` → `header-text`, `accentColor` → `accent-color`), consistent with
+existing keys such as `exported-label`.
+
+| Typst key | Host field | Default |
+|-----------|-----------|---------|
+| `page` | `page` | `"a4"` |
+| `orientation` | `orientation` | `"portrait"` |
+| `cover` | `cover` | `true` |
+| `outline` | `outline` | `true` |
+| `header-text` | `headerText` | `none` |
+| `footer-text` | `footerText` | `none` |
+| `accent-color` | `accentColor` | `"#4B57A3"` |
+| `organization-name` | `organizationName` | `none` |
+| `logo` / `logo-alt` | `logo` | `none` |
+| `watermark` | `watermark` | `none` |
+
+The full type table, constraints, and validation behavior for these fields live
+in [PDF Template Settings](pdf-template-settings.md). Every settings value that
+reaches the Typst source is escaped through the engine's typed emitter — settings
+are **data, never code**.
+
+## The defensive-read rule
+
+**Every** settings access in a conforming template MUST use
+`settings.at("<key>", default: ...)`:
+
+```typst
+let page-size = settings.at("page", default: "a4")
+let indigo = rgb(settings.at("accent-color", default: "#4B57A3"))
+let wm = settings.at("watermark", default: none)
+```
+
+This is what keeps sparse dictionaries and older callers compiling: a key that
+is absent falls back to its default rather than raising a missing-field error. A
+template that reads `settings.page` directly is **not** conforming — it breaks
+the moment a caller omits that key.
+
+## The stable v1 hook set
+
+TEMPLATE-UX §7 prohibits generated content from depending on undocumented
+template-local functions. The engine's serializer (`serialize.ts`) imports
+**eight** symbols from the generated `atlcli.typ`, and all eight are the frozen
+v1 hook set a conforming template must export:
+
+| Symbol | Purpose |
+|--------|---------|
+| `atlcli-doc` | The `render(meta, body, settings)` document wrapper. |
+| `callout` | Info/note/warning/tip/panel callout block. |
+| `status-badge` | Colored status label. |
+| `table-par` | Width-aware paragraph wrapper for table cells. |
+| `dense-token` | Fit-or-fallback token for dense tables. |
+| `dense-link` | Progressive-shortening link for dense tables. |
+| `dense-status-badge` | Width-aware status badge for dense tables. |
+| `task-item` | Checkbox + body task-list row. |
+
+Generated content may depend on these and **no other** template-local
+functions. Shrinking this set — relocating the five dense-table / table helpers
+into engine-owned code so an external template overrides fewer hooks — is a
+deliberate follow-up once a real Level-B template needs it. It is **not** part
+of this contract's first cut, and any such change bumps the API string (see
+below).
+
+## Versioning policy
+
+The contract, the manifest, and the compiler travel together. A template pack's
+manifest pins `engine.api` (the contract string, `wiki.pdf-template/v1`),
+`schemaVersion`, and — for Typst — `engine.compilerRange`; the import gate
+rejects unknown or incompatible values (see
+[Template Pack Format](template-pack-format.md)).
+
+For the contract itself:
+
+- **Adding a settings key is non-breaking.** Because every read is a defensive
+  `settings.at("<key>", default: ...)`, an older template simply ignores a key
+  it does not know, and a newer template falls back to the default when a caller
+  omits it. No API-string change.
+- **Removing or renaming a settings key, or changing the hook set, is
+  breaking.** It bumps the `engine.api` string (a new `wiki.pdf-template/vN`),
+  because existing generated content or existing templates would otherwise read
+  or export a symbol that no longer means what it did.
+
+This mirrors the manifest's own `schemaVersion` + `engine.api` +
+`engine.compilerRange` gating: adding is defensive, removing/renaming is a
+version bump.
+
+## Example
+
+A minimal conforming template skeleton — note the defaulted signature and the
+defensive reads:
+
+```typst
+#let atlcli-doc(meta: (:), settings: (:), body) = {
+  let is-german = meta.at("language", default: "en") == "de"
+  let indigo = rgb(settings.at("accent-color", default: "#4B57A3"))
+
+  set document(title: meta.title, author: meta.author, date: meta.exported-at)
+  set page(
+    paper: if settings.at("page", default: "a4") == "letter" { "us-letter" } else { "a4" },
+    flipped: settings.at("orientation", default: "portrait") == "landscape",
+  )
+
+  if settings.at("cover", default: true) {
+    // cover block …
+    pagebreak()
+  }
+  if settings.at("outline", default: true) {
+    outline(depth: 3)
+    pagebreak()
+  }
+  body
+}
+
+// A conforming template must also export the other seven hook-set symbols:
+// callout, status-badge, table-par, dense-token, dense-link,
+// dense-status-badge, task-item.
+```
+
+## Related topics
+
+- [PDF Template Settings](pdf-template-settings.md) — the host-facing settings
+  and their validation.
+- [Template Pack Format](template-pack-format.md) — the `.wiki-pdf-template`
+  container, manifest schema, and import gate.
+- [PDF Export Engine](pdf-engine.md) — the pipeline this contract renders in.

--- a/src/content/docs/reference/pdf-template-settings.md
+++ b/src/content/docs/reference/pdf-template-settings.md
@@ -270,6 +270,10 @@ cause.
 
 ## Related topics
 
+- [PDF Template Contract](pdf-template-contract.md) — the `wiki.pdf-template/v1`
+  render surface these settings flow into.
+- [Template Pack Format](template-pack-format.md) — the `.wiki-pdf-template`
+  container for shareable templates.
 - [PDF Export Engine](pdf-engine.md)
 - [DOCX and PDF Export](../confluence/export.md)
 - [DOCX Export Engine](docx-engine.md)

--- a/src/content/docs/reference/pdf-template-settings.md
+++ b/src/content/docs/reference/pdf-template-settings.md
@@ -1,0 +1,183 @@
+---
+title: "PDF Template Settings"
+description: "Level-A settings that configure the built-in PDF template: page size, orientation, cover/outline toggles, header/footer text, accent color, organization name, logo, and watermark"
+---
+
+# PDF Template Settings
+
+The PDF exporter renders through a single versioned template contract,
+`wiki.pdf-template/v1`. Level-A **settings** let you configure that template
+without editing Typst source: page size, orientation, section toggles,
+header/footer text, brand accent color, organization name, a logo, and a
+watermark. Settings are plain, serializable values, so every host — CLI flags,
+the extension form, or a further host — supplies the same shape.
+
+Settings are **data, never code**. The engine validates every value in
+TypeScript and rejects anything malformed with a structured error; it never
+silently clamps an out-of-range value. Host-supplied strings are escaped before
+they reach the generated document, so a header or watermark string can never
+inject template source.
+
+## On this page
+
+- [Prerequisites](#prerequisites)
+- [How settings flow](#how-settings-flow)
+- [Settings reference](#settings-reference)
+- [Watermark settings](#watermark-settings)
+- [Logo settings](#logo-settings)
+- [Minimal example](#minimal-example)
+- [Advanced example](#advanced-example)
+- [Validation and error handling](#validation-and-error-handling)
+- [Troubleshooting](#troubleshooting)
+- [Related topics](#related-topics)
+
+## Prerequisites
+
+- A working PDF export pipeline (see [PDF Export Engine](pdf-engine.md)).
+- A host that forwards a `settings` object into the export call. Omitting
+  settings entirely reproduces the default document exactly.
+
+## How settings flow
+
+```text
+host settings (plain object)
+   -> RunPdfExportInput.settings
+   -> PdfSerializeOptions.settings
+   -> resolvePdfSettings()  (validate + default; throws on invalid)
+   -> main.typ: #show: atlcli-doc.with(meta: (...), settings: (...))
+   -> atlcli-doc(meta, settings, body)   // wiki.pdf-template/v1
+```
+
+Validation runs as the first step of an export, before any attachment is
+fetched, so a settings typo fails fast and never pays for network work it would
+discard.
+
+## Settings reference
+
+All fields are optional. Omitting a field applies its default.
+
+| Field | Type | Default | Required | Constraints |
+|-------|------|---------|----------|-------------|
+| `page` | `"a4" \| "letter"` | `"a4"` | Optional | Must be exactly `a4` or `letter`. |
+| `orientation` | `"portrait" \| "landscape"` | `"portrait"` | Optional | Must be exactly `portrait` or `landscape`. |
+| `cover` | `boolean` | `true` | Optional | — |
+| `outline` | `boolean` | `true` | Optional | — |
+| `headerText` | `string` | *(none)* | Optional | At most 200 characters. |
+| `footerText` | `string` | *(none)* | Optional | At most 200 characters. |
+| `accentColor` | `string` | `"#4B57A3"` | Optional | Any color the exporter can normalize to `#RRGGBB` (`#RGB`, `#RRGGBB`, `rgb(...)`, or a named CSS color). |
+| `organizationName` | `string` | *(none)* | Optional | At most 200 characters. |
+| `logo` | `PdfLogoAsset` | *(none)* | Optional | See [Logo settings](#logo-settings). |
+| `watermark` | `PdfWatermarkSettings` | *(none)* | Optional | See [Watermark settings](#watermark-settings). |
+
+The default accent color is the built-in Editorial Indigo. The default page is
+A4 portrait with the cover and outline sections both enabled — identical to the
+document produced when no settings are supplied.
+
+## Watermark settings
+
+A watermark is a rotated text layer drawn under the content, so it becomes a
+page Artifact and does not interfere with text selection. Set `watermark` to a
+`PdfWatermarkSettings` object; `text` is required and every other field
+defaults.
+
+| Field | Type | Default | Required | Constraints |
+|-------|------|---------|----------|-------------|
+| `text` | `string` | — | **Required** | Must be non-empty (whitespace-only is rejected). |
+| `color` | `string` | `"#DE350B"` | Optional | Normalizable to `#RRGGBB`. |
+| `opacity` | `number` | `0.08` | Optional | In the half-open range `(0, 1]`. `0`, negative values, `NaN`, and `Infinity` are rejected. |
+| `angle` | `number` | `-54` | Optional | Degrees, `-180..180` inclusive. |
+| `size` | `number` | `96` | Optional | Points, `8..400` inclusive. |
+
+Image watermarks and foreground (over-content) watermarks are **not** supported
+in v1: a foreground layer would cover text and break copy/select.
+
+## Logo settings
+
+A `logo` is a `PdfLogoAsset` with three fields:
+
+| Field | Type | Required | Constraints |
+|-------|------|----------|-------------|
+| `bytes` | `Uint8Array` | **Required** | Non-empty; at most 5 MiB (rejected, never downscaled). |
+| `mediaType` | `"image/png" \| "image/svg+xml"` | **Required** | For PNG, the bytes must begin with the PNG signature. |
+| `alt` | `string` | **Required when a logo is present** | Non-empty alternative text. |
+
+Security rules (restated from the template security model):
+
+- **PNG or sanitized SVG only.** SVG bytes must contain an `<svg>` root and are
+  rejected if they contain `<script>` or `<foreignObject>`, any `on*` event
+  handler attribute, or an external (`http(s):`/`data:`) reference.
+- **Bundled bytes only.** The engine never fetches a logo; supply the bytes.
+- **A present logo always requires a non-empty `alt`.** A meaning-bearing logo
+  without alternative text is rejected.
+
+## Minimal example
+
+Export to US Letter with no cover page:
+
+```ts
+await runPdfExport(
+  {
+    blocks,
+    metadata,
+    filename: "guide.pdf",
+    settings: { page: "letter", cover: false },
+  },
+  env,
+);
+```
+
+## Advanced example
+
+A confidential, branded export: Letter landscape, a legal footer line, a brand
+accent, an organization name, and a draft watermark.
+
+```ts
+await runPdfExport(
+  {
+    blocks,
+    metadata,
+    filename: "acme-confidential.pdf",
+    settings: {
+      page: "letter",
+      orientation: "landscape",
+      outline: false,
+      footerText: "Acme Confidential — do not distribute",
+      accentColor: "#0052CC",
+      organizationName: "Acme Corp",
+      logo: { bytes: acmeLogoPng, mediaType: "image/png", alt: "Acme Corp" },
+      watermark: { text: "DRAFT", opacity: 0.1, angle: -45 },
+    },
+  },
+  env,
+);
+```
+
+## Validation and error handling
+
+Invalid settings throw before any asset is fetched. Each failure names the exact
+offending field through a `PdfSettingsError` with:
+
+- `path` — the field, e.g. `watermark.opacity` or `logo.alt`.
+- `value` — the offending value.
+- `constraint` — a human-readable description of the rule.
+
+When run through the export orchestrator, the failure surfaces at the
+`configuration` phase (distinct from `prepare`, so a settings typo is never
+mistaken for an asset-fetch failure), carrying the `PdfSettingsError` as its
+cause.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| Export fails at the `configuration` phase | A settings value is out of range or malformed | Read the `PdfSettingsError` `path`/`constraint`; correct that field. |
+| `watermark.opacity` rejected for `0` | Fully transparent is not a valid watermark | Use a small positive value such as `0.08`. |
+| `logo.bytes` rejected as "do not match the declared PNG media type" | `mediaType` says PNG but the bytes are not PNG | Supply real PNG bytes or set `mediaType` to `image/svg+xml`. |
+| `logo.alt` rejected | A logo was supplied without alternative text | Provide a non-empty `alt`. |
+| SVG logo rejected as "active or externally loaded content" | The SVG has a script, event handler, `<foreignObject>`, or external reference | Export a static, self-contained SVG, or use PNG. |
+
+## Related topics
+
+- [PDF Export Engine](pdf-engine.md)
+- [DOCX and PDF Export](../confluence/export.md)
+- [DOCX Export Engine](docx-engine.md)

--- a/src/content/docs/reference/pdf-template-settings.md
+++ b/src/content/docs/reference/pdf-template-settings.md
@@ -63,10 +63,10 @@ All fields are optional. Omitting a field applies its default.
 | `orientation` | `"portrait" \| "landscape"` | `"portrait"` | Optional | Must be exactly `portrait` or `landscape`. |
 | `cover` | `boolean` | `true` | Optional | — |
 | `outline` | `boolean` | `true` | Optional | — |
-| `headerText` | `string` | *(none)* | Optional | At most 200 characters. |
-| `footerText` | `string` | *(none)* | Optional | At most 200 characters. |
+| `headerText` | `string` | *(none)* | Optional | At most 200 Unicode code points. |
+| `footerText` | `string` | *(none)* | Optional | At most 200 Unicode code points. |
 | `accentColor` | `string` | `"#4B57A3"` | Optional | Any color the exporter can normalize to `#RRGGBB` (`#RGB`, `#RRGGBB`, `rgb(...)`, or a named CSS color). |
-| `organizationName` | `string` | *(none)* | Optional | At most 200 characters. |
+| `organizationName` | `string` | *(none)* | Optional | At most 200 Unicode code points. |
 | `logo` | `PdfLogoAsset` | *(none)* | Optional | See [Logo settings](#logo-settings). |
 | `watermark` | `PdfWatermarkSettings` | *(none)* | Optional | See [Watermark settings](#watermark-settings). |
 
@@ -130,8 +130,12 @@ A `logo` is a `PdfLogoAsset` with three fields:
 Security rules (restated from the template security model):
 
 - **PNG or sanitized SVG only.** SVG bytes must contain an `<svg>` root and are
-  rejected if they contain `<script>` or `<foreignObject>`, any `on*` event
-  handler attribute, or an external (`http(s):`/`data:`) reference.
+  rejected (namespace prefixes such as `svg:script` do not bypass the checks)
+  if they contain any of: a `DOCTYPE` or `ENTITY` declaration, a `script` or
+  `foreignObject` element, an `on*` event handler attribute, or any
+  `href`/`xlink:href` value that is not empty or a pure `#fragment` reference —
+  external URLs, `data:`/`javascript:` URIs, and relative paths are all
+  rejected.
 - **Bundled bytes only.** The engine never fetches a logo; supply the bytes.
 - **A present logo always requires a non-empty `alt`.** A meaning-bearing logo
   without alternative text is rejected.

--- a/src/content/docs/reference/pdf-template-settings.md
+++ b/src/content/docs/reference/pdf-template-settings.md
@@ -25,6 +25,7 @@ inject template source.
 - [Settings reference](#settings-reference)
 - [Watermark settings](#watermark-settings)
 - [Logo settings](#logo-settings)
+- [Custom fonts (engine seam)](#custom-fonts-engine-seam)
 - [Minimal example](#minimal-example)
 - [Advanced example](#advanced-example)
 - [Validation and error handling](#validation-and-error-handling)
@@ -73,6 +74,23 @@ The default accent color is the built-in Editorial Indigo. The default page is
 A4 portrait with the cover and outline sections both enabled — identical to the
 document produced when no settings are supplied.
 
+Rendered behavior:
+
+- `page` / `orientation` set the page geometry for the whole document
+  (`letter` maps to the US Letter paper size, 612 × 792 pt).
+- `cover: false` and `outline: false` each remove exactly one page — the
+  section *and* its trailing page break — never leaving a blank page behind.
+  The closing document-integrity page always renders.
+- `headerText` replaces the default running header (page title and space key)
+  on body pages. `footerText` renders left of the centered page number.
+- `accentColor` recolors every accent the template draws: the cover eyebrow
+  and rule, and the closing-page accents.
+- `organizationName` renders in uppercase before the space label on the cover
+  and right-aligned in the footer.
+- `logo` renders on the cover above the title inside a fixed 45 × 12 mm box
+  (scaled to fit, never widening the cover layout); its `alt` text becomes the
+  image's alternative text in the tagged PDF.
+
 ## Watermark settings
 
 A watermark is a rotated text layer drawn under the content, so it becomes a
@@ -88,8 +106,16 @@ defaults.
 | `angle` | `number` | `-54` | Optional | Degrees, `-180..180` inclusive. |
 | `size` | `number` | `96` | Optional | Points, `8..400` inclusive. |
 
-Image watermarks and foreground (over-content) watermarks are **not** supported
-in v1: a foreground layer would cover text and break copy/select.
+The watermark is wired into the page background, so it repeats on the cover,
+every body page, and the closing page, and it never changes the page count.
+Because it sits under the content as a page Artifact, text selection, search,
+and assistive-technology reading order are unaffected.
+
+Two variants are **explicitly rejected** for v1, not merely unimplemented:
+
+- **Foreground (over-content) watermarks** — a layer above the text would
+  cover content and break copy/select.
+- **Image watermarks** — out of scope for v1; the watermark is text-only.
 
 ## Logo settings
 
@@ -109,6 +135,72 @@ Security rules (restated from the template security model):
 - **Bundled bytes only.** The engine never fetches a logo; supply the bytes.
 - **A present logo always requires a non-empty `alt`.** A meaning-bearing logo
   without alternative text is rejected.
+
+## Custom fonts (engine seam)
+
+Corporate fonts are **not** a `PdfTemplateSettings` field. They enter through a
+separate engine seam: a host resolves approved font bytes and constructs the
+browser compiler with `bundledFonts ∪ customFonts`. The PDF engine never fetches
+a font — the host supplies the bytes, exactly like the logo.
+
+Two types describe the seam:
+
+| Type | Shape | Purpose |
+|------|-------|---------|
+| `FontAsset` | `{ family, style: "normal" \| "italic", weight, sha256, license? }` | One approved face. `sha256` is the lowercase hex digest of the exact bytes; `license` is an optional attestation (`OFL` / `Apache-2.0` / `proprietary`). |
+| `FontSource` | `{ list(): Promise<FontAsset[]>; getBytes(sha256): Promise<Uint8Array> }` | Host-provided port (mirrors `PdfAssetResolver`). The host owns storage and the upload/attestation flow. |
+
+### Accepted and rejected formats
+
+`parseFontMeta(bytes)` inspects sfnt bytes and returns one record per face:
+
+- **Accepted:** TrueType (`00 01 00 00`), CFF/OpenType (`OTTO`), and TrueType
+  Collections (`ttcf`). A collection returns **one record per bundled face**, so
+  a multi-face `.ttc` never silently drops faces.
+- **Rejected — WOFF/WOFF2** (`wOFF` / `wOF2`) with the actionable message
+  *"web-packaged font detected — the PDF compiler consumes TTF/OTF; export the
+  desktop font from your font source."* The pinned Typst compiler consumes sfnt
+  only.
+- **Rejected — malformed input** (empty buffer, over the 10 MB per-font cap,
+  truncated headers, out-of-range table offsets, hostile table counts, unknown
+  magic) with a typed `FontParseError` carrying a machine-readable `reason`. It
+  never throws an anonymous `RangeError`.
+
+### Mandatory verification before use
+
+`verifyFontBytes(asset, bytes)` re-hashes delivered bytes against
+`asset.sha256` and throws a typed `FontVerificationError` on any mismatch. This
+step is **mandatory host wiring** between `FontSource.getBytes` and the
+compiler's `fonts` array: without it, a corrupted or swapped delivery would be
+embedded under the approved font's license claim with no error.
+
+```ts
+new BrowserPdfCompiler({
+  wasm,
+  fonts: [
+    ...bundledFonts,
+    ...(await Promise.all(
+      customFonts.map(async (f) => {
+        const bytes = await fontSource.getBytes(f.sha256);
+        await verifyFontBytes(f, bytes); // gates every custom font
+        return bytes;
+      }),
+    )),
+  ],
+});
+```
+
+`BrowserPdfCompilerAssets.fonts` is already `Uint8Array[]` and the compiler's
+`add_raw_font` accepts arbitrary extra fonts, so **no change is needed in the
+compiler package** to add custom fonts.
+
+### How templates reference fonts
+
+Template-pack manifests reference approved fonts as a `choice` setting whose
+options a host generates from `FontSource.list()` — Level A keeps the "font
+choice from an approved set" model with **no free-form font input**. The upload
+UI, the license-attestation flow, and font storage are host follow-ups, not part
+of this engine seam.
 
 ## Minimal example
 

--- a/src/content/docs/reference/template-pack-format.md
+++ b/src/content/docs/reference/template-pack-format.md
@@ -1,0 +1,278 @@
+---
+title: "Template Pack Format (.wiki-pdf-template)"
+description: "The deterministic .wiki-pdf-template container: manifest schema, deterministic packing, payload vs archive hashing, size caps, traversal protections, the import gate, and the DOCX scan policy"
+---
+
+# Template Pack Format — `.wiki-pdf-template`
+
+A `.wiki-pdf-template` file is a deterministic ZIP container that carries a
+template so it can be built in one place and imported in another. One container
+format serves **both** engines: a Typst PDF template (`engine.kind: "typst"`,
+API [`wiki.pdf-template/v1`](pdf-template-contract.md)) and a Word template
+(`engine.kind: "docx"`, API `wiki.docx-template/v1`). Only the *container* is
+shared — never the render contract.
+
+The reader, packer, and validator live in the isomorphic package
+`@atlcli/template-pack` (browser-safe, pure byte-in/byte-out functions). This
+package is the canonical owner of the size-cap constants.
+
+## On this page
+
+- [Prerequisites](#prerequisites)
+- [Container layout](#container-layout)
+- [Manifest schema](#manifest-schema)
+- [Deterministic packing](#deterministic-packing)
+- [Payload hash vs archive hash](#payload-hash-vs-archive-hash)
+- [Size caps](#size-caps)
+- [Traversal and structural protections](#traversal-and-structural-protections)
+- [The import gate](#the-import-gate)
+- [DOCX scan policy](#docx-scan-policy)
+- [Minimal example (Typst)](#minimal-example-typst)
+- [Advanced example (DOCX)](#advanced-example-docx)
+- [Related topics](#related-topics)
+
+## Prerequisites
+
+- The [PDF Template Contract](pdf-template-contract.md) for the `typst` engine
+  API the manifest pins.
+- For the `docx` engine, the existing DOCX template scanner (`scanTemplate`)
+  from the DOCX engine.
+
+## Container layout
+
+Every pack contains a manifest as its first entry, followed by the template
+payload files:
+
+```text
+wiki-pdf-template.json     ← the manifest (always first)
+template.typ               ← engine.entry for a typst pack
+…any additional assets…
+```
+
+For a `docx` pack the entry is `template.docx` instead.
+
+## Manifest schema
+
+The manifest file is `wiki-pdf-template.json`:
+
+```json
+{
+  "schemaVersion": 1,
+  "id": "com.acme.tech-doc",
+  "name": "Acme Tech Doc",
+  "version": "1.0.0",
+  "engine": { "kind": "typst", "api": "wiki.pdf-template/v1", "entry": "template.typ", "compilerRange": ">=0.14 <0.15" },
+  "requiredFonts": [{ "family": "Source Sans 3", "style": "normal", "weight": 400 }],
+  "settings": { "cover": { "type": "boolean", "default": true } },
+  "provenance": { "payloadSha256": "…", "createdWith": "atlcli 0.x" }
+}
+```
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `schemaVersion` | `number` | Yes | Only `1` is recognized at ship time. |
+| `id` | `string` | Yes | Reverse-DNS-style pack id. |
+| `name` | `string` | Yes | Human-readable name. |
+| `version` | `string` | Yes | Pack version. |
+| `engine.kind` | `"typst" \| "docx"` | Yes | Selects the render contract. |
+| `engine.api` | `string` | Yes | `wiki.pdf-template/v1` (typst) or `wiki.docx-template/v1` (docx). |
+| `engine.entry` | `string` | Yes | Payload file to render; must exist in the archive. |
+| `engine.compilerRange` | `string` | Typst only | Semver range, e.g. `">=0.14 <0.15"`. |
+| `requiredFonts` | `RequiredFont[]` | Optional | `{ family, style, weight }` per face. Declarative only — availability is **not** cross-checked in this format. |
+| `settings` | `Record<string, ManifestSetting>` | Optional | Open, typed dictionary of Level-B settings. Setting `type` is one of `text \| boolean \| choice \| color \| number \| asset`. |
+| `provenance.payloadSha256` | `string` | Optional | Digest of the payload members (see below). |
+| `provenance.createdWith` | `string` | Optional | Tool identifier. |
+
+The manifest's open `settings` map is **not** the same shape as the built-in
+`PdfTemplateSettings` (the fixed Level-A fields documented in
+[PDF Template Settings](pdf-template-settings.md)). The two stay separate in
+v1: threading manifest-declared settings into a render call needs host-side
+Level-B loading glue that is out of scope for this format.
+
+## Deterministic packing
+
+`packTemplate(contents)` produces a **byte-deterministic** archive: packing the
+same inputs twice yields byte-identical bytes. Determinism comes from three
+controls:
+
+- a fixed DOS-epoch timestamp (1980-01-01 00:00:00) on every entry, built from
+  local calendar components so it is timezone-independent;
+- a fixed `DOS` platform so version/attribute fields are stable;
+- an explicit file order — manifest first, then payload paths ascending — and a
+  sorted-key manifest serialization.
+
+ASCII entry paths carry no Info-ZIP unicode-path extra field, so no
+platform-dependent extra fields are emitted.
+
+## Payload hash vs archive hash
+
+Two different hashes answer two different questions; do not conflate them.
+
+| Hash | What it covers | Where it lives |
+|------|----------------|----------------|
+| `provenance.payloadSha256` | The pack's **payload members** — everything *except* the manifest | Inside the manifest |
+| `TemplateLibraryEntry.sha256` | The delivered **archive bytes as stored** | Library entry metadata, outside the archive |
+
+`provenance.payloadSha256` is deliberately **not self-referential**: it cannot
+be the hash of the very archive it lives in (that value is unknowable before the
+manifest is written). It is defined precisely as the digest of a canonicalized
+payload description: for every payload member in ascending path order, emit its
+`path`, its byte length (decimal), and its lowercase-hex SHA-256 as three lines,
+newline-join all lines, and SHA-256 the UTF-8 bytes of that string. The manifest
+is excluded because it is the carrier of the value.
+
+`TemplateLibraryEntry.sha256` is the separate, unambiguous integrity check used
+when a template is downloaded — it hashes the archive bytes exactly as
+delivered.
+
+## Size caps
+
+`unpackTemplate` enforces hard caps before and during extraction. These are the
+literal exported constants of `@atlcli/template-pack`:
+
+| Constant | Value | Guards |
+|----------|-------|--------|
+| `MAX_TEMPLATE_PACK_BYTES` | 30 MiB | Outer archive size, checked before unzip. |
+| `MAX_TEMPLATE_PACK_UNCOMPRESSED_BYTES` | 64 MiB | Cumulative **declared** uncompressed payload — accounted before any inflation (zip-bomb guard). |
+| `MAX_TEMPLATE_PACK_FILE_BYTES` | 32 MiB | Any single member's declared uncompressed size. |
+| `MAX_TEMPLATE_PACK_ENTRIES` | 2048 | Number of archive entries. |
+
+The cumulative and per-file caps are measured from each entry's **declared**
+uncompressed size and abort extraction *before* inflating — counting compressed
+bytes alone would not stop a zip bomb.
+
+The inner DOCX cap (`MAX_TEMPLATE_BYTES` = 20 MiB in the DOCX engine) is
+unrelated and unchanged. It still applies once a `kind: "docx"` container's
+`template.docx` is scanned, and is smaller than the outer caps above, so a
+compliant container can never smuggle an over-cap DOCX payload through size
+checks alone.
+
+## Traversal and structural protections
+
+`unpackTemplate` rejects (throwing a typed `TemplatePackError`) any archive that
+is unsafe or malformed:
+
+- **Path traversal** — `..` segments, absolute paths, backslashes, or
+  drive-letter paths (`too-large-archive`, `path-traversal`).
+- **Symlink entries** — detected via unix permission bits (`symlink`).
+- **Missing manifest** or a manifest that is not valid JSON
+  (`missing-manifest`, `bad-manifest`).
+- **Missing entry** — `engine.entry` must be present in the archive
+  (`missing-entry`).
+
+Each rejection carries a typed `kind` so a host can present specific feedback
+instead of a generic parse error.
+
+## The import gate
+
+`validateManifest` is not merely a shape check — it is the **import gate**. It
+rejects incompatible packs with a typed `ManifestValidationError.reason` so a
+host can render an upgrade/downgrade hint:
+
+| Reason | Trigger |
+|--------|---------|
+| `unknown-schema-version` | `schemaVersion` is anything other than `1`. |
+| `unknown-api` | `engine.api` is not the known value for the declared `engine.kind`. |
+| `compiler-range-mismatch` | For a `typst` pack, the pinned Typst compiler version does not satisfy `engine.compilerRange`. |
+| `shape-error` | A required field is missing or mistyped, or `compilerRange` uses an unsupported form. |
+
+The compiler-range check is a pure semver comparison against the pinned compiler
+version; actually compiling the template against the canonical feature set stays
+a deferred Level-B host follow-up.
+
+`validatePack(bytes)` combines unpack + import gate + an engine-specific hook and
+returns a typed report `{ ok, manifest?, scanReport?, issues }`. It throws
+**only** on package corruption (the `TemplatePackError`s above); manifest-gate
+failures and engine-hook problems are surfaced as `issues` with `ok: false`.
+
+## DOCX scan policy
+
+For a `kind: "docx"` pack, `validatePack` runs the DOCX template scanner and
+applies the same policy as the live product — no stricter:
+
+- A package-level failure (a scan/unzip error on a corrupt inner `.docx`) is
+  **fatal**: `ok: false` with the error surfaced in `issues`
+  (`docx-scan-failed`).
+- `never`-classified placeholders are a **warning** (`never-placeholders`), not
+  a rejection — those placeholders render empty, an accepted case in the product.
+- A missing content placeholder is **not** a rejection — the exporter appends
+  content before the final section break as a documented fallback.
+
+Warnings keep `ok: true`; only errors flip it to `false`.
+
+## Minimal example (Typst)
+
+A minimal Typst pack manifest — one entry, no custom settings:
+
+```json
+{
+  "schemaVersion": 1,
+  "id": "com.example.minimal",
+  "name": "Minimal",
+  "version": "1.0.0",
+  "engine": {
+    "kind": "typst",
+    "api": "wiki.pdf-template/v1",
+    "entry": "template.typ"
+  }
+}
+```
+
+Packed and read back:
+
+```ts
+import { packTemplate, validatePack } from "@atlcli/template-pack";
+
+const bytes = await packTemplate({
+  manifest,
+  files: { "template.typ": templateSource },
+});
+
+const report = validatePack(bytes);
+// report.ok === true, report.issues === []
+```
+
+## Advanced example (DOCX)
+
+A branded DOCX pack that pins the API, declares required fonts and a Level-B
+setting, and carries provenance:
+
+```json
+{
+  "schemaVersion": 1,
+  "id": "com.acme.tech-doc",
+  "name": "Acme Tech Doc",
+  "version": "2.1.0",
+  "engine": {
+    "kind": "docx",
+    "api": "wiki.docx-template/v1",
+    "entry": "template.docx"
+  },
+  "requiredFonts": [
+    { "family": "Source Sans 3", "style": "normal", "weight": 400 },
+    { "family": "Source Sans 3", "style": "normal", "weight": 700 }
+  ],
+  "settings": {
+    "accent": { "type": "color", "default": "#0052CC" },
+    "cover": { "type": "boolean", "default": true }
+  },
+  "provenance": { "payloadSha256": "…", "createdWith": "atlcli 0.x" }
+}
+```
+
+```ts
+const report = validatePack(docxPackBytes);
+// A pack whose inner .docx uses only `never`-classified placeholders:
+//   report.ok === true, report.issues === [{ severity: "warning", code: "never-placeholders", … }]
+// A pack with a corrupt inner .docx:
+//   report.ok === false, report.issues === [{ severity: "error", code: "docx-scan-failed", … }]
+```
+
+## Related topics
+
+- [PDF Template Contract](pdf-template-contract.md) — the `wiki.pdf-template/v1`
+  render surface the `typst` engine pins.
+- [PDF Template Settings](pdf-template-settings.md) — the fixed Level-A settings
+  (distinct from a manifest's open `settings` map).
+- [PDF Export Engine](pdf-engine.md) — the pipeline that consumes a resolved
+  template.

--- a/src/content/docs/reference/template-pack-format.md
+++ b/src/content/docs/reference/template-pack-format.md
@@ -115,11 +115,21 @@ Two different hashes answer two different questions; do not conflate them.
 
 `provenance.payloadSha256` is deliberately **not self-referential**: it cannot
 be the hash of the very archive it lives in (that value is unknowable before the
-manifest is written). It is defined precisely as the digest of a canonicalized
-payload description: for every payload member in ascending path order, emit its
-`path`, its byte length (decimal), and its lowercase-hex SHA-256 as three lines,
-newline-join all lines, and SHA-256 the UTF-8 bytes of that string. The manifest
-is excluded because it is the carrier of the value.
+manifest is written). It is defined precisely as the digest of a canonicalized,
+**delimiter-safe** payload description: for every payload member in ascending
+path order, emit one self-delimiting record
+
+```text
+<P>:<path>,<byteLength>,<sha256hex>;
+```
+
+where `<P>` is the decimal UTF-8 byte length of `<path>`, `<byteLength>` is the
+member's decimal byte count, and `<sha256hex>` is its lowercase-hex SHA-256
+(always exactly 64 characters). Concatenate all records (no join separator) and
+SHA-256 the UTF-8 bytes of the result. The netstring length prefix frames the
+path, so the encoding is injective by construction — no member path can forge
+record boundaries, independent of path validation. The manifest is excluded
+because it is the carrier of the value.
 
 `TemplateLibraryEntry.sha256` is the separate, unambiguous integrity check used
 when a template is downloaded — it hashes the archive bytes exactly as
@@ -154,6 +164,10 @@ is unsafe or malformed:
 
 - **Path traversal** — `..` segments, absolute paths, backslashes, or
   drive-letter paths (`too-large-archive`, `path-traversal`).
+- **Control characters in member paths** — any ASCII control character
+  (0x00–0x1F, 0x7F), including newline/CR/NUL, is rejected (`invalid-path`).
+  `packTemplate` enforces the same rule at pack time, so a compliant packer can
+  never produce an archive the reader rejects.
 - **Symlink entries** — detected via unix permission bits (`symlink`).
 - **Missing manifest** or a manifest that is not valid JSON
   (`missing-manifest`, `bad-manifest`).


### PR DESCRIPTION
Implements `specs/export-expansion/007-pdf-template-settings/PLAN.md` (Lane P: T2.1–T2.5 + B5 font seam). **Spec complete.**

## Landed
- **T2.1** Settings threading & `wiki.pdf-template/v1` contract: `PdfTemplateSettings`, reject-not-clamp validation (`PdfSettingsError` with path/value/constraint), `configuration` phase before any asset fetch, post-emit abort-check fix. Every settings string reaches Typst source via `typstString` only.
- **T2.2** Level-A rendering: A4/Letter + orientation, cover/outline toggles with encapsulated pagebreaks (2×2 page-count matrix pinned: 4/3/3/2), header/footer text, accent color, organization name, cover logo.
- **T2.3** Watermark as `set page(background:)` text layer — Artifact-marked in the tagged PDF (proven in E2E: excluded from pdftotext reading order, present as rotated 96pt artifact segment).
- **T2.4** Template library (`packages/core`, browser-safe) + `@atlcli/template-pack`: deterministic zip, 30/64 MiB caps, traversal/zip-bomb/control-char guards, manifest import gate (schemaVersion/api/compilerRange), docx `scanTemplate` hook. CLI wrapper deferred to 008 per plan.
- **B5** Font intake seam: sfnt parser (TTF/OTF/TTC incl. all collection faces), WOFF2 rejection with guidance, mandatory `verifyFontBytes` sha256 gate; real-font compile test.
- **T2.5** Hardcoding ledger (113 tokens) + ledger-driven lint (proof-of-detection verified); consumed by spec 012.
- **Docs**: settings reference, v1 contract page, template-pack format page, PDF engine — all in the sidebar.

## Review
Adversarial Sonnet review over the full diff: verdict FIX-FIRST with 2 major findings, both fixed with regression tests:
1. `payloadSha256` canonicalization was collidable via newline paths → netstring-framed injective canonicalization + control-char path rejection (proven collision pair is now a regression test).
2. SVG logo sanitizer bypasses (namespace-prefixed `<svg:script>`, `javascript:`/relative href, DOCTYPE/XXE) → shared prefix-aware `svg-safety` helper used by settings **and** prepared assets; href restricted to `#fragment`.
Injection STOP condition, zip guards, pagebreak fix, abort fix, browser-safety: reviewed, no findings.

## E2E (DOCSY, profile mayflower)
Real page → `storageToBlocks` → real WASM compile → assertions → page deleted. **16/16 checks**: A4 control, Letter MediaBox 612×792, watermark artifact segment + reading-order exclusion, footer/header/org branding via pdftotext, toggle page counts, fail-fast `configuration` phase, hostile-settings injection stays literal. (008's PDF CLI doesn't exist yet; flag-level E2E re-runs there.)

## Gates
2024 tests green, `bun run typecheck` 0, browser-build gate 11 entrypoints, hardcoding-ledger lint 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
