### PR TITLE
docs(spec): correct stale status lines for merged specs 003/004/008

### DIFF
--- a/specs/export-expansion/003-content-features/PLAN.md
+++ b/specs/export-expansion/003-content-features/PLAN.md
@@ -1,6 +1,6 @@
 # 003 — Content features & scroll-* compatibility macros
 
-Status: Plan. Covers UMSETZUNGSPLAN Lane C (T1.4–T1.6) and BASELINE-DESIGN §3
+Status: **Implemented**, 2026-07-20 (PR #54). Merged to `main`; live E2E verified against DOCSY. Covers UMSETZUNGSPLAN Lane C (T1.4–T1.6) and BASELINE-DESIGN §3
 cluster C-content (C1–C9). Compatibility-critical work (C4/C5/C6) lands first,
 then C3 captions and table hardening; C1/C2/C7/C8/C9 are scoped as follow-up
 work packages at the end of this plan.

--- a/specs/export-expansion/004-macro-renderer/PLAN.md
+++ b/specs/export-expansion/004-macro-renderer/PLAN.md
@@ -1,6 +1,6 @@
 # 004 — Macro renderer registry & third-party macro support
 
-Status: Plan, 2026-07-19. Part of the `export-expansion` series.
+Status: **Implemented**, 2026-07-20 (PR #55). Merged to `main`; live E2E verified against DOCSY (Jira project ATLCLI). Part of the `export-expansion` series.
 
 ## Reference
 

--- a/specs/export-expansion/008-pdf-cli/PLAN.md
+++ b/specs/export-expansion/008-pdf-cli/PLAN.md
@@ -1,6 +1,6 @@
 # 008 — PDF CLI & headless export
 
-Status: Plan. Covers Lane K of `specs/export-expansion/UMSETZUNGSPLAN.md`
+Status: **Implemented**, 2026-07-20 (PR #53). Merged to `main`; gated PDF E2E verified against DOCSY. Includes the deferred 002 PDF-CLI hand-off. Covers Lane K of `specs/export-expansion/UMSETZUNGSPLAN.md`
 (T3.1–T3.5): the PDF compile port for Bun, `atlcli wiki export --format pdf`,
 scope/label flags for both engines, CI/CD developer experience, and the
 preparation to make the ts DOCX engine the CLI default.


### PR DESCRIPTION
Cosmetic: the top-of-file Status lines for specs 003/004/008 still read "Plan" after their PRs (#54/#55/#53) merged. Corrects them to Implemented for a consistent program view. Docs-only, no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)