### PR TITLE
fix(export): emit complete/requestedScope/resolvedScope on the PDF path

### DIFF
--- a/apps/cli/src/commands/export-pdf.ts
+++ b/apps/cli/src/commands/export-pdf.ts
@@ -41,6 +41,7 @@ import {
 } from "@atlcli/pdf";
 import {
   buildReport,
+  buildTreeExportReport,
   classifyError,
   noteToIssue,
   pdfReportContributions,
@@ -48,7 +49,12 @@ import {
   type Issue,
   type SourcePageEntry,
 } from "./export-report.js";
-import { buildExportScope, type ParsedExportRequest } from "./export-request.js";
+import {
+  buildExportScope,
+  buildScopeReportFields,
+  type ParsedExportRequest,
+  type ScopeReportFields,
+} from "./export-request.js";
 import { createAssetByteCache, tokenAssetFetcher, tokenMentionLookup } from "./export-internals.js";
 import { getPdfCompiler } from "./export-pdf-assets.js";
 import {
@@ -168,6 +174,12 @@ interface ResolvedScope {
   sourcePages: SourcePageEntry[];
   outNameKey: string;
   mentionUnresolved: number;
+  /**
+   * Scope traceability for the report (spec 002 A5), built by the shared
+   * {@link buildScopeReportFields}. Tree/space only — a single-page export has
+   * no scope resolution to trace, matching the DOCX single-page path.
+   */
+  scopeReport?: ScopeReportFields;
 }
 
 export interface ExportPdfArgs {
@@ -279,6 +291,9 @@ async function resolveScope(
     sourcePages,
     outNameKey: request.scopeKind === "space" ? request.spaceKey! : rootId,
     mentionUnresolved: mention.unresolved,
+    // Same builder the DOCX tree path uses — a `--scope space` request stays
+    // traceable to the tree rooted at the resolved homepage id (spec 002 A5).
+    scopeReport: buildScopeReportFields(request, scope),
   };
 }
 
@@ -351,16 +366,27 @@ export async function exportPdf(args: ExportPdfArgs): Promise<ExportOutcome> {
         : []),
     ];
 
+    // Report-contract parity with the DOCX path. `complete` rides on EVERY
+    // successful export (spec 002's completeness contract, which a CI consumer
+    // reads via `jq -r '.complete'` — it must never be null on success); the
+    // scope-traceability pair is tree/space-only, exactly as on the DOCX side,
+    // and comes from the same shared builder. A tree/space export goes through
+    // `buildTreeExportReport`, which makes both REQUIRED at compile time.
+    const common = {
+      format,
+      sourcePages: scope.sourcePages,
+      outputDetails: [outputDetail],
+      issues: allIssues,
+      timings: { ...report.timings, totalMs: Date.now() - startedAt },
+      complete: report.complete,
+      strict,
+    };
+
     return {
       ok: true,
-      report: buildReport({
-        format,
-        sourcePages: scope.sourcePages,
-        outputDetails: [outputDetail],
-        issues: allIssues,
-        timings: { ...report.timings, totalMs: Date.now() - startedAt },
-        strict,
-      }),
+      report: scope.scopeReport
+        ? buildTreeExportReport({ ...common, scope: scope.scopeReport })
+        : buildReport(common),
     };
   } catch (error) {
     progress.clear();

--- a/apps/cli/src/commands/export-report-parity.test.ts
+++ b/apps/cli/src/commands/export-report-parity.test.ts
@@ -1,0 +1,453 @@
+/**
+ * Report-contract parity between the PDF and DOCX export paths.
+ *
+ * M1 acceptance finding: `atlcli wiki export <root> --scope tree --json` emitted
+ * a DIFFERENT top-level field set depending on `--format`. The DOCX ts path
+ * carried spec 002's `complete` (the completeness contract a CI consumer reads
+ * via `jq -r '.complete'`) and the `requestedScope`/`resolvedScope` A5
+ * traceability pair; the PDF path silently dropped all three, so the guarantee
+ * was unobservable on `--format pdf`.
+ *
+ * NO MOCKS. These tests drive the REAL engines offline — the real Typst wasm
+ * compiler via `runPdfExport`, and the real DOCX engine via `runExport` against
+ * a real `buildDocx` template fixture — and then assemble the reports through
+ * the very same construction sites the command paths use
+ * (`buildScopeReportFields` → `buildTreeExportReport` / `buildReport`). The only
+ * ports supplied are in-memory sinks/resolvers, which this codebase treats as
+ * legitimate port implementations rather than API mocks (see the `TreeSource`
+ * port docs in `packages/confluence/src/tree-fetch.ts`).
+ */
+import { beforeAll, describe, expect, it } from "bun:test";
+import Ajv from "ajv";
+import { runExport } from "@atlcli/docx";
+import { buildDocx, para } from "@atlcli/docx/fixtures";
+import {
+  runPdfExport,
+  type ExportBlock,
+  type PdfExportMetadata,
+  type PdfOutputSink,
+} from "@atlcli/pdf";
+import { ensurePdfFonts } from "../../../../packages/pdf/scripts/ensure-fonts.js";
+import { getPdfCompiler } from "./export-pdf-assets.js";
+import {
+  buildReport,
+  buildTreeExportReport,
+  pdfReportContributions,
+  type ExportReport,
+  type Issue,
+  type SourcePageEntry,
+} from "./export-report.js";
+import {
+  buildExportScope,
+  buildScopeReportFields,
+  parseExportRequest,
+} from "./export-request.js";
+
+beforeAll(async () => {
+  await ensurePdfFonts({ logger: () => {} });
+});
+
+/**
+ * Fields that are legitimately format-specific and therefore NOT part of the
+ * shared report contract: `engine` distinguishes the python/ts DOCX engines (the
+ * PDF path has no such choice), and `placeholders` is documented in the schema
+ * as "DOCX ts-engine placeholder metrics". Everything else must match.
+ */
+const DOCX_ONLY_FIELDS = ["engine", "placeholders"] as const;
+
+const BLOCKS: ExportBlock[] = [
+  { type: "heading", level: 1, content: [{ type: "text", text: "Chapter one" }] },
+  { type: "paragraph", content: [{ type: "text", text: "Tree body text." }] },
+];
+
+const SOURCE_PAGES: SourcePageEntry[] = [
+  { id: "111", title: "Root", notes: [] },
+  { id: "222", title: "Child", notes: [] },
+];
+
+/** One real warning-severity issue so `notesByCode` is exercised on BOTH sides. */
+const ISSUES: Issue[] = [
+  { code: "label-filtered", severity: "warning", phase: "compose", retryable: false },
+];
+
+class MemorySink implements PdfOutputSink {
+  bytes: Uint8Array | null = null;
+  async emit(_name: string, bytes: Uint8Array): Promise<void> {
+    this.bytes = bytes;
+  }
+}
+
+const noAssets = {
+  async resolve(): Promise<never> {
+    throw new Error("fixture has no assets");
+  },
+};
+
+const DOCX_TEMPLATE = buildDocx({ body: para("$scroll.content") });
+
+/**
+ * Run the REAL Typst pipeline and return its report (carries `complete`). The
+ * emitted byte count is returned too so callers can prove the compile really
+ * happened rather than silently no-opping.
+ */
+async function realPdfEngineReport(complete: boolean) {
+  const metadata: PdfExportMetadata = {
+    title: "Root",
+    space: "DOCSY",
+    exportedAt: new Date("2026-07-20T00:00:00Z"),
+  };
+  const compiler = await getPdfCompiler();
+  const sink = new MemorySink();
+  const report = await runPdfExport(
+    { blocks: BLOCKS, metadata, filename: "tree.pdf", complete },
+    { assets: noAssets, compiler, output: sink }
+  );
+  return { report, emittedBytes: sink.bytes?.length ?? 0 };
+}
+
+/** Run the REAL DOCX engine against a real template and return its report. */
+async function realDocxEngineReport(complete: boolean) {
+  let emittedBytes = 0;
+  const report = await runExport(
+    {
+      details: { id: "111", title: "Root", storage: "", spaceKey: "DOCSY" },
+      template: { name: "t.docx", modificationDate: new Date(0) },
+      blocks: BLOCKS,
+      complete,
+    },
+    {
+      templates: { getBytes: async () => DOCX_TEMPLATE },
+      assets: { fetch: async () => new Uint8Array() },
+      output: { emit: async (_name, bytes) => { emittedBytes = bytes.length; } },
+    }
+  );
+  return { report, emittedBytes };
+}
+
+/**
+ * Both engines really ran: a real PDF and a real DOCX package came out. If this
+ * ever fails, every parity assertion below is comparing hollow reports.
+ */
+function assertRealArtifacts(
+  pdf: { report: { pageCount?: number }; emittedBytes: number },
+  docx: { emittedBytes: number }
+): void {
+  expect(pdf.report.pageCount).toBeGreaterThanOrEqual(1);
+  expect(pdf.emittedBytes).toBeGreaterThan(500);
+  expect(docx.emittedBytes).toBeGreaterThan(500);
+}
+
+/**
+ * Assemble the two tree-scope reports exactly as `exportPdf` and
+ * `exportTreeWithTsEngine` do: one shared `buildScopeReportFields` result fed
+ * into `buildTreeExportReport` on both sides.
+ */
+async function treeReportsForSameRequest(
+  pageRef: string | undefined,
+  flags: Record<string, string | boolean | string[]>,
+  resolvedRootId: string,
+  complete = true
+): Promise<{ pdf: ExportReport; docx: ExportReport }> {
+  const request = parseExportRequest(pageRef, flags);
+  const exportScope = buildExportScope(request, resolvedRootId);
+  const scope = buildScopeReportFields(request, exportScope);
+
+  const [pdfRun, docxRun] = await Promise.all([
+    realPdfEngineReport(complete),
+    realDocxEngineReport(complete),
+  ]);
+  assertRealArtifacts(pdfRun, docxRun);
+  const pdfEngine = pdfRun.report;
+  const docxEngine = docxRun.report;
+
+  const { outputDetail } = pdfReportContributions(
+    pdfEngine,
+    "/tmp/tree.pdf",
+    pdfEngine.compilerDiagnostics ?? []
+  );
+
+  const pdf = buildTreeExportReport({
+    format: "pdf",
+    sourcePages: SOURCE_PAGES,
+    outputDetails: [outputDetail],
+    issues: ISSUES,
+    timings: { ...pdfEngine.timings, totalMs: 1 },
+    complete: pdfEngine.complete,
+    scope,
+  });
+
+  const docx = buildTreeExportReport({
+    format: "docx",
+    engine: "ts",
+    sourcePages: SOURCE_PAGES,
+    outputDetails: [
+      {
+        output: "/tmp/tree.docx",
+        embeddedImages: docxEngine.embeddedImages,
+        renderedDiagrams: docxEngine.renderedDiagrams,
+        skippedAssets: docxEngine.skippedImages,
+      },
+    ],
+    issues: ISSUES,
+    timings: { durationMs: docxEngine.durationMs },
+    complete: docxEngine.complete,
+    scope,
+    placeholders: {
+      resolved: docxEngine.resolvedCount,
+      unsupported: docxEngine.unsupportedNames,
+    },
+  });
+
+  return { pdf, docx };
+}
+
+function symmetricDifference(a: string[], b: string[]): string[] {
+  const setA = new Set(a);
+  const setB = new Set(b);
+  return [...a.filter((k) => !setB.has(k)), ...b.filter((k) => !setA.has(k))].sort();
+}
+
+describe("export report parity — PDF vs DOCX tree scope", () => {
+  it("emits the SAME top-level field set for the same logical tree request", async () => {
+    const { pdf, docx } = await treeReportsForSameRequest("111", { scope: "tree", engine: "ts" }, "111");
+
+    // The only permitted divergence is the documented DOCX-ts-only pair. Any new
+    // field wired on one path only fails here.
+    expect(symmetricDifference(Object.keys(pdf), Object.keys(docx))).toEqual(
+      [...DOCX_ONLY_FIELDS].sort()
+    );
+
+    // And the three fields the M1 run found missing are present on BOTH.
+    for (const report of [pdf, docx]) {
+      expect(Object.keys(report)).toContain("complete");
+      expect(Object.keys(report)).toContain("requestedScope");
+      expect(Object.keys(report)).toContain("resolvedScope");
+      expect(Object.keys(report)).toContain("notesByCode");
+    }
+    expect(pdf.notesByCode).toEqual(docx.notesByCode);
+    expect(pdf.requestedScope).toEqual(docx.requestedScope);
+    expect(pdf.resolvedScope).toEqual(docx.resolvedScope);
+  }, 60_000);
+
+  it("REGRESSION: `complete` is present (not undefined) on the PDF tree path", async () => {
+    // The exact M1 finding: `jq -r '.complete'` yielded null for --format pdf.
+    const { pdf, docx } = await treeReportsForSameRequest("111", { scope: "tree", engine: "ts" }, "111");
+    expect(pdf.complete).toBeDefined();
+    expect(pdf.complete).not.toBeUndefined();
+    expect(Object.hasOwn(pdf, "complete")).toBe(true);
+    // A strict full export is complete on both paths.
+    expect(pdf.complete).toBe(true);
+    expect(docx.complete).toBe(true);
+    // JSON round-trip (what a CI consumer actually reads off stdout).
+    expect(JSON.parse(JSON.stringify(pdf)).complete).toBe(true);
+  }, 60_000);
+
+  it("carries `complete: false` through both formats for a partial export", async () => {
+    const { pdf, docx } = await treeReportsForSameRequest(
+      "111",
+      { scope: "tree", engine: "ts", completeness: "partial" },
+      "111",
+      false
+    );
+    expect(pdf.complete).toBe(false);
+    expect(docx.complete).toBe(false);
+    expect(pdf.requestedScope).toMatchObject({ completeness: "partial" });
+  }, 60_000);
+
+  it("traces a --scope space request to the tree resolved at the homepage id (A5)", async () => {
+    // spec 002 A5: a `--scope space` request that resolved to a homepage id must
+    // stay traceable — requested stays `space`, resolved becomes a tree rooted at
+    // the homepage. Identical on both formats.
+    const { pdf, docx } = await treeReportsForSameRequest(
+      undefined,
+      { scope: "space", space: "DOCSY", engine: "ts" },
+      "9001"
+    );
+    for (const report of [pdf, docx]) {
+      expect(report.requestedScope).toEqual({
+        kind: "space",
+        spaceKey: "DOCSY",
+        completeness: "strict",
+      });
+      expect(report.resolvedScope).toEqual({
+        kind: "tree",
+        rootPageId: "9001",
+        includeRoot: true,
+      });
+    }
+  }, 60_000);
+
+  it("validates both formats' tree reports against the checked-in JSON Schema (ajv)", async () => {
+    const schema = JSON.parse(
+      await Bun.file(new URL("./export-report.schema.json", import.meta.url)).text()
+    );
+    const ajv = new Ajv({ allErrors: true });
+    const validate = ajv.compile(schema);
+
+    const { pdf, docx } = await treeReportsForSameRequest(
+      "111",
+      { scope: "tree", engine: "ts", "max-depth": "2", "label-exclude": "internal" },
+      "111"
+    );
+    expect(validate(pdf) ? [] : validate.errors).toEqual([]);
+    expect(validate(docx) ? [] : validate.errors).toEqual([]);
+
+    // The schema really is being enforced (not vacuously passing).
+    expect(validate({ ...pdf, extraneous: true })).toBe(false);
+    expect(validate({ ...pdf, complete: "yes" })).toBe(false);
+  }, 60_000);
+});
+
+describe("buildScopeReportFields — the shared scope-traceability builder", () => {
+  const cases: Array<{
+    name: string;
+    pageRef?: string;
+    flags: Record<string, string | boolean | string[]>;
+    rootId: string;
+    requestedScope: Record<string, unknown>;
+    resolvedScope: Record<string, unknown>;
+  }> = [
+    {
+      name: "plain tree scope",
+      pageRef: "111",
+      flags: { scope: "tree", engine: "ts" },
+      rootId: "111",
+      requestedScope: { kind: "tree", pageRef: "111", completeness: "strict" },
+      resolvedScope: { kind: "tree", rootPageId: "111", includeRoot: true },
+    },
+    {
+      name: "tree scope with traversal + label flags",
+      pageRef: "111",
+      flags: {
+        scope: "tree",
+        engine: "ts",
+        "max-depth": "2",
+        "max-pages": "50",
+        "max-folders": "5",
+        "label-include": "public",
+        "label-exclude": "internal",
+      },
+      rootId: "111",
+      requestedScope: {
+        kind: "tree",
+        pageRef: "111",
+        maxDepth: 2,
+        maxPages: 50,
+        maxFolders: 5,
+        labels: { include: ["public"], exclude: ["internal"] },
+        completeness: "strict",
+      },
+      resolvedScope: { kind: "tree", rootPageId: "111", includeRoot: true, maxDepth: 2 },
+    },
+    {
+      name: "space scope resolves to a tree at the homepage (A5)",
+      flags: { scope: "space", space: "DOCSY", engine: "ts" },
+      rootId: "9001",
+      requestedScope: { kind: "space", spaceKey: "DOCSY", completeness: "strict" },
+      resolvedScope: { kind: "tree", rootPageId: "9001", includeRoot: true },
+    },
+    {
+      name: "space scope with partial completeness and max-depth",
+      flags: {
+        scope: "space",
+        space: "DOCSY",
+        engine: "ts",
+        completeness: "partial",
+        "max-depth": "0",
+      },
+      rootId: "9001",
+      requestedScope: {
+        kind: "space",
+        spaceKey: "DOCSY",
+        maxDepth: 0,
+        completeness: "partial",
+      },
+      resolvedScope: { kind: "tree", rootPageId: "9001", includeRoot: true, maxDepth: 0 },
+    },
+  ];
+
+  for (const testCase of cases) {
+    it(`reflects the request: ${testCase.name}`, () => {
+      const request = parseExportRequest(testCase.pageRef, testCase.flags);
+      const fields = buildScopeReportFields(request, buildExportScope(request, testCase.rootId));
+      expect(fields.requestedScope).toEqual(testCase.requestedScope);
+      expect(fields.resolvedScope).toEqual(testCase.resolvedScope);
+      // Plain JSON — the report is serialized to stdout.
+      expect(JSON.parse(JSON.stringify(fields))).toEqual(fields);
+    });
+  }
+
+  it("returns a detached copy, so mutating the report cannot corrupt the scope", () => {
+    const request = parseExportRequest("111", { scope: "tree", engine: "ts" });
+    const exportScope = buildExportScope(request, "111");
+    const fields = buildScopeReportFields(request, exportScope);
+    (fields.resolvedScope as { rootPageId: string }).rootPageId = "tampered";
+    expect(exportScope).toMatchObject({ rootPageId: "111" });
+  });
+});
+
+describe("export report parity — PDF vs DOCX single-page scope", () => {
+  /**
+   * Single-page exports carry NO scope-traceability pair BY DESIGN — there is no
+   * scope resolution to trace — but they must still be symmetric between the two
+   * formats, and `complete` must still be present so `jq -r '.complete'` is never
+   * null on a successful export.
+   */
+  it("emits the same field set, with `complete` present and no scope pair", async () => {
+    const [pdfRun, docxRun] = await Promise.all([
+      realPdfEngineReport(true),
+      realDocxEngineReport(true),
+    ]);
+    assertRealArtifacts(pdfRun, docxRun);
+    const pdfEngine = pdfRun.report;
+    const docxEngine = docxRun.report;
+    const { outputDetail } = pdfReportContributions(
+      pdfEngine,
+      "/tmp/page.pdf",
+      pdfEngine.compilerDiagnostics ?? []
+    );
+
+    // Mirrors exportPdf()'s page-scope branch.
+    const pdf = buildReport({
+      format: "pdf",
+      sourcePages: [{ id: "111", title: "Root", notes: [] }],
+      outputDetails: [outputDetail],
+      issues: ISSUES,
+      timings: { ...pdfEngine.timings, totalMs: 1 },
+      complete: pdfEngine.complete,
+    });
+
+    // Mirrors exportWithTsEngine()'s single-page report.
+    const docx = buildReport({
+      format: "docx",
+      engine: "ts",
+      sourcePages: [{ id: "111", title: "Root", notes: [] }],
+      outputDetails: [
+        {
+          output: "/tmp/page.docx",
+          embeddedImages: docxEngine.embeddedImages,
+          renderedDiagrams: docxEngine.renderedDiagrams,
+          skippedAssets: docxEngine.skippedImages,
+        },
+      ],
+      issues: ISSUES,
+      timings: { totalMs: docxEngine.durationMs },
+      complete: docxEngine.complete,
+      placeholders: {
+        resolved: docxEngine.resolvedCount,
+        unsupported: docxEngine.unsupportedNames,
+      },
+    });
+
+    expect(symmetricDifference(Object.keys(pdf), Object.keys(docx))).toEqual(
+      [...DOCX_ONLY_FIELDS].sort()
+    );
+    // `complete` present on both; scope pair absent from both (symmetric).
+    expect(pdf.complete).toBe(true);
+    expect(docx.complete).toBe(true);
+    for (const report of [pdf, docx]) {
+      expect(Object.keys(report)).not.toContain("requestedScope");
+      expect(Object.keys(report)).not.toContain("resolvedScope");
+    }
+  }, 60_000);
+});

--- a/apps/cli/src/commands/export-report.ts
+++ b/apps/cli/src/commands/export-report.ts
@@ -382,6 +382,51 @@ export function buildReport(input: BuildReportInput): ExportReport {
   };
 }
 
+/**
+ * Input for {@link buildTreeExportReport}. Identical to {@link BuildReportInput}
+ * except that the three spec-002 tree fields are REQUIRED rather than optional —
+ * that is the whole point of the type.
+ */
+export interface TreeExportReportInput
+  extends Omit<BuildReportInput, "complete" | "requestedScope" | "resolvedScope"> {
+  /**
+   * Spec 002's completeness contract. REQUIRED: its DoD says the report carries
+   * `complete: boolean` at the top level so a CI consumer can tell a full export
+   * from a partial one, and `jq -r '.complete'` must never yield null.
+   */
+  complete: boolean;
+  /**
+   * Spec 002 A5 scope traceability, from `buildScopeReportFields`. REQUIRED so a
+   * `--scope space` request that resolved to a tree at the homepage id stays
+   * traceable in the report.
+   */
+  scope: { requestedScope: Record<string, unknown>; resolvedScope: Record<string, unknown> };
+}
+
+/**
+ * Assemble the success report for a `--scope tree|space` export — the ONE site
+ * that decides which spec-002 fields a tree/space export carries, used by BOTH
+ * the PDF (`export-pdf.ts`) and DOCX ts (`export.ts`) paths.
+ *
+ * Why this exists rather than each path calling {@link buildReport} directly:
+ * `complete`/`requestedScope`/`resolvedScope` are optional on
+ * {@link BuildReportInput} (single-page exports legitimately omit the scope
+ * pair), so a tree path could — and the PDF path did — silently forget them and
+ * still typecheck. Making them REQUIRED here turns that report-contract gap into
+ * a compile error instead of a field a `--json` consumer discovers is missing.
+ *
+ * Format-specific extras (`engine`, `placeholders`) stay pass-through: they are
+ * documented DOCX-ts-only fields, not part of the shared scope contract.
+ */
+export function buildTreeExportReport(input: TreeExportReportInput): ExportReport {
+  const { scope, ...rest } = input;
+  return buildReport({
+    ...rest,
+    requestedScope: scope.requestedScope,
+    resolvedScope: scope.resolvedScope,
+  });
+}
+
 /** One-line human summary for text mode (stdout stays clean for `--report json`). */
 export function summarizeReport(report: ExportReport): string {
   if (report.exitCode !== EXPORT_EXIT.SUCCESS && report.exitCode !== EXPORT_EXIT.STRICT_WARNINGS) {

--- a/apps/cli/src/commands/export-request.ts
+++ b/apps/cli/src/commands/export-request.ts
@@ -343,3 +343,43 @@ export function buildExportScope(
       };
   }
 }
+
+/** The report's scope-traceability pair (spec 002 A5), as emitted under `--json`. */
+export interface ScopeReportFields {
+  requestedScope: Record<string, unknown>;
+  resolvedScope: Record<string, unknown>;
+}
+
+/**
+ * The ONE construction site for the report's `requestedScope`/`resolvedScope`
+ * traceability pair (spec 002 A5), shared by the DOCX (`export.ts`) and PDF
+ * (`export-pdf.ts`) tree/space paths so both formats emit an IDENTICAL field set
+ * for the same logical request.
+ *
+ * `requestedScope` mirrors the flags as given (a `--scope space --space DOCSY`
+ * request stays visible as `kind: "space"`); `resolvedScope` is the
+ * {@link buildExportScope} output, so the space→tree-at-homepage resolution is
+ * traceable in the `--json` report rather than being silently collapsed.
+ *
+ * Pure: no IO, no network. Both fields are plain JSON-serializable records that
+ * validate against `export-report.schema.json`'s open `requestedScope`/
+ * `resolvedScope` objects.
+ */
+export function buildScopeReportFields(
+  request: ParsedExportRequest,
+  resolvedScope: ExportScope
+): ScopeReportFields {
+  return {
+    requestedScope: {
+      kind: request.scopeKind,
+      ...(request.pageRef ? { pageRef: request.pageRef } : {}),
+      ...(request.spaceKey ? { spaceKey: request.spaceKey } : {}),
+      ...(request.maxDepth !== undefined ? { maxDepth: request.maxDepth } : {}),
+      ...(request.maxPages !== undefined ? { maxPages: request.maxPages } : {}),
+      ...(request.maxFolders !== undefined ? { maxFolders: request.maxFolders } : {}),
+      ...(request.labels ? { labels: request.labels } : {}),
+      completeness: request.completenessMode,
+    },
+    resolvedScope: { ...resolvedScope },
+  };
+}

--- a/apps/cli/src/commands/export.ts
+++ b/apps/cli/src/commands/export.ts
@@ -39,11 +39,13 @@ import {
 import {
   ExportRequestError,
   buildExportScope,
+  buildScopeReportFields,
   parseExportRequest,
   type ParsedExportRequest,
 } from "./export-request.js";
 import {
   buildReport,
+  buildTreeExportReport,
   classifyError,
   emitReportOutcome,
   noteToIssue,
@@ -1322,6 +1324,12 @@ async function exportWithTsEngine(args: TsEngineArgs): Promise<void> {
           })),
         ],
         timings: { totalMs: report.durationMs },
+        // Completeness contract (spec 002): present on EVERY successful export,
+        // not just tree/space, so `jq -r '.complete'` is never null on success.
+        // Single-page exports are always complete. Scope traceability
+        // (requestedScope/resolvedScope) stays tree/space-only by design — and
+        // is absent on the PDF single-page path too (symmetric).
+        complete: report.complete,
         placeholders: { resolved: report.resolvedCount, unsupported: report.unsupportedNames },
         strict,
       }),
@@ -1603,7 +1611,7 @@ async function exportTreeWithTsEngine(args: TreeEngineArgs): Promise<void> {
     emitReportOutcome(
       {
         ok: true,
-        report: buildReport({
+        report: buildTreeExportReport({
           format: "docx",
           engine: "ts",
           sourcePages,
@@ -1626,17 +1634,11 @@ async function exportTreeWithTsEngine(args: TreeEngineArgs): Promise<void> {
             })),
           ],
           timings: { durationMs: docxReport.durationMs, ...docxReport.timings },
-          requestedScope: {
-            kind: request.scopeKind,
-            ...(request.pageRef ? { pageRef: request.pageRef } : {}),
-            ...(request.spaceKey ? { spaceKey: request.spaceKey } : {}),
-            ...(request.maxDepth !== undefined ? { maxDepth: request.maxDepth } : {}),
-            ...(request.maxPages !== undefined ? { maxPages: request.maxPages } : {}),
-            ...(request.maxFolders !== undefined ? { maxFolders: request.maxFolders } : {}),
-            ...(request.labels ? { labels: request.labels } : {}),
-            completeness: request.completenessMode,
-          },
-          resolvedScope: scope as unknown as Record<string, unknown>,
+          // Scope traceability (spec 002 A5) from the ONE shared builder the PDF
+          // path also uses — both formats emit an identical field set here.
+          // `scope` + `complete` are REQUIRED by buildTreeExportReport, so a tree
+          // path can no longer drop them and still compile.
+          scope: buildScopeReportFields(request, scope),
           complete: docxReport.complete,
           placeholders: {
             resolved: docxReport.resolvedCount,

--- a/src/content/docs/confluence/export.md
+++ b/src/content/docs/confluence/export.md
@@ -351,12 +351,21 @@ pipe in a headless job:
 | `sourcePages` | One entry per exported page: `id`, `title`, compose/fetch notes |
 | `outputDetails` / `outputs` | Per-artifact metrics: `embeddedImages`, `renderedDiagrams`, `skippedAssets` (and `pageCount` for PDF) |
 | `issues` / `warnings` / `errors` | Structured problems; `notesByCode` is the per-code tally |
-| `requestedScope` | The scope as requested (e.g. `space` + `spaceKey`) |
-| `resolvedScope` | The resolved scope (e.g. a `tree` rooted at the homepage id) |
-| `complete` | `false` when partial mode omitted content |
-| `placeholders` | ts-engine placeholder metrics (`resolved`, `unsupported`) |
+| `requestedScope` | The scope as requested (e.g. `space` + `spaceKey`) — `--scope tree`/`space` only |
+| `resolvedScope` | The resolved scope (e.g. a `tree` rooted at the homepage id) — `--scope tree`/`space` only |
+| `complete` | `false` when partial mode omitted content; present on every successful export |
+| `placeholders` | ts-engine placeholder metrics (`resolved`, `unsupported`) — DOCX `--engine ts` only |
+| `engine` | `python` or `ts` — DOCX only (the PDF path has a single engine) |
 | `timings` | Per-phase wall clocks |
 | `exitCode` | The process exit code, embedded for artifact archiving |
+
+**Format parity.** For the same logical request, `--format docx` and
+`--format pdf` emit the *same* top-level field set — including `complete` and the
+`requestedScope`/`resolvedScope` traceability pair — so a CI job can branch on
+`jq -r '.complete'` regardless of output format. The only documented exceptions
+are `engine` and `placeholders`, which describe DOCX-engine specifics that have
+no PDF equivalent. `requestedScope`/`resolvedScope` are omitted for single-page
+exports on **both** formats: there is no scope resolution to trace.
 
 Exit codes follow the [unified table](#exit-codes): `0` success · `1` usage/config ·
 `2` warnings under `--strict` · `3` auth · `4` remote/API · `5` compile/validation ·

--- a/src/content/docs/recipes/export-automation.md
+++ b/src/content/docs/recipes/export-automation.md
@@ -66,6 +66,13 @@ jobs:
       - name: Summarize
         run: |
           jq -r '"Exported \(.outputs[0]) — \(.outputDetails[0].pageCount) pages, \(.warnings | length) warnings"' report.json
+      - name: Fail on an incomplete export
+        run: |
+          # `complete` is emitted for --format pdf and --format docx alike, so
+          # this gate is identical whichever format the job produces.
+          [ "$(jq -r '.complete' report.json)" = "true" ] || {
+            echo "Export incomplete:" >&2; jq '.notesByCode' report.json >&2; exit 1;
+          }
       - uses: actions/upload-artifact@v4
         with:
           name: handbook-pdf


### PR DESCRIPTION
Found during the **M1 acceptance run** against a live 57-page DOCSY tree: `--json` reports differed by format. The PDF path omitted `complete`, `requestedScope` and `resolvedScope` — so `jq -r '.complete'` returned `null` on a PDF export, making spec 002's completeness contract unobservable, and A5 scope traceability (a `--scope space` request resolved to a homepage id) was missing.

## Fix
- `buildScopeReportFields(request, exportScope)` in `export-request.ts` — one construction site for the requested/resolved scope pair, replacing the DOCX path's inline literal
- `buildTreeExportReport(...)` in `export-report.ts` — wraps `buildReport` but makes `complete` and `scope` **required**, so the bug class can't recur: omitting them is now a compile error, not a silent gap (verified by deleting the field and observing TS2345)
- Single-page reports are symmetric across formats too: `complete` is always present; the scope pair is absent by design (nothing to trace)
- Schema needed no change — all three fields were already declared; the PDF path simply never sent them

## Verification
- 11 new parity tests (no mocks; real Typst wasm + real DOCX engine, with an `assertRealArtifacts` guard so parity can't be asserted on hollow reports); mutation-tested (dropping `complete` turns 4 red)
- `bun test`: 2794 pass, 0 fail · typecheck (forced, 0 cached) · extension typecheck uncached · check:browser green
- Live E2E against DOCSY, both formats, tree + single-page
- Docs updated: field table marks scope-/format-dependent fields; the PDF CI recipe now shows the `.complete` gate this unblocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)