### PR TITLE
fix(extension): add stylerefStyleNames to ScanResult test fixtures

### DIFF
--- a/apps/extension/tests/docx/export-deps.test.ts
+++ b/apps/extension/tests/docx/export-deps.test.ts
@@ -14,6 +14,7 @@ function scan(...raw: string[]): ScanResult {
     never: [],
     parts: ["word/document.xml"],
     hasContentPlaceholder: true,
+    stylerefStyleNames: [],
   };
 }
 

--- a/apps/extension/tests/docx/report-view.test.tsx
+++ b/apps/extension/tests/docx/report-view.test.tsx
@@ -16,6 +16,7 @@ const emptyScan: ExportReport["scan"] = {
   never: [],
   parts: ["word/document.xml"],
   hasContentPlaceholder: true,
+    stylerefStyleNames: [],
 };
 
 function makeReport(notes: ExportReport["notes"]): ExportReport {

--- a/apps/extension/tests/docx/scan-view.test.tsx
+++ b/apps/extension/tests/docx/scan-view.test.tsx
@@ -18,6 +18,7 @@ function makeScan(hasContentPlaceholder: boolean): ScanResult {
     never: [],
     parts: ["word/document.xml"],
     hasContentPlaceholder,
+    stylerefStyleNames: [],
   };
 }
 
@@ -73,6 +74,7 @@ describe("ScanView — per-placeholder reasons (E2E finding)", () => {
     ],
     parts: ["word/document.xml"],
     hasContentPlaceholder: true,
+    stylerefStyleNames: [],
   };
 
   it("renders each unsupported row's own reason, not one shared note", () => {


### PR DESCRIPTION
Hotfix for main CI: spec 006 (#58) made `ScanResult.stylerefStyleNames` required, but the three extension test fixtures were missed — the extension typecheck's turbo cache produced a stale local pass, so it only surfaced in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)