### PR TITLE
fix(pdf): chapter running head names the FIRST chapter opening on a page

### DIFF
--- a/packages/pdf-compiler-browser/src/chapter-running-head.test.ts
+++ b/packages/pdf-compiler-browser/src/chapter-running-head.test.ts
@@ -6,6 +6,10 @@
  * fixed `headerText` string. Neither is chapter-aware, so a 57-page tree export
  * repeated the root page title on every page. `"chapter"` is the third mode.
  *
+ * A second follow-up (2026-07-20, user review of the M1 acceptance artifacts)
+ * refined *which* chapter a page names when several chapters begin on one page:
+ * the FIRST one, not the last. See the "first on the page" section below.
+ *
  * ## Why the assertions look the way they do
  *
  * Typst subsets its fonts and emits glyph ids, so header text is NOT recoverable
@@ -25,8 +29,10 @@ import { fileURLToPath } from "node:url";
 import {
   PDF_RUNTIME_ASSETS,
   preparePdfDocument,
+  validatePdfOutput,
   type ExportBlock,
   type PdfExportMetadata,
+  type PdfTemplateSettings,
 } from "@atlcli/pdf/browser";
 import {
   BUILTIN_PDF_TEMPLATE_MANIFEST,
@@ -41,11 +47,20 @@ import {
 } from "@atlcli/template-pack";
 import { ensurePdfFonts } from "../../pdf/scripts/ensure-fonts.js";
 import { ensureVendoredTypst } from "../scripts/vendor-typst.js";
-import { BrowserPdfCompiler } from "./index.js";
+import { BrowserPdfCompiler, PDF_BROWSER_COMPILER_VERSION } from "./index.js";
 
-/** The Typst construct the chapter mode is built on (verified below). */
-const CHAPTER_QUERY =
-  "query(heading.where(level: 1)).filter(h => h.outlined and h.location().page() <= here().page())";
+/**
+ * The Typst constructs the chapter mode is built on (all verified below).
+ *
+ * `CHAPTER_QUERY` is the chapter *set* — every outlined level-1 heading.
+ * `OPENING_ON_PAGE` / `STILL_RUNNING` split it by page index, and the head is
+ * the FIRST of the ones opening on this page, else the LAST of the ones already
+ * running.
+ */
+const CHAPTER_QUERY = "query(heading.where(level: 1)).filter(h => h.outlined)";
+const OPENING_ON_PAGE = "chapters.filter(h => h.location().page() == here().page())";
+const STILL_RUNNING = "chapters.filter(h => h.location().page() < here().page())";
+const FIRST_ON_PAGE = "if opening.len() > 0 { opening.first().body }";
 
 /**
  * A validated built-in manifest with an explicit running-head mode. Re-runs the
@@ -77,6 +92,77 @@ function filler(tag: string): ExportBlock[] {
   );
 }
 
+/**
+ * Three chapters short enough that all three BEGIN on the same body page — the
+ * case the first-on-page rule is about. Asserted, not assumed: the tests that
+ * use it check the resulting page count.
+ */
+function crowdedPage(): ExportBlock[] {
+  return [
+    heading("Alpha Chapter"),
+    paragraph("Alpha is a stub chapter: a single line of body copy."),
+    heading("Beta Chapter"),
+    paragraph("Beta is a stub chapter: a single line of body copy."),
+    heading("Gamma Chapter"),
+    paragraph("Gamma is a stub chapter: a single line of body copy."),
+  ];
+}
+
+/**
+ * The equivalence fixture: one chapter per page, which is what `composeChapters`
+ * produces with its default per-chapter `pageBreak`. Under this layout the
+ * pre-refinement rule ("last outlined level-1 heading at or before this page")
+ * and the refined rule ("first one opening on this page, else the still-running
+ * one") select the same heading on every page.
+ *
+ * KEEP BYTE-STABLE: {@link ONE_PER_PAGE_PRE_REFINEMENT_DIGEST} is a digest of
+ * this exact fixture. Editing the blocks, the metadata, or the manifest
+ * invalidates the pinned number and the equivalence proof with it.
+ */
+const ONE_PER_PAGE_CHAPTERS = ["Alpha", "Beta", "Gamma", "Delta"] as const;
+
+const ONE_PER_PAGE_BLOCKS: ExportBlock[] = ONE_PER_PAGE_CHAPTERS.flatMap((name, index) => [
+  ...(index === 0 ? [] : [{ type: "pageBreak" } as ExportBlock]),
+  heading(`${name} Chapter`),
+  paragraph(`${name} body copy, short enough to leave the page well before its foot.`),
+]);
+
+const ONE_PER_PAGE_METADATA: PdfExportMetadata = {
+  title: "One Chapter Per Page",
+  space: "DOCSY",
+  version: 3,
+  author: "Ada Lovelace",
+  exporter: "atlcli",
+  language: "en",
+  region: "GB",
+  exportedAt: new Date("2026-07-19T00:00:00.000Z"),
+};
+
+/**
+ * sha256 of {@link ONE_PER_PAGE_BLOCKS} rendered in `chapter` mode through the
+ * built-in manifest by the PRE-REFINEMENT rule, i.e. by
+ *
+ *   let started = query(heading.where(level: 1))
+ *     .filter(h => h.outlined and h.location().page() <= here().page())
+ *   let chapter-head = if started.len() > 0 { started.last().body } else { meta.title }
+ *
+ * Provenance: captured from `origin/main` at commit
+ * `62a003134bb139270441be907bd1572ed41c7c4a` (PR #66, the commit immediately
+ * before the first-on-page refinement) with the pinned compiler
+ * {@link PINNED_COMPILER}, by compiling this fixture with that checkout's
+ * unmodified `packages/pdf/src/template.ts`. The refined rule reproducing this
+ * digest byte-for-byte is the proof that the normal one-chapter-per-page case
+ * did not regress.
+ *
+ * A change here is NOT a re-baselining candidate: it means the refinement
+ * altered output in the very case it was supposed to leave alone.
+ */
+const ONE_PER_PAGE_PRE_REFINEMENT_DIGEST =
+  "90bef12c83c654c059f5cc3918b21469c3640c7dad78683676b7766b02023ca0";
+
+/** Digests are only comparable within one compiler version. */
+const PINNED_COMPILER = "typst.ts 0.7.0 / Typst 0.14.2";
+
 function metadata(title: string): PdfExportMetadata {
   return {
     title,
@@ -99,14 +185,19 @@ let compiler: BrowserPdfCompiler;
 async function render(
   blocks: ExportBlock[],
   meta: PdfExportMetadata,
-  templateManifest: TemplateManifest
+  templateManifest: TemplateManifest,
+  settings?: PdfTemplateSettings
 ): Promise<Uint8Array> {
   const prepared = await preparePdfDocument(blocks, {
     resolve: async () => {
       throw new Error("this fixture has no external assets");
     },
   });
-  const bundle = serializePdfDocument(prepared, { metadata: meta, templateManifest });
+  const bundle = serializePdfDocument(prepared, {
+    metadata: meta,
+    templateManifest,
+    ...(settings === undefined ? {} : { settings }),
+  });
   const result = await compiler.compile(bundle);
   const errors = result.diagnostics.filter((d) => d.severity === "error");
   if (errors.length) throw new Error(`compile failed: ${JSON.stringify(errors)}`);
@@ -171,14 +262,31 @@ describe("chapter running head (real compiler)", () => {
   it("chapter mode emits the verified page-index query, not the lagging before(here()) form", () => {
     const source = createAtlcliTypstTemplate(manifestWithHeaderMode("chapter").design!);
     expect(source).toContain(CHAPTER_QUERY);
-    // `here()` in a page header resolves to the TOP of the page, so a
-    // `.before(here())` selector excludes a chapter that opens on that page and
-    // lags one page behind at every chapter opening. Verified against the pinned
-    // compiler; the page-index comparison is the construct that survived.
+    // Invariant 1: a chapter that OPENS on this page must be selected. `here()`
+    // in a page header resolves to the TOP of the page, so a `.before(here())`
+    // selector excludes such a chapter and lags one page behind at every
+    // chapter opening. Verified against the pinned compiler; the page-index
+    // equality comparison is the construct that survived.
+    expect(source).toContain(OPENING_ON_PAGE);
     expect(source).not.toContain(".before(here())");
+    // Invariant 3: first-on-page, and the still-running chapter as the fallback
+    // for a page no chapter opens on.
+    expect(source).toContain(FIRST_ON_PAGE);
+    expect(source).toContain(STILL_RUNNING);
+    expect(source).toContain("running.last().body");
+    // ...never `.last()` over the headings opening on this page.
+    expect(source).not.toContain("opening.last()");
     // The space key stays on the right and the hairline is unchanged.
     expect(source).toContain("grid(columns: (1fr, auto), chapter-head, meta.space)");
     expect(source).toContain("line(length: 100%,");
+  });
+
+  it("chapter mode keeps the outlined filter that excludes the ToC heading", () => {
+    // Invariant 2, asserted on the source as well as behaviorally (the fallback
+    // test below is the render-level regression guard). `outline()` emits its
+    // own level-1 heading; it is the only one with `outlined: false`.
+    const source = createAtlcliTypstTemplate(manifestWithHeaderMode("chapter").design!);
+    expect(source).toContain("h.outlined");
   });
 
   it("a single chapter whose title equals the document title renders identically in both modes", async () => {
@@ -260,6 +368,127 @@ describe("chapter running head (real compiler)", () => {
     const chaptered = await render(blocks, meta, manifestWithHeaderMode("chapter"));
     expect(digest(chaptered)).not.toBe(digest(titled));
   }, 180_000);
+
+  // -------------------------------------------------------------------------
+  // (d) several chapters on one page -> the FIRST of them
+  // -------------------------------------------------------------------------
+  //
+  // Refinement of 2026-07-20 (user review of the M1 acceptance artifacts). The
+  // head sits at the TOP of the page and the content directly below it starts
+  // with the first chapter that begins there, so naming a later one contradicts
+  // what the reader sees. It is also the dictionary/guide-word convention.
+
+  it("names the FIRST chapter when several chapters begin on the same page", async () => {
+    // Three short chapters share one body page (asserted). Header-bearing pages
+    // are the ToC page (fallback -> document title) and that one body page. With
+    // the document title set to the FIRST chapter, title mode reads
+    // "Alpha Chapter" on both, and chapter mode can only agree if the body page
+    // resolves to "Alpha Chapter" too. The previous `.last()` rule resolved it
+    // to "Gamma Chapter" and this assertion fails under it.
+    const blocks = crowdedPage();
+    const meta = metadata("Alpha Chapter");
+    const chaptered = await render(blocks, meta, manifestWithHeaderMode("chapter"));
+    // cover + ToC + one body page + closing page: all three chapters share a page.
+    expect(validatePdfOutput(chaptered).pageCount).toBe(4);
+    const titled = await render(blocks, meta, manifestWithHeaderMode("title"));
+    expect(digest(chaptered)).toBe(digest(titled));
+  }, 180_000);
+
+  it("does NOT name the last chapter when several chapters begin on the same page", async () => {
+    // The mirrored control. Same fixture, document title set to the LAST chapter
+    // instead: chapter mode must now DIFFER from title mode, because the body
+    // page reads "Alpha Chapter" while the title-mode head reads "Gamma
+    // Chapter". Without this control the test above would also pass for a rule
+    // that ignored chapters entirely and always emitted the document title.
+    const blocks = crowdedPage();
+    const meta = metadata("Gamma Chapter");
+    const titled = await render(blocks, meta, manifestWithHeaderMode("title"));
+    const chaptered = await render(blocks, meta, manifestWithHeaderMode("chapter"));
+    expect(digest(chaptered)).not.toBe(digest(titled));
+  }, 180_000);
+
+  // -------------------------------------------------------------------------
+  // (e) the two page kinds, isolated
+  // -------------------------------------------------------------------------
+
+  it("a chapter that OPENS on a page heads that page (invariant 1, isolated)", async () => {
+    // One short chapter: the only body page is the page the chapter opens on.
+    // Document title differs from the chapter, so title mode heads that page
+    // "Unrelated Document" and chapter mode must head it "Alpha Chapter" — the
+    // renders differ, and the opening page is the ONLY page that can account for
+    // it (the ToC page falls back to the document title in both modes). A
+    // `.before(here())` selector, which excludes a chapter opening on this very
+    // page, would make the two renders equal and fail here.
+    const blocks = [heading("Alpha Chapter"), paragraph("A chapter short enough to fit its page.")];
+    const opening = await render(blocks, metadata("Unrelated Document"), manifestWithHeaderMode("chapter"));
+    expect(validatePdfOutput(opening).pageCount).toBe(4);
+    const titled = await render(blocks, metadata("Unrelated Document"), manifestWithHeaderMode("title"));
+    expect(digest(opening)).not.toBe(digest(titled));
+
+    // ...and the positive pins it to exactly the chapter's own text.
+    const meta = metadata("Alpha Chapter");
+    expect(digest(await render(blocks, meta, manifestWithHeaderMode("chapter")))).toBe(
+      digest(await render(blocks, meta, manifestWithHeaderMode("title")))
+    );
+  }, 240_000);
+
+  it("a CONTINUATION page heads the still-running chapter (isolated)", async () => {
+    // Cover and outline are switched off, so the chapter opens on page 1 — where
+    // the header is suppressed — and the closing page is the last. Every
+    // header-bearing page is therefore a pure continuation page of "Alpha
+    // Chapter": no chapter begins on it. If the still-running branch were
+    // missing (a page with no chapter opening on it falling through to the
+    // document-title fallback) these two renders would be EQUAL, so the
+    // inequality is attributable to continuation pages and nothing else.
+    const blocks = [heading("Alpha Chapter"), ...filler("alpha"), ...filler("alpha continued")];
+    const bare: PdfTemplateSettings = { cover: false, outline: false };
+    const chaptered = await render(blocks, metadata("Unrelated Document"), manifestWithHeaderMode("chapter"), bare);
+    // >= 4 pages means at least two header-bearing continuation pages exist.
+    expect(validatePdfOutput(chaptered).pageCount).toBeGreaterThanOrEqual(4);
+    const titled = await render(blocks, metadata("Unrelated Document"), manifestWithHeaderMode("title"), bare);
+    expect(digest(chaptered)).not.toBe(digest(titled));
+
+    // ...and the positive pins those continuation heads to the chapter's text.
+    const meta = metadata("Alpha Chapter");
+    expect(digest(await render(blocks, meta, manifestWithHeaderMode("chapter"), bare))).toBe(
+      digest(await render(blocks, meta, manifestWithHeaderMode("title"), bare))
+    );
+  }, 240_000);
+
+  // -------------------------------------------------------------------------
+  // (f) equivalence with the pre-refinement rule in the normal case
+  // -------------------------------------------------------------------------
+
+  it("a one-chapter-per-page document is byte-identical to the pre-refinement render", async () => {
+    // For documents with at most ONE chapter starting per page — the normal
+    // case, since `composeChapters` inserts a pageBreak per chapter by default —
+    // "first chapter opening on this page" and "last heading at or before this
+    // page" select the same heading, so the refinement must be a no-op.
+    //
+    // The old rule cannot be executed any more, so the proof is a pinned digest
+    // of a render produced by it. See ONE_PER_PAGE_PRE_REFINEMENT_DIGEST for the
+    // provenance of that number.
+    const chaptered = await render(
+      ONE_PER_PAGE_BLOCKS,
+      ONE_PER_PAGE_METADATA,
+      manifestWithHeaderMode("chapter")
+    );
+    // cover + ToC + one page per chapter + closing page: exactly one chapter
+    // starts on each body page, which is the precondition the claim is about.
+    expect(validatePdfOutput(chaptered).pageCount).toBe(3 + ONE_PER_PAGE_CHAPTERS.length);
+    expect(PDF_BROWSER_COMPILER_VERSION).toBe(PINNED_COMPILER);
+    expect(digest(chaptered)).toBe(ONE_PER_PAGE_PRE_REFINEMENT_DIGEST);
+
+    // Guard the fixture: the head really does track the chapters here (the
+    // document title matches none of them), so the digest above is not the
+    // trivially chapter-independent title-mode output.
+    const titled = await render(
+      ONE_PER_PAGE_BLOCKS,
+      ONE_PER_PAGE_METADATA,
+      manifestWithHeaderMode("title")
+    );
+    expect(digest(chaptered)).not.toBe(digest(titled));
+  }, 240_000);
 
   // -------------------------------------------------------------------------
   // Manuscript ships the mode

--- a/packages/pdf/src/template.ts
+++ b/packages/pdf/src/template.ts
@@ -115,20 +115,35 @@ export function createAtlcliTypstTemplate(
   const headerResolution =
     headerMode === "chapter"
       ? String.raw`          // Chapter running head ("Kolumnentitel"): the level-1 heading that owns
-          // this page. Two behaviours were verified against the pinned compiler
-          // and both matter:
-          //   1. here() inside a page header resolves to the TOP of the page, so
-          //      a before-here selector EXCLUDES a chapter that opens on this
-          //      very page and lags one page behind at every chapter opening.
-          //      Comparing page indices picks the chapter that owns the page.
-          //   2. the table of contents renders its own level-1 heading, so an
-          //      unfiltered query names the whole document "Contents". That
-          //      heading is the only one with outlined: false, and "appears in
-          //      the table of contents" is exactly what a chapter is.
+          // this page. Three decisions are load-bearing here; all three were
+          // verified against the pinned compiler, none is an assumption:
+          //   1. OPEN-ON-PAGE. here() inside a page header resolves to the TOP
+          //      of the page, so a before-here selector EXCLUDES a chapter that
+          //      opens on this very page and lags one page behind at every
+          //      chapter opening. Comparing page indices is what fixes that, so
+          //      the == branch below must keep matching this page's own page
+          //      index — never a strictly-before comparison.
+          //   2. OUTLINED FILTER. The table of contents renders its own level-1
+          //      heading, so an unfiltered query names the whole document
+          //      "Contents". That heading is the only one with outlined: false,
+          //      and "appears in the table of contents" is exactly what a
+          //      chapter is.
+          //   3. FIRST ON PAGE. When SEVERAL chapters begin on one page the head
+          //      names the FIRST of them, not the last. The head sits at the top
+          //      of the page and the content immediately below it starts with
+          //      that first chapter; naming a later one contradicts what the
+          //      reader sees, and the first-on-page reading is also the
+          //      dictionary/guide-word convention. For the normal case — at most
+          //      one chapter per page, which is what composeChapters produces
+          //      with its default per-chapter pageBreak — first and last are the
+          //      same heading, so this refinement is a no-op there (pinned as a
+          //      byte-equality test against a pre-refinement render).
           // Front matter (no chapter heading yet) falls back to the document
           // title, never to an empty head.
-          let started = query(heading.where(level: 1)).filter(h => h.outlined and h.location().page() <= here().page())
-          let chapter-head = if started.len() > 0 { started.last().body } else { meta.title }
+          let chapters = query(heading.where(level: 1)).filter(h => h.outlined)
+          let opening = chapters.filter(h => h.location().page() == here().page())
+          let running = chapters.filter(h => h.location().page() < here().page())
+          let chapter-head = if opening.len() > 0 { opening.first().body } else if running.len() > 0 { running.last().body } else { meta.title }
           grid(columns: (1fr, auto), chapter-head, meta.space)`
       : String.raw`          grid(columns: (1fr, auto), meta.title, meta.space)`;
 

--- a/packages/pdf/src/template.ts
+++ b/packages/pdf/src/template.ts
@@ -132,11 +132,14 @@ export function createAtlcliTypstTemplate(
           //      names the FIRST of them, not the last. The head sits at the top
           //      of the page and the content immediately below it starts with
           //      that first chapter; naming a later one contradicts what the
-          //      reader sees, and the first-on-page reading is also the
-          //      dictionary/guide-word convention. For the normal case — at most
-          //      one chapter per page, which is what composeChapters produces
-          //      with its default per-chapter pageBreak — first and last are the
-          //      same heading, so this refinement is a no-op there (pinned as a
+          //      reader sees. This is also what Word's STYLEREF field does by
+          //      default (search the page top-down, take the first match; if the
+          //      style is absent from the page, fall back to the one still
+          //      running) — its \l switch is what reverses the on-page search to
+          //      bottom-up and yields the last. For the normal case — at most one
+          //      chapter per page, which is what composeChapters produces with
+          //      its default per-chapter pageBreak — first and last are the same
+          //      heading, so this refinement is a no-op there (pinned as a
           //      byte-equality test against a pre-refinement render).
           // Front matter (no chapter heading yet) falls back to the document
           // title, never to an empty head.

--- a/specs/export-expansion/012-pdf-template-migration/PLAN.md
+++ b/specs/export-expansion/012-pdf-template-migration/PLAN.md
@@ -534,8 +534,7 @@ it belongs to this same follow-up rather than to a new spec. When SEVERAL
 chapters begin on one page, `started.last()` named the *last* of them; the head
 now names the *first*. Rationale: the head sits at the top of the page and the
 content directly below it starts with that first chapter, so naming a later one
-contradicts what the reader sees — and first-on-page is the dictionary /
-guide-word convention. The resolution became:
+contradicts what the reader sees. The resolution became:
 
 ```typst
 let chapters = query(heading.where(level: 1)).filter(h => h.outlined)
@@ -550,6 +549,36 @@ Both behaviours the entry above measured survive unchanged and are pinned by
 their own tests: the `== here().page()` branch still selects a chapter that
 *opens* on this page (the one-page lag of `.before(here())` does not return), and
 the `h.outlined` filter still keeps the ToC's own "Contents" heading out.
+
+**Correction: this CONVERGED with Word, it did not diverge from it.** The entry
+above, and the reference docs derived from it, claimed Word's `STYLEREF` rule is
+"the last H1 that began on or before this page". That is wrong, and the review of
+this refinement is what caught it. Word's default for a `STYLEREF` field in a
+header searches the page **top-down** and takes the **first** matching paragraph;
+if the style does not occur on the page it searches back toward the start of the
+document, i.e. the chapter still running. The `\l` switch is what reverses the
+on-page search to bottom-up and yields the *last* one — Microsoft's ECMA-376
+implementation notes state that `\l` in a header "causes the search to go from the
+bottom of the page to the beginning of the document and then to the end of the
+document" and has no effect elsewhere ([MS-OI29500 §17.16.5.59] /
+[MS-OE376 §2.16.5.66], note (f)). So the pre-refinement PDF rule was the `\l`
+behaviour, and the refinement moved PDF onto Word's *default*. The remaining
+difference is only the exhausted case: Word then searches forward to the end of
+the document, PDF falls back to `meta.title`. `docx-engine.md` and
+`pdf-template-contract.md` were corrected accordingly; the stale "last H1"
+wording also sat in this repo's DOCX release-train manual-verification step,
+which would have produced a wrong verdict on a multi-chapter page.
+
+`collectStylerefFields` (`packages/docx/src/scan.ts`, spec 006 G1) captures only
+the quoted style name — it does not parse switches, so `\l` is ignored, as are
+`\* MERGEFORMAT` and the numbering switches. That is correct for its purpose (the
+diagnostic asks only *does this export emit the style the field names*) and
+nothing in the DOCX engine encodes a first/last assumption anywhere:
+`validateStylerefFields` compares style names, and the field instruction survives
+byte-exactly for Word to resolve. Noted in `docx-engine.md`.
+
+[MS-OI29500 §17.16.5.59]: https://learn.microsoft.com/en-us/openspecs/office_standards/ms-oi29500/0f5599c3-3b12-4970-931d-659e489369f4
+[MS-OE376 §2.16.5.66]: https://learn.microsoft.com/en-us/openspecs/office_standards/ms-oe376/34d69bba-3782-470b-97d3-e9852c3257f0
 
 **Equivalence in the normal case, proven not asserted.** `composeChapters`
 inserts a `pageBreak` per chapter by default, so ordinary tree/space exports put

--- a/specs/export-expansion/012-pdf-template-migration/PLAN.md
+++ b/specs/export-expansion/012-pdf-template-migration/PLAN.md
@@ -528,6 +528,49 @@ byte-identically in both modes; a document with no chapter heading does too,
 which is simultaneously the fallback proof and the ToC-exclusion regression
 guard). That is a stronger claim than a substring match, not a weaker one.
 
+**Refinement — first chapter on the page, not the last (2026-07-20).** Came from
+the user's review of the M1 acceptance artifacts produced by the entry above, so
+it belongs to this same follow-up rather than to a new spec. When SEVERAL
+chapters begin on one page, `started.last()` named the *last* of them; the head
+now names the *first*. Rationale: the head sits at the top of the page and the
+content directly below it starts with that first chapter, so naming a later one
+contradicts what the reader sees — and first-on-page is the dictionary /
+guide-word convention. The resolution became:
+
+```typst
+let chapters = query(heading.where(level: 1)).filter(h => h.outlined)
+let opening = chapters.filter(h => h.location().page() == here().page())
+let running = chapters.filter(h => h.location().page() < here().page())
+let chapter-head = if opening.len() > 0 { opening.first().body }
+  else if running.len() > 0 { running.last().body }
+  else { meta.title }
+```
+
+Both behaviours the entry above measured survive unchanged and are pinned by
+their own tests: the `== here().page()` branch still selects a chapter that
+*opens* on this page (the one-page lag of `.before(here())` does not return), and
+the `h.outlined` filter still keeps the ToC's own "Contents" heading out.
+
+**Equivalence in the normal case, proven not asserted.** `composeChapters`
+inserts a `pageBreak` per chapter by default, so ordinary tree/space exports put
+at most one chapter on a page — and there "first opening here" and "last at or
+before here" are the same heading. Because the old rule can no longer be
+executed, the proof is a pinned digest: a one-chapter-per-page fixture was
+compiled against `origin/main` at `62a0031` (the commit before this refinement)
+with the pinned compiler, and its sha256
+`90bef12c83c654c059f5cc3918b21469c3640c7dad78683676b7766b02023ca0` is asserted by
+`chapter-running-head.test.ts` after the change. It reproduces byte-for-byte.
+Provenance is recorded on the constant; a change there means the refinement
+altered output in the case it was supposed to leave alone, so it is never a
+re-baselining candidate.
+
+The new discriminating tests were themselves checked by temporarily restoring the
+`started.last()` rule: the first-on-page assertion and its mirrored control both
+fail under it, while the equivalence digest passes under *both* rules — which is
+exactly the split the change claims. `template-migration-parity.test.ts` still
+pins `351fd2d4…` unchanged (the default design is `title` mode, so the chapter
+branch is never emitted for it).
+
 ## Definition of Done
 
 - The built-in template's default output is proven parity-identical

--- a/src/content/docs/reference/docx-engine.md
+++ b/src/content/docs/reference/docx-engine.md
@@ -336,8 +336,9 @@ field (`STYLEREF "Scroll Heading 1" \* MERGEFORMAT`). The engine keeps this work
 > **PDF equivalent.** The PDF engine offers the same capability as a declared template
 > design field, `design.features.header.mode: "chapter"` — see
 > [Running-head modes](pdf-template-contract.md#running-head-modes). Same result (each page
-> headed by the last H1 that began on or before it), different declaration point: DOCX
-> inherits the field from the user's `.docx`, PDF validates a manifest enum.
+> headed by the first H1 beginning on it, or by the chapter still running if none begins
+> there), different declaration point: DOCX inherits the field from the user's `.docx`,
+> PDF validates a manifest enum.
 
 
 - Field **instructions survive byte-exactly** — the preprocessor and docxtemplater never touch
@@ -346,6 +347,23 @@ field (`STYLEREF "Scroll Heading 1" \* MERGEFORMAT`). The engine keeps this work
   (`resolveHeadingStyleId` against the template's `word/styles.xml`).
 - `word/settings.xml` gets `<w:updateFields w:val="true"/>` so Word offers to refresh fields on
   open.
+
+**Which heading a page gets.** By default Word searches the page from the **top down** and
+shows the **first** paragraph in the named style; if the style does not occur on the page, it
+searches back toward the start of the document, so the chapter still running stays in the
+header. The `\l` switch (`STYLEREF "Scroll Heading 1" \l`) reverses the on-page search to
+bottom-up and shows the **last** such heading instead — the pair is how Word builds
+dictionary-style headers. With one chapter per page (what `composeChapters` produces by
+default) both directions give the same heading.
+
+:::note[The scan records style names only]
+`collectStylerefFields` matches `STYLEREF "<style name>"` and captures the name; it does not
+parse switches, so `\l` — like `\* MERGEFORMAT` and the numbering switches — is ignored. That
+is intentional for a diagnostic whose only question is *does this export emit the style the
+field names*, and it means the notes below read the same for `\l` and non-`\l` fields. Nothing
+in the engine reorders, rewrites, or depends on a field's search direction: the instruction
+survives byte-exactly and Word alone resolves it.
+:::
 
 Two diagnostics flag a field that will not resolve as intended (they change nothing — the export
 still succeeds):
@@ -364,7 +382,10 @@ but not sufficient. Once per release, confirm in Word 365:
 1. Export a multi-page document whose template header carries the STYLEREF field.
 2. Open in Word 365. If the header shows a **stale** chapter, press **F9** (or reopen) to refresh
    fields — `updateFields` prompts this automatically on first open.
-3. Confirm each page's header shows the **last H1 that began on or before that page**.
+3. Confirm each page's header shows the **first H1 beginning on that page**, or — on a page
+   where no H1 begins — the chapter still running from an earlier page. (With one chapter per
+   page these coincide; they differ only where a page opens several chapters, and a `\l` field
+   would show the last one instead.)
 4. If it stays blank or stale after refresh, check the report for a `styleref-*` note — a
    warning means promotion left the referenced style unused (fix the template's field to name the
    effective heading style), an info means the style name is not in the template.

--- a/src/content/docs/reference/pdf-template-contract.md
+++ b/src/content/docs/reference/pdf-template-contract.md
@@ -130,7 +130,7 @@ manifest at `design.features.header.mode` — not a Level-A setting.
 | Mode | Running head shows | Use it for |
 |------|--------------------|------------|
 | `"title"` *(default)* | Document title (left) + space key (right) | Single-page and short exports. |
-| `"chapter"` | The level-1 heading that owns the page (left) + space key (right) | Book-like documents and page-tree exports. |
+| `"chapter"` | The level-1 heading that owns the page — the **first** chapter beginning on it, else the chapter still running (left) + space key (right) | Book-like documents and page-tree exports. |
 | `"custom"` | The `headerText` setting | A fixed legal or classification line. |
 
 The field is **optional**. A manifest that omits it — including every manifest
@@ -149,28 +149,52 @@ With `"title"`, a 57-page page-tree export repeats the root page's title on all
 the section instead:
 
 ```typst
-let started = query(heading.where(level: 1))
-  .filter(h => h.outlined and h.location().page() <= here().page())
-let chapter-head = if started.len() > 0 { started.last().body } else { meta.title }
+let chapters = query(heading.where(level: 1)).filter(h => h.outlined)
+let opening = chapters.filter(h => h.location().page() == here().page())
+let running = chapters.filter(h => h.location().page() < here().page())
+let chapter-head = if opening.len() > 0 {
+  opening.first().body
+} else if running.len() > 0 {
+  running.last().body
+} else {
+  meta.title
+}
 grid(columns: (1fr, auto), chapter-head, meta.space)
 ```
 
-Two details of that query are load-bearing and were verified against the pinned
-compiler (`typst.ts 0.7.0 / Typst 0.14.2`):
+In words: **the first chapter that begins on this page; if none begins here, the
+chapter still running.** Three details of that resolution are load-bearing, and
+all three were verified against the pinned compiler
+(`typst.ts 0.7.0 / Typst 0.14.2`):
 
-- **Page comparison, not `.before(here())`.** Inside a page header, `here()`
+- **A chapter opening on this page counts.** Inside a page header, `here()`
   resolves to the *top* of the page, so a `.before(here())` selector excludes a
   chapter that opens on that very page — the head would lag one page behind at
-  every chapter opening. Comparing page indices picks the chapter that actually
-  owns the page.
+  every chapter opening. Matching this page's own page index is what picks the
+  chapter that actually owns the page.
 - **`h.outlined` filter.** `outline()` renders its own level-1 heading for the
   "Contents" title. It is the only heading with `outlined: false`, and "appears
   in the table of contents" is precisely what makes a heading a chapter — without
   the filter, every page of every document would be headed *Contents*.
+- **First on the page, not last.** When several short chapters begin on one page,
+  the head names the **first** of them. The head sits at the top of the page and
+  the content directly beneath it starts with that first chapter, so naming a
+  later one would contradict what the reader sees; it is also the convention a
+  dictionary's guide words follow. This only ever applies to pages that open more
+  than one chapter — with at most one chapter per page, "first opening here" and
+  "last at or before here" are the same heading, which is why the refinement left
+  ordinary output byte-identical.
 
 Pages before the first chapter heading (a cover, the table of contents, front
 matter) fall back to the **document title**, never to an empty head. The space
 key on the right and the hairline rule below are identical in all three modes.
+
+:::note[Several chapters per page is not the usual layout]
+`composeChapters` inserts a page break per chapter by default, so a tree or space
+export puts exactly one chapter on each page and the first-on-page rule never
+fires. It matters for documents assembled without those breaks
+(`chapterBreak: "none"`) or with very short chapters.
+:::
 
 Of the two curated built-in templates, **Manuscript** ships `"chapter"` (it is a
 book-like design) and **Editorial Indigo** stays on the default `"title"`.
@@ -183,7 +207,10 @@ user template puts a `STYLEREF` field in its header
 — field instructions survive byte-exactly, headings carry the exact `w:pStyle`
 id the field names, and `updateFields` prompts Word to refresh on open. Word's
 own rule for that field is *the last H1 that began on or before this page*, which
-is the behavior the Typst query above reproduces.
+is what the Typst resolution above reproduces on every page that opens at most
+one chapter — that is, on every page of a normal chapterized export. The two
+rules part only where several chapters begin on the same page: Word names the
+last of them, PDF names the first, deliberately (see the third bullet above).
 
 The two engines differ in **where the decision lives**, not in what it does: PDF
 declares the mode in a validated manifest field, DOCX inherits it from whatever

--- a/src/content/docs/reference/pdf-template-contract.md
+++ b/src/content/docs/reference/pdf-template-contract.md
@@ -179,11 +179,11 @@ all three were verified against the pinned compiler
 - **First on the page, not last.** When several short chapters begin on one page,
   the head names the **first** of them. The head sits at the top of the page and
   the content directly beneath it starts with that first chapter, so naming a
-  later one would contradict what the reader sees; it is also the convention a
-  dictionary's guide words follow. This only ever applies to pages that open more
-  than one chapter — with at most one chapter per page, "first opening here" and
-  "last at or before here" are the same heading, which is why the refinement left
-  ordinary output byte-identical.
+  later one would contradict what the reader sees. This also matches Word's
+  default `STYLEREF` behavior — see [DOCX equivalence](#docx-equivalence). It
+  only ever applies to pages that open more than one chapter: with at most one
+  chapter per page, "first opening here" and "last at or before here" are the
+  same heading, which is why the refinement left ordinary output byte-identical.
 
 Pages before the first chapter heading (a cover, the table of contents, front
 matter) fall back to the **document title**, never to an empty head. The space
@@ -205,12 +205,25 @@ The DOCX engine has the same capability, expressed the way Word expresses it: a
 user template puts a `STYLEREF` field in its header
 (`STYLEREF "Scroll Heading 1" \* MERGEFORMAT`) and the engine keeps it resolving
 — field instructions survive byte-exactly, headings carry the exact `w:pStyle`
-id the field names, and `updateFields` prompts Word to refresh on open. Word's
-own rule for that field is *the last H1 that began on or before this page*, which
-is what the Typst resolution above reproduces on every page that opens at most
-one chapter — that is, on every page of a normal chapterized export. The two
-rules part only where several chapters begin on the same page: Word names the
-last of them, PDF names the first, deliberately (see the third bullet above).
+id the field names, and `updateFields` prompts Word to refresh on open.
+
+**The two engines resolve the head the same way.** For a `STYLEREF` field in a
+header, Word searches the current page from the **top down** and takes the
+**first** paragraph in the named style; if the style does not occur on the page
+at all, it searches back from the top of the page toward the beginning of the
+document, i.e. it keeps showing the chapter that is still running. That is
+exactly the PDF resolution above. The `\l` switch
+(`STYLEREF "Scroll Heading 1" \l`) reverses the on-page search to **bottom-up**,
+making Word take the **last** heading beginning on the page instead — the two
+directions together are how Word builds dictionary-style headers, one plain field
+for the first entry on the page and one `\l` field for the last. PDF's `chapter`
+mode corresponds to the **default** (no `\l`) behavior; there is no PDF analogue
+of `\l` today.
+
+Sources for that: Microsoft's ECMA-376 implementation notes state that `\l` in a
+header "causes the search to go from the bottom of the page to the beginning of
+the document" and has no effect elsewhere
+([MS-OI29500 §17.16.5.59](https://learn.microsoft.com/en-us/openspecs/office_standards/ms-oi29500/0f5599c3-3b12-4970-931d-659e489369f4)).
 
 The two engines differ in **where the decision lives**, not in what it does: PDF
 declares the mode in a validated manifest field, DOCX inherits it from whatever


### PR DESCRIPTION
User review of the M1 acceptance artifacts: on a page where three chapters begin, the running head named the **last** of them while the page visibly starts with the first.

## Change
```typst
let chapters = query(heading.where(level: 1)).filter(h => h.outlined)
let opening  = chapters.filter(h => h.location().page() == here().page())
let running  = chapters.filter(h => h.location().page() <  here().page())
let chapter-head = if opening.len() > 0 { opening.first().body }
                   else if running.len() > 0 { running.last().body }
                   else { meta.title }
```
Both previously-measured invariants are preserved and test-guarded: a chapter **opening** on the page is still selected (the `.before(here())` form lags one page), and the `h.outlined` filter still excludes the ToC's own level-1 heading.

## No-op in the normal case — proven, not asserted
A reference render was produced from the **pre-change** code (commit `62a0031`) for a one-chapter-per-page document and its digest pinned as `ONE_PER_PAGE_PRE_REFINEMENT_DIGEST` with full provenance. The refined rule reproduces it byte-for-byte, so the change demonstrably affects only pages where several chapters begin. Counter-checked by temporarily restoring the old rule: the two new tests fail, the equivalence test passes under both.

## Docs correction (this PR also fixes a pre-existing factual error)
The claim that Word's `STYLEREF` names the *last* matching paragraph on a page was **wrong** — in a header it searches the page **top-down and takes the first**, falling back to the still-running one when the style is absent from the page; the `\l` switch is the opt-in for bottom-up/last. Source: Microsoft's ECMA-376 implementation notes, [MS-OI29500 §17.16.5.59](https://learn.microsoft.com/en-us/openspecs/office_standards/ms-oi29500/0f5599c3-3b12-4970-931d-659e489369f4).

So this refinement **converged PDF onto Word's default behaviour** rather than diverging from it — both branches match; the only residual difference is the exhausted case (Word searches forward to document end, PDF falls back to the document title), stated explicitly instead of claiming full parity.

The same wrong claim existed in `docx-engine.md` (from spec 006), including in a manual Word verification step that would have had a human confirm the wrong thing — both fixed. Also noted: `collectStylerefFields` does not parse field switches, so `\l` is ignored by the scanner (harmless — the field instruction reaches Word byte-exactly).

## Verification
`bun test` 2815 pass / 0 fail · typecheck (incl. uncached extension) · check:browser · hardcoding ledger · `PRE_MIGRATION_DIGEST` unchanged · `docs:check` 0 errors · 17 running-head tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)