### PR TITLE
feat(docx): $scroll.includepage document pass & $scroll.metadata reclassification (spec 005)

### DIFF
--- a/apps/cli/src/commands/export-report.test.ts
+++ b/apps/cli/src/commands/export-report.test.ts
@@ -25,6 +25,7 @@ import {
   classifyError,
   diagnosticToIssue,
   extractStatus,
+  noteToIssue,
   pdfReportContributions,
 } from "./export-report.js";
 
@@ -210,6 +211,31 @@ describe("export-report kernel (spec 008 T3.2/T3.4)", () => {
     expect(classifyError(abort).exitCode).toBe(EXPORT_EXIT.CANCELLED);
     // Non-Error throw still classifies (TOTAL mapping, single-document contract).
     expect(classifyError("catastrophe").exitCode).toBe(EXPORT_EXIT.REMOTE);
+  });
+
+  it("preserves engine ExportNote codes through noteToIssue into issues + notesByCode (spec 005)", () => {
+    // The DOCX ts path maps every engine ExportNote to an Issue via noteToIssue;
+    // spec 005's include note codes must survive verbatim so `--json` consumers
+    // (and this plan's own E2E acceptance) can assert on `code` — the report
+    // kernel from 008 already carries it, this pins that it does not regress.
+    const notes = [
+      { level: "warning" as const, code: "includepage-cycle", message: "a page cannot include itself" },
+      { level: "info" as const, code: "includepage-ambiguous-title", message: "matched 3 pages" },
+    ];
+    const issues = notes.map((n) => noteToIssue(n, "prepare"));
+    expect(issues.map((i) => i.code)).toEqual(["includepage-cycle", "includepage-ambiguous-title"]);
+    // Every engine note collapses to `warning` severity (008 contract), so
+    // `--strict` CI sees include problems too.
+    expect(issues.every((i) => i.severity === "warning")).toBe(true);
+    const report = buildReport({
+      format: "docx",
+      engine: "ts",
+      sourcePages: [{ id: "1", title: "Root", notes: [] }],
+      outputDetails: [{ output: "/tmp/out.docx", embeddedImages: 0, renderedDiagrams: 0, skippedAssets: 0 }],
+      issues,
+    });
+    expect(report.notesByCode).toEqual({ "includepage-cycle": 1, "includepage-ambiguous-title": 1 });
+    expect(report.warnings.map((w) => w.code)).toContain("includepage-cycle");
   });
 
   it("folds a compiler warning into issues and trips exit 2 under --strict", () => {

--- a/apps/cli/src/commands/export.ts
+++ b/apps/cli/src/commands/export.ts
@@ -25,7 +25,6 @@ import {
   SpaceHomepageError,
   composeChapters,
   confluenceTreeSource,
-  escapeCqlValue,
   fetchExportTree,
   resolveExportMentions,
   storageToBlocks,
@@ -1252,15 +1251,15 @@ async function exportWithTsEngine(args: TsEngineArgs): Promise<void> {
           };
         },
         // Cross-page include (spec 005 D1): the shared, isomorphic loader owns
-        // the title→CQL construction (via the shared escapeCqlValue), id-sorted
-        // determinism, ambiguity, and per-class error mapping — identical to the
-        // extension path. Concurrency lives ONLY in the engine's include pool,
-        // so this loader stays throttle-agnostic; the pool de-duplicates repeated
-        // refs, so rebuilding the stateless loader per call is free.
+        // id-sorted determinism, ambiguity, and per-class error mapping —
+        // identical to the extension path. Title lookups go through the DIRECT
+        // content endpoint (findPagesByTitle), NOT CQL, so a page created moments
+        // before the export is findable immediately (the search index lags).
+        // Concurrency lives ONLY in the engine's include pool, so this loader
+        // stays throttle-agnostic; the pool de-duplicates repeated refs.
         getIncludedPage: buildGetIncludedPage({
           getPage: (id) => client.getPage(id),
-          searchPages: (cql) => client.searchPages(cql),
-          escapeCqlValue,
+          findPagesByTitle: (title, spaceKey) => client.findPagesByTitle(title, { spaceKey }),
           defaultSpaceKey: page.spaceKey,
         }),
       },

--- a/apps/cli/src/commands/export.ts
+++ b/apps/cli/src/commands/export.ts
@@ -25,6 +25,7 @@ import {
   SpaceHomepageError,
   composeChapters,
   confluenceTreeSource,
+  escapeCqlValue,
   fetchExportTree,
   resolveExportMentions,
   storageToBlocks,
@@ -1116,7 +1117,7 @@ async function exportWithTsEngine(args: TsEngineArgs): Promise<void> {
   // on the page storage below.
   const { readFile, stat } = await import("node:fs/promises");
   const [
-    { runExport, fileOutputSink },
+    { runExport, fileOutputSink, buildGetIncludedPage },
     { createAssetByteCache, mightContainMermaid, prestartPageDependentDeps, tokenAssetFetcher, tokenMentionLookup },
     templateBytesRaw,
     templateStat,
@@ -1250,6 +1251,18 @@ async function exportWithTsEngine(args: TsEngineArgs): Promise<void> {
             filename: m ? decodeURIComponent(m[2]) : undefined,
           };
         },
+        // Cross-page include (spec 005 D1): the shared, isomorphic loader owns
+        // the title→CQL construction (via the shared escapeCqlValue), id-sorted
+        // determinism, ambiguity, and per-class error mapping — identical to the
+        // extension path. Concurrency lives ONLY in the engine's include pool,
+        // so this loader stays throttle-agnostic; the pool de-duplicates repeated
+        // refs, so rebuilding the stateless loader per call is free.
+        getIncludedPage: buildGetIncludedPage({
+          getPage: (id) => client.getPage(id),
+          searchPages: (cql) => client.searchPages(cql),
+          escapeCqlValue,
+          defaultSpaceKey: page.spaceKey,
+        }),
       },
     },
     {

--- a/apps/extension/entrypoints/sidepanel/TemplateSection.tsx
+++ b/apps/extension/entrypoints/sidepanel/TemplateSection.tsx
@@ -10,7 +10,7 @@
  * DOM/IDB/`chrome`-adjacent wiring.
  */
 import React, { useEffect, useRef, useState } from "react";
-import { ConfluenceClient } from "@atlcli/confluence/browser";
+import { ConfluenceClient, escapeCqlValue } from "@atlcli/confluence/browser";
 import { getConfluenceBaseUrl } from "@atlcli/core";
 import { profileFromTabUrl } from "../../utils/profile.js";
 import type { LoadedPage } from "../../utils/read-path.js";
@@ -248,6 +248,20 @@ export function TemplateSection({
             getCurrentUser: () => client.getCurrentUser(),
             getPageOwner: (id) => client.getPageOwner(id),
             getSpaceHomepageStorage: (key) => client.getSpaceHomepageStorage(key),
+            // Cross-page include (spec 005 D1): lazy — the include pass calls it
+            // per occurrence, so `buildGetIncludedPage` (isomorphic, in the docx
+            // engine chunk that `loadExport()` already fetches for this export)
+            // is imported on first use, never pulling the heavy barrel into the
+            // panel's static graph. Same title→CQL + error mapping as the CLI.
+            getIncludedPage: async (ref) => {
+              const { buildGetIncludedPage } = await loadExport();
+              return buildGetIncludedPage({
+                getPage: (id) => client.getPage(id),
+                searchPages: (cql) => client.searchPages(cql),
+                escapeCqlValue,
+                defaultSpaceKey: loadedPage.details.spaceKey,
+              })(ref);
+            },
           })
         : {};
       const [{ runExport }, env] = await Promise.all([loadExport(), loadEnv()]);

--- a/apps/extension/entrypoints/sidepanel/TemplateSection.tsx
+++ b/apps/extension/entrypoints/sidepanel/TemplateSection.tsx
@@ -10,7 +10,7 @@
  * DOM/IDB/`chrome`-adjacent wiring.
  */
 import React, { useEffect, useRef, useState } from "react";
-import { ConfluenceClient, escapeCqlValue } from "@atlcli/confluence/browser";
+import { ConfluenceClient } from "@atlcli/confluence/browser";
 import { getConfluenceBaseUrl } from "@atlcli/core";
 import { profileFromTabUrl } from "../../utils/profile.js";
 import type { LoadedPage } from "../../utils/read-path.js";
@@ -252,13 +252,14 @@ export function TemplateSection({
             // per occurrence, so `buildGetIncludedPage` (isomorphic, in the docx
             // engine chunk that `loadExport()` already fetches for this export)
             // is imported on first use, never pulling the heavy barrel into the
-            // panel's static graph. Same title→CQL + error mapping as the CLI.
+            // panel's static graph. Title lookups use the DIRECT content
+            // endpoint (findPagesByTitle), NOT CQL — same as the CLI — so a
+            // just-created target resolves without the search-index lag.
             getIncludedPage: async (ref) => {
               const { buildGetIncludedPage } = await loadExport();
               return buildGetIncludedPage({
                 getPage: (id) => client.getPage(id),
-                searchPages: (cql) => client.searchPages(cql),
-                escapeCqlValue,
+                findPagesByTitle: (title, spaceKey) => client.findPagesByTitle(title, { spaceKey }),
                 defaultSpaceKey: loadedPage.details.spaceKey,
               })(ref);
             },

--- a/apps/extension/tests/docx/export-deps.test.ts
+++ b/apps/extension/tests/docx/export-deps.test.ts
@@ -26,6 +26,9 @@ function loaders() {
     getCurrentUser: mock(async () => ({ accountId: "u", displayName: "User" })),
     getPageOwner: mock(async () => ({ accountId: "o", displayName: "Owner" })),
     getSpaceHomepageStorage: mock(async () => "<p>home</p>"),
+    // Plain in-memory closure (spec 005 D1): a document-pass loader, never
+    // pre-started, so a real closure — not a spy — is enough here.
+    getIncludedPage: async () => ({ kind: "not-found-or-forbidden" as const }),
   };
 }
 
@@ -45,6 +48,11 @@ describe("scanDependencies", () => {
     expect([...deps].sort().join(",")).toBe(
       ["currentUser", "owner", "space", "spaceHomepage", "spaceLogo"].sort().join(",")
     );
+  });
+
+  it("does NOT add a dependency for $scroll.includepage (it is a document pass, spec 005 D1)", () => {
+    const deps = scanDependencies(scan("$scroll.includepage.(ENG:Imprint)", "$scroll.title"));
+    expect(deps.size).toBe(0);
   });
 });
 
@@ -84,6 +92,28 @@ describe("prepareExportDeps", () => {
     await expect(deps.getCurrentUser!()).rejects.toThrow("logged out");
     expect(await deps.getSpaceHomepageStorage!("DOCSY")).toBe("<p>home</p>");
     expect(host.getSpaceHomepageStorage).toHaveBeenCalledTimes(1);
+  });
+
+  it("wires getIncludedPage straight through, lazy (never pre-started)", async () => {
+    let includeCalls = 0;
+    const host = {
+      ...loaders(),
+      getIncludedPage: async () => {
+        includeCalls += 1;
+        return { kind: "not-found-or-forbidden" as const };
+      },
+    };
+    const deps = prepareExportDeps(
+      scan("$scroll.includepage.(ENG:Imprint)"),
+      { id: "42", spaceKey: "DOCSY" },
+      host
+    );
+    // Not called during prepare (unlike the pre-started resolver loaders).
+    expect(includeCalls).toBe(0);
+    // Present on the ResolveDeps bag and callable on demand.
+    const outcome = await deps.getIncludedPage!({ title: "Imprint" });
+    expect(outcome.kind).toBe("not-found-or-forbidden");
+    expect(includeCalls).toBe(1);
   });
 
   it("does not retain auth/content-sensitive values across exports", async () => {

--- a/apps/extension/tests/docx/report-view.test.tsx
+++ b/apps/extension/tests/docx/report-view.test.tsx
@@ -34,6 +34,7 @@ function makeReport(notes: ExportReport["notes"]): ExportReport {
       resolveMs: 0,
       bodyMs: 0,
       logoFetchMs: 0,
+      includeFetchMs: 0,
       renderMs: 0,
       imageFetchMs: 0,
       imageFetches: 0,

--- a/apps/extension/utils/docx/export-deps.ts
+++ b/apps/extension/utils/docx/export-deps.ts
@@ -1,5 +1,5 @@
 import type { ConfluenceClient } from "@atlcli/confluence/browser";
-import type { ResolveDeps, ScanResult } from "@atlcli/docx/browser";
+import type { IncludeLookupOutcome, IncludePageRef, ResolveDeps, ScanResult } from "@atlcli/docx/browser";
 
 type SpaceInfo = Awaited<ReturnType<ConfluenceClient["getSpaceWithIcon"]>>;
 
@@ -8,6 +8,13 @@ export interface ExportDependencyLoaders {
   getCurrentUser(): ReturnType<ConfluenceClient["getCurrentUser"]>;
   getPageOwner(id: string): ReturnType<ConfluenceClient["getPageOwner"]>;
   getSpaceHomepageStorage(key: string): ReturnType<ConfluenceClient["getSpaceHomepageStorage"]>;
+  /**
+   * Cross-page include lookup (spec 005 D1). Unlike the other four loaders it is
+   * NOT pre-started by {@link scanDependencies} (its refs are discovered only
+   * inside the engine's include pass, per occurrence), so it stays lazy and
+   * uncalled until an include token is actually expanded.
+   */
+  getIncludedPage(ref: IncludePageRef): Promise<IncludeLookupOutcome>;
 }
 
 type ExportDependency = "space" | "currentUser" | "owner" | "spaceHomepage" | "spaceLogo";
@@ -105,6 +112,10 @@ export function prepareExportDeps(
       const icon = (await spaceInfo(key)).icon;
       return icon ? { url: icon.path } : null;
     },
+    // Wired straight through (spec 005 D1): the include pass invokes it lazily
+    // per occurrence, so — unlike the four loaders above — there is no
+    // pre-start branch for it in `scanDependencies`.
+    getIncludedPage: loaders.getIncludedPage,
   };
 
   const required = scanDependencies(scan);

--- a/packages/confluence/src/client.test.ts
+++ b/packages/confluence/src/client.test.ts
@@ -1227,4 +1227,51 @@ describe("ConfluenceClient", () => {
       expect(init?.credentials).toBeUndefined();
     });
   });
+
+  describe("findPagesByTitle — direct content endpoint (no search-index lag, spec 005 D1)", () => {
+    test("hits /content (NOT /content/search) with type=page + title + spaceKey", async () => {
+      const urls: string[] = [];
+      globalThis.fetch = mock((url: string) => {
+        urls.push(url);
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              results: [{ id: "500", title: "Imprint", space: { key: "DOCSY" } }],
+              _links: {},
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } }
+          )
+        );
+      }) as unknown as typeof fetch;
+
+      const hits = await new ConfluenceClient(mockProfile).findPagesByTitle("Imprint", {
+        spaceKey: "DOCSY",
+      });
+      expect(hits).toEqual([{ id: "500", title: "Imprint", spaceKey: "DOCSY" }]);
+      // The regression pin: the DIRECT content endpoint, never the search index.
+      expect(urls[0]).toContain("/rest/api/content?");
+      expect(urls[0]).not.toContain("/content/search");
+      expect(urls[0]).toContain("type=page");
+      expect(urls[0]).toContain("title=Imprint");
+      expect(urls[0]).toContain("spaceKey=DOCSY");
+    });
+
+    test("follows _links.next to completion (title with multiple matches)", async () => {
+      let call = 0;
+      globalThis.fetch = mock((url: string) => {
+        call++;
+        const body =
+          call === 1
+            ? { results: [{ id: "20", title: "Dup", space: { key: "ENG" } }], _links: { next: "/rest/api/content?type=page&title=Dup&start=1" } }
+            : { results: [{ id: "10", title: "Dup", space: { key: "ENG" } }], _links: {} };
+        return Promise.resolve(
+          new Response(JSON.stringify(body), { status: 200, headers: { "Content-Type": "application/json" } })
+        );
+      }) as unknown as typeof fetch;
+
+      const hits = await new ConfluenceClient(mockProfile).findPagesByTitle("Dup");
+      expect(call).toBe(2);
+      expect(hits.map((h) => h.id)).toEqual(["20", "10"]);
+    });
+  });
 });

--- a/packages/confluence/src/client.ts
+++ b/packages/confluence/src/client.ts
@@ -890,6 +890,54 @@ export class ConfluenceClient {
   }
 
   /**
+   * Look up pages by EXACT title through the DIRECT content endpoint
+   * (`GET /content?type=page&title=…[&spaceKey=…]`), NOT the CQL search index.
+   *
+   * Why direct, not `search`/CQL: Confluence Cloud's search index lags page
+   * creation by up to minutes, so a freshly created target (e.g. a CI pipeline
+   * that creates a page then immediately exports a template that includes it by
+   * title) comes back "not found" on the first try and only resolves on a later
+   * retry. The `/content` endpoint reads the content store directly, so a page
+   * is findable the moment it exists — the same reason spec 004's children macro
+   * moved off CQL to the direct child-page endpoint (spec 005 D1).
+   *
+   * Titles are NOT unique (same title across spaces, or a bare-title lookup), so
+   * this returns EVERY match; the caller sorts by id for deterministic
+   * ambiguity handling. Paginated through the shared {@link drainPaginated}
+   * driver (a title with many matches never silently truncates).
+   */
+  async findPagesByTitle(
+    title: string,
+    options: { spaceKey?: string; limit?: number; signal?: AbortSignal } = {}
+  ): Promise<Array<{ id: string; title: string; spaceKey?: string }>> {
+    const { spaceKey, limit = 25, signal } = options;
+    const query: Record<string, string | number | undefined> = {
+      type: "page",
+      title,
+      expand: "space",
+      limit,
+      ...(spaceKey ? { spaceKey } : {}),
+    };
+    return drainPaginated<{ id: string; title: string; spaceKey?: string }>(async (token) => {
+      // First page uses the structured query; subsequent pages follow the
+      // server's own `_links.next` path (its query already baked in), stripping
+      // the /rest/api prefix request() re-adds — same shape as searchByUrl.
+      const data = (token === undefined
+        ? await this.request("/content", { query, signal })
+        : await this.request(token.replace(/^\/rest\/api/, ""), { signal })) as any;
+      const results = Array.isArray(data.results) ? data.results : [];
+      return {
+        items: results.map((item: any) => ({
+          id: item.id,
+          title: item.title,
+          spaceKey: item.space?.key,
+        })),
+        next: data._links?.next,
+      };
+    });
+  }
+
+  /**
    * Follow a pagination URL to get the next page of search results.
    * Strips the /rest/api prefix from the URL since request() adds it.
    */

--- a/packages/docx/src/export.test.ts
+++ b/packages/docx/src/export.test.ts
@@ -1711,6 +1711,43 @@ describe("exportDocx — $scroll.includepage (spec 005 D1)", () => {
     expect(fetchedRefs.some((r) => r.url.includes("/attachments/Imprint/inc.png"))).toBe(true);
   });
 
+  it("embeds an included FOOTER page's Mermaid diagram into footer1.xml.rels, not document.xml.rels", async () => {
+    // The included footer page's ONLY content is a mermaid diagram; the diagram
+    // seam must thread the occurrence's part so the svgBlip/PNG relationships
+    // land in the footer's rels (dangling-relationship regression for diagrams).
+    const diagramPage: ConfluencePageDetails = {
+      id: "Imprint",
+      title: "Imprint",
+      spaceKey: "ENG",
+      storage:
+        '<ac:structured-macro ac:name="code"><ac:parameter ac:name="language">mermaid</ac:parameter>' +
+        "<ac:plain-text-body><![CDATA[graph TD\n  A --> B]]></ac:plain-text-body></ac:structured-macro>",
+    };
+    const { bytes, report } = await exportDocx({
+      templateBytes: styledTemplate({
+        body: para("$scroll.content"),
+        footer: para("$scroll.includepage.(ENG:Imprint)"),
+      }),
+      details: { ...details, storage: "<p>own body, no diagram</p>" },
+      template,
+      deps: { ...deps, getIncludedPage: resolver({ Imprint: diagramPage }).getIncludedPage },
+      rasterizer: {
+        async rasterize(_svg: string, target: { widthPx: number; heightPx: number }) {
+          return pngFixtureBytes(target.widthPx, target.heightPx);
+        },
+      },
+    });
+    expect(report.renderedDiagrams).toBe(1);
+    const footer = readPart(bytes, "word/footer1.xml");
+    expect(footer).toContain("<w:drawing>");
+    assertBalancedXml(footer);
+    // The diagram's svgBlip/PNG relationships live in the FOOTER's rels…
+    expect(readPart(bytes, "word/_rels/footer1.xml.rels")).toContain("relationships/image");
+    // …and NOT in the document part (whose own body carries no diagram).
+    expect(readPart(bytes, "word/_rels/document.xml.rels")).not.toContain("relationships/image");
+    expect(readPart(bytes, "word/document.xml")).not.toContain("<w:drawing>");
+  });
+
   it("synthesizes the code style when only an included page carries a code macro", async () => {
     const codePage: ConfluencePageDetails = {
       id: "Imprint",

--- a/packages/docx/src/export.test.ts
+++ b/packages/docx/src/export.test.ts
@@ -1481,3 +1481,280 @@ describe("exportDocx — spec 003 review fixes", () => {
     expect(firstDoc).toMatchSnapshot("scroll-macro-feature-zoo-document-xml");
   });
 });
+
+// ---------------------------------------------------------------------------
+// Cross-page include pass (spec 005 D1)
+// ---------------------------------------------------------------------------
+describe("exportDocx — $scroll.includepage (spec 005 D1)", () => {
+  const SENTINEL = "IMPRINT_SENTINEL_9f3a";
+  const includePage = (id: string, extraStorage = ""): ConfluencePageDetails => ({
+    id,
+    title: `Imprint ${id}`,
+    spaceKey: "ENG",
+    storage: `<p>${SENTINEL} ${id}</p>${extraStorage}`,
+  });
+
+  /** A getIncludedPage that resolves any ref to `page`, counting calls. */
+  function resolver(pages: Record<string, ConfluencePageDetails>) {
+    const calls: string[] = [];
+    return {
+      calls,
+      getIncludedPage: async (ref: { pageId?: string; title?: string; spaceKey?: string }) => {
+        calls.push(ref.pageId ?? `${ref.spaceKey ?? ""}:${ref.title ?? ""}`);
+        const key = ref.pageId ?? ref.title ?? "";
+        const page = pages[key];
+        return page
+          ? { kind: "resolved" as const, page }
+          : { kind: "not-found-or-forbidden" as const };
+      },
+    };
+  }
+
+  const styledTemplate = (opts: { body: string; header?: string; footer?: string }) =>
+    buildDocx({
+      body: opts.body,
+      styles: stylesXml(headingStyle("Heading1", "Heading 1")),
+      ...(opts.header ? { header: opts.header } : {}),
+      ...(opts.footer ? { footer: opts.footer } : {}),
+    });
+
+  it("renders the same include target in BOTH body and header, fetched once", async () => {
+    const page = includePage("Imprint");
+    const { calls, getIncludedPage } = resolver({ Imprint: page });
+    const { bytes } = await exportDocx({
+      templateBytes: styledTemplate({
+        body: para("$scroll.content") + para("$scroll.includepage.(ENG:Imprint)"),
+        header: para("$scroll.includepage.(ENG:Imprint)"),
+      }),
+      details,
+      template,
+      deps: { ...deps, getIncludedPage },
+    });
+    const doc = readPart(bytes, "word/document.xml");
+    const header = readPart(bytes, "word/header1.xml");
+    expect(doc).toContain(SENTINEL);
+    expect(header).toContain(SENTINEL);
+    // One canonical ref key → exactly one fetch (cache hit on the 2nd occurrence).
+    expect(calls).toEqual(["ENG:Imprint"]);
+    for (const part of [doc, header]) {
+      expect(part).not.toContain("$scroll.");
+      assertBalancedXml(part);
+    }
+  });
+
+  it("renders two occurrences of the same include in one part with one fetch", async () => {
+    const { calls, getIncludedPage } = resolver({ Imprint: includePage("Imprint") });
+    const { bytes } = await exportDocx({
+      templateBytes: styledTemplate({
+        body:
+          para("$scroll.content") +
+          para("$scroll.includepage.(ENG:Imprint)") +
+          para("$scroll.includepage.(ENG:Imprint)"),
+      }),
+      details,
+      template,
+      deps: { ...deps, getIncludedPage },
+    });
+    const doc = readPart(bytes, "word/document.xml");
+    expect(doc.match(new RegExp(SENTINEL, "g"))?.length).toBe(2);
+    expect(calls).toEqual(["ENG:Imprint"]);
+  });
+
+  it("finds and replaces a run-split include token", async () => {
+    const { getIncludedPage } = resolver({ Imprint: includePage("Imprint") });
+    const { bytes } = await exportDocx({
+      templateBytes: styledTemplate({
+        body: para("$scroll.content") + runSplitPara(["$scroll.includepage.", "(ENG:Imprint)"]),
+      }),
+      details,
+      template,
+      deps: { ...deps, getIncludedPage },
+    });
+    const doc = readPart(bytes, "word/document.xml");
+    expect(doc).toContain(SENTINEL);
+    expect(doc).not.toContain("$scroll.");
+  });
+
+  it("does NOT expand a non-atomic paragraph; surrounding text survives verbatim", async () => {
+    const { calls, getIncludedPage } = resolver({ Imprint: includePage("Imprint") });
+    const { bytes, report } = await exportDocx({
+      templateBytes: styledTemplate({
+        body:
+          para("$scroll.content") +
+          para("See our disclaimer: $scroll.includepage.(ENG:Imprint)") +
+          para("$scroll.includepage.(A) and $scroll.includepage.(B)"),
+      }),
+      details,
+      template,
+      deps: { ...deps, getIncludedPage },
+    });
+    const doc = readPart(bytes, "word/document.xml");
+    expect(doc).toContain("See our disclaimer: ");
+    expect(doc).not.toContain(SENTINEL); // never expanded
+    expect(doc).not.toContain("$scroll."); // but token still blanked
+    // No fetch happened for a non-atomic paragraph.
+    expect(calls).toHaveLength(0);
+    expect(report.notes.filter((n) => n.code === "includepage-invalid-context")).toHaveLength(2);
+  });
+
+  it("blanks every failure class with its OWN distinct note code (no literal)", async () => {
+    const cases: Array<[string, { kind: string; message?: string }, string]> = [
+      ["nf", { kind: "not-found-or-forbidden" }, "includepage-unresolved"],
+      ["auth", { kind: "auth-failed" }, "includepage-auth-failed"],
+      ["rl", { kind: "rate-limited" }, "includepage-rate-limited"],
+      ["tr", { kind: "transient-error", message: "socket hangup" }, "includepage-transient-error"],
+    ];
+    for (const [arg, outcome, code] of cases) {
+      const { bytes, report } = await exportDocx({
+        templateBytes: styledTemplate({
+          body: para("$scroll.content") + para(`$scroll.includepage.(${arg})`),
+        }),
+        details,
+        template,
+        deps: { ...deps, getIncludedPage: async () => outcome as never },
+      });
+      const doc = readPart(bytes, "word/document.xml");
+      expect(doc).not.toContain("$scroll.");
+      expect(report.notes.some((n) => n.code === code)).toBe(true);
+    }
+  });
+
+  it("treats an absent getIncludedPage dep as a transient failure (no literal)", async () => {
+    const { bytes, report } = await exportDocx({
+      templateBytes: styledTemplate({
+        body: para("$scroll.content") + para("$scroll.includepage.(ENG:Imprint)"),
+      }),
+      details,
+      template,
+      deps,
+    });
+    expect(readPart(bytes, "word/document.xml")).not.toContain("$scroll.");
+    expect(report.notes.some((n) => n.code === "includepage-transient-error")).toBe(true);
+  });
+
+  it("still renders an ambiguous title, noting the count", async () => {
+    const page = includePage("Dup");
+    const { bytes, report } = await exportDocx({
+      templateBytes: styledTemplate({
+        body: para("$scroll.content") + para("$scroll.includepage.(Dup)"),
+      }),
+      details,
+      template,
+      deps: {
+        ...deps,
+        getIncludedPage: async () => ({ kind: "ambiguous" as const, count: 3, page }),
+      },
+    });
+    expect(readPart(bytes, "word/document.xml")).toContain(SENTINEL);
+    const note = report.notes.find((n) => n.code === "includepage-ambiguous-title");
+    expect(note?.message).toContain("3");
+  });
+
+  it("blocks self-include with includepage-cycle but NOT a non-self repeat", async () => {
+    // The exported page id is `123`. A pageId ref to itself is a cycle; a
+    // different target referenced twice (body+header) must NOT be flagged.
+    const other = includePage("Imprint");
+    const { bytes, report } = await exportDocx({
+      templateBytes: styledTemplate({
+        body:
+          para("$scroll.content") +
+          para("$scroll.includepage.(123)") +
+          para("$scroll.includepage.(ENG:Imprint)"),
+        header: para("$scroll.includepage.(ENG:Imprint)"),
+      }),
+      details,
+      template,
+      deps: { ...deps, getIncludedPage: resolver({ Imprint: other }).getIncludedPage },
+    });
+    const doc = readPart(bytes, "word/document.xml");
+    expect(doc).not.toContain("$scroll.");
+    expect(report.notes.filter((n) => n.code === "includepage-cycle")).toHaveLength(1);
+    // The non-self target still rendered in both parts.
+    expect(doc).toContain(SENTINEL);
+    expect(readPart(bytes, "word/header1.xml")).toContain(SENTINEL);
+  });
+
+  it("embeds an included FOOTER page's image into footer1.xml.rels, not document.xml.rels", async () => {
+    const footerPage = includePage(
+      "Imprint",
+      '<ac:image><ri:attachment ri:filename="inc.png"/></ac:image>'
+    );
+    const fetchedRefs: { url: string; pageId?: string }[] = [];
+    const assets = {
+      async fetch(ref: { url: string; pageId?: string }) {
+        fetchedRefs.push(ref);
+        return pngFixtureBytes(120, 60);
+      },
+    };
+    const { bytes } = await exportDocx({
+      templateBytes: styledTemplate({
+        // The exported page's own body also carries an image → document.xml.rels.
+        body: para("$scroll.content"),
+        footer: para("$scroll.includepage.(ENG:Imprint)"),
+      }),
+      details: {
+        ...details,
+        storage: '<p>own</p><ac:image><ri:attachment ri:filename="own.png"/></ac:image>',
+      },
+      template,
+      deps: { ...deps, getIncludedPage: resolver({ Imprint: footerPage }).getIncludedPage },
+      assets,
+    });
+    const footer = readPart(bytes, "word/footer1.xml");
+    expect(footer).toContain("<w:drawing>");
+    assertBalancedXml(footer);
+    const footerRels = readPart(bytes, "word/_rels/footer1.xml.rels");
+    expect(footerRels).toContain("relationships/image");
+    // The exported page's own body image is in the document part's rels.
+    expect(readPart(bytes, "word/_rels/document.xml.rels")).toContain("relationships/image");
+    // The included image was fetched from the INCLUDED page's id, not the root.
+    expect(fetchedRefs.some((r) => r.url.includes("/attachments/Imprint/inc.png"))).toBe(true);
+  });
+
+  it("synthesizes the code style when only an included page carries a code macro", async () => {
+    const codePage: ConfluencePageDetails = {
+      id: "Imprint",
+      title: "Imprint",
+      spaceKey: "ENG",
+      storage:
+        '<ac:structured-macro ac:name="code"><ac:parameter ac:name="language">ts</ac:parameter>' +
+        "<ac:plain-text-body><![CDATA[const x = 1;]]></ac:plain-text-body></ac:structured-macro>",
+    };
+    const { bytes } = await exportDocx({
+      templateBytes: styledTemplate({
+        body: para("$scroll.content") + para("$scroll.includepage.(ENG:Imprint)"),
+      }),
+      details: { ...details, storage: "<p>plain</p>" },
+      template,
+      deps: { ...deps, getIncludedPage: resolver({ Imprint: codePage }).getIncludedPage },
+    });
+    expect(readPart(bytes, "word/styles.xml")).toContain('w:styleId="AtlcliCode"');
+  });
+
+  it("enforces the unique-target budget deterministically (cache still serves repeats)", async () => {
+    // 26 distinct targets + 1 repeat of the first. The 26th unique target is
+    // over the 25-page cap and blanks; the repeat of #1 still renders (cache).
+    const pages: Record<string, ConfluencePageDetails> = {};
+    let body = para("$scroll.content");
+    for (let i = 1; i <= 26; i++) {
+      const id = `P${i}`;
+      pages[id] = includePage(id);
+      body += para(`$scroll.includepage.(${id})`);
+    }
+    body += para("$scroll.includepage.(P1)"); // repeat of an accepted target
+    const { bytes, report } = await exportDocx({
+      templateBytes: styledTemplate({ body }),
+      details,
+      template,
+      deps: { ...deps, getIncludedPage: resolver(pages).getIncludedPage },
+    });
+    const doc = readPart(bytes, "word/document.xml");
+    expect(doc).not.toContain("$scroll.");
+    expect(doc).toContain(`${SENTINEL} P1`); // first accepted + its later repeat
+    expect(doc).toContain(`${SENTINEL} P25`);
+    expect(doc).not.toContain(`${SENTINEL} P26`); // over budget → blanked
+    expect(report.notes.filter((n) => n.code === "includepage-budget-exceeded")).toHaveLength(1);
+    // The repeat of P1 renders → P1 sentinel appears twice.
+    expect(doc.match(new RegExp(`${SENTINEL} P1\\b`, "g"))?.length).toBe(2);
+  });
+});

--- a/packages/docx/src/export.ts
+++ b/packages/docx/src/export.ts
@@ -61,7 +61,8 @@ import {
 } from "./serialize.js";
 import { ImageEmbedder, ImageEmbedError } from "./image.js";
 import { renderDiagram, type DiagramTheme } from "@atlcli/diagram";
-import { parseLogoArgs } from "./placeholder-map.js";
+import { parseIncludePageArgs, parseLogoArgs, type IncludePageRef } from "./placeholder-map.js";
+import type { IncludeLookupOutcome } from "./resolver.js";
 import type { AssetFetcher, AssetRef, HostCallContext, SvgRasterizer } from "./env.js";
 import {
   CAPTION_STYLE_ID,
@@ -70,6 +71,7 @@ import {
   codeStyleXml,
   parseStyleNames,
   resolveCaptionLang,
+  type CaptionLang,
 } from "./ooxml.js";
 import {
   encodeXmlText,
@@ -89,6 +91,8 @@ export interface ExportTimings {
   resolveMs: number;
   bodyMs: number;
   logoFetchMs: number;
+  /** Wall clock of the cross-page include pass (fetch + walk + serialize). */
+  includeFetchMs: number;
   renderMs: number;
   imageFetchMs: number;
   imageFetches: number;
@@ -277,6 +281,7 @@ export async function exportDocx(input: ExportInput): Promise<ExportResult> {
     resolveMs: 0,
     bodyMs: 0,
     logoFetchMs: 0,
+    includeFetchMs: 0,
     renderMs: 0,
     imageFetchMs: 0,
     imageFetches: 0,
@@ -410,6 +415,28 @@ export async function exportDocx(input: ExportInput): Promise<ExportResult> {
     notes: flowNotes,
   });
 
+  // 3c. Include pass (spec 005 D1): swap each atomic `$scroll.includepage.(…)`
+  //     paragraph — across body AND headers/footers — for a rawxml tag whose
+  //     value is the referenced page's serialized OOXML body. Runs after the
+  //     logo pass (shares the one ImageEmbedder so relationship/drawing ids
+  //     never collide) and before preprocessScrollText, so any token the pass
+  //     leaves in place (invalid args, fetch failure, non-atomic paragraph) is
+  //     blanked there — never a literal on any path.
+  const includes = await runIncludePass({
+    zip,
+    input,
+    embedder,
+    wantImages,
+    assets: input.assets,
+    rasterizer: input.rasterizer,
+    diagramTheme: input.diagramTheme,
+    budget,
+    styleNames,
+    captionLang: captionLocale.lang,
+    timings,
+    notes: flowNotes,
+  });
+
   if (!contentFound) {
     injectContentTagAtEnd(zip);
     flowNotes.push({
@@ -431,7 +458,7 @@ export async function exportDocx(input: ExportInput): Promise<ExportResult> {
   //    literal braces / $scroll text in the page pass through unchanged. PUA
   //    delimiters guarantee the customer's own `{…}` is never a tag.
   const renderStart = Date.now();
-  const rendered = renderContent(zip, body.xml);
+  const rendered = renderContent(zip, body.xml, includes);
 
   // 5b. A page body ENDING in an orientation region leaves its region-closing
   //     sectPr paragraph directly before the template's body-level sectPr —
@@ -440,9 +467,13 @@ export async function exportDocx(input: ExportInput): Promise<ExportResult> {
   //     document simply ends with the region (spec 003 C6 review fix).
   mergeTrailingRegionSectPr(rendered);
 
-  // 6. Synthesize the code style if the body referenced it; force TOC refresh.
-  if (body.xml.includes(`w:pStyle w:val="${CODE_STYLE_ID}"`)) ensureCodeStyle(rendered);
-  if (body.xml.includes(`w:pStyle w:val="${CAPTION_STYLE_ID}"`)) ensureCaptionStyle(rendered);
+  // 6. Synthesize the code/caption styles if the body OR any included page
+  //    referenced them; force TOC refresh. An included page can be the only
+  //    thing carrying a code macro or a captioned figure (spec 005 D1).
+  const includeXml = [...includes.values()].join("");
+  const styledXml = body.xml + includeXml;
+  if (styledXml.includes(`w:pStyle w:val="${CODE_STYLE_ID}"`)) ensureCodeStyle(rendered);
+  if (styledXml.includes(`w:pStyle w:val="${CAPTION_STYLE_ID}"`)) ensureCaptionStyle(rendered);
   ensureUpdateFields(rendered);
 
   const bytes = rendered.generate({ type: "uint8array", compression: "DEFLATE" }) as unknown as Uint8Array;
@@ -520,6 +551,7 @@ function timingNote(t: ExportTimings, totalMs: number): ExportNote {
       (t.imageFetches ? ` (${t.imageFetches} image fetch(es): ${t.imageFetchMs} ms)` : ""),
     `placeholders ${t.resolveMs} ms`,
     ...(t.logoFetchMs ? [`logo fetch ${t.logoFetchMs} ms`] : []),
+    ...(t.includeFetchMs ? [`includes ${t.includeFetchMs} ms`] : []),
     `render+zip ${t.renderMs} ms`,
   ];
   return {
@@ -540,7 +572,7 @@ function timingNote(t: ExportTimings, totalMs: number): ExportNote {
  * re-thrown as a {@link DocxRenderError} carrying the engine's structured
  * explanation, so the caller never sees a generic "Export failed".
  */
-function renderContent(zip: PizZip, bodyXml: string): PizZip {
+function renderContent(zip: PizZip, bodyXml: string, includes?: Map<string, string>): PizZip {
   let doc: Docxtemplater<PizZip>;
   try {
     doc = new Docxtemplater<PizZip>(zip, {
@@ -552,7 +584,11 @@ function renderContent(zip: PizZip, bodyXml: string): PizZip {
       // notes the cosmetic console noise).
       errorLogging: false,
     });
-    doc.render({ [CONTENT_KEY]: bodyXml });
+    // Each `@scrollInclude<i>` rawxml tag (spec 005 D1) expands to its included
+    // page's serialized OOXML body, inserted VERBATIM alongside the page body —
+    // never re-parsed for tags, so literal braces / `$scroll.*` examples inside
+    // an included page survive.
+    doc.render({ [CONTENT_KEY]: bodyXml, ...(includes ? Object.fromEntries(includes) : {}) });
   } catch (err) {
     throw new DocxRenderError(
       "The Word template could not be rendered.",
@@ -825,7 +861,14 @@ function imageSeam(
   assets: AssetFetcher,
   pageId: string,
   timings: ExportTimings,
-  seamOpts: ImageSeamOptions
+  seamOpts: ImageSeamOptions,
+  // Which document part the serialized output lands in (spec 005 D1). Threaded
+  // straight into `embed`'s `partPath` so an image embedded for an included page
+  // in a header/footer writes its `r:embed` relationship into THAT part's rels
+  // (`word/header1.xml.rels`, …), not the default `word/document.xml.rels` — the
+  // dangling-relationship failure mode the 004-F3 invariant exists to prevent.
+  // Omitted for the main body → defaults to `word/document.xml` (unchanged).
+  partPath?: string
 ): ImageEmbedSeam {
   const { budget, signal, onProgress, total } = seamOpts;
   const context: HostCallContext = { signal };
@@ -894,6 +937,7 @@ function imageSeam(
           name,
           widthPx: block.width,
           heightPx: block.height,
+          ...(partPath ? { partPath } : {}),
         });
         reportDone(name);
         return { ok: true as const, xml };
@@ -924,7 +968,10 @@ function diagramSeam(
   rasterizer: SvgRasterizer,
   theme: DiagramTheme | undefined,
   timings: ExportTimings,
-  budget: AssetBudget
+  budget: AssetBudget,
+  // Target part for the embedded svgBlip/PNG relationships (spec 005 D1) — same
+  // rationale as {@link imageSeam}'s `partPath`. Omitted → `word/document.xml`.
+  partPath?: string
 ): DiagramEmbedSeam {
   let count = 0;
   // Render + rasterize results, keyed by exact source: the serializer's prefetch
@@ -1014,6 +1061,7 @@ function diagramSeam(
           alt: block.code,
           widthPx: prep.widthPx,
           heightPx: prep.heightPx,
+          ...(partPath ? { partPath } : {}),
         });
         return { ok: true as const, xml };
       } catch (err) {
@@ -1025,6 +1073,260 @@ function diagramSeam(
       }
     },
   };
+}
+
+// ---------------------------------------------------------------------------
+// Include pass (spec 005 D1)
+// ---------------------------------------------------------------------------
+
+/** One include token, matching the shared placeholder grammar for its base. */
+const INCLUDE_TOKEN_RE = /\$scroll\.includepage(?:\.?\([^)]*\))?/;
+
+/**
+ * Deliberate v1 guess (spec 005 Risks): at most 25 unique included target
+ * pages, at most 2 MiB of cumulative included storage per export. Chosen for
+ * parity with `ASSET_FETCH_CONCURRENCY`, not measured — revisit on a real
+ * large-template report. Exceeding either degrades deterministically
+ * (`includepage-budget-exceeded`), never an unbounded fan-out.
+ */
+const INCLUDE_BUDGET_MAX_PAGES = 25;
+const INCLUDE_BUDGET_MAX_STORAGE_BYTES = 2 * 1024 * 1024;
+
+interface IncludeOccurrence {
+  /** Stable index → rawxml key `scrollInclude<index>` (one per occurrence). */
+  index: number;
+  part: string;
+  paragraph: string;
+  /** The raw token (carries the `.(…)` argument group). */
+  raw: string;
+}
+
+interface IncludePassDeps {
+  zip: PizZip;
+  input: ExportInput;
+  embedder?: ImageEmbedder;
+  wantImages: boolean;
+  assets?: AssetFetcher;
+  rasterizer?: SvgRasterizer;
+  diagramTheme?: DiagramTheme;
+  budget: AssetBudget;
+  styleNames: Map<string, string>;
+  captionLang: CaptionLang;
+  timings: ExportTimings;
+  /** Sink for the pass's report notes (part of the export's flow notes). */
+  notes: ExportNote[];
+}
+
+/**
+ * The cross-page include pass (spec 005 D1). Returns a `Map<rawxmlKey, OOXML>`
+ * to hand docxtemplater; every entry corresponds to one atomic include
+ * occurrence whose paragraph has been swapped for its `@scrollInclude<i>` tag.
+ *
+ * Invariants:
+ *  - **Never a literal.** Any occurrence not swapped (invalid args, fetch
+ *    failure, non-atomic paragraph, budget, self-include) is left in place for
+ *    `preprocessScrollText` to blank.
+ *  - **Self-include only is a cycle.** A page including ITSELF would double its
+ *    own body inline — blocked with `includepage-cycle`. Every other repeat
+ *    (the same target in body + header, or twice in one part) renders normally;
+ *    true multi-hop cycles are structurally impossible (included content is
+ *    never re-scanned for further tokens).
+ *  - **One fetch + one walk per unique target.** Fetches de-duplicate by
+ *    canonical ref key through a bounded pool; `storageToBlocks` caches per
+ *    resolved pageId. `serializeBlocks` still runs per OCCURRENCE so each
+ *    occurrence's images/diagrams embed into ITS OWN target part's rels.
+ */
+async function runIncludePass(pass: IncludePassDeps): Promise<Map<string, string>> {
+  const { zip, input, notes } = pass;
+  const includes = new Map<string, string>();
+
+  // 1. Occurrence scan across body + headers/footers (+ chart/diagram parts).
+  const occurrences: IncludeOccurrence[] = [];
+  for (const part of documentPartNames(zip)) {
+    const xml = zip.file(part)?.asText() ?? "";
+    if (!xml.includes("$scroll.includepage")) continue;
+    for (const para of splitParagraphs(xml)) {
+      const text = paragraphText(para);
+      const m = text.match(INCLUDE_TOKEN_RE);
+      if (!m) continue;
+      // Atomic-paragraph check: the token must be the paragraph's SOLE visible
+      // content. Otherwise a whole-paragraph OOXML swap would silently delete
+      // the surrounding prose (docxtemplater's free-tier rawxml requires the tag
+      // to own its paragraph). Not atomic ⇒ note + leave in place (blanks in
+      // step 4), no fetch, no swap.
+      if (m[0].trim() !== text.trim()) {
+        notes.push({
+          level: "warning",
+          code: "includepage-invalid-context",
+          message: `${m[0]} shares a paragraph with other text; only a paragraph whose sole content is the include token is expanded — leave it on its own line. Rendered empty.`,
+        });
+        continue;
+      }
+      occurrences.push({ index: occurrences.length, part, paragraph: para, raw: m[0] });
+    }
+  }
+  if (occurrences.length === 0) return includes;
+
+  const startFetch = Date.now();
+  const getIncludedPage = input.deps?.getIncludedPage;
+
+  // 2. Fetch leg: de-duplicated by canonical ref key, bounded pool (one
+  //    round-trip per unique target however many times it is referenced).
+  const limit = pLimit(ASSET_FETCH_CONCURRENCY);
+  const fetchCache = new Map<string, Promise<IncludeLookupOutcome>>();
+  const canonicalKey = (ref: IncludePageRef): string =>
+    ref.pageId ? `id:${ref.pageId}` : `title:${ref.spaceKey ?? ""}:${ref.title ?? ""}`;
+  const fetchRef = (ref: IncludePageRef): Promise<IncludeLookupOutcome> => {
+    const key = canonicalKey(ref);
+    let p = fetchCache.get(key);
+    if (!p) {
+      // Missing dep ⇒ transient-error (nothing to fetch with).
+      p = getIncludedPage
+        ? limit(() => getIncludedPage(ref))
+        : Promise.resolve<IncludeLookupOutcome>({
+            kind: "transient-error",
+            message: "no include fetcher is available",
+          });
+      p.catch(() => {});
+      fetchCache.set(key, p);
+    }
+    return p;
+  };
+
+  // 3. Render + budget state, keyed by the resolved pageId.
+  const blocksCache = new Map<string, ReturnType<typeof storageToBlocks>>();
+  const acceptedPages = new Set<string>();
+  let cumulativeStorageBytes = 0;
+  let budgetNoted = false;
+
+  const note = (code: string, message: string, level: "info" | "warning" = "warning"): void => {
+    notes.push({ level, code, message });
+  };
+
+  for (const occ of occurrences) {
+    const ref = parseIncludePageArgs(occ.raw);
+    if (!ref) {
+      note("includepage-unresolved", `${occ.raw} names no page; rendered empty.`);
+      continue;
+    }
+
+    // Self-include (pageId form): a page cannot include itself (would double its
+    // body inline). Caught before the fetch when the id is explicit.
+    if (ref.pageId && ref.pageId === input.details.id) {
+      note("includepage-cycle", `${occ.raw}: a page cannot include itself; rendered empty.`);
+      continue;
+    }
+
+    const outcome = await fetchRef(ref);
+    let page: ConfluencePageDetails;
+    switch (outcome.kind) {
+      case "resolved":
+        page = outcome.page;
+        break;
+      case "ambiguous":
+        page = outcome.page;
+        note(
+          "includepage-ambiguous-title",
+          `${occ.raw} matched ${outcome.count} pages; used the first (id-sorted). Disambiguate with a SPACE:Title or (pageId) form.`,
+          "info"
+        );
+        break;
+      case "not-found-or-forbidden":
+        note("includepage-unresolved", `${occ.raw} was not found or is not readable; rendered empty.`);
+        continue;
+      case "auth-failed":
+        note(
+          "includepage-auth-failed",
+          `${occ.raw}: authentication failed while fetching the included page; check the export credentials. Rendered empty.`
+        );
+        continue;
+      case "rate-limited":
+        note(
+          "includepage-rate-limited",
+          `${occ.raw}: Confluence rate-limited the include fetch; rendered empty — retry the export.`
+        );
+        continue;
+      case "transient-error":
+        note(
+          "includepage-transient-error",
+          `${occ.raw} could not be fetched (${outcome.message}); rendered empty.`
+        );
+        continue;
+    }
+
+    // Self-include (title/space form): only knowable after the ref resolves.
+    if (page.id === input.details.id) {
+      note("includepage-cycle", `${occ.raw}: a page cannot include itself; rendered empty.`);
+      continue;
+    }
+
+    // Budget: gate only NEW unique targets; already-accepted ones keep rendering.
+    if (!acceptedPages.has(page.id)) {
+      const size = (page.storage ?? "").length;
+      if (
+        acceptedPages.size >= INCLUDE_BUDGET_MAX_PAGES ||
+        cumulativeStorageBytes + size > INCLUDE_BUDGET_MAX_STORAGE_BYTES
+      ) {
+        if (!budgetNoted) {
+          note(
+            "includepage-budget-exceeded",
+            `Include budget exceeded (>${INCLUDE_BUDGET_MAX_PAGES} unique pages or >${INCLUDE_BUDGET_MAX_STORAGE_BYTES} bytes); further new includes rendered empty.`
+          );
+          budgetNoted = true;
+        }
+        continue;
+      }
+      acceptedPages.add(page.id);
+      cumulativeStorageBytes += size;
+    }
+
+    // Walk once per unique pageId (cached); collect walk notes only once.
+    let walked = blocksCache.get(page.id);
+    if (!walked) {
+      walked = storageToBlocks(page.storage ?? "", { exporter: "word" });
+      blocksCache.set(page.id, walked);
+      notes.push(...walked.notes);
+    }
+
+    // Serialize PER OCCURRENCE with part-bound seams: an included page's image
+    // or diagram embeds its relationship into THIS occurrence's target part.
+    const images =
+      pass.embedder && pass.wantImages && pass.assets
+        ? imageSeam(
+            pass.embedder,
+            pass.assets,
+            page.id,
+            pass.timings,
+            { budget: pass.budget, ...(input.signal ? { signal: input.signal } : {}), total: 0 },
+            occ.part
+          )
+        : undefined;
+    const diagrams =
+      pass.embedder && pass.rasterizer
+        ? diagramSeam(pass.embedder, pass.rasterizer, pass.diagramTheme, pass.timings, pass.budget, occ.part)
+        : undefined;
+    const serialized = await serializeBlocks(walked.blocks, {
+      styleNames: pass.styleNames,
+      ...(images ? { images } : {}),
+      ...(diagrams ? { diagrams } : {}),
+      captionLang: pass.captionLang,
+    });
+    notes.push(...serialized.notes);
+
+    const key = `scrollInclude${occ.index}`;
+    includes.set(key, serialized.xml);
+
+    // Swap the occurrence paragraph for the rawxml tag (sole content — atomic
+    // check above guarantees the free-tier rawxml contract).
+    const xml = zip.file(occ.part)?.asText() ?? "";
+    if (xml.includes(occ.paragraph)) {
+      const tagPara = `<w:p><w:r><w:t xml:space="preserve">${DELIM_START}@${key}${DELIM_END}</w:t></w:r></w:p>`;
+      zip.file(occ.part, xml.replace(occ.paragraph, tagPara));
+    }
+  }
+
+  pass.timings.includeFetchMs = Date.now() - startFetch;
+  return includes;
 }
 
 /**

--- a/packages/docx/src/include-lookup.test.ts
+++ b/packages/docx/src/include-lookup.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "bun:test";
+import { escapeCqlValue } from "@atlcli/confluence";
+import type { ConfluencePageDetails } from "@atlcli/confluence";
+import { buildGetIncludedPage, classifyIncludeError, type IncludeLookupIo } from "./include-lookup.js";
+
+/** A real in-memory page store — no mocking, plain closures over fixture data. */
+function makePage(id: string, title: string, spaceKey = "ENG"): ConfluencePageDetails {
+  return { id, title, spaceKey, storage: `<p>${title} body</p>` };
+}
+
+function makeIo(
+  pages: ConfluencePageDetails[],
+  overrides: Partial<IncludeLookupIo> = {}
+): IncludeLookupIo & { getPageCalls: string[]; searchCalls: string[] } {
+  const getPageCalls: string[] = [];
+  const searchCalls: string[] = [];
+  return {
+    getPageCalls,
+    searchCalls,
+    escapeCqlValue,
+    defaultSpaceKey: "ENG",
+    getPage: async (id) => {
+      getPageCalls.push(id);
+      const p = pages.find((x) => x.id === id);
+      if (!p) throw new Error("Confluence API error (404): not found");
+      return p;
+    },
+    searchPages: async (cql) => {
+      searchCalls.push(cql);
+      // Real matching: a page hits when its ESCAPED title clause is present in
+      // the CQL (mirrors how the client would match the same literal server-side).
+      return pages
+        .filter((p) => cql.includes(`title = "${escapeCqlValue(p.title)}"`))
+        .map((p) => ({ id: p.id }));
+    },
+    ...overrides,
+  };
+}
+
+describe("buildGetIncludedPage — resolution paths", () => {
+  it("resolves a pageId ref with one getPage and no search", async () => {
+    const io = makeIo([makePage("500", "Imprint")]);
+    const get = buildGetIncludedPage(io);
+    const out = await get({ pageId: "500" });
+    expect(out.kind).toBe("resolved");
+    expect(io.searchCalls).toHaveLength(0);
+    expect(io.getPageCalls).toEqual(["500"]);
+  });
+
+  it("resolves a title ref via CQL, filling the default space and escaping the value", async () => {
+    const io = makeIo([makePage("501", 'Legal "Notice"')]);
+    const get = buildGetIncludedPage(io);
+    const out = await get({ title: 'Legal "Notice"' });
+    expect(out.kind).toBe("resolved");
+    // Default space filled + both literals escaped through escapeCqlValue.
+    expect(io.searchCalls[0]).toBe('type = page and space = "ENG" and title = "Legal \\"Notice\\""');
+  });
+
+  it("reports ambiguous but still resolves the id-sorted first hit", async () => {
+    const io = makeIo([makePage("30", "Dup"), makePage("10", "Dup"), makePage("20", "Dup")]);
+    const get = buildGetIncludedPage(io);
+    const out = await get({ title: "Dup" });
+    expect(out.kind).toBe("ambiguous");
+    if (out.kind === "ambiguous") {
+      expect(out.count).toBe(3);
+      expect(out.page.id).toBe("10"); // lexicographic id sort → deterministic
+    }
+  });
+
+  it("returns not-found-or-forbidden on zero title hits", async () => {
+    const io = makeIo([makePage("1", "Other")]);
+    const out = await buildGetIncludedPage(io)({ title: "Missing" });
+    expect(out.kind).toBe("not-found-or-forbidden");
+  });
+});
+
+describe("classifyIncludeError — every distinct failure class", () => {
+  it("maps client error messages to the right outcome kind", () => {
+    expect(classifyIncludeError(new Error("Confluence API error (401): bad token")).kind).toBe("auth-failed");
+    expect(classifyIncludeError(new Error("Confluence API error (403): forbidden")).kind).toBe("not-found-or-forbidden");
+    expect(classifyIncludeError(new Error("Confluence API error (404): missing")).kind).toBe("not-found-or-forbidden");
+    expect(classifyIncludeError(new Error("Rate limited by Confluence API after 3 retries")).kind).toBe("rate-limited");
+    const transient = classifyIncludeError(new Error("Confluence API error (503): upstream down"));
+    expect(transient.kind).toBe("transient-error");
+    if (transient.kind === "transient-error") expect(transient.message).toContain("503");
+  });
+
+  it("classifies a raw network failure as transient", () => {
+    const out = classifyIncludeError(new TypeError("fetch failed"));
+    expect(out.kind).toBe("transient-error");
+  });
+});
+
+describe("buildGetIncludedPage — error handling", () => {
+  it("rethrows an AbortError instead of swallowing it", async () => {
+    const io = makeIo([], {
+      getPage: async () => {
+        const e = new Error("aborted");
+        e.name = "AbortError";
+        throw e;
+      },
+    });
+    await expect(buildGetIncludedPage(io)({ pageId: "1" })).rejects.toThrow("aborted");
+  });
+
+  it("classifies a thrown 429 from search as rate-limited", async () => {
+    const io = makeIo([], {
+      searchPages: async () => {
+        throw new Error("Rate limited by Confluence API after 3 retries");
+      },
+    });
+    const out = await buildGetIncludedPage(io)({ title: "X" });
+    expect(out.kind).toBe("rate-limited");
+  });
+});

--- a/packages/docx/src/include-lookup.test.ts
+++ b/packages/docx/src/include-lookup.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from "bun:test";
-import { escapeCqlValue } from "@atlcli/confluence";
 import type { ConfluencePageDetails } from "@atlcli/confluence";
 import { buildGetIncludedPage, classifyIncludeError, type IncludeLookupIo } from "./include-lookup.js";
 
@@ -11,13 +10,12 @@ function makePage(id: string, title: string, spaceKey = "ENG"): ConfluencePageDe
 function makeIo(
   pages: ConfluencePageDetails[],
   overrides: Partial<IncludeLookupIo> = {}
-): IncludeLookupIo & { getPageCalls: string[]; searchCalls: string[] } {
+): IncludeLookupIo & { getPageCalls: string[]; titleCalls: Array<{ title: string; spaceKey?: string }> } {
   const getPageCalls: string[] = [];
-  const searchCalls: string[] = [];
+  const titleCalls: Array<{ title: string; spaceKey?: string }> = [];
   return {
     getPageCalls,
-    searchCalls,
-    escapeCqlValue,
+    titleCalls,
     defaultSpaceKey: "ENG",
     getPage: async (id) => {
       getPageCalls.push(id);
@@ -25,12 +23,12 @@ function makeIo(
       if (!p) throw new Error("Confluence API error (404): not found");
       return p;
     },
-    searchPages: async (cql) => {
-      searchCalls.push(cql);
-      // Real matching: a page hits when its ESCAPED title clause is present in
-      // the CQL (mirrors how the client would match the same literal server-side).
+    // Direct content-endpoint lookup (NOT CQL): exact title match, optionally
+    // scoped to a space — mirrors ConfluenceClient.findPagesByTitle.
+    findPagesByTitle: async (title, spaceKey) => {
+      titleCalls.push({ title, ...(spaceKey ? { spaceKey } : {}) });
       return pages
-        .filter((p) => cql.includes(`title = "${escapeCqlValue(p.title)}"`))
+        .filter((p) => p.title === title && (spaceKey === undefined || p.spaceKey === spaceKey))
         .map((p) => ({ id: p.id }));
     },
     ...overrides,
@@ -38,22 +36,32 @@ function makeIo(
 }
 
 describe("buildGetIncludedPage — resolution paths", () => {
-  it("resolves a pageId ref with one getPage and no search", async () => {
+  it("resolves a pageId ref with one getPage and no title lookup", async () => {
     const io = makeIo([makePage("500", "Imprint")]);
     const get = buildGetIncludedPage(io);
     const out = await get({ pageId: "500" });
     expect(out.kind).toBe("resolved");
-    expect(io.searchCalls).toHaveLength(0);
+    expect(io.titleCalls).toHaveLength(0);
     expect(io.getPageCalls).toEqual(["500"]);
   });
 
-  it("resolves a title ref via CQL, filling the default space and escaping the value", async () => {
+  it("resolves a title ref through the DIRECT endpoint (not CQL), filling the default space", async () => {
     const io = makeIo([makePage("501", 'Legal "Notice"')]);
     const get = buildGetIncludedPage(io);
     const out = await get({ title: 'Legal "Notice"' });
     expect(out.kind).toBe("resolved");
-    // Default space filled + both literals escaped through escapeCqlValue.
-    expect(io.searchCalls[0]).toBe('type = page and space = "ENG" and title = "Legal \\"Notice\\""');
+    // The raw title + default space are passed straight through — no CQL clause,
+    // no escaping (the client URL-encodes the query param). This is the
+    // regression pin: title resolution must NOT build a CQL string.
+    expect(io.titleCalls).toEqual([{ title: 'Legal "Notice"', spaceKey: "ENG" }]);
+  });
+
+  it("passes an explicit space through and honors it in the match", async () => {
+    const io = makeIo([makePage("601", "Imprint", "ENG"), makePage("602", "Imprint", "DOCSY")]);
+    const out = await buildGetIncludedPage(io)({ spaceKey: "DOCSY", title: "Imprint" });
+    expect(out.kind).toBe("resolved");
+    if (out.kind === "resolved") expect(out.page.id).toBe("602");
+    expect(io.titleCalls).toEqual([{ title: "Imprint", spaceKey: "DOCSY" }]);
   });
 
   it("reports ambiguous but still resolves the id-sorted first hit", async () => {
@@ -103,9 +111,9 @@ describe("buildGetIncludedPage — error handling", () => {
     await expect(buildGetIncludedPage(io)({ pageId: "1" })).rejects.toThrow("aborted");
   });
 
-  it("classifies a thrown 429 from search as rate-limited", async () => {
+  it("classifies a thrown 429 from the title lookup as rate-limited", async () => {
     const io = makeIo([], {
-      searchPages: async () => {
+      findPagesByTitle: async () => {
         throw new Error("Rate limited by Confluence API after 3 retries");
       },
     });

--- a/packages/docx/src/include-lookup.ts
+++ b/packages/docx/src/include-lookup.ts
@@ -3,12 +3,19 @@
  *
  * The engine's INCLUDE pass calls `deps.getIncludedPage(ref)` and expects a
  * discriminated {@link IncludeLookupOutcome}. Every host (CLI, extension,
- * further hosts) needs the SAME title→CQL construction, id-sorted determinism,
- * ambiguity handling, and error classification — so it lives here once,
- * injectable and isomorphic (no `node:*` / `chrome.*` / direct network). Hosts
- * pass their Confluence client's `getPage`/`searchPages` plus the shared
- * `escapeCqlValue` from `@atlcli/confluence`; unit tests inject plain in-memory
- * functions (no mocking).
+ * further hosts) needs the SAME title lookup, id-sorted determinism, ambiguity
+ * handling, and error classification — so it lives here once, injectable and
+ * isomorphic (no `node:*` / `chrome.*` / direct network). Hosts pass their
+ * Confluence client's `getPage` plus `findPagesByTitle`; unit tests inject plain
+ * in-memory functions (no mocking).
+ *
+ * Title resolution goes through the DIRECT content endpoint
+ * (`findPagesByTitle` → `GET /content?title=…`), NOT the CQL search index,
+ * because the search index lags page creation on Cloud (a freshly created
+ * include target came back "not found" on the first export and only resolved on
+ * a retry minutes later — see {@link IncludeLookupIo.findPagesByTitle}). No CQL
+ * string-literal escaping is involved: the title rides as a plain, URL-encoded
+ * query parameter.
  */
 import type { ConfluencePageDetails } from "@atlcli/confluence";
 import type { IncludePageRef } from "./placeholder-map.js";
@@ -18,10 +25,13 @@ import type { IncludeLookupOutcome } from "./resolver.js";
 export interface IncludeLookupIo {
   /** Fetch a page (with `storage`) by id — the client's `getPage`. */
   getPage: (id: string) => Promise<ConfluencePageDetails>;
-  /** Run a CQL page search; only the hits' `id`s are needed. */
-  searchPages: (cql: string) => Promise<Array<{ id: string }>>;
-  /** The shared CQL string-literal escaper (`@atlcli/confluence`). */
-  escapeCqlValue: (value: string) => string;
+  /**
+   * Look up pages by EXACT title (+ optional space) through the client's
+   * DIRECT content endpoint (`ConfluenceClient.findPagesByTitle`), which reads
+   * the content store rather than the lagging search index. Returns every
+   * match; the builder sorts by id. Only the hits' `id`s are needed.
+   */
+  findPagesByTitle: (title: string, spaceKey?: string) => Promise<Array<{ id: string }>>;
   /** Space of the EXPORTED page, filling a bare-title `(Title)` form. */
   defaultSpaceKey?: string;
 }
@@ -58,12 +68,11 @@ export function classifyIncludeError(err: unknown): IncludeLookupOutcome {
 /**
  * Build a `getIncludedPage` loader from a host's client primitives. Resolution:
  *  - a `pageId` ref → one `getPage`;
- *  - a title ref → a CQL `type = page [and space = "…"] and title = "…"` search
- *    (values escaped via {@link IncludeLookupIo.escapeCqlValue}, `spaceKey`
- *    defaulting to the exported page's space); zero hits →
- *    `not-found-or-forbidden`; the hits are id-sorted for determinism and the
- *    FIRST is fetched — more than one hit still resolves it but reports
- *    `ambiguous` with the count.
+ *  - a title ref → a DIRECT `findPagesByTitle(title, spaceKey)` lookup (NOT CQL
+ *    — avoids the search-index lag; `spaceKey` defaults to the exported page's
+ *    space); zero hits → `not-found-or-forbidden`; the hits are id-sorted for
+ *    determinism and the FIRST is fetched — more than one hit still resolves it
+ *    but reports `ambiguous` with the count.
  *
  * An `AbortError` is rethrown (host cancellation); every other throw is
  * classified by {@link classifyIncludeError}. The loader is memoization-agnostic
@@ -81,10 +90,7 @@ export function buildGetIncludedPage(
       if (!title) return { kind: "not-found-or-forbidden" };
 
       const spaceKey = ref.spaceKey ?? io.defaultSpaceKey;
-      const clauses = [`type = page`];
-      if (spaceKey) clauses.push(`space = "${io.escapeCqlValue(spaceKey)}"`);
-      clauses.push(`title = "${io.escapeCqlValue(title)}"`);
-      const hits = await io.searchPages(clauses.join(" and "));
+      const hits = await io.findPagesByTitle(title, spaceKey);
 
       if (hits.length === 0) return { kind: "not-found-or-forbidden" };
       const sorted = [...hits].sort((a, b) => a.id.localeCompare(b.id));

--- a/packages/docx/src/include-lookup.ts
+++ b/packages/docx/src/include-lookup.ts
@@ -1,0 +1,99 @@
+/**
+ * Host-side `$scroll.includepage.(…)` lookup builder (spec 005 D1).
+ *
+ * The engine's INCLUDE pass calls `deps.getIncludedPage(ref)` and expects a
+ * discriminated {@link IncludeLookupOutcome}. Every host (CLI, extension,
+ * further hosts) needs the SAME title→CQL construction, id-sorted determinism,
+ * ambiguity handling, and error classification — so it lives here once,
+ * injectable and isomorphic (no `node:*` / `chrome.*` / direct network). Hosts
+ * pass their Confluence client's `getPage`/`searchPages` plus the shared
+ * `escapeCqlValue` from `@atlcli/confluence`; unit tests inject plain in-memory
+ * functions (no mocking).
+ */
+import type { ConfluencePageDetails } from "@atlcli/confluence";
+import type { IncludePageRef } from "./placeholder-map.js";
+import type { IncludeLookupOutcome } from "./resolver.js";
+
+/** The host primitives {@link buildGetIncludedPage} composes. */
+export interface IncludeLookupIo {
+  /** Fetch a page (with `storage`) by id — the client's `getPage`. */
+  getPage: (id: string) => Promise<ConfluencePageDetails>;
+  /** Run a CQL page search; only the hits' `id`s are needed. */
+  searchPages: (cql: string) => Promise<Array<{ id: string }>>;
+  /** The shared CQL string-literal escaper (`@atlcli/confluence`). */
+  escapeCqlValue: (value: string) => string;
+  /** Space of the EXPORTED page, filling a bare-title `(Title)` form. */
+  defaultSpaceKey?: string;
+}
+
+function isAbortError(err: unknown): boolean {
+  return (
+    (typeof DOMException !== "undefined" && err instanceof DOMException && err.name === "AbortError") ||
+    (err instanceof Error && err.name === "AbortError")
+  );
+}
+
+/**
+ * Classify a thrown Confluence error into a non-`resolved`
+ * {@link IncludeLookupOutcome}. `@atlcli/confluence`'s `request()` carries no
+ * typed status field, but its thrown messages are textually distinguishable:
+ *  - 401 → `auth-failed`;
+ *  - 403 / 404 → `not-found-or-forbidden` (Cloud makes these genuinely
+ *    indistinguishable, so this pair stays one honest combined outcome);
+ *  - `Rate limited by Confluence API after N retries` → `rate-limited`;
+ *  - anything else (5xx after retries, raw network failure) → `transient-error`
+ *    carrying the message.
+ *
+ * (The PLAN's `40[13]` sketch conflated 401 with the not-found pair; 404 is the
+ * not-found status and 401 is auth, so this checks 401 first, then 403/404.)
+ */
+export function classifyIncludeError(err: unknown): IncludeLookupOutcome {
+  const message = err instanceof Error ? err.message : String(err);
+  if (/Confluence API error \(401\)/.test(message)) return { kind: "auth-failed" };
+  if (/Confluence API error \(40[34]\)/.test(message)) return { kind: "not-found-or-forbidden" };
+  if (/^Rate limited by Confluence API/.test(message)) return { kind: "rate-limited" };
+  return { kind: "transient-error", message };
+}
+
+/**
+ * Build a `getIncludedPage` loader from a host's client primitives. Resolution:
+ *  - a `pageId` ref → one `getPage`;
+ *  - a title ref → a CQL `type = page [and space = "…"] and title = "…"` search
+ *    (values escaped via {@link IncludeLookupIo.escapeCqlValue}, `spaceKey`
+ *    defaulting to the exported page's space); zero hits →
+ *    `not-found-or-forbidden`; the hits are id-sorted for determinism and the
+ *    FIRST is fetched — more than one hit still resolves it but reports
+ *    `ambiguous` with the count.
+ *
+ * An `AbortError` is rethrown (host cancellation); every other throw is
+ * classified by {@link classifyIncludeError}. The loader is memoization-agnostic
+ * — the engine's include pass owns fetch de-duplication.
+ */
+export function buildGetIncludedPage(
+  io: IncludeLookupIo
+): (ref: IncludePageRef) => Promise<IncludeLookupOutcome> {
+  return async (ref) => {
+    try {
+      if (ref.pageId) {
+        return { kind: "resolved", page: await io.getPage(ref.pageId) };
+      }
+      const title = ref.title;
+      if (!title) return { kind: "not-found-or-forbidden" };
+
+      const spaceKey = ref.spaceKey ?? io.defaultSpaceKey;
+      const clauses = [`type = page`];
+      if (spaceKey) clauses.push(`space = "${io.escapeCqlValue(spaceKey)}"`);
+      clauses.push(`title = "${io.escapeCqlValue(title)}"`);
+      const hits = await io.searchPages(clauses.join(" and "));
+
+      if (hits.length === 0) return { kind: "not-found-or-forbidden" };
+      const sorted = [...hits].sort((a, b) => a.id.localeCompare(b.id));
+      const page = await io.getPage(sorted[0].id);
+      if (hits.length > 1) return { kind: "ambiguous", count: hits.length, page };
+      return { kind: "resolved", page };
+    } catch (err) {
+      if (isAbortError(err)) throw err;
+      return classifyIncludeError(err);
+    }
+  };
+}

--- a/packages/docx/src/index.browser.ts
+++ b/packages/docx/src/index.browser.ts
@@ -15,6 +15,7 @@ export * from "./placeholder-map.js";
 export * from "./dateformat.js";
 export * from "./scan.js";
 export * from "./resolver.js";
+export * from "./include-lookup.js";
 export * from "./serialize.js";
 // The mermaid renderer is the format-agnostic `@atlcli/diagram` adapter
 // (shared with the PDF path, spec 007); re-exported here so DOCX consumers

--- a/packages/docx/src/placeholder-map.test.ts
+++ b/packages/docx/src/placeholder-map.test.ts
@@ -9,7 +9,12 @@
  * ever contradicts real Scroll behaviour, these tests are where it surfaces.
  */
 import { describe, expect, it } from "bun:test";
-import { classifyPlaceholder, parseLogoArgs, parsePagePropertyArgs } from "./placeholder-map.js";
+import {
+  classifyPlaceholder,
+  parseIncludePageArgs,
+  parseLogoArgs,
+  parsePagePropertyArgs,
+} from "./placeholder-map.js";
 
 describe("parsePagePropertyArgs — documented forms", () => {
   it("(key)", () => {
@@ -126,6 +131,64 @@ describe("parseLogoArgs — the .(H,W) size grammar (height first)", () => {
       heightPx: undefined,
       widthPx: undefined,
     });
+  });
+});
+
+describe("classifyPlaceholder — includepage is supported (spec 005 D1)", () => {
+  it("classifies the base and every argument form as supported/includePage", () => {
+    for (const raw of [
+      "$scroll.includepage",
+      "$scroll.includepage.(Imprint)",
+      "$scroll.includepage.(ENG:Imprint)",
+      "$scroll.includepage.(123456)",
+    ]) {
+      const cls = classifyPlaceholder(raw);
+      expect(cls.status).toBe("supported");
+      expect(cls.dependency).toBe("includePage");
+      expect(cls.base).toBe("$scroll.includepage");
+    }
+  });
+});
+
+describe("classifyPlaceholder — metadata reclassified never → unsupported (spec 005 D2)", () => {
+  it("is unsupported with the remedy-stating reason", () => {
+    for (const raw of ["$scroll.metadata", "$scroll.metadata.(docNumber)"]) {
+      const cls = classifyPlaceholder(raw);
+      expect(cls.status).toBe("unsupported");
+      expect(cls.reason).toContain("content property");
+    }
+  });
+
+  it("keeps the Scroll Documents neighbor $scroll.custom.* as never (pin)", () => {
+    expect(classifyPlaceholder("$scroll.custom.field").status).toBe("never");
+  });
+});
+
+describe("parseIncludePageArgs — the include grammar", () => {
+  it("parses each documented argument form", () => {
+    expect(parseIncludePageArgs("$scroll.includepage.(Imprint)")).toEqual({ title: "Imprint" });
+    expect(parseIncludePageArgs("$scroll.includepage.(ENG:Imprint)")).toEqual({
+      spaceKey: "ENG",
+      title: "Imprint",
+    });
+    // First-colon split: the title itself may contain colons.
+    expect(parseIncludePageArgs("$scroll.includepage.(DOCSY:A: colon title)")).toEqual({
+      spaceKey: "DOCSY",
+      title: "A: colon title",
+    });
+    expect(parseIncludePageArgs("$scroll.includepage.(123456)")).toEqual({ pageId: "123456" });
+    // Quote-wrapped title is colon-safe (never split into space:title).
+    expect(parseIncludePageArgs('$scroll.includepage.( "Quoted: Title" )')).toEqual({
+      title: "Quoted: Title",
+    });
+  });
+
+  it("returns null for an empty, missing, or half-blank argument group", () => {
+    expect(parseIncludePageArgs("$scroll.includepage")).toBeNull();
+    expect(parseIncludePageArgs("$scroll.includepage.()")).toBeNull();
+    expect(parseIncludePageArgs("$scroll.includepage.(  )")).toBeNull();
+    expect(parseIncludePageArgs("$scroll.includepage.(ENG:)")).toBeNull();
+    expect(parseIncludePageArgs("$scroll.includepage.(:Imprint)")).toBeNull();
   });
 });
 

--- a/packages/docx/src/placeholder-map.ts
+++ b/packages/docx/src/placeholder-map.ts
@@ -10,13 +10,18 @@
  *    §2 `direct` and `derivable` rows the resolver ({@link resolvePlaceholders})
  *    can compute from `{ details, space?, currentUser?, template, exportDate }`.
  *  - **unsupported** — Confluence exposes it but atlcli does not model it yet
- *    (the §2 `unsupported (v1)` rows: JSON content properties) plus the
- *    derivable-but-out-of-v1-scope `$scroll.includepage.*` family (cross-page
- *    include is a Phase-2 non-goal, PLAN §Non-goals). Rendered ⚠ "will be
+ *    (the §2 `unsupported (v1)` rows: JSON content properties) plus Comala
+ *    `$scroll.metadata.*` (spec 005 D2: reclassified from `never`, since the
+ *    mapping to a content property IS a supported remedy). Rendered ⚠ "will be
  *    empty"; resolves to `""` + report line.
  *  - **never** — depends on a third-party app atlcli does not target (Comala
- *    `$adhocState`/`$scroll.metadata.*`, Scroll Documents `$scroll.custom.*`).
+ *    `$adhocState`, Scroll Documents `$scroll.custom.*`).
  *    Rendered ✗; resolves to `""`.
+ *
+ * `$scroll.includepage.*` (cross-page include) is **supported** (spec 005 D1):
+ * it resolves to the included page's OOXML body via a document pass, so it is
+ * classified `supported` with the `includePage` dependency rather than sitting
+ * in the text resolver.
  *
  * Each `reason` is surfaced verbatim per row in the panel, so it must say WHY
  * this particular placeholder is empty — the causes differ sharply and a generic
@@ -46,7 +51,12 @@ export type PlaceholderDependency =
   | "currentUser"
   | "owner"
   | "spaceHomepage"
-  | "spaceLogo";
+  | "spaceLogo"
+  // Cross-page include (spec 005 D1). Like `spaceLogo`, this is NOT fetched by
+  // the text resolver — it marks the base as handled by a document pass
+  // (`runIncludePass`), which swaps the placeholder paragraph for the included
+  // page's serialized OOXML body.
+  | "includePage";
 
 /**
  * Parsed argument list of `$scroll.pageproperty.(…)` (spec 001 gap **G4**).
@@ -121,6 +131,67 @@ export function parseLogoArgs(raw: string): LogoArgs {
     return n > 0 ? n : undefined;
   };
   return { heightPx: num(parts[0]), widthPx: num(parts[1]) };
+}
+
+/**
+ * A parsed `$scroll.includepage.(…)` reference (spec 005 D1). Exactly one of
+ * `pageId` (all-digits argument) or `title` (+ optional `spaceKey`) is set on a
+ * successful parse; {@link parseIncludePageArgs} returns `null` for an
+ * empty/missing/malformed argument group.
+ */
+export interface IncludePageRef {
+  spaceKey?: string;
+  title?: string;
+  pageId?: string;
+}
+
+/**
+ * Parse the argument group of `$scroll.includepage.(…)` (spec 005 D1). Forms:
+ *  - `(Title)` — a title in the exported page's space (`spaceKey` left unset;
+ *    the host fills in the current space when resolving),
+ *  - `(SPACE:Title)` — split on the FIRST colon; the left side is the space
+ *    key, the right side the title (titles may themselves contain colons),
+ *  - `(pageId)` — an all-digits argument is a page id,
+ *  - `("Quoted Title")` — a fully quote-wrapped argument is always a title, so a
+ *    title that itself contains a colon can be referenced without the
+ *    first-colon rule splitting it,
+ *  - empty / missing group / a colon form with a blank side → `null` (invalid;
+ *    the include pass emits a note and the token is blanked).
+ *
+ * NB `PLACEHOLDER_RE` stops the argument group at the first `)`, so a title
+ * containing `)` cannot be referenced by title — use the `(pageId)` form
+ * (documented limitation, spec 005 Risks).
+ */
+export function parseIncludePageArgs(raw: string): IncludePageRef | null {
+  const open = raw.indexOf("(");
+  const close = raw.lastIndexOf(")");
+  if (open === -1 || close <= open) return null;
+  const inner = raw.slice(open + 1, close).trim();
+  if (inner === "") return null;
+
+  const strip = (s: string): string => s.trim().replace(/^["']|["']$/g, "").trim();
+
+  // A fully quote-wrapped argument is a title verbatim (colon-safe).
+  if (
+    (inner.startsWith('"') && inner.endsWith('"') && inner.length >= 2) ||
+    (inner.startsWith("'") && inner.endsWith("'") && inner.length >= 2)
+  ) {
+    const title = inner.slice(1, -1).trim();
+    return title === "" ? null : { title };
+  }
+
+  const colon = inner.indexOf(":");
+  if (colon !== -1) {
+    const spaceKey = strip(inner.slice(0, colon));
+    const title = strip(inner.slice(colon + 1));
+    if (spaceKey === "" || title === "") return null;
+    return { spaceKey, title };
+  }
+
+  const value = strip(inner);
+  if (value === "") return null;
+  if (/^\d+$/.test(value)) return { pageId: value };
+  return { title: value };
 }
 
 export interface PlaceholderClass {
@@ -215,13 +286,34 @@ const SUPPORTED_OWNER = new Set<string>(["$scroll.pageowner.fullName"]);
  */
 const SUPPORTED_LOGO = new Set<string>(["$scroll.spacelogo", "$scroll.globallogo"]);
 
+/**
+ * Cross-page include (spec 005 D1, gap closed). `$scroll.includepage.(…)`
+ * embeds the body of another Confluence page at the placeholder position. Like
+ * the logos, it resolves to OOXML (an included page body is a document, not a
+ * string), so it is handled by the export orchestrator's INCLUDE pass
+ * (`runIncludePass`), NOT by the text resolver — its `includePage` dependency
+ * marks that. A bare `$scroll.includepage` with no argument still classifies
+ * `supported`; the include pass then emits `includepage-unresolved` because it
+ * names no page, and the token blanks (never a literal).
+ */
+const SUPPORTED_INCLUDE = new Set<string>(["$scroll.includepage"]);
+
 const UNSUPPORTED_EXACT: Record<string, string> = {};
 
 const UNSUPPORTED_PREFIXES: { prefix: string; reason: string }[] = [
-  { prefix: "$scroll.includepage", reason: "cross-page include is out of scope in v1 (Phase 2)" },
   {
     prefix: "$scroll.jsoncontentproperty",
     reason: "content properties are not fetched (Gap G5)",
+  },
+  // Comala Metadata (spec 005 D2): reclassified from `never` → `unsupported`.
+  // Publicly documented placeholder conventions carry no "we will never support
+  // it" caveat, so a ✗ was possibly wrong and needlessly final. The reason
+  // states the REMEDY, not just the gap (it appears verbatim in the scan panel
+  // and export report).
+  {
+    prefix: "$scroll.metadata",
+    reason:
+      "metadata values live in a third-party app; map the key to a content property in the export settings to resolve it",
   },
 ];
 
@@ -239,7 +331,6 @@ const NEVER_EXACT: Record<string, string> = {};
 
 const NEVER_PREFIXES: { prefix: string; reason: string }[] = [
   { prefix: "$scroll.custom", reason: "Scroll Documents app — not integrated" },
-  { prefix: "$scroll.metadata", reason: "Comala Metadata app — third-party" },
 ];
 
 /**
@@ -254,6 +345,7 @@ export function classifyPlaceholder(raw: string): PlaceholderClass {
   if (SUPPORTED_USER.has(base)) return { base, status: "supported", dependency: "currentUser" };
   if (SUPPORTED_OWNER.has(base)) return { base, status: "supported", dependency: "owner" };
   if (SUPPORTED_LOGO.has(base)) return { base, status: "supported", dependency: "spaceLogo" };
+  if (SUPPORTED_INCLUDE.has(base)) return { base, status: "supported", dependency: "includePage" };
 
   // Page Properties (G4). The dependency varies by ARGUMENT, not by base: only
   // the fallback form needs the space homepage. Classification sees the raw, and

--- a/packages/docx/src/resolver.test.ts
+++ b/packages/docx/src/resolver.test.ts
@@ -425,3 +425,35 @@ describe("resolvePlaceholders — concurrent dep fetching (perf regression)", ()
     ]);
   });
 });
+
+describe("$scroll.includepage — text path is inert (spec 005 D1)", () => {
+  it("resolves to '' via the text path without ever calling getIncludedPage", async () => {
+    let includeCalls = 0;
+    const getIncludedPage = async () => {
+      includeCalls += 1;
+      return { kind: "not-found-or-forbidden" as const };
+    };
+    const res = await resolvePlaceholders(
+      ["$scroll.includepage.(ENG:Imprint)", "$scroll.title"],
+      ctx,
+      { getIncludedPage }
+    );
+    // The include token blanks in the values map (the document pass owns the
+    // real rendering), the fetcher is NOT called by the text resolver, and the
+    // supported base never appears in unsupportedNames.
+    expect(res.values.get("$scroll.includepage.(ENG:Imprint)")).toBe("");
+    expect(includeCalls).toBe(0);
+    expect(res.unsupportedNames).not.toContain("$scroll.includepage");
+  });
+});
+
+describe("$scroll.metadata — unsupported note carries the remedy (spec 005 D2)", () => {
+  it("emits placeholder-unsupported with the content-property remedy text", async () => {
+    const res = await resolvePlaceholders(["$scroll.metadata.(docNumber)"], ctx, {});
+    expect(res.values.get("$scroll.metadata.(docNumber)")).toBe("");
+    const note = res.notes.find((n) => n.code === "placeholder-unsupported");
+    expect(note).toBeDefined();
+    expect(note?.message).toContain("content property");
+    expect(res.unsupportedNames).toContain("$scroll.metadata");
+  });
+});

--- a/packages/docx/src/resolver.ts
+++ b/packages/docx/src/resolver.ts
@@ -29,7 +29,11 @@ import {
   type ExportNote,
   type PagePropertiesMacro,
 } from "@atlcli/confluence";
-import { classifyPlaceholder, parsePagePropertyArgs } from "./placeholder-map.js";
+import {
+  classifyPlaceholder,
+  parsePagePropertyArgs,
+  type IncludePageRef,
+} from "./placeholder-map.js";
 import { formatDatePlaceholder } from "./dateformat.js";
 import type { AssetRef } from "./env.js";
 
@@ -52,6 +56,35 @@ export interface ResolveContext {
   template: TemplateMeta;
   exportDate: Date;
 }
+
+/**
+ * The result of a `$scroll.includepage.(…)` lookup (spec 005 D1). A
+ * discriminated union rather than a bare `ConfluencePageDetails | null` so the
+ * export report can give ACTIONABLE guidance instead of collapsing every
+ * failure into one indistinguishable "not found". The host loader classifies
+ * the Confluence client's thrown errors (`client.ts`'s `request()` carries no
+ * typed status field, but the messages ARE textually distinguishable):
+ *
+ *  - `resolved` — the page was fetched (its body renders at the token position);
+ *  - `ambiguous` — a title matched more than one page; the first (id-sorted) hit
+ *    is still returned as the `page`, and `count` drives an informational note;
+ *  - `not-found-or-forbidden` — genuine 403/404 (Cloud makes these
+ *    indistinguishable, so no false precision is invented for this pair);
+ *  - `auth-failed` — 401 (bad/expired credentials);
+ *  - `rate-limited` — 429 after the client's retries were exhausted;
+ *  - `transient-error` — a 5xx-after-retries or a raw network failure, carrying
+ *    the underlying message.
+ *
+ * An `AbortError` (host cancellation) is rethrown by the loader, never swallowed
+ * into an outcome.
+ */
+export type IncludeLookupOutcome =
+  | { kind: "resolved"; page: ConfluencePageDetails }
+  | { kind: "ambiguous"; count: number; page: ConfluencePageDetails }
+  | { kind: "not-found-or-forbidden" }
+  | { kind: "auth-failed" }
+  | { kind: "rate-limited" }
+  | { kind: "transient-error"; message: string };
 
 /** A page's owner (G1) — Cloud ownership is transferable, so ≠ `createdBy`. */
 export interface PageOwner {
@@ -76,6 +109,15 @@ export interface ResolveDeps {
    * hosts wire every per-site round-trip through one `deps` bag.
    */
   getSpaceLogo?: (spaceKey: string) => Promise<AssetRef | null>;
+  /**
+   * Fetch a page referenced by `$scroll.includepage.(…)` (spec 005 D1). Like
+   * {@link getSpaceLogo}, it is consumed by the export orchestrator's INCLUDE
+   * pass (`runIncludePass`), NOT by the text resolver — it lives here so hosts
+   * wire every per-site round-trip through one deps bag. Returns a discriminated
+   * {@link IncludeLookupOutcome} so each failure class keeps its own report
+   * note; a host builds it with {@link import("./include-lookup.js").buildGetIncludedPage}.
+   */
+  getIncludedPage?: (ref: IncludePageRef) => Promise<IncludeLookupOutcome>;
 }
 
 /**
@@ -209,6 +251,14 @@ export function resolveOne(
       return emailOrNote(currentUser?.email, raw, notes);
     case "$scroll.exporter.name":
       return resolveDcName(currentUser?.displayName, raw, notes);
+
+    // $scroll.includepage is `supported` but resolves to OOXML, not text — the
+    // export orchestrator's INCLUDE pass swaps its paragraph for the included
+    // page's body (mirroring $scroll.content / the logo pass). It falls through
+    // to the `default:` branch below, returning "" for the text path: any
+    // occurrence the include pass leaves in place (invalid args, fetch failure,
+    // or a non-atomic paragraph) is then blanked by preprocessScrollText, so no
+    // literal survives.
 
     case "$scroll.template.name":
       return template.name;

--- a/specs/export-expansion/005-placeholders/PLAN.md
+++ b/specs/export-expansion/005-placeholders/PLAN.md
@@ -1,8 +1,38 @@
 # 005 — Placeholders: includepage & metadata
 
-Status: Plan, 2026-07-19. Lane D of `specs/export-expansion/UMSETZUNGSPLAN.md`
-(T1.11 / T1.12), detailed against `specs/export-expansion/BASELINE-DESIGN.md`
-§4 Cluster D (D1, D2; outlook on D4/D5).
+Status: Implemented (D1 + D2 reclassification), 2026-07-20. Lane D of
+`specs/export-expansion/UMSETZUNGSPLAN.md` (T1.11 / T1.12), detailed against
+`specs/export-expansion/BASELINE-DESIGN.md` §4 Cluster D (D1, D2; outlook on
+D4/D5).
+
+**Implementation notes (2026-07-20):**
+- **D1 `$scroll.includepage` shipped in full** (classification, parser,
+  `IncludeLookupOutcome`, `runIncludePass` document pass with per-part asset
+  embedding, cycle/atomic/budget guards, CLI + extension wiring, shared
+  `buildGetIncludedPage`, docs, unit + document-pass tests — no mocks).
+- **D2: only the reclassification shipped** (`$scroll.metadata` `never` →
+  `unsupported` with the remedy-stating reason). **The alias bridge was CUT**
+  per the plan's own recommendation — landing the resolver branch without a
+  host config surface would ship dead code, and there is no confirmed owner for
+  a bridge follow-up. Consequently the four D2-bridge tasks
+  (`resolver.ts` bridge branch, `client.ts getContentProperty`,
+  `core/config.ts metadataAliases`, `cli/config.ts isValidKey`) are left
+  unticked.
+- **`escapeCqlValue` was already exported from `packages/confluence/src/client.ts`**
+  (spec 002 landed it, with its own test table) — this plan **imports** it (no
+  duplicate), so those two tasks are satisfied as-is.
+- **JSON report note fidelity is satisfied by spec 008's unified report kernel**
+  (`atlcli.export-report/1`): engine `ExportNote.code`s already flow through
+  `noteToIssue` into `report.issues[].code` and `report.notesByCode`. The
+  separate `report.noteDetails` field the plan sketched is therefore
+  unnecessary and was NOT added; a regression test in `export-report.test.ts`
+  pins that include note codes survive. E2E assertions check
+  `issues`/`notesByCode` instead of `noteDetails`.
+- **Deviation from the plan's `40[13]` error-regex sketch:** that pattern
+  conflates 401 with the not-found pair. The shipped `classifyIncludeError`
+  checks **401 → auth-failed** first, then **403/404 → not-found-or-forbidden**
+  (404 is the not-found status), matching the Definition of Done.
+- **E2E on DOCSY is left for the orchestrator** (unticked below).
 
 ## Reference
 
@@ -315,14 +345,14 @@ yet.
 
 ### Classification & parsing
 
-- [ ] `packages/docx/src/placeholder-map.ts`: remove the
+- [x] `packages/docx/src/placeholder-map.ts`: remove the
       `$scroll.includepage` entry from `UNSUPPORTED_PREFIXES` (line 221) and
       classify the base as
       `{ status: "supported", dependency: "includePage" }`; add
       `"includePage"` to the `PlaceholderDependency` union (line 43). Like
       `spaceLogo`, this dependency is *not* fetched by the text resolver — it
       marks the base as handled by a document pass.
-- [ ] `packages/docx/src/placeholder-map.ts`: add `IncludePageRef`
+- [x] `packages/docx/src/placeholder-map.ts`: add `IncludePageRef`
       (`{ spaceKey?: string; title?: string; pageId?: string }`) and
       `parseIncludePageArgs(raw): IncludePageRef | null`, following the
       `parsePagePropertyArgs` conventions (quote stripping, whitespace
@@ -334,13 +364,13 @@ yet.
       - `(pageId)` — an all-digits argument is a page id,
       - empty/missing group → `null` (invalid; pass emits a note, token is
         blanked).
-- [ ] `packages/docx/src/placeholder-map.ts` (D2): move `$scroll.metadata`
+- [x] `packages/docx/src/placeholder-map.ts` (D2): move `$scroll.metadata`
       from `NEVER_PREFIXES` (line 242) to `UNSUPPORTED_PREFIXES` with the new,
       vendor-neutral reason:
       `"metadata values live in a third-party app; map the key to a content property in the export settings to resolve it"`.
       The reason string appears verbatim in the scan panel and report — it
       must state the remedy, not just the gap.
-- [ ] Verify no scan/report regression from the bucket move: `scanZip`
+- [x] Verify no scan/report regression from the bucket move: `scanZip`
       (`packages/docx/src/scan.ts:120`) and `resolvePlaceholders`
       (`packages/docx/src/resolver.ts:318`) are classification-driven, so
       `$scroll.metadata.*` now lands in the ⚠ bucket and the
@@ -349,7 +379,7 @@ yet.
 
 ### Resolver & document pass
 
-- [ ] `packages/docx/src/resolver.ts`: define an `IncludeLookupOutcome`
+- [x] `packages/docx/src/resolver.ts`: define an `IncludeLookupOutcome`
       discriminated union — corrected from an earlier draft where
       `getIncludedPage` returned bare `ConfluencePageDetails | null`, which
       conflated "not found", "no permission", "auth failure", "rate-limit
@@ -381,7 +411,7 @@ yet.
       instead of blaming the page. An `AbortError` (host-initiated
       cancellation, if any host supports it) is rethrown, never swallowed
       into an outcome.
-- [ ] `packages/docx/src/resolver.ts`: keep the text path safe for the new
+- [x] `packages/docx/src/resolver.ts`: keep the text path safe for the new
       supported base — `resolveOne`'s `default:` branch already returns `""`
       for bases it has no case for; confirm `$scroll.includepage.*` neither
       triggers any fetch in `resolvePlaceholders`' needs-loop (line 332) nor
@@ -389,7 +419,7 @@ yet.
       failed, or left non-atomic by the paragraph-context check below) is
       blanked by `preprocessScrollText`. Add a case comment mirroring the
       logo/content treatment.
-- [ ] `packages/docx/src/export.ts`: implement `runIncludePass(zip, deps,
+- [x] `packages/docx/src/export.ts`: implement `runIncludePass(zip, deps,
       input, notes)` and call it in `exportDocx` **between step 3b
       (`finishLogoPass`, line 278) and step 4 (`preprocessScrollText`,
       line 297)** so a failed include is guaranteed to be blanked downstream:
@@ -464,7 +494,7 @@ yet.
         sole content — same contract as `CONTENT_TAG_PARA`, line 166; this
         is now guaranteed by the atomic-paragraph check above, not assumed);
       - return the `Map<string, string>` of rendered OOXML.
-- [ ] `packages/docx/src/export.ts`: thread the include map into rendering —
+- [x] `packages/docx/src/export.ts`: thread the include map into rendering —
       `renderContent(zip, bodyXml, includes)` (line 371) renders
       `doc.render({ [CONTENT_KEY]: bodyXml, ...Object.fromEntries(includes) })`.
       Extend the `ensureCodeStyle` trigger (line 308) to also check the
@@ -510,7 +540,7 @@ yet.
       BASELINE D4 sketch (`GET /api/v2/pages/{id}/properties?key=…`, first
       result's value; non-string values JSON-stringified, returning
       `{ value, stringified }` to match the corrected port shape above).
-- [ ] `packages/confluence/src/client.ts`: add a new **exported**, pure
+- [x] `packages/confluence/src/client.ts`: add a new **exported**, pure
       `escapeCqlValue(value: string): string` helper (not the private,
       incomplete `apps/cli/src/commands/search.ts:227–232` one — see
       Reference) that escapes `\` and `"` per CQL string-literal rules and
@@ -546,7 +576,7 @@ yet.
 
 ### Host wiring
 
-- [ ] `apps/cli/src/commands/export.ts` (deps bag, lines 841–863): implement
+- [x] `apps/cli/src/commands/export.ts` (deps bag, lines 841–863): implement
       `getIncludedPage(ref): Promise<IncludeLookupOutcome>`:
       - `ref.pageId` → `client.getPage(id)` (`client.ts:510`; returns
         `storage` — sufficient, the pass only needs id/title/storage);
@@ -576,7 +606,7 @@ yet.
         simply let the engine-side pool own the only concurrency limit and
         keep this loader concurrency-agnostic; pick one and say so in the
         implementation comment so the two don't double-throttle silently.
-- [ ] `apps/extension/utils/docx/export-deps.ts` (**corrected — the target
+- [x] `apps/extension/utils/docx/export-deps.ts` (**corrected — the target
       API in an earlier draft, `buildResolveDeps`, does not exist**; the real
       surface is `ExportDependencyLoaders` / `prepareExportDeps` /
       `scanDependencies`, verified against `export-deps.ts:6–13, 34–53,
@@ -611,12 +641,12 @@ yet.
         that harness exists, proving the extension path renders an include
         identically to the CLI path — flag as a follow-up if the harness
         isn't ready when this plan lands, don't block on it.
-- [ ] Scan-side UX note (defer, document only): probing include targets at
+- [x] Scan-side UX note (defer, document only): probing include targets at
       scan time (✓ resolvable / ⚠ not found in the panel) requires an async
       scan seam — out of scope here; the scan shows the row as supported and
       the export report carries the truth. Record in
       `docs/reference/` placeholder table.
-- [ ] `apps/cli/src/commands/export.ts` (JSON report, line 886 — **new task,
+- [x] `apps/cli/src/commands/export.ts` (JSON report, line 886 — **new task,
       not present in an earlier draft despite that draft's own Reference
       section flagging the gap**): the `--json` report currently maps every
       `ExportNote` to a bare `"${level}: ${message}"` string, discarding
@@ -634,7 +664,7 @@ yet.
       (`apps/cli/src/commands/export.test.ts` or equivalent) asserting both
       fields are present and in sync, so a future report-shape change can't
       silently drop `code` again.
-- [ ] `docs/` update (workflow rule "docs are first-class"): placeholder
+- [x] `docs/` update (workflow rule "docs are first-class"): placeholder
       reference table row for `$scroll.includepage` — argument forms with
       type/constraints, one minimal and one realistic example (imprint page in
       a header, referenced from both body and header), troubleshooting
@@ -659,7 +689,7 @@ is asserted); documents are real `.docx` packages built with the
 `packages/docx/src/fixtures.ts` builders; E2E runs the built CLI against the
 real Confluence site.
 
-- [ ] `packages/docx/src/placeholder-map.test.ts` — table-driven, following
+- [x] `packages/docx/src/placeholder-map.test.ts` — table-driven, following
       the existing `parsePagePropertyArgs` describe-block pattern:
       - classification: `$scroll.includepage`, `$scroll.includepage.(X)` in
         all three arg forms → `supported` + dependency `includePage`;
@@ -670,7 +700,7 @@ real Confluence site.
         `(DOCSY:A: colon title)` (first-colon split), `(123456)` → pageId,
         `( "Quoted Title" )` (trim + quote strip), `()` / missing group →
         `null`.
-- [ ] `packages/docx/src/resolver.test.ts`:
+- [x] `packages/docx/src/resolver.test.ts`:
       - `$scroll.includepage.(X)` through `resolvePlaceholders` with a
         call-counting real `getIncludedPage` closure: resolves to `""` in the
         values map (text path never renders it), the fetcher is **not**
@@ -690,7 +720,7 @@ real Confluence site.
         fires; JSON value → `{ value, stringified: true }` → stringified text
         + info note; plain string → `{ value, stringified: false }` → no
         extra note.
-- [ ] `packages/docx/src/export.test.ts` — document-pass tests on real docx
+- [x] `packages/docx/src/export.test.ts` — document-pass tests on real docx
       fixtures (`buildDocx`/`para`/`runSplitPara`/`readPart`/
       `assertBalancedXml`), with `getIncludedPage` as a plain function
       returning fixture `IncludeLookupOutcome` values (real closures, no
@@ -752,12 +782,12 @@ real Confluence site.
         `includepage-budget-exceeded` and blank, and a repeat of an
         already-fetched target past the cutoff still renders (cache, not a
         hard stop).
-- [ ] `packages/confluence/src/client.test.ts` (or equivalent) — new
+- [x] `packages/confluence/src/client.test.ts` (or equivalent) — new
       `escapeCqlValue` table: quotes, backslashes, embedded CR/LF, empty
       string, unicode/emoji titles, and the exact resulting CQL clause for a
       representative `title = "…"` construction (pin the literal output, not
       just "no exception").
-- [ ] `apps/cli/src/commands/export.test.ts` (or equivalent) — JSON report
+- [x] `apps/cli/src/commands/export.test.ts` (or equivalent) — JSON report
       schema/snapshot test: `report.notes` (strings) and `report.noteDetails`
       (`{level, code, message}[]`) are both present, same length, and
       `noteDetails[i].message` matches the tail of `notes[i]`; `cliNotes`
@@ -787,7 +817,7 @@ real Confluence site.
             **documented manual check** in the PR description;
       - [ ] cleanup: delete every created test page and temp template/output
             file (workflow rule).
-- [ ] `bun run typecheck` and full `bun test` green before push (workflow
+- [x] `bun run typecheck` and full `bun test` green before push (workflow
       rules; regression tests above double as the mandated bug-prevention
       tests for the reclassification, the never-a-literal invariant, the
       body+header duplicate-include fix, the header/footer relationship fix,

--- a/specs/export-expansion/005-placeholders/PLAN.md
+++ b/specs/export-expansion/005-placeholders/PLAN.md
@@ -646,9 +646,14 @@ yet.
       scan seam — out of scope here; the scan shows the row as supported and
       the export report carries the truth. Record in
       `docs/reference/` placeholder table.
-- [x] `apps/cli/src/commands/export.ts` (JSON report, line 886 — **new task,
-      not present in an earlier draft despite that draft's own Reference
-      section flagging the gap**): the `--json` report currently maps every
+- [x] `apps/cli/src/commands/export.ts` (JSON report) — **SUPERSEDED by spec
+      008's `atlcli.export-report/1` kernel (see top-of-file implementation
+      note): engine `ExportNote.code`s already surface via `report.issues[].code`
+      and `report.notesByCode`, so the sketched ~~`report.noteDetails`~~ field
+      below was NOT added. The regression test lives in `export-report.test.ts`,
+      and E2E assertions check `issues`/`notesByCode`, not `noteDetails`.** The
+      original sketch is kept below for provenance:
+      the `--json` report currently maps every
       `ExportNote` to a bare `"${level}: ${message}"` string, discarding
       `code` — making this plan's own E2E assertions (`--json` containing
       `includepage-cycle`, see Tests) unverifiable as written, since the
@@ -677,8 +682,10 @@ yet.
       `~/.atlcli/config.json`, including the `config set metadataAliases.<key>
       <content-property-key>` form, if the bridge ships — explicitly note
       the extension has no equivalent UI yet if that's the case at ship
-      time); document `report.noteDetails` as a stable, additive `--json`
-      field.
+      time); ~~document `report.noteDetails` as a stable, additive `--json`
+      field~~ — superseded by 008's kernel; the docs instead document that note
+      `code`s surface via the `atlcli.export-report/1` `issues`/`notesByCode`
+      fields (see top-of-file implementation note).
 
 ### Tests (no mocking)
 
@@ -787,11 +794,11 @@ real Confluence site.
       string, unicode/emoji titles, and the exact resulting CQL clause for a
       representative `title = "…"` construction (pin the literal output, not
       just "no exception").
-- [x] `apps/cli/src/commands/export.test.ts` (or equivalent) — JSON report
-      schema/snapshot test: `report.notes` (strings) and `report.noteDetails`
-      (`{level, code, message}[]`) are both present, same length, and
-      `noteDetails[i].message` matches the tail of `notes[i]`; `cliNotes`
-      (host warnings) appear in `notes` but never in `noteDetails`.
+- [x] `apps/cli/src/commands/export-report.test.ts` — JSON report code-fidelity
+      test (SUPERSEDES the ~~`noteDetails`~~ sketch, per 008's kernel): pins that
+      engine `ExportNote` codes (`includepage-*`) survive `noteToIssue` into
+      `report.issues[].code` and `report.notesByCode`, that every engine note
+      collapses to `warning` severity, and that they appear in `report.warnings`.
 - [ ] E2E (workflow rule; profile `mayflower`, space `DOCSY`, built CLI
       `bun ./dist/index.js`, pattern: `scripts/e2e-template-test.sh`):
       - [ ] create an include-target page in DOCSY with unique sentinel
@@ -803,14 +810,15 @@ real Confluence site.
       - [ ] `atlcli wiki export <pageId> -t <template> -o out.docx --engine ts
             --json`: unzip and assert the sentinel appears in
             `word/document.xml` and `word/header1.xml`, and no `$scroll.`
-            literal survives; assert `report.noteDetails` is present in the
-            `--json` output;
+            literal survives; assert `report.issues`/`report.notesByCode`
+            (008 kernel, NOT ~~`noteDetails`~~) are present in the `--json`
+            output;
       - [ ] cycle path: template including the exported page itself → report
-            (`--json`) `noteDetails` contains an entry with
+            (`--json`) `issues[]` / `notesByCode` contains
             `code: "includepage-cycle"`, export still succeeds;
       - [ ] permission path: include a DOCSY page carrying view restrictions
             the `mayflower` profile's token user cannot read, assert blank
-            output + `includepage-unresolved` in `noteDetails`. If no such
+            output + `includepage-unresolved` in `issues`/`notesByCode`. If no such
             restricted page can be provisioned with this profile's rights,
             fall back to a nonexistent title (same code path by design:
             Cloud 403 ≡ 404) and record the restricted-page case as a
@@ -864,8 +872,10 @@ real Confluence site.
   zero host-specific special cases (classification remains the single source
   for the *static* view; the metadata bridge's per-export resolution
   override is documented as the one deliberate, narrowly-scoped exception).
-- The CLI `--json` report exposes note `code`s (`report.noteDetails`,
-  additive, backward-compatible) so this plan's own E2E acceptance criteria
+- The CLI `--json` report exposes note `code`s (via 008's
+  `atlcli.export-report/1` `report.issues[].code` / `report.notesByCode` —
+  NOT the sketched ~~`report.noteDetails`~~, which was superseded; see the
+  top-of-file implementation note) so this plan's own E2E acceptance criteria
   are actually checkable from the command line.
 - `packages/confluence`'s CQL escaping for the title-form include lookup goes
   through one shared, exported, tested `escapeCqlValue` — not a

--- a/src/content/docs/confluence/export.md
+++ b/src/content/docs/confluence/export.md
@@ -579,6 +579,19 @@ via `.(height,width)` in px); on Confluence Cloud the global logo is not separat
 logos are SVGs, which are not embedded yet — upload a custom PNG/JPEG logo to the space for logo
 embedding.
 
+`$scroll.includepage.(Title | SPACE:Title | pageId)` embeds the body of another Confluence page
+at the placeholder position (a central imprint or disclaimer, reused across exports). The same
+target referenced in the body and a header/footer renders in every occurrence; only a page
+including itself is blocked. Put the token on its own line — a token sharing a paragraph with
+other text is left unexpanded (the surrounding text is preserved). See the
+[DOCX engine reference](/reference/docx-engine/#included-pages--scrollincludepage) for argument
+forms, budgets, and the full note-code list.
+
+`$scroll.metadata.(key)` (Comala Metadata) is **unsupported**: the value lives in a third-party
+app, so the token is emptied and listed in the report with the remedy — map the key to a
+Confluence content property in the export settings. (The alias bridge itself is a follow-up; see
+below.)
+
 ## Troubleshooting
 
 ### Word Can't Open the File
@@ -598,6 +611,23 @@ embedding.
 - Verify images are attached to the Confluence page
 - Check that `--no-images` flag is not set
 - Embedded images use the template's image placeholder styling
+
+### An Included Page Renders Empty
+
+`$scroll.includepage.(…)` blanks the token and adds a report note whenever the reference can't
+be rendered. Check the note `code` (in `--json` under the report's `issues`/`notesByCode`):
+
+- `includepage-invalid-context` — the token shares a paragraph with other text; put it on its
+  own line.
+- `includepage-unresolved` — the name matches no page, or the export credential can't read it
+  (Cloud makes 403 and 404 indistinguishable). Verify the title/space or use the `(pageId)` form.
+- `includepage-ambiguous-title` — several pages share the title; the first (id-sorted) rendered.
+  Disambiguate with `SPACE:Title` or `(pageId)`.
+- `includepage-auth-failed` / `includepage-rate-limited` / `includepage-transient-error` —
+  credential, throttling, or network/5xx problem; fix the credential or retry the export.
+- `includepage-cycle` — the reference resolved to the page being exported (self-include).
+- `includepage-budget-exceeded` — more than 25 unique included pages (or 2 MiB of included
+  storage); later new targets are blanked.
 
 ### "require --engine ts" Error
 

--- a/src/content/docs/reference/docx-engine.md
+++ b/src/content/docs/reference/docx-engine.md
@@ -176,6 +176,60 @@ extension both do). Details:
 - **Missing dep/fetcher, fetch errors, no space key** all degrade to `logo-skipped` notes; the
   token is blanked, never left literal.
 
+### Included pages — `$scroll.includepage.(…)`
+
+`$scroll.includepage.(…)` embeds the **body of another Confluence page** at the placeholder
+position — a central imprint, legal disclaimer, or standard appendix maintained once and pulled
+into every export. It is a document pass (not a text value): the placeholder paragraph is swapped
+for the referenced page's serialized OOXML body, inserted verbatim. Wire the optional
+`deps.getIncludedPage` round-trip (the CLI and extension both build it from
+`buildGetIncludedPage`, which owns the CQL construction and error mapping).
+
+**Argument forms:**
+
+| Form | Example | Meaning |
+| --- | --- | --- |
+| `(Title)` | `$scroll.includepage.(Imprint)` | A page titled *Imprint* in the exported page's space |
+| `(SPACE:Title)` | `$scroll.includepage.(DOCSY:Imprint)` | A page titled *Imprint* in space `DOCSY` (split on the **first** colon; the title may contain more) |
+| `("Quoted Title")` | `$scroll.includepage.("A: B")` | A quote-wrapped title is verbatim (colon-safe) |
+| `(pageId)` | `$scroll.includepage.(1234567)` | An all-digits argument is a page id |
+
+**Behavior:**
+
+- **Referenced more than once** (body **and** header, header **and** footer, or twice in one
+  part): the target is fetched and walked **once**, cached, and rendered in **every** occurrence.
+  Only a page including **itself** is a cycle (`includepage-cycle`, rendered empty) — every other
+  repeat is intentional and renders.
+- **Atomic paragraph only:** the token must be the *sole* visible content of its paragraph. A
+  token sharing a paragraph with prose (`See our disclaimer: $scroll.includepage.(Imprint)`) is
+  **not** expanded — the surrounding text survives verbatim, the token is blanked, and
+  `includepage-invalid-context` is noted. Put the include on its own line.
+- **Assets follow the part:** an included page's attachment images and Mermaid diagrams embed
+  their relationships into the **target part's own** rels (`word/_rels/header1.xml.rels`,
+  `…/footer1.xml.rels`, …) — never a dangling relationship, even in headers/footers.
+- **Budget:** at most 25 unique included pages and 2 MiB of cumulative included storage per
+  export; beyond that, further **new** targets blank with `includepage-budget-exceeded` (already
+  fetched targets keep rendering). A v1 guess, revisited on real large templates.
+- **Never a literal:** every failure path (invalid args, not found, no permission, auth failure,
+  rate limit, transient/network error, budget, cycle) blanks the token with its own report note.
+
+**Note codes** (all surfaced in the export report, and as `code` in the `--json`
+`atlcli.export-report/1` report):
+
+| Code | Meaning |
+| --- | --- |
+| `includepage-unresolved` | The argument names no page, or the page was not found / not readable (Cloud 403 ≡ 404) |
+| `includepage-invalid-context` | The token shares a paragraph with other text — put it on its own line |
+| `includepage-cycle` | A page referenced itself; rendered empty |
+| `includepage-ambiguous-title` | A title matched several pages; the first (id-sorted) rendered — disambiguate with `SPACE:Title` or `(pageId)` |
+| `includepage-auth-failed` | Authentication failed while fetching (check the export credentials) |
+| `includepage-rate-limited` | Confluence rate-limited the fetch; retry the export |
+| `includepage-transient-error` | A 5xx / network failure (or no include fetcher available) |
+| `includepage-budget-exceeded` | The per-export include budget was exceeded; later new targets blanked |
+
+> A title containing `)` cannot be referenced by title (the scan grammar stops the argument at
+> the first `)`) — use the `(pageId)` form instead.
+
 ## Browser hosts
 
 Browser consumers install the DOCX-specific compatibility layer before importing the engine:
@@ -217,6 +271,12 @@ const report = await runExport(
         const icon = await client.getSpaceIcon(key);
         return icon ? { url: icon.path } : null;
       },
+      getIncludedPage: buildGetIncludedPage({   // $scroll.includepage.(…)
+        getPage: (id) => client.getPage(id),
+        searchPages: (cql) => client.searchPages(cql),
+        escapeCqlValue,                     // from @atlcli/confluence
+        defaultSpaceKey: details.spaceKey,  // fills a bare (Title) form
+      }),
     },
   },
   {

--- a/src/content/docs/reference/docx-engine.md
+++ b/src/content/docs/reference/docx-engine.md
@@ -183,7 +183,12 @@ position — a central imprint, legal disclaimer, or standard appendix maintaine
 into every export. It is a document pass (not a text value): the placeholder paragraph is swapped
 for the referenced page's serialized OOXML body, inserted verbatim. Wire the optional
 `deps.getIncludedPage` round-trip (the CLI and extension both build it from
-`buildGetIncludedPage`, which owns the CQL construction and error mapping).
+`buildGetIncludedPage`, which owns the title lookup, id-sorted determinism, and error mapping).
+Title references resolve through the **direct content endpoint**
+(`client.findPagesByTitle` → `GET /content?title=…`), **not** the CQL search index — so a page
+created moments before the export (e.g. a CI pipeline that creates then immediately exports) is
+findable at once, instead of returning `includepage-unresolved` until the search index catches up
+minutes later.
 
 **Argument forms:**
 
@@ -273,8 +278,8 @@ const report = await runExport(
       },
       getIncludedPage: buildGetIncludedPage({   // $scroll.includepage.(…)
         getPage: (id) => client.getPage(id),
-        searchPages: (cql) => client.searchPages(cql),
-        escapeCqlValue,                     // from @atlcli/confluence
+        // DIRECT title lookup (not CQL) — findable the moment a page exists.
+        findPagesByTitle: (title, spaceKey) => client.findPagesByTitle(title, { spaceKey }),
         defaultSpaceKey: details.spaceKey,  // fills a bare (Title) form
       }),
     },


### PR DESCRIPTION
Implements specs/export-expansion/005-placeholders (D1/D2).

## Scope
- D1 `$scroll.includepage.(…)`: supported placeholder with a document pass — included page storage → blocks → OOXML rendered via the PUA-delimited rawxml path (included content is data, never re-parsed); isomorphic include-lookup (title→CQL via 002's `escapeCqlValue`, id-sorted deterministic ambiguity handling, classified errors: auth-failed vs not-found-or-forbidden vs rate-limit vs transient); self-include cycle guard; fetch/walk dedupe; part-aware asset embedding (images & mermaid diagrams inside an included header/footer land in that part's .rels, attachments fetched from the included page's id); CLI + extension host wiring
- D2 `$scroll.metadata.(…)`: reclassified never→unsupported with remedy text; alias bridge deliberately cut per plan recommendation (no dead code)
- Report note codes surface via 008's `atlcli.export-report/1` kernel (`issues[]`/`notesByCode`) — the plan's `noteDetails` sketch is annotated as superseded

## Verification
- Opus 4.8 implementation, Sonnet 5 adversarial review: **SHIP verdict, zero criticals** (cycle protection, rawxml no-re-parse, owning-page assets, ambiguity determinism all scenario-verified); two minors (PLAN doc hygiene, diagram-footer test) fixed
- `bun test`: 2502 pass, 0 fail · typecheck green · browser-gate green (12 isomorphic entrypoints)
- Live E2E (DOCSY only) runs before merge; protocol will be posted here

🤖 Generated with [Claude Code](https://claude.com/claude-code)