### PR TITLE
test(e2e): live-resource naming, run-id ownership marker & recovery sweeper (spec 011)

### DIFF
--- a/.github/workflows/e2e-nightly.yml
+++ b/.github/workflows/e2e-nightly.yml
@@ -1,0 +1,104 @@
+# Nightly live-tenant E2E (spec 011 "E2E resource discipline").
+#
+# WHY NIGHTLY AND NEVER PER-PR
+# ----------------------------
+# Everything in this workflow talks to the real Atlassian Cloud tenant:
+#
+#   * Rate limits — every case spends real REST budget shared with human users
+#     of the tenant. A per-PR trigger would multiply that by the PR rate.
+#   * Space history — created and deleted pages leave permanent entries in the
+#     DOCSY page history and in activity feeds. Cheap once a night, noise if it
+#     runs on every push.
+#   * Credentials — the tenant token is a repository secret. Fork PRs must
+#     never see it, which per-PR triggers cannot guarantee (`pull_request_target`
+#     would leak it). So: `schedule` and `workflow_dispatch` only, main only,
+#     and an explicit repository guard so forks running this file get nothing.
+#
+# RESOURCE DISCIPLINE
+# -------------------
+# Each E2E case cleans up after itself in a `finally` block
+# (`apps/cli/src/e2e/resources.ts`), so the tenant is already clean when the
+# test step ends. The sweeper below is RECOVERY ONLY, for what a crashed
+# process or a cancelled job could not delete — which is why it runs with
+# `if: always()`.
+#
+# The sweeper only ever deletes resources carrying the `atlcli-e2e-run-id`
+# ownership marker, following the `atlcli-e2e-<feature>-<timestamp>` naming
+# convention, older than 24 h, in space DOCSY / project ATLCLI, and it aborts
+# fail-closed if it ever selects more than 50 resources. Deliberately retained
+# DOCSY fixtures carry no marker and are therefore unreachable.
+#
+# See: src/content/docs/contributing.md — "E2E resources"
+
+name: E2E Nightly
+
+on:
+  schedule:
+    # 03:17 UTC — off the hour to avoid the GitHub-wide cron stampede.
+    - cron: "17 3 * * *"
+  workflow_dispatch:
+
+# Live tenant writes must never overlap: two concurrent sweeps or two concurrent
+# E2E runs would race for the same DOCSY fixtures.
+concurrency:
+  group: e2e-nightly
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  e2e:
+    name: Live E2E + recovery sweep
+    runs-on: ubuntu-latest
+    # Never on forks (they have no secrets and must not be handed any), and
+    # never off main.
+    if: github.repository == 'BjoernSchotte/atlcli' && github.ref == 'refs/heads/main'
+    timeout-minutes: 45
+
+    env:
+      ATLCLI_E2E: "1"
+      ATLCLI_E2E_PROFILE: mayflower
+      ATLCLI_BASE_URL: ${{ secrets.ATLCLI_E2E_BASE_URL }}
+      ATLCLI_EMAIL: ${{ secrets.ATLCLI_E2E_EMAIL }}
+      ATLCLI_API_TOKEN: ${{ secrets.ATLCLI_E2E_API_TOKEN }}
+      ATLCLI_E2E_PAGE_ID: ${{ vars.ATLCLI_E2E_PAGE_ID }}
+      ATLCLI_E2E_TREE_ROOT_ID: ${{ vars.ATLCLI_E2E_TREE_ROOT_ID }}
+      ATLCLI_DISABLE_UPDATE_CHECK: "1"
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.5
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Verify tenant credentials are present
+        run: |
+          if [ -z "$ATLCLI_BASE_URL" ] || [ -z "$ATLCLI_API_TOKEN" ]; then
+            echo "::error::ATLCLI_E2E_BASE_URL / ATLCLI_E2E_API_TOKEN secrets are not configured."
+            exit 1
+          fi
+
+      # The E2E suites are gated behind ATLCLI_E2E=1 and skip themselves
+      # otherwise, so this step is a no-op for anyone running it without a tenant.
+      - name: Run live E2E cases
+        id: e2e
+        run: bun --conditions=development test apps/cli/src/commands/*.e2e.test.ts
+
+      # RECOVERY ONLY. Runs even when the E2E step failed or was cancelled —
+      # that is exactly the case where per-test `finally` cleanup did not get to
+      # run and residue is left behind.
+      - name: Recovery sweep of E2E residue
+        if: always()
+        run: bun apps/cli/src/e2e/cleanup.ts --force --profile mayflower
+
+      # A dry run of the same query, published as a log, so an operator can see
+      # what the sweeper considered protected and why.
+      - name: Report remaining E2E residue
+        if: always()
+        run: bun apps/cli/src/e2e/cleanup.ts --profile mayflower

--- a/apps/cli/src/commands/auth.test.ts
+++ b/apps/cli/src/commands/auth.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
+import { describe, test, expect, afterAll, beforeEach, afterEach, mock } from "bun:test";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -41,6 +41,15 @@ const { ERROR_CODES, getFlag, hasFlag, normalizeBaseUrl, slugify } = utils;
  * factory always carries the full real surface plus the intended overrides.
  */
 const actualCore = await import("@atlcli/core");
+
+/**
+ * A snapshot of the REAL exports, taken before `mock.module` runs.
+ *
+ * `actualCore` is a live module namespace, so spreading it *after* mocking
+ * would copy the stubs back out again. This eager copy is what `afterAll`
+ * below restores.
+ */
+const realCoreSnapshot = { ...actualCore };
 
 let config: Config;
 
@@ -117,6 +126,18 @@ mock.module("@atlcli/core", () => ({
 }));
 
 const { handleAuth } = await import("./auth.js");
+
+/**
+ * `mock.module` mutates the PROCESS-WIDE module registry, so these overrides
+ * outlive this file and leak into every test that runs after it. The
+ * `getLogger` stub above is the sharpest edge: it returns a logger with only an
+ * `auth` method, so any later test exercising a real API client dies on
+ * `logger.api is not a function`. Put the genuine barrel back when this file is
+ * done.
+ */
+afterAll(() => {
+  mock.module("@atlcli/core", () => realCoreSnapshot);
+});
 
 const opts = { json: true };
 

--- a/apps/cli/src/commands/helloworld.test.ts
+++ b/apps/cli/src/commands/helloworld.test.ts
@@ -1,11 +1,23 @@
-import { describe, expect, test, mock, beforeEach } from "bun:test";
+import { describe, expect, test, mock, afterAll, beforeEach } from "bun:test";
 import type { OutputOptions } from "@atlcli/core";
 
 const outputMock = mock<(data: unknown, opts: OutputOptions) => void>(() => {});
 
+// Spread the real barrel rather than replacing it: when `@atlcli/core` has not
+// been evaluated yet, Bun treats the factory result as the COMPLETE export set,
+// so a bare `{ output }` would make every other export vanish for this process.
+const actualCore = { ...(await import("@atlcli/core")) };
+
 mock.module("@atlcli/core", () => ({
+  ...actualCore,
   output: outputMock,
 }));
+
+// `mock.module` is process-wide; restore the genuine barrel so this stub does
+// not leak into later test files.
+afterAll(() => {
+  mock.module("@atlcli/core", () => actualCore);
+});
 
 const { handleHelloworld } = await import("./helloworld");
 

--- a/apps/cli/src/commands/session-guard.test.ts
+++ b/apps/cli/src/commands/session-guard.test.ts
@@ -1,7 +1,22 @@
-import { describe, test, expect, beforeEach, mock } from "bun:test";
+import { describe, test, expect, afterAll, beforeEach, mock } from "bun:test";
 
 const utils = await import("../../../../packages/core/src/utils");
 const { ERROR_CODES, getFlag, hasFlag } = utils;
+
+// `mock.module` mutates the process-wide module registry, so without restoring
+// it these stubs leak into every test file that runs after this one — silently
+// replacing `@atlcli/core` with the handful of names stubbed below and making
+// the real clients throw on construction. Capture the genuine modules first and
+// put them back in `afterAll`.
+const realCore = { ...(await import("@atlcli/core")) };
+const realConfluence = { ...(await import("@atlcli/confluence")) };
+const realJira = { ...(await import("@atlcli/jira")) };
+
+afterAll(() => {
+  mock.module("@atlcli/core", () => realCore);
+  mock.module("@atlcli/confluence", () => realConfluence);
+  mock.module("@atlcli/jira", () => realJira);
+});
 
 type Profile = {
   name: string;

--- a/apps/cli/src/e2e/cleanup.test.ts
+++ b/apps/cli/src/e2e/cleanup.test.ts
@@ -19,7 +19,8 @@ import { MemoryConfluence, MemoryJira } from "./memory-ports.js";
 import {
   DEFAULT_MAX_DELETES,
   DEFAULT_PROFILE,
-  assertMarked,
+  MIN_TTL_HOURS,
+  assertSweepable,
   classifyCandidate,
   executeSweep,
   parseSweeperArgs,
@@ -74,7 +75,70 @@ describe("sweeper safety (a): the ownership marker is required", () => {
     // The types make this unreachable from `planSweep`; the runtime assertion
     // covers a caller casting their own SweepTarget together.
     const forged = { id: "p1", name: agedTitle("x", 48 * HOUR), scope: E2E_SPACE_KEY, runId: "" };
-    expect(() => assertMarked(forged)).toThrow(/no atlcli-e2e-run-id ownership marker/);
+    expect(() => assertSweepable(forged, pagePlanOptions)).toThrow(/no-marker/);
+  });
+});
+
+describe("the delete-site assertion re-runs every gate, not just the marker", () => {
+  // A marker check alone would let a forged runId on an off-convention name
+  // through — i.e. a retained fixture — which is what the module header claims
+  // is structurally impossible.
+  const gates: Array<[string, SweepCandidate & { runId: string }, string]> = [
+    [
+      "a retained fixture with a forged marker",
+      { id: "1117356071", name: "DOCX Feature Zoo E2E", scope: E2E_SPACE_KEY, runId: "gha-forged" },
+      "name-mismatch",
+    ],
+    [
+      "a marked, well-named page from another space",
+      { id: "p1", name: agedTitle("x", 48 * HOUR), scope: "ENGINEERING", runId: "gha-1" },
+      "wrong-scope",
+    ],
+    [
+      "a marked, well-named page still inside its TTL",
+      { id: "p2", name: agedTitle("x", HOUR), scope: E2E_SPACE_KEY, runId: "gha-1" },
+      "within-ttl",
+    ],
+  ];
+
+  for (const [label, target, reason] of gates) {
+    it(`refuses ${label}`, () => {
+      expect(() => assertSweepable(target, pagePlanOptions)).toThrow(new RegExp(reason));
+    });
+  }
+
+  it("lets a genuinely sweepable target through", () => {
+    expect(() => assertSweepable(sweepableCandidate() as never, pagePlanOptions)).not.toThrow();
+  });
+
+  it("blocks a hand-assembled plan aimed at a retained fixture", async () => {
+    // The reviewer's probe: build a plan by hand (bypassing planSweep) that
+    // targets retained page 1117356071 with a forged marker, and hand it to the
+    // executor. It must not delete.
+    const deleted: string[] = [];
+    const plan = {
+      kind: "page" as const,
+      scope: E2E_SPACE_KEY,
+      targets: [
+        { id: "1117356071", name: "DOCX Feature Zoo E2E", scope: E2E_SPACE_KEY, runId: "gha-forged" },
+      ],
+      skipped: [],
+      maxDeletes: DEFAULT_MAX_DELETES,
+      circuitBreakerTripped: false,
+      now: NOW,
+      ttlMs: E2E_TTL_MS,
+    };
+
+    await expect(
+      executeSweep({
+        plan,
+        force: true,
+        deleteResource: async (target) => {
+          deleted.push(target.id);
+        },
+      })
+    ).rejects.toThrow(/name-mismatch/);
+    expect(deleted).toEqual([]);
   });
 
   it("deletes nothing from a space made entirely of unmarked pages", async () => {
@@ -435,9 +499,73 @@ describe("sweeper argument parsing", () => {
   it("fails closed on typos and malformed values rather than guessing", () => {
     expect(() => parseSweeperArgs(["--forse"])).toThrow(/Unknown argument/);
     expect(() => parseSweeperArgs(["-f"])).toThrow(/Unknown argument/);
-    expect(() => parseSweeperArgs(["--ttl-hours", "soon"])).toThrow(/non-negative number/);
+    expect(() => parseSweeperArgs(["--ttl-hours", "soon"])).toThrow(/at least/);
     expect(() => parseSweeperArgs(["--max-deletes", "-1"])).toThrow(/non-negative integer/);
     expect(() => parseSweeperArgs(["--profile"])).toThrow(/requires a value/);
+  });
+
+  it("warns in the help text that --profile selects the tenant, which the name lock does not cover", () => {
+    expect(sweeperHelp()).toMatch(/--profile.*selects the TENANT/s);
+  });
+});
+
+describe("the TTL gate cannot be switched off from the command line", () => {
+  // `--ttl-hours 0 --force` used to delete a page a DIFFERENT run had created
+  // seconds earlier — defeating the gate's entire stated purpose.
+  it("rejects a zero or sub-hour TTL", () => {
+    expect(() => parseSweeperArgs(["--ttl-hours", "0"])).toThrow(/cannot be disabled/);
+    expect(() => parseSweeperArgs(["--ttl-hours=0"])).toThrow(/cannot be disabled/);
+    expect(() => parseSweeperArgs(["--ttl-hours", "0.5"])).toThrow(/cannot be disabled/);
+    expect(() => parseSweeperArgs(["--ttl-hours", "-5"])).toThrow(/cannot be disabled/);
+  });
+
+  it("allows the TTL to be raised — being more patient is always safe", () => {
+    expect(parseSweeperArgs(["--ttl-hours", "72"]).ttlMs).toBe(72 * HOUR);
+    expect(parseSweeperArgs([`--ttl-hours=${MIN_TTL_HOURS}`]).ttlMs).toBe(MIN_TTL_HOURS * HOUR);
+  });
+
+  it("still protects a freshly created page at the lowest permitted TTL", async () => {
+    const confluence = new MemoryConfluence();
+    confluence.seed({ title: agedTitle("other-run", 5_000), spaceKey: E2E_SPACE_KEY, runId: "gha-other" });
+
+    await runSweep({
+      confluence,
+      args: { force: true, ttlMs: MIN_TTL_HOURS * HOUR, maxDeletes: DEFAULT_MAX_DELETES },
+      now: NOW,
+      log: () => {},
+    });
+
+    expect(confluence.deleteLog).toEqual([]);
+  });
+});
+
+describe("the circuit breaker cannot be raised from the command line", () => {
+  // Raising the limit is the obvious reflex right after seeing an abort — i.e.
+  // exactly when a bad query is the likeliest explanation.
+  it("refuses a limit above the built-in ceiling", () => {
+    expect(() => parseSweeperArgs(["--max-deletes", "1000000"])).toThrow(/may not exceed/);
+    expect(() => parseSweeperArgs([`--max-deletes=${DEFAULT_MAX_DELETES + 1}`])).toThrow(/may not exceed/);
+  });
+
+  it("allows the limit to be lowered", () => {
+    expect(parseSweeperArgs(["--max-deletes", "5"]).maxDeletes).toBe(5);
+    expect(parseSweeperArgs(["--max-deletes", "0"]).maxDeletes).toBe(0);
+    expect(parseSweeperArgs([`--max-deletes=${DEFAULT_MAX_DELETES}`]).maxDeletes).toBe(DEFAULT_MAX_DELETES);
+  });
+
+  it("still aborts on a 500-page sweep, because the ceiling cannot be argued away", async () => {
+    const confluence = new MemoryConfluence();
+    for (let i = 0; i < 500; i++) {
+      confluence.seed({ title: agedTitle(`stale-${i}`, 48 * HOUR), spaceKey: E2E_SPACE_KEY, runId: "gha-1" });
+    }
+
+    // The largest limit the parser will hand back.
+    const args = parseSweeperArgs(["--force", `--max-deletes=${DEFAULT_MAX_DELETES}`]);
+    const code = await runSweep({ confluence, args, now: NOW, log: () => {} });
+
+    expect(code).toBe(2);
+    expect(confluence.deleteLog).toEqual([]);
+    expect(confluence.pages.size).toBe(500);
   });
 });
 

--- a/apps/cli/src/e2e/cleanup.test.ts
+++ b/apps/cli/src/e2e/cleanup.test.ts
@@ -1,0 +1,482 @@
+/**
+ * Safety tests for the E2E recovery sweeper (spec 011 "E2E resource
+ * discipline").
+ *
+ * The sweeper deletes real content in a real space, so each of its four safety
+ * properties gets its own explicit proof here:
+ *
+ *   (a) it requires the `atlcli-e2e-run-id` ownership marker,
+ *   (b) it honors the 24 h TTL,
+ *   (c) it is a dry run unless `--force` is given,
+ *   (d) it never touches anything outside space `DOCSY` / project `ATLCLI`,
+ *
+ * plus the max-delete circuit breaker. Everything runs against in-memory port
+ * implementations — real implementations of the designed ports, not mocks.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { MemoryConfluence, MemoryJira } from "./memory-ports.js";
+import {
+  DEFAULT_MAX_DELETES,
+  DEFAULT_PROFILE,
+  assertMarked,
+  classifyCandidate,
+  executeSweep,
+  parseSweeperArgs,
+  planSweep,
+  resolveSweeperProfile,
+  runSweep,
+  sweeperHelp,
+  toIssueCandidate,
+  toPageCandidate,
+  type SweepCandidate,
+} from "./cleanup.js";
+import { E2E_PROJECT_KEY, E2E_SPACE_KEY, E2E_TTL_MS } from "./resources.js";
+
+const NOW = 1_789_000_000_000; // ms
+const HOUR = 60 * 60 * 1000;
+
+/** A name whose encoded timestamp is `ageMs` old relative to NOW. */
+function agedTitle(feature: string, ageMs: number): string {
+  return `atlcli-e2e-${feature}-${Math.floor((NOW - ageMs) / 1000)}`;
+}
+
+/** A candidate that passes every gate, so individual tests can break exactly one. */
+function sweepableCandidate(overrides: Partial<SweepCandidate> = {}): SweepCandidate {
+  return {
+    id: "page-1",
+    name: agedTitle("scope-tree", 48 * HOUR),
+    scope: E2E_SPACE_KEY,
+    runId: "gha-12345",
+    ...overrides,
+  };
+}
+
+const pagePlanOptions = { scope: E2E_SPACE_KEY, now: NOW, ttlMs: E2E_TTL_MS };
+
+describe("sweeper safety (a): the ownership marker is required", () => {
+  it("never selects a page that carries no marker, however perfect its name", () => {
+    const candidate = sweepableCandidate({ runId: undefined });
+    expect(classifyCandidate(candidate, pagePlanOptions)).toBe("no-marker");
+
+    const plan = planSweep("page", [candidate], pagePlanOptions);
+    expect(plan.targets).toEqual([]);
+    expect(plan.skipped).toEqual([{ candidate, reason: "no-marker" }]);
+  });
+
+  it("treats an empty or whitespace marker as no marker at all", () => {
+    for (const runId of ["", "   "]) {
+      expect(classifyCandidate(sweepableCandidate({ runId }), pagePlanOptions)).toBe("no-marker");
+    }
+  });
+
+  it("refuses at the delete site too, if a target is hand-built past the type system", () => {
+    // The types make this unreachable from `planSweep`; the runtime assertion
+    // covers a caller casting their own SweepTarget together.
+    const forged = { id: "p1", name: agedTitle("x", 48 * HOUR), scope: E2E_SPACE_KEY, runId: "" };
+    expect(() => assertMarked(forged)).toThrow(/no atlcli-e2e-run-id ownership marker/);
+  });
+
+  it("deletes nothing from a space made entirely of unmarked pages", async () => {
+    const confluence = new MemoryConfluence();
+    for (let i = 0; i < 10; i++) {
+      confluence.seed({ title: agedTitle(`unmarked-${i}`, 72 * HOUR), spaceKey: E2E_SPACE_KEY });
+    }
+
+    const code = await runSweep({
+      confluence,
+      args: { force: true, ttlMs: E2E_TTL_MS, maxDeletes: DEFAULT_MAX_DELETES },
+      now: NOW,
+      log: () => {},
+    });
+
+    expect(code).toBe(0);
+    expect(confluence.deleteLog).toEqual([]);
+    expect(confluence.pages.size).toBe(10);
+  });
+});
+
+describe("sweeper safety (b): the TTL is honored", () => {
+  it("protects a resource younger than the TTL", () => {
+    const fresh = sweepableCandidate({ name: agedTitle("scope-tree", 1 * HOUR) });
+    expect(classifyCandidate(fresh, pagePlanOptions)).toBe("within-ttl");
+  });
+
+  it("protects a resource created seconds ago by a still-running E2E", () => {
+    const running = sweepableCandidate({ name: agedTitle("scope-tree", 5_000) });
+    expect(classifyCandidate(running, pagePlanOptions)).toBe("within-ttl");
+  });
+
+  it("selects a resource older than the TTL", () => {
+    const stale = sweepableCandidate({ name: agedTitle("scope-tree", 25 * HOUR) });
+    expect(classifyCandidate(stale, pagePlanOptions)).toBeNull();
+  });
+
+  it("treats the TTL boundary as exclusive — exactly 24 h old is still protected", () => {
+    const boundary = sweepableCandidate({ name: agedTitle("scope-tree", E2E_TTL_MS) });
+    expect(classifyCandidate(boundary, pagePlanOptions)).toBe("within-ttl");
+  });
+
+  it("does not delete a fresh marked page in a live sweep", async () => {
+    const confluence = new MemoryConfluence();
+    confluence.seed({ title: agedTitle("fresh", 2 * HOUR), spaceKey: E2E_SPACE_KEY, runId: "gha-1" });
+    confluence.seed({ title: agedTitle("stale", 48 * HOUR), spaceKey: E2E_SPACE_KEY, runId: "gha-0" });
+
+    await runSweep({
+      confluence,
+      args: { force: true, ttlMs: E2E_TTL_MS, maxDeletes: DEFAULT_MAX_DELETES },
+      now: NOW,
+      log: () => {},
+    });
+
+    expect([...confluence.pages.values()].map((p) => p.title)).toEqual([agedTitle("fresh", 2 * HOUR)]);
+  });
+});
+
+describe("sweeper safety (c): dry run by default, --force to delete", () => {
+  it("defaults to a dry run", () => {
+    expect(parseSweeperArgs([]).force).toBe(false);
+    expect(parseSweeperArgs(["--dry-run"]).force).toBe(false);
+    expect(parseSweeperArgs(["--force"]).force).toBe(true);
+  });
+
+  it("performs zero deletions without --force, but reports what it would delete", async () => {
+    const confluence = new MemoryConfluence();
+    const doomed = confluence.seed({
+      title: agedTitle("stale", 48 * HOUR),
+      spaceKey: E2E_SPACE_KEY,
+      runId: "gha-1",
+    });
+    const lines: string[] = [];
+
+    const code = await runSweep({
+      confluence,
+      args: { force: false, ttlMs: E2E_TTL_MS, maxDeletes: DEFAULT_MAX_DELETES },
+      now: NOW,
+      log: (message) => lines.push(message),
+    });
+
+    expect(code).toBe(0);
+    expect(confluence.deleteLog).toEqual([]);
+    expect(confluence.pages.size).toBe(1);
+    expect(lines.join("\n")).toContain("DRY RUN");
+    expect(lines.join("\n")).toContain(doomed.id);
+  });
+
+  it("actually deletes with --force", async () => {
+    const confluence = new MemoryConfluence();
+    const jira = new MemoryJira();
+    const page = confluence.seed({ title: agedTitle("stale", 48 * HOUR), spaceKey: E2E_SPACE_KEY, runId: "gha-1" });
+    const issue = jira.seed({ summary: agedTitle("stale", 48 * HOUR), projectKey: E2E_PROJECT_KEY, runId: "gha-1" });
+
+    const code = await runSweep({
+      confluence,
+      jira,
+      args: { force: true, ttlMs: E2E_TTL_MS, maxDeletes: DEFAULT_MAX_DELETES },
+      now: NOW,
+      log: () => {},
+    });
+
+    expect(code).toBe(0);
+    expect(confluence.deleteLog).toEqual([page.id]);
+    expect(jira.deleteLog).toEqual([issue.key]);
+  });
+
+  it("exits non-zero when a deletion fails, so a broken sweep is visible", async () => {
+    const confluence = new MemoryConfluence();
+    const page = confluence.seed({ title: agedTitle("stale", 48 * HOUR), spaceKey: E2E_SPACE_KEY, runId: "gha-1" });
+    confluence.failDeletesFor.add(page.id);
+
+    const code = await runSweep({
+      confluence,
+      args: { force: true, ttlMs: E2E_TTL_MS, maxDeletes: DEFAULT_MAX_DELETES },
+      now: NOW,
+      log: () => {},
+    });
+
+    expect(code).toBe(1);
+  });
+});
+
+describe("sweeper safety (d): scope is locked to DOCSY / ATLCLI", () => {
+  it("never selects a marked, stale, correctly named page from another space", () => {
+    const foreign = sweepableCandidate({ scope: "ENGINEERING" });
+    expect(classifyCandidate(foreign, pagePlanOptions)).toBe("wrong-scope");
+    expect(planSweep("page", [foreign], pagePlanOptions).targets).toEqual([]);
+  });
+
+  it("never selects an issue from another project", () => {
+    const foreign = { id: "OTHER-9", name: agedTitle("stale", 48 * HOUR), scope: "OTHER", runId: "gha-1" };
+    expect(classifyCandidate(foreign, { scope: E2E_PROJECT_KEY, now: NOW, ttlMs: E2E_TTL_MS })).toBe("wrong-scope");
+  });
+
+  it("fails closed when the API omits the space key", () => {
+    expect(classifyCandidate(sweepableCandidate({ scope: "" }), pagePlanOptions)).toBe("wrong-scope");
+  });
+
+  it("offers no CLI flag that could widen the scope", () => {
+    expect(() => parseSweeperArgs(["--space", "ENGINEERING"])).toThrow(/Unknown argument/);
+    expect(() => parseSweeperArgs(["--project", "OTHER"])).toThrow(/Unknown argument/);
+    expect(sweeperHelp()).toContain(E2E_SPACE_KEY);
+    expect(sweeperHelp()).toContain(E2E_PROJECT_KEY);
+  });
+
+  it("only ever lists from the locked scopes", async () => {
+    const confluence = new MemoryConfluence();
+    confluence.seed({ title: agedTitle("stale", 48 * HOUR), spaceKey: "ENGINEERING", runId: "gha-1" });
+    const inScope = confluence.seed({
+      title: agedTitle("stale", 48 * HOUR),
+      spaceKey: E2E_SPACE_KEY,
+      runId: "gha-1",
+    });
+
+    await runSweep({
+      confluence,
+      args: { force: true, ttlMs: E2E_TTL_MS, maxDeletes: DEFAULT_MAX_DELETES },
+      now: NOW,
+      log: () => {},
+    });
+
+    expect(confluence.deleteLog).toEqual([inScope.id]);
+  });
+});
+
+describe("max-delete circuit breaker", () => {
+  it("trips when the plan exceeds the limit", () => {
+    const candidates = Array.from({ length: 51 }, (_, i) =>
+      sweepableCandidate({ id: `p${i}`, name: agedTitle(`stale-${i}`, 48 * HOUR) })
+    );
+    const plan = planSweep("page", candidates, { ...pagePlanOptions, maxDeletes: 50 });
+    expect(plan.circuitBreakerTripped).toBe(true);
+  });
+
+  it("does not trip exactly at the limit", () => {
+    const candidates = Array.from({ length: 50 }, (_, i) =>
+      sweepableCandidate({ id: `p${i}`, name: agedTitle(`stale-${i}`, 48 * HOUR) })
+    );
+    expect(planSweep("page", candidates, { ...pagePlanOptions, maxDeletes: 50 }).circuitBreakerTripped).toBe(false);
+  });
+
+  it("deletes NOTHING at all when tripped — not even up to the limit", async () => {
+    const confluence = new MemoryConfluence();
+    for (let i = 0; i < 51; i++) {
+      confluence.seed({ title: agedTitle(`stale-${i}`, 48 * HOUR), spaceKey: E2E_SPACE_KEY, runId: "gha-1" });
+    }
+
+    const code = await runSweep({
+      confluence,
+      args: { force: true, ttlMs: E2E_TTL_MS, maxDeletes: 50 },
+      now: NOW,
+      log: () => {},
+    });
+
+    expect(code).toBe(2);
+    expect(confluence.deleteLog).toEqual([]);
+    expect(confluence.pages.size).toBe(51);
+  });
+
+  it("aborts the whole sweep, so a tripped page plan also blocks issue deletion", async () => {
+    const confluence = new MemoryConfluence();
+    const jira = new MemoryJira();
+    for (let i = 0; i < 51; i++) {
+      confluence.seed({ title: agedTitle(`stale-${i}`, 48 * HOUR), spaceKey: E2E_SPACE_KEY, runId: "gha-1" });
+    }
+    jira.seed({ summary: agedTitle("stale", 48 * HOUR), projectKey: E2E_PROJECT_KEY, runId: "gha-1" });
+
+    const code = await runSweep({
+      confluence,
+      jira,
+      args: { force: true, ttlMs: E2E_TTL_MS, maxDeletes: 50 },
+      now: NOW,
+      log: () => {},
+    });
+
+    expect(code).toBe(2);
+    expect(jira.deleteLog).toEqual([]);
+  });
+
+  it("reports the tripped plan as a dry run so an operator can see the query blew up", async () => {
+    const plan = planSweep(
+      "page",
+      Array.from({ length: 3 }, (_, i) => sweepableCandidate({ id: `p${i}` })),
+      { ...pagePlanOptions, maxDeletes: 2 }
+    );
+    const lines: string[] = [];
+    const result = await executeSweep({
+      plan,
+      force: true,
+      deleteResource: async () => {
+        throw new Error("must never be called");
+      },
+      log: (message) => lines.push(message),
+    });
+
+    expect(result.aborted).toBe(true);
+    expect(result.deleted).toEqual([]);
+    expect(result.wouldDelete).toHaveLength(3);
+    expect(lines.join("\n")).toContain("ABORT");
+  });
+});
+
+describe("deliberately retained DOCSY fixtures stay safe", () => {
+  // These exist in the real DOCSY space and must survive every sweep. None of
+  // them carries the marker, so gate (a) alone is enough — but the naming gate
+  // rejects them first, which is why the sweeper never even reads a property
+  // for them.
+  const retained = [
+    { id: "1117356071", title: "DOCX Feature Zoo E2E" },
+    { id: "1118437396", title: "Spec-005 Logo & Image E2E (temp)" },
+    { id: "1125482517", title: "M1 Abnahme" },
+    ...Array.from({ length: 57 }, (_, i) => ({ id: `m1-${i}`, title: `M1 Abnahme ${i + 1}` })),
+  ];
+
+  it("classifies every retained fixture as protected", () => {
+    for (const fixture of retained) {
+      const candidate: SweepCandidate = { id: fixture.id, name: fixture.title, scope: E2E_SPACE_KEY };
+      expect(classifyCandidate(candidate, pagePlanOptions)).toBe("name-mismatch");
+    }
+  });
+
+  it("protects them even if something stamped a marker on them by accident", () => {
+    for (const fixture of retained) {
+      const candidate: SweepCandidate = {
+        id: fixture.id,
+        name: fixture.title,
+        scope: E2E_SPACE_KEY,
+        runId: "gha-99999",
+      };
+      expect(classifyCandidate(candidate, pagePlanOptions)).toBe("name-mismatch");
+    }
+  });
+
+  it("survives a forced sweep of a space that also contains real residue", async () => {
+    const confluence = new MemoryConfluence();
+    for (const fixture of retained) {
+      confluence.seed({ id: fixture.id, title: fixture.title, spaceKey: E2E_SPACE_KEY });
+    }
+    const residue = confluence.seed({
+      title: agedTitle("crashed-run", 48 * HOUR),
+      spaceKey: E2E_SPACE_KEY,
+      runId: "gha-crashed",
+    });
+
+    await runSweep({
+      confluence,
+      args: { force: true, ttlMs: E2E_TTL_MS, maxDeletes: DEFAULT_MAX_DELETES },
+      now: NOW,
+      log: () => {},
+    });
+
+    expect(confluence.deleteLog).toEqual([residue.id]);
+    for (const fixture of retained) {
+      expect(confluence.pages.has(fixture.id)).toBe(true);
+    }
+  });
+});
+
+describe("planning helpers", () => {
+  it("projects page and issue records onto the same candidate shape", () => {
+    expect(toPageCandidate({ id: "1", title: "t", spaceKey: "DOCSY", runId: "r" })).toEqual({
+      id: "1",
+      name: "t",
+      scope: "DOCSY",
+      runId: "r",
+    });
+    expect(toIssueCandidate({ key: "ATLCLI-1", summary: "s", projectKey: "ATLCLI" })).toEqual({
+      id: "ATLCLI-1",
+      name: "s",
+      scope: "ATLCLI",
+      runId: undefined,
+    });
+  });
+
+  it("records a skip reason for every rejected candidate", () => {
+    const plan = planSweep(
+      "page",
+      [
+        sweepableCandidate({ id: "ok" }),
+        sweepableCandidate({ id: "young", name: agedTitle("x", HOUR) }),
+        sweepableCandidate({ id: "unmarked", runId: undefined }),
+        sweepableCandidate({ id: "foreign", scope: "OTHER" }),
+        sweepableCandidate({ id: "human", name: "Release notes 2026" }),
+      ],
+      pagePlanOptions
+    );
+
+    expect(plan.targets.map((t) => t.id)).toEqual(["ok"]);
+    expect(plan.skipped.map((s) => [s.candidate.id, s.reason])).toEqual([
+      ["young", "within-ttl"],
+      ["unmarked", "no-marker"],
+      ["foreign", "wrong-scope"],
+      ["human", "name-mismatch"],
+    ]);
+  });
+});
+
+describe("sweeper argument parsing", () => {
+  it("defaults to the mayflower profile, a 24 h TTL and a 50-resource breaker", () => {
+    const args = parseSweeperArgs([]);
+    expect(args).toEqual({
+      force: false,
+      profile: DEFAULT_PROFILE,
+      ttlMs: E2E_TTL_MS,
+      maxDeletes: DEFAULT_MAX_DELETES,
+    });
+  });
+
+  it("accepts both --flag value and --flag=value", () => {
+    expect(parseSweeperArgs(["--profile", "other"]).profile).toBe("other");
+    expect(parseSweeperArgs(["--profile=other"]).profile).toBe("other");
+    expect(parseSweeperArgs(["--ttl-hours", "48"]).ttlMs).toBe(48 * HOUR);
+    expect(parseSweeperArgs(["--ttl-hours=48"]).ttlMs).toBe(48 * HOUR);
+    expect(parseSweeperArgs(["--max-deletes=10"]).maxDeletes).toBe(10);
+  });
+
+  it("fails closed on typos and malformed values rather than guessing", () => {
+    expect(() => parseSweeperArgs(["--forse"])).toThrow(/Unknown argument/);
+    expect(() => parseSweeperArgs(["-f"])).toThrow(/Unknown argument/);
+    expect(() => parseSweeperArgs(["--ttl-hours", "soon"])).toThrow(/non-negative number/);
+    expect(() => parseSweeperArgs(["--max-deletes", "-1"])).toThrow(/non-negative integer/);
+    expect(() => parseSweeperArgs(["--profile"])).toThrow(/requires a value/);
+  });
+});
+
+describe("resolveSweeperProfile", () => {
+  const configured = {
+    profiles: {
+      mayflower: {
+        name: "mayflower",
+        baseUrl: "https://example.atlassian.net",
+        auth: { type: "apiToken" as const, email: "a@b.c" },
+      },
+    },
+  };
+
+  it("prefers a configured profile", () => {
+    expect(resolveSweeperProfile(configured, "mayflower", {})?.baseUrl).toBe("https://example.atlassian.net");
+  });
+
+  it("falls back to env vars so CI never writes credentials to disk", () => {
+    const profile = resolveSweeperProfile({ profiles: {} }, "mayflower", {
+      ATLCLI_BASE_URL: "https://ci.atlassian.net",
+      ATLCLI_EMAIL: "ci@example.com",
+    });
+    expect(profile).toEqual({
+      name: "mayflower",
+      baseUrl: "https://ci.atlassian.net",
+      auth: { type: "apiToken", email: "ci@example.com" },
+    });
+  });
+
+  it("never stores the token in the profile — it is resolved from the environment", () => {
+    const profile = resolveSweeperProfile({ profiles: {} }, "mayflower", {
+      ATLCLI_BASE_URL: "https://ci.atlassian.net",
+      ATLCLI_API_TOKEN: "super-secret",
+    });
+    expect(JSON.stringify(profile)).not.toContain("super-secret");
+  });
+
+  it("returns null when neither a profile nor a base URL is available", () => {
+    expect(resolveSweeperProfile({ profiles: {} }, "mayflower", {})).toBeNull();
+  });
+});

--- a/apps/cli/src/e2e/cleanup.ts
+++ b/apps/cli/src/e2e/cleanup.ts
@@ -1,0 +1,490 @@
+#!/usr/bin/env bun
+/**
+ * Nightly **recovery** sweeper for live E2E residue (spec 011 "E2E resource
+ * discipline").
+ *
+ * This is not the primary cleanup mechanism. Every E2E test deletes what it
+ * created in a `finally` block ({@link withE2eResources} in `./resources.ts`),
+ * so the tenant is already clean after a normal run. This script exists for the
+ * abnormal ones: a crashed process, a killed CI job, a machine that went away
+ * mid-test.
+ *
+ * ## Safety design
+ *
+ * The sweeper deletes real customer-visible content, so it is built to be
+ * *structurally* incapable of deleting anything it cannot prove it owns. Four
+ * independent gates, each covered by a test in `./cleanup.test.ts`:
+ *
+ *  1. **Marker required.** A resource is only ever a deletion target if it
+ *     carries the `atlcli-e2e-run-id` property. The name is not evidence.
+ *     Enforced in the type system: {@link planSweep} only ever emits
+ *     {@link SweepTarget}s, whose `runId` is a required `string`, and
+ *     {@link executeSweep} accepts nothing else — an unmarked
+ *     {@link SweepCandidate} cannot be passed to the deleter without a type
+ *     error, and {@link assertMarked} re-checks at runtime.
+ *  2. **TTL honored.** Resources younger than 24 h are never touched, so a
+ *     currently-running E2E is never swept out from under itself.
+ *  3. **Dry-run by default.** Without `--force` the script only prints what it
+ *     *would* delete and performs zero deletions.
+ *  4. **Scope locked.** Only space `DOCSY` and project `ATLCLI`, hardcoded with
+ *     no CLI override; records from any other scope are dropped by the planner.
+ *
+ * Plus a **max-delete circuit breaker** (default 50): if the plan selects more
+ * than that, the whole sweep aborts fail-closed with a non-zero exit and *zero*
+ * deletions, rather than letting a bad query quietly empty the space.
+ *
+ * DOCSY holds deliberately retained fixtures (the DOCX feature zoo, the spec-005
+ * logo/image page, the "M1 Abnahme …" set). None of them carries the marker, so
+ * gate 1 alone makes them unreachable; gates 2 and 4 are belt and braces.
+ *
+ * @example
+ * ```bash
+ * bun apps/cli/src/e2e/cleanup.ts              # dry run — lists, deletes nothing
+ * bun apps/cli/src/e2e/cleanup.ts --force      # actually deletes
+ * ```
+ *
+ * @module
+ */
+
+import { getActiveProfile, loadConfig, type Config, type Profile } from "@atlcli/core";
+import {
+  E2E_PROJECT_KEY,
+  E2E_SPACE_KEY,
+  E2E_TTL_MS,
+  parseE2eTitle,
+  type E2eConfluencePort,
+  type E2eIssueRecord,
+  type E2eJiraPort,
+  type E2ePageRecord,
+} from "./resources.js";
+
+/** Default max resources a single sweep may delete before it aborts fail-closed. */
+export const DEFAULT_MAX_DELETES = 50;
+
+/** Default profile the sweeper authenticates with. */
+export const DEFAULT_PROFILE = "mayflower";
+
+/** A resource the sweeper is *considering*. `runId` may be absent — that is the point. */
+export interface SweepCandidate {
+  /** Confluence page ID or Jira issue key. */
+  id: string;
+  /** Page title or issue summary. */
+  name: string;
+  /** Confluence space key or Jira project key. */
+  scope: string;
+  /** Value of the ownership marker property, if the resource carries one. */
+  runId?: string;
+}
+
+/**
+ * A candidate that has passed every gate.
+ *
+ * The required `runId` is load-bearing: it is what makes it impossible to hand
+ * an unmarked resource to {@link executeSweep}.
+ */
+export interface SweepTarget extends SweepCandidate {
+  runId: string;
+}
+
+/** Why a candidate was not selected. Ordered by the check that rejected it. */
+export type SweepSkipReason = "wrong-scope" | "name-mismatch" | "no-marker" | "within-ttl";
+
+export interface SweepSkip {
+  candidate: SweepCandidate;
+  reason: SweepSkipReason;
+}
+
+export interface SweepPlan {
+  kind: "page" | "issue";
+  scope: string;
+  targets: SweepTarget[];
+  skipped: SweepSkip[];
+  maxDeletes: number;
+  /** True when `targets` exceeded `maxDeletes`. The sweep must then delete nothing. */
+  circuitBreakerTripped: boolean;
+}
+
+export interface PlanSweepOptions {
+  /** The one scope this sweep is allowed to touch. */
+  scope: string;
+  /** Current time in ms since epoch. */
+  now: number;
+  ttlMs?: number;
+  maxDeletes?: number;
+}
+
+/** Project a Confluence page record onto the scope-agnostic candidate shape. */
+export function toPageCandidate(page: E2ePageRecord): SweepCandidate {
+  return { id: page.id, name: page.title, scope: page.spaceKey, runId: page.runId };
+}
+
+/** Project a Jira issue record onto the scope-agnostic candidate shape. */
+export function toIssueCandidate(issue: E2eIssueRecord): SweepCandidate {
+  return { id: issue.key, name: issue.summary, scope: issue.projectKey, runId: issue.runId };
+}
+
+/**
+ * Decide whether a single candidate may be deleted.
+ *
+ * @returns The reason it may not, or `null` when every gate passes.
+ */
+export function classifyCandidate(
+  candidate: SweepCandidate,
+  options: { scope: string; now: number; ttlMs: number }
+): SweepSkipReason | null {
+  // Gate 4 — scope lock. An unknown/absent scope fails closed.
+  if (candidate.scope !== options.scope) return "wrong-scope";
+
+  // Naming convention. Human-authored titles stop here.
+  const parsed = parseE2eTitle(candidate.name);
+  if (!parsed) return "name-mismatch";
+
+  // Gate 1 — the ownership marker. The only actual proof of ownership.
+  if (typeof candidate.runId !== "string" || candidate.runId.trim() === "") return "no-marker";
+
+  // Gate 2 — TTL. Never delete a resource a live run may still be using.
+  // "older than the TTL" is strict: at exactly the TTL the resource is still
+  // protected, so the boundary rounds towards keeping content.
+  const ageMs = options.now - parsed.timestampSeconds * 1000;
+  if (ageMs <= options.ttlMs) return "within-ttl";
+
+  return null;
+}
+
+/**
+ * Turn a candidate list into a deletion plan.
+ *
+ * Pure: no IO, fully unit-testable, and the only way to produce a
+ * {@link SweepTarget}.
+ */
+export function planSweep(
+  kind: "page" | "issue",
+  candidates: SweepCandidate[],
+  options: PlanSweepOptions
+): SweepPlan {
+  const ttlMs = options.ttlMs ?? E2E_TTL_MS;
+  const maxDeletes = options.maxDeletes ?? DEFAULT_MAX_DELETES;
+
+  const targets: SweepTarget[] = [];
+  const skipped: SweepSkip[] = [];
+
+  for (const candidate of candidates) {
+    const reason = classifyCandidate(candidate, { scope: options.scope, now: options.now, ttlMs });
+    if (reason) {
+      skipped.push({ candidate, reason });
+      continue;
+    }
+    // Safe: `classifyCandidate` returning null proves runId is a non-empty string.
+    targets.push({ ...candidate, runId: candidate.runId as string });
+  }
+
+  return {
+    kind,
+    scope: options.scope,
+    targets,
+    skipped,
+    maxDeletes,
+    circuitBreakerTripped: targets.length > maxDeletes,
+  };
+}
+
+/**
+ * Runtime re-assertion of the marker gate.
+ *
+ * The type system already prevents an unmarked candidate from reaching the
+ * deleter; this catches the cast-away case (a caller building a `SweepTarget`
+ * by hand) before any DELETE goes out.
+ */
+export function assertMarked(target: SweepTarget): void {
+  if (typeof target.runId !== "string" || target.runId.trim() === "") {
+    throw new Error(
+      `Refusing to delete ${target.id}: no ${"atlcli-e2e-run-id"} ownership marker. ` +
+        "The sweeper only deletes resources it can prove it owns."
+    );
+  }
+}
+
+export interface SweepExecution {
+  /** Empty on a dry run. */
+  deleted: string[];
+  /** Populated on a dry run: what `--force` would have removed. */
+  wouldDelete: string[];
+  failures: Array<{ id: string; error: string }>;
+  aborted: boolean;
+}
+
+/**
+ * Execute (or, without `force`, merely report) a plan.
+ *
+ * A tripped circuit breaker aborts before the first deletion — not after the
+ * 50th. Nothing is deleted at all.
+ */
+export async function executeSweep(input: {
+  plan: SweepPlan;
+  force: boolean;
+  deleteResource: (target: SweepTarget) => Promise<void>;
+  log?: (message: string) => void;
+}): Promise<SweepExecution> {
+  const { plan, force, deleteResource } = input;
+  const log = input.log ?? (() => {});
+  const ids = plan.targets.map((t) => t.id);
+
+  if (plan.circuitBreakerTripped) {
+    log(
+      `ABORT: ${plan.targets.length} ${plan.kind}(s) selected exceeds the max-delete circuit breaker ` +
+        `(${plan.maxDeletes}). No resources were deleted. Investigate before re-running.`
+    );
+    return { deleted: [], wouldDelete: ids, failures: [], aborted: true };
+  }
+
+  if (!force) {
+    log(`DRY RUN: would delete ${ids.length} ${plan.kind}(s) in ${plan.scope}. Pass --force to delete.`);
+    for (const target of plan.targets) {
+      log(`  would delete ${plan.kind} ${target.id} "${target.name}" (run ${target.runId})`);
+    }
+    return { deleted: [], wouldDelete: ids, failures: [], aborted: false };
+  }
+
+  const deleted: string[] = [];
+  const failures: Array<{ id: string; error: string }> = [];
+  for (const target of plan.targets) {
+    assertMarked(target);
+    try {
+      await deleteResource(target);
+      deleted.push(target.id);
+      log(`deleted ${plan.kind} ${target.id} "${target.name}" (run ${target.runId})`);
+    } catch (error) {
+      failures.push({ id: target.id, error: error instanceof Error ? error.message : String(error) });
+    }
+  }
+
+  return { deleted, wouldDelete: [], failures, aborted: false };
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+export interface SweeperArgs {
+  force: boolean;
+  profile: string;
+  ttlMs: number;
+  maxDeletes: number;
+}
+
+/**
+ * Parse sweeper flags.
+ *
+ * Deliberately offers **no** space/project override: the scope lock is not
+ * something an operator can widen from the command line.
+ *
+ * @throws On any unrecognized or malformed argument — fail closed rather than
+ *   silently ignoring a typo on a destructive command.
+ */
+export function parseSweeperArgs(argv: string[]): SweeperArgs {
+  const args: SweeperArgs = {
+    force: false,
+    profile: DEFAULT_PROFILE,
+    ttlMs: E2E_TTL_MS,
+    maxDeletes: DEFAULT_MAX_DELETES,
+  };
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]!;
+    if (arg === "--force") {
+      args.force = true;
+    } else if (arg === "--dry-run") {
+      args.force = false;
+    } else if (arg === "--profile") {
+      const value = argv[++i];
+      if (!value) throw new Error("--profile requires a value");
+      args.profile = value;
+    } else if (arg.startsWith("--profile=")) {
+      args.profile = arg.slice("--profile=".length);
+    } else if (arg === "--ttl-hours" || arg.startsWith("--ttl-hours=")) {
+      const raw = arg.startsWith("--ttl-hours=") ? arg.slice("--ttl-hours=".length) : argv[++i];
+      const hours = Number(raw);
+      if (!Number.isFinite(hours) || hours < 0) throw new Error(`--ttl-hours requires a non-negative number, got: ${raw}`);
+      args.ttlMs = hours * 60 * 60 * 1000;
+    } else if (arg === "--max-deletes" || arg.startsWith("--max-deletes=")) {
+      const raw = arg.startsWith("--max-deletes=") ? arg.slice("--max-deletes=".length) : argv[++i];
+      const max = Number(raw);
+      if (!Number.isInteger(max) || max < 0) throw new Error(`--max-deletes requires a non-negative integer, got: ${raw}`);
+      args.maxDeletes = max;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return args;
+}
+
+export function sweeperHelp(): string {
+  return [
+    "Usage: bun apps/cli/src/e2e/cleanup.ts [options]",
+    "",
+    "Recovery sweeper for live E2E residue. Deletes ONLY resources that carry the",
+    `atlcli-e2e-run-id ownership marker, follow the atlcli-e2e-<feature>-<timestamp>`,
+    `naming convention, are older than the TTL, and live in space ${E2E_SPACE_KEY} /`,
+    `project ${E2E_PROJECT_KEY}. Dry run unless --force is given.`,
+    "",
+    "Options:",
+    "  --force               Actually delete (default: dry run, deletes nothing)",
+    `  --profile <name>      Profile to authenticate with (default: ${DEFAULT_PROFILE})`,
+    "  --ttl-hours <n>       Minimum resource age before sweeping (default: 24)",
+    `  --max-deletes <n>     Circuit breaker; abort if more are selected (default: ${DEFAULT_MAX_DELETES})`,
+    "  --help, -h            Show this help",
+  ].join("\n");
+}
+
+/**
+ * Run a full sweep against the given ports.
+ *
+ * @returns A process exit code: 0 clean, 1 deletion failures, 2 circuit breaker tripped.
+ */
+export async function runSweep(input: {
+  confluence?: E2eConfluencePort;
+  jira?: E2eJiraPort;
+  args: Pick<SweeperArgs, "force" | "ttlMs" | "maxDeletes">;
+  now?: number;
+  log?: (message: string) => void;
+}): Promise<number> {
+  const log = input.log ?? ((message: string) => console.log(message));
+  const now = input.now ?? Date.now();
+  const { force, ttlMs, maxDeletes } = input.args;
+
+  const plans: SweepPlan[] = [];
+  const deleters = new Map<SweepPlan, (target: SweepTarget) => Promise<void>>();
+
+  if (input.confluence) {
+    const pages = await input.confluence.listPages(E2E_SPACE_KEY);
+    const plan = planSweep("page", pages.map(toPageCandidate), {
+      scope: E2E_SPACE_KEY,
+      now,
+      ttlMs,
+      maxDeletes,
+    });
+    plans.push(plan);
+    deleters.set(plan, (target) => input.confluence!.deletePage(target.id));
+  }
+
+  if (input.jira) {
+    const issues = await input.jira.listIssues(E2E_PROJECT_KEY);
+    const plan = planSweep("issue", issues.map(toIssueCandidate), {
+      scope: E2E_PROJECT_KEY,
+      now,
+      ttlMs,
+      maxDeletes,
+    });
+    plans.push(plan);
+    deleters.set(plan, (target) => input.jira!.deleteIssue(target.id));
+  }
+
+  for (const plan of plans) {
+    const bySkipReason = new Map<SweepSkipReason, number>();
+    for (const skip of plan.skipped) {
+      bySkipReason.set(skip.reason, (bySkipReason.get(skip.reason) ?? 0) + 1);
+    }
+    const breakdown = [...bySkipReason.entries()].map(([reason, count]) => `${reason}=${count}`).join(", ");
+    log(
+      `[${plan.kind}] ${plan.scope}: ${plan.targets.length} sweepable, ${plan.skipped.length} protected` +
+        (breakdown ? ` (${breakdown})` : "")
+    );
+  }
+
+  // Fail closed across the whole sweep: if ANY plan tripped, delete nothing at all.
+  if (plans.some((plan) => plan.circuitBreakerTripped)) {
+    for (const plan of plans) {
+      await executeSweep({ plan, force: false, deleteResource: async () => {}, log });
+    }
+    log("Circuit breaker tripped — aborting the entire sweep without deleting anything.");
+    return 2;
+  }
+
+  let failures = 0;
+  for (const plan of plans) {
+    const result = await executeSweep({
+      plan,
+      force,
+      deleteResource: deleters.get(plan)!,
+      log,
+    });
+    failures += result.failures.length;
+    for (const failure of result.failures) {
+      log(`FAILED to delete ${plan.kind} ${failure.id}: ${failure.error}`);
+    }
+  }
+
+  return failures > 0 ? 1 : 0;
+}
+
+/**
+ * Resolve the profile the sweeper authenticates with.
+ *
+ * Prefers a configured profile (the local-agent case, profile `mayflower`).
+ * Falls back to an ephemeral profile built from `ATLCLI_*` env vars so CI can
+ * pass repo secrets straight through the environment instead of writing
+ * credentials to `~/.atlcli/config.json` on a shared runner.
+ *
+ * @returns The profile, or `null` when neither source is configured.
+ */
+export function resolveSweeperProfile(
+  config: Config,
+  profileName: string,
+  env: Record<string, string | undefined> = process.env
+): Profile | null {
+  const configured = getActiveProfile(config, profileName);
+  if (configured) return configured;
+
+  const baseUrl = env.ATLCLI_BASE_URL?.trim();
+  if (!baseUrl) return null;
+
+  const authType = env.ATLCLI_AUTH_TYPE?.trim() === "bearer" ? "bearer" : "apiToken";
+  return {
+    name: profileName,
+    baseUrl,
+    // The token itself is read by `resolveToken`, which already prefers
+    // ATLCLI_API_TOKEN over anything stored — it is never placed here.
+    auth: authType === "bearer" ? { type: "bearer" } : { type: "apiToken", email: env.ATLCLI_EMAIL?.trim() },
+  };
+}
+
+async function main(argv: string[]): Promise<number> {
+  if (argv.includes("--help") || argv.includes("-h")) {
+    console.log(sweeperHelp());
+    return 0;
+  }
+
+  let args: SweeperArgs;
+  try {
+    args = parseSweeperArgs(argv);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    console.error(sweeperHelp());
+    return 1;
+  }
+
+  const config = await loadConfig();
+  const profile = resolveSweeperProfile(config, args.profile);
+  if (!profile) {
+    console.error(
+      `Profile '${args.profile}' is not configured, and no ATLCLI_BASE_URL fallback is set. ` +
+        "Run `atlcli auth login` or export ATLCLI_BASE_URL / ATLCLI_EMAIL / ATLCLI_API_TOKEN."
+    );
+    return 1;
+  }
+
+  // Imported lazily so the pure planner stays importable (and unit-testable)
+  // without dragging in the REST clients.
+  const { createConfluencePort, createJiraPort } = await import("./rest-ports.js");
+
+  return runSweep({
+    confluence: createConfluencePort(profile),
+    jira: createJiraPort(profile),
+    args,
+  });
+}
+
+if (import.meta.main) {
+  process.exit(await main(process.argv.slice(2)));
+}

--- a/apps/cli/src/e2e/cleanup.ts
+++ b/apps/cli/src/e2e/cleanup.ts
@@ -21,21 +21,29 @@
  *     {@link SweepTarget}s, whose `runId` is a required `string`, and
  *     {@link executeSweep} accepts nothing else — an unmarked
  *     {@link SweepCandidate} cannot be passed to the deleter without a type
- *     error, and {@link assertMarked} re-checks at runtime.
+ *     error, and {@link assertSweepable} re-runs every gate at the delete site.
  *  2. **TTL honored.** Resources younger than 24 h are never touched, so a
- *     currently-running E2E is never swept out from under itself.
+ *     currently-running E2E is never swept out from under itself. `--ttl-hours`
+ *     can raise this but never lower it below {@link MIN_TTL_HOURS}.
  *  3. **Dry-run by default.** Without `--force` the script only prints what it
  *     *would* delete and performs zero deletions.
  *  4. **Scope locked.** Only space `DOCSY` and project `ATLCLI`, hardcoded with
  *     no CLI override; records from any other scope are dropped by the planner.
  *
- * Plus a **max-delete circuit breaker** (default 50): if the plan selects more
- * than that, the whole sweep aborts fail-closed with a non-zero exit and *zero*
- * deletions, rather than letting a bad query quietly empty the space.
+ * Plus a **max-delete circuit breaker** ({@link DEFAULT_MAX_DELETES}): if the
+ * plan selects more than that, the whole sweep aborts fail-closed with a
+ * non-zero exit and *zero* deletions, rather than letting a bad query quietly
+ * empty the space. `--max-deletes` can lower it but never raise it.
  *
- * DOCSY holds deliberately retained fixtures (the DOCX feature zoo, the spec-005
- * logo/image page, the "M1 Abnahme …" set). None of them carries the marker, so
- * gate 1 alone makes them unreachable; gates 2 and 4 are belt and braces.
+ * What protects the deliberately retained DOCSY fixtures (the DOCX feature zoo,
+ * the spec-005 logo/image page, the "M1 Abnahme …" set) is the **naming gate**:
+ * their titles do not parse as `atlcli-e2e-<feature>-<timestamp>`, so they are
+ * rejected even if something stamps a valid-looking marker on them. That is a
+ * structural property of their names, not the contingent fact that they happen
+ * to be unmarked today.
+ *
+ * Note what is NOT covered: `--profile` selects the *tenant*. The DOCSY/ATLCLI
+ * lock constrains which space and project get swept, not which site.
  *
  * @example
  * ```bash
@@ -58,8 +66,15 @@ import {
   type E2ePageRecord,
 } from "./resources.js";
 
-/** Default max resources a single sweep may delete before it aborts fail-closed. */
+/**
+ * Max resources a single sweep may delete before it aborts fail-closed.
+ *
+ * Also the hard ceiling: `--max-deletes` may lower it, never raise it.
+ */
 export const DEFAULT_MAX_DELETES = 50;
+
+/** Floor for `--ttl-hours`. The TTL gate can be widened but never switched off. */
+export const MIN_TTL_HOURS = 1;
 
 /** Default profile the sweeper authenticates with. */
 export const DEFAULT_PROFILE = "mayflower";
@@ -102,6 +117,13 @@ export interface SweepPlan {
   maxDeletes: number;
   /** True when `targets` exceeded `maxDeletes`. The sweep must then delete nothing. */
   circuitBreakerTripped: boolean;
+  /**
+   * The gate inputs this plan was built with, carried so the executor can
+   * independently re-verify every target immediately before deleting it
+   * (see {@link assertSweepable}) instead of trusting the plan it was handed.
+   */
+  now: number;
+  ttlMs: number;
 }
 
 export interface PlanSweepOptions {
@@ -185,21 +207,35 @@ export function planSweep(
     skipped,
     maxDeletes,
     circuitBreakerTripped: targets.length > maxDeletes,
+    now: options.now,
+    ttlMs,
   };
 }
 
 /**
- * Runtime re-assertion of the marker gate.
+ * Re-run **every** gate against a target immediately before it is deleted.
  *
- * The type system already prevents an unmarked candidate from reaching the
- * deleter; this catches the cast-away case (a caller building a `SweepTarget`
- * by hand) before any DELETE goes out.
+ * The type system already stops an unmarked candidate from reaching the
+ * deleter, and in the shipped flow `runSweep` always builds its plan through
+ * {@link planSweep}. This is the last line of defence for the case neither
+ * covers: a caller hand-assembling a `SweepTarget` (or casting one together)
+ * and passing it to {@link executeSweep} directly.
+ *
+ * Deliberately a full re-classification rather than a marker check. Checking
+ * only the marker would let a forged `runId` on an off-convention name — a
+ * deliberately retained fixture, say — through the final gate, which is exactly
+ * the claim this module's header makes about being structurally incapable of
+ * deleting content it does not own.
  */
-export function assertMarked(target: SweepTarget): void {
-  if (typeof target.runId !== "string" || target.runId.trim() === "") {
+export function assertSweepable(
+  target: SweepTarget,
+  options: { scope: string; now: number; ttlMs: number }
+): void {
+  const reason = classifyCandidate(target, options);
+  if (reason) {
     throw new Error(
-      `Refusing to delete ${target.id}: no ${"atlcli-e2e-run-id"} ownership marker. ` +
-        "The sweeper only deletes resources it can prove it owns."
+      `Refusing to delete ${target.id} ("${target.name}"): ${reason}. ` +
+        "The sweeper only deletes resources that pass every gate at the moment of deletion."
     );
   }
 }
@@ -248,7 +284,7 @@ export async function executeSweep(input: {
   const deleted: string[] = [];
   const failures: Array<{ id: string; error: string }> = [];
   for (const target of plan.targets) {
-    assertMarked(target);
+    assertSweepable(target, { scope: plan.scope, now: plan.now, ttlMs: plan.ttlMs });
     try {
       await deleteResource(target);
       deleted.push(target.id);
@@ -304,12 +340,28 @@ export function parseSweeperArgs(argv: string[]): SweeperArgs {
     } else if (arg === "--ttl-hours" || arg.startsWith("--ttl-hours=")) {
       const raw = arg.startsWith("--ttl-hours=") ? arg.slice("--ttl-hours=".length) : argv[++i];
       const hours = Number(raw);
-      if (!Number.isFinite(hours) || hours < 0) throw new Error(`--ttl-hours requires a non-negative number, got: ${raw}`);
+      // Floored, not merely non-negative. `--ttl-hours 0` used to disable the
+      // TTL gate outright, which would delete a resource a *different*, still
+      // running E2E had created seconds earlier — the precise scenario the TTL
+      // exists to prevent. The flag may only ever make the sweep more patient.
+      if (!Number.isFinite(hours) || hours < MIN_TTL_HOURS) {
+        throw new Error(`--ttl-hours must be at least ${MIN_TTL_HOURS} (the TTL gate cannot be disabled), got: ${raw}`);
+      }
       args.ttlMs = hours * 60 * 60 * 1000;
     } else if (arg === "--max-deletes" || arg.startsWith("--max-deletes=")) {
       const raw = arg.startsWith("--max-deletes=") ? arg.slice("--max-deletes=".length) : argv[++i];
       const max = Number(raw);
       if (!Number.isInteger(max) || max < 0) throw new Error(`--max-deletes requires a non-negative integer, got: ${raw}`);
+      // Clamped in one direction only: lowering the breaker is a legitimate way
+      // to be extra careful, raising it defeats the point. Raising it is also
+      // the obvious reflex right after seeing an abort — i.e. exactly when the
+      // breaker is doing its job and a bad query is the likeliest explanation.
+      if (max > DEFAULT_MAX_DELETES) {
+        throw new Error(
+          `--max-deletes may not exceed the ${DEFAULT_MAX_DELETES}-resource circuit breaker (got ${max}). ` +
+            "If a sweep legitimately needs to remove more, run it repeatedly rather than raising the limit."
+        );
+      }
       args.maxDeletes = max;
     } else {
       throw new Error(`Unknown argument: ${arg}`);
@@ -331,9 +383,16 @@ export function sweeperHelp(): string {
     "Options:",
     "  --force               Actually delete (default: dry run, deletes nothing)",
     `  --profile <name>      Profile to authenticate with (default: ${DEFAULT_PROFILE})`,
-    "  --ttl-hours <n>       Minimum resource age before sweeping (default: 24)",
-    `  --max-deletes <n>     Circuit breaker; abort if more are selected (default: ${DEFAULT_MAX_DELETES})`,
+    `  --ttl-hours <n>       Minimum resource age before sweeping (default: 24, minimum ${MIN_TTL_HOURS});`,
+    "                        may only be raised — the TTL gate cannot be disabled",
+    `  --max-deletes <n>     Circuit breaker; abort if more are selected (default and`,
+    `                        maximum ${DEFAULT_MAX_DELETES}); may only be lowered`,
     "  --help, -h            Show this help",
+    "",
+    `WARNING: --profile (and the ATLCLI_BASE_URL fallback) selects the TENANT. The`,
+    `${E2E_SPACE_KEY}/${E2E_PROJECT_KEY} name lock constrains which space and project are`,
+    "swept, NOT which site — point this at the wrong instance and it will happily",
+    `sweep that instance's ${E2E_SPACE_KEY}.`,
   ].join("\n");
 }
 

--- a/apps/cli/src/e2e/memory-ports.ts
+++ b/apps/cli/src/e2e/memory-ports.ts
@@ -1,0 +1,189 @@
+/**
+ * In-memory implementations of the E2E ports.
+ *
+ * These are real implementations of the designed port interfaces, not mocks:
+ * they hold state, enforce the same not-found errors the REST adapters surface,
+ * and can be driven end to end. Tests use them to exercise the tracker and the
+ * sweeper without a tenant; nothing here stubs `fetch`.
+ *
+ * @module
+ */
+
+import {
+  E2E_RUN_ID_PROPERTY,
+  type E2eConfluencePort,
+  type E2eIssueRecord,
+  type E2eJiraPort,
+  type E2ePageRecord,
+} from "./resources.js";
+
+export interface MemoryPage {
+  id: string;
+  title: string;
+  spaceKey: string;
+  storage: string;
+  parentId?: string;
+  properties: Map<string, string>;
+}
+
+export interface MemoryIssue {
+  id: string;
+  key: string;
+  summary: string;
+  projectKey: string;
+  issueType: string;
+  properties: Map<string, string>;
+}
+
+/** An in-memory Confluence, with hooks for forcing the failure paths. */
+export class MemoryConfluence implements E2eConfluencePort {
+  readonly pages = new Map<string, MemoryPage>();
+  /** Every deletePage call in order, including ones that threw. */
+  readonly deleteLog: string[] = [];
+  /** Set to make the next property write fail (orphan-marker path). */
+  failNextPropertyWrite = false;
+  /** Page IDs whose deletion should fail. */
+  readonly failDeletesFor = new Set<string>();
+
+  private nextId = 1000;
+
+  /** Seed a page directly, e.g. a retained fixture that must never be swept. */
+  seed(page: {
+    id?: string;
+    title: string;
+    spaceKey: string;
+    runId?: string;
+    properties?: Record<string, string>;
+  }): MemoryPage {
+    const id = page.id ?? String(this.nextId++);
+    const properties = new Map(Object.entries(page.properties ?? {}));
+    if (page.runId !== undefined) properties.set(E2E_RUN_ID_PROPERTY, page.runId);
+    const record: MemoryPage = {
+      id,
+      title: page.title,
+      spaceKey: page.spaceKey,
+      storage: "",
+      properties,
+    };
+    this.pages.set(id, record);
+    return record;
+  }
+
+  async createPage(input: { spaceKey: string; title: string; storage: string; parentId?: string }) {
+    const id = String(this.nextId++);
+    this.pages.set(id, {
+      id,
+      title: input.title,
+      spaceKey: input.spaceKey,
+      storage: input.storage,
+      parentId: input.parentId,
+      properties: new Map(),
+    });
+    return { id, title: input.title };
+  }
+
+  async deletePage(pageId: string): Promise<void> {
+    this.deleteLog.push(pageId);
+    if (this.failDeletesFor.has(pageId)) throw new Error(`HTTP 500 deleting page ${pageId}`);
+    if (!this.pages.has(pageId)) throw new Error(`Page ${pageId} not found`);
+    this.pages.delete(pageId);
+  }
+
+  async setPageProperty(pageId: string, key: string, value: string): Promise<void> {
+    if (this.failNextPropertyWrite) {
+      this.failNextPropertyWrite = false;
+      throw new Error(`HTTP 403 setting content property ${key} on page ${pageId}`);
+    }
+    const page = this.pages.get(pageId);
+    if (!page) throw new Error(`Page ${pageId} not found`);
+    page.properties.set(key, value);
+  }
+
+  async getPageProperty(pageId: string, key: string): Promise<string | undefined> {
+    return this.pages.get(pageId)?.properties.get(key);
+  }
+
+  async listPages(spaceKey: string): Promise<E2ePageRecord[]> {
+    return [...this.pages.values()]
+      .filter((page) => page.spaceKey === spaceKey)
+      .map((page) => ({
+        id: page.id,
+        title: page.title,
+        spaceKey: page.spaceKey,
+        runId: page.properties.get(E2E_RUN_ID_PROPERTY),
+      }));
+  }
+}
+
+/** An in-memory Jira, with the same failure hooks. */
+export class MemoryJira implements E2eJiraPort {
+  readonly issues = new Map<string, MemoryIssue>();
+  readonly deleteLog: string[] = [];
+  failNextPropertyWrite = false;
+  readonly failDeletesFor = new Set<string>();
+
+  private nextId = 5000;
+
+  seed(issue: { key?: string; summary: string; projectKey: string; runId?: string }): MemoryIssue {
+    const id = String(this.nextId++);
+    const key = issue.key ?? `${issue.projectKey}-${id}`;
+    const properties = new Map<string, string>();
+    if (issue.runId !== undefined) properties.set(E2E_RUN_ID_PROPERTY, issue.runId);
+    const record: MemoryIssue = {
+      id,
+      key,
+      summary: issue.summary,
+      projectKey: issue.projectKey,
+      issueType: "Task",
+      properties,
+    };
+    this.issues.set(key, record);
+    return record;
+  }
+
+  async createIssue(input: { projectKey: string; summary: string; issueType: string }) {
+    const id = String(this.nextId++);
+    const key = `${input.projectKey}-${id}`;
+    this.issues.set(key, {
+      id,
+      key,
+      summary: input.summary,
+      projectKey: input.projectKey,
+      issueType: input.issueType,
+      properties: new Map(),
+    });
+    return { id, key };
+  }
+
+  async deleteIssue(issueKey: string): Promise<void> {
+    this.deleteLog.push(issueKey);
+    if (this.failDeletesFor.has(issueKey)) throw new Error(`HTTP 500 deleting issue ${issueKey}`);
+    if (!this.issues.has(issueKey)) throw new Error(`Issue ${issueKey} not found`);
+    this.issues.delete(issueKey);
+  }
+
+  async setIssueProperty(issueKey: string, key: string, value: string): Promise<void> {
+    if (this.failNextPropertyWrite) {
+      this.failNextPropertyWrite = false;
+      throw new Error(`HTTP 403 setting issue property ${key} on ${issueKey}`);
+    }
+    const issue = this.issues.get(issueKey);
+    if (!issue) throw new Error(`Issue ${issueKey} not found`);
+    issue.properties.set(key, value);
+  }
+
+  async getIssueProperty(issueKey: string, key: string): Promise<string | undefined> {
+    return this.issues.get(issueKey)?.properties.get(key);
+  }
+
+  async listIssues(projectKey: string): Promise<E2eIssueRecord[]> {
+    return [...this.issues.values()]
+      .filter((issue) => issue.projectKey === projectKey)
+      .map((issue) => ({
+        key: issue.key,
+        summary: issue.summary,
+        projectKey: issue.projectKey,
+        runId: issue.properties.get(E2E_RUN_ID_PROPERTY),
+      }));
+  }
+}

--- a/apps/cli/src/e2e/registry-isolation.test.ts
+++ b/apps/cli/src/e2e/registry-isolation.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Regression: `mock.module` stubs must not leak out of the file that installed
+ * them.
+ *
+ * Three command tests replace whole `@atlcli/*` barrels with `mock.module`,
+ * which is process-wide. They now restore the real modules in `afterAll`; two
+ * details make that easy to get wrong, and both were:
+ *
+ *  - the restore snapshot must be taken BEFORE the mock is installed (spreading
+ *    the live module namespace afterwards just copies the stubs back out), and
+ *  - `mock.module` must be handed a plain object, not the namespace itself.
+ *
+ * Asserting this from an ordinary test file would pin it by alphabetical luck —
+ * the same fragility that let the original bug through. So this spawns a real
+ * `bun test` process with an explicit file order: the three polluters first,
+ * the probe last. Same approach as `commands/auth-test-isolation.test.ts`.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+
+const REPO_ROOT = join(import.meta.dir, "..", "..", "..", "..");
+
+const POLLUTERS = [
+  "apps/cli/src/commands/auth.test.ts",
+  "apps/cli/src/commands/helloworld.test.ts",
+  "apps/cli/src/commands/session-guard.test.ts",
+];
+const PROBE = "apps/cli/src/e2e/registry-probe.test.ts";
+
+describe("mock.module isolation", () => {
+  test("the real @atlcli barrels survive every mock.module user", () => {
+    const res = spawnSync(
+      "bun",
+      // `--conditions=development` keeps the in-repo `@atlcli/*` resolution
+      // working (spec 009); without it the probe cannot import the real
+      // packages at all and the test would pass for the wrong reason.
+      ["--conditions=development", "test", ...POLLUTERS, PROBE],
+      { cwd: REPO_ROOT, encoding: "utf8", timeout: 120_000 }
+    );
+    const output = `${res.stdout ?? ""}${res.stderr ?? ""}`;
+
+    // The exact symptom of the leak, asserted directly so a future regression
+    // reads as itself rather than as a generic failure.
+    expect(output).not.toContain("logger.api is not a function");
+    expect(output).not.toContain("should not be constructed");
+    expect(output).toContain(" 0 fail");
+    expect(res.status).toBe(0);
+  }, 120_000);
+});

--- a/apps/cli/src/e2e/registry-probe.test.ts
+++ b/apps/cli/src/e2e/registry-probe.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Probe: after the `mock.module` users have run, is the module registry intact?
+ *
+ * `auth.test.ts`, `helloworld.test.ts` and `session-guard.test.ts` all replace
+ * `@atlcli/core` / `@atlcli/confluence` / `@atlcli/jira` via `mock.module`,
+ * which mutates the registry for the WHOLE process. Without an `afterAll` that
+ * puts the real barrels back, their stubs leak into every file that runs later:
+ * `getLogger()` came back with only an `auth` method, so anything touching a
+ * real API client died on `logger.api is not a function`, and the clients threw
+ * on construction.
+ *
+ * This file holds only the assertions. `registry-isolation.test.ts` is what
+ * makes them meaningful — it runs this file in a dedicated `bun test` process
+ * *after* the three polluters, so the check no longer depends on the alphabetical
+ * file order that caused the original bug. Running standalone (as it does in the
+ * normal suite) it simply passes.
+ */
+
+import { describe, expect, it } from "bun:test";
+import type { Profile } from "@atlcli/core";
+
+describe("module registry integrity for later test files", () => {
+  it("hands later files the real @atlcli/core logger, not a test stub", async () => {
+    const { getLogger } = await import("@atlcli/core");
+    const logger = getLogger();
+    // `api` is the method the leaked stub omitted, which is what broke the
+    // Confluence/Jira clients for every file that ran after the mock.
+    expect(typeof logger.api).toBe("function");
+    expect(typeof logger.auth).toBe("function");
+  });
+
+  it("hands later files constructible API clients", async () => {
+    const { ConfluenceClient } = await import("@atlcli/confluence");
+    const { JiraClient } = await import("@atlcli/jira");
+    const profile: Profile = {
+      name: "registry-probe",
+      baseUrl: "https://probe.example.com",
+      deploymentType: "data-center",
+      auth: { type: "bearer", pat: "probe-token" },
+    };
+    expect(() => new ConfluenceClient(profile)).not.toThrow();
+    expect(() => new JiraClient(profile)).not.toThrow();
+  });
+});

--- a/apps/cli/src/e2e/resources.test.ts
+++ b/apps/cli/src/e2e/resources.test.ts
@@ -37,6 +37,27 @@ describe("makeE2eTitle", () => {
     expect(() => makeE2eTitle("trailing-", AT)).toThrow();
     expect(() => makeE2eTitle("under_score", AT)).toThrow();
   });
+
+  it("rejects a clock that would mint a name parseE2eTitle cannot read back", () => {
+    // Validating the slug but not the timestamp left a hole: an epoch-0 clock
+    // produced `atlcli-e2e-probe-0`, which parses as null — permanently
+    // unsweepable residue, the very failure this function claims to prevent.
+    expect(() => makeE2eTitle("probe", new Date(0))).toThrow(/epoch seconds/);
+    expect(() => makeE2eTitle("probe", new Date(999_999_999_000))).toThrow(/epoch seconds/);
+    expect(() => makeE2eTitle("probe", new Date(Number.NaN))).toThrow(/epoch seconds/);
+  });
+
+  it("guarantees every name it mints parses back", () => {
+    for (const feature of ["a", "scope-tree", "scope-tree-labels-and-macros"]) {
+      for (const at of [AT, new Date(1_000_000_000_000), new Date()]) {
+        const title = makeE2eTitle(feature, at);
+        expect(parseE2eTitle(title)).toEqual({
+          feature,
+          timestampSeconds: Math.floor(at.getTime() / 1000),
+        });
+      }
+    }
+  });
 });
 
 describe("parseE2eTitle", () => {
@@ -219,40 +240,9 @@ describe("withE2eResources", () => {
   });
 });
 
-describe("module registry is intact for later test files", () => {
-  /**
-   * Regression: `auth.test.ts`, `helloworld.test.ts` and `session-guard.test.ts`
-   * all call `mock.module(...)`, which mutates the registry for the WHOLE
-   * process. Without an `afterAll` that puts the real barrels back, their stubs
-   * leaked into every file that runs after them — `getLogger()` came back with
-   * only an `auth` method, so any later test touching a real API client died on
-   * `logger.api is not a function`, and the real clients threw on construction.
-   *
-   * This file sorts after `src/commands/`, so it is exactly where such a leak
-   * shows up. Asserting it here keeps the restores honest.
-   */
-  it("hands later files the real @atlcli/core logger, not a test stub", async () => {
-    const { getLogger } = await import("@atlcli/core");
-    const logger = getLogger();
-    // `api` is the method the leaked stub omitted, which is what broke the
-    // Confluence/Jira clients for every file that ran after the mock.
-    expect(typeof logger.api).toBe("function");
-    expect(typeof logger.auth).toBe("function");
-  });
-
-  it("hands later files constructible API clients", async () => {
-    const { ConfluenceClient } = await import("@atlcli/confluence");
-    const { JiraClient } = await import("@atlcli/jira");
-    const profile: Profile = {
-      name: "registry-probe",
-      baseUrl: "https://probe.example.com",
-      deploymentType: "data-center",
-      auth: { type: "bearer", pat: "probe-token" },
-    };
-    expect(() => new ConfluenceClient(profile)).not.toThrow();
-    expect(() => new JiraClient(profile)).not.toThrow();
-  });
-});
+// Registry-integrity coverage lives in `registry-probe.test.ts`, pinned to a
+// deterministic file order by `registry-isolation.test.ts` — asserting it here
+// would depend on the same alphabetical luck that caused the original bug.
 
 // ---------------------------------------------------------------------------
 // REST adapter against a real local HTTP server

--- a/apps/cli/src/e2e/resources.test.ts
+++ b/apps/cli/src/e2e/resources.test.ts
@@ -1,0 +1,505 @@
+/**
+ * Tests for the live-E2E naming, ownership-marker and per-test-cleanup helpers
+ * (spec 011 "E2E resource discipline").
+ *
+ * Offline by design: the tracker is exercised against in-memory port
+ * implementations, and the REST adapter against a real local Bun HTTP server
+ * standing in for the Confluence/Jira REST API. Nothing stubs `fetch`.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import type { Profile } from "@atlcli/core";
+import { MemoryConfluence, MemoryJira } from "./memory-ports.js";
+import { createConfluencePort, createJiraPort } from "./rest-ports.js";
+import {
+  E2E_PROJECT_KEY,
+  E2E_RUN_ID_PROPERTY,
+  E2E_SPACE_KEY,
+  E2eResourceTracker,
+  makeE2eTitle,
+  parseE2eTitle,
+  resolveRunId,
+  withE2eResources,
+} from "./resources.js";
+
+const AT = new Date(1_789_000_000_000); // 2026-09-08T…Z, epoch seconds 1789000000
+
+describe("makeE2eTitle", () => {
+  it("builds atlcli-e2e-<feature>-<epoch seconds>", () => {
+    expect(makeE2eTitle("scope-tree", AT)).toBe("atlcli-e2e-scope-tree-1789000000");
+  });
+
+  it("rejects feature slugs that would produce an unrecoverable name", () => {
+    // An out-of-convention name is invisible to the sweeper forever, so this is
+    // a hard error rather than a silent slugify.
+    expect(() => makeE2eTitle("Scope Tree", AT)).toThrow(/lowercase, dash-separated/);
+    expect(() => makeE2eTitle("", AT)).toThrow();
+    expect(() => makeE2eTitle("trailing-", AT)).toThrow();
+    expect(() => makeE2eTitle("under_score", AT)).toThrow();
+  });
+});
+
+describe("parseE2eTitle", () => {
+  it("round-trips a generated name", () => {
+    expect(parseE2eTitle(makeE2eTitle("macro-render", AT))).toEqual({
+      feature: "macro-render",
+      timestampSeconds: 1_789_000_000,
+    });
+  });
+
+  it("keeps multi-segment feature slugs intact", () => {
+    expect(parseE2eTitle("atlcli-e2e-scope-tree-labels-1789000000")?.feature).toBe("scope-tree-labels");
+  });
+
+  it("returns null for anything not following the convention", () => {
+    for (const title of [
+      "Spec-005 Logo & Image E2E (temp)",
+      "M1 Abnahme 07",
+      "DOCX feature zoo",
+      "atlcli-e2e-1789000000", // no feature segment
+      "atlcli-e2e-scope-tree", // no timestamp
+      "atlcli-e2e-scope-tree-42", // timestamp too short to be epoch seconds
+      "prefixed-atlcli-e2e-scope-tree-1789000000",
+      "",
+    ]) {
+      expect(parseE2eTitle(title)).toBeNull();
+    }
+  });
+});
+
+describe("resolveRunId", () => {
+  it("prefers the CI run identity, including the attempt number", () => {
+    expect(resolveRunId({ GITHUB_RUN_ID: "12345", GITHUB_RUN_ATTEMPT: "2" })).toBe("gha-12345-2");
+    expect(resolveRunId({ GITHUB_RUN_ID: "12345" })).toBe("gha-12345");
+  });
+
+  it("falls back to a unique local id", () => {
+    const first = resolveRunId({});
+    const second = resolveRunId({});
+    expect(first).toStartWith("local-");
+    expect(first).not.toBe(second);
+  });
+});
+
+describe("E2eResourceTracker", () => {
+  it("creates a conventionally named page carrying the ownership marker", async () => {
+    const confluence = new MemoryConfluence();
+    const tracker = new E2eResourceTracker({ confluence }, "run-abc");
+
+    const page = await tracker.createPage("scope-tree", { now: AT });
+
+    expect(page.title).toBe("atlcli-e2e-scope-tree-1789000000");
+    expect(confluence.pages.get(page.id)?.spaceKey).toBe(E2E_SPACE_KEY);
+    expect(await confluence.getPageProperty(page.id, E2E_RUN_ID_PROPERTY)).toBe("run-abc");
+  });
+
+  it("creates a conventionally named issue carrying the ownership marker", async () => {
+    const jira = new MemoryJira();
+    const tracker = new E2eResourceTracker({ jira }, "run-abc");
+
+    const issue = await tracker.createIssue("jira-macro", { now: AT });
+
+    expect(issue.summary).toBe("atlcli-e2e-jira-macro-1789000000");
+    expect(jira.issues.get(issue.key)?.projectKey).toBe(E2E_PROJECT_KEY);
+    expect(await jira.getIssueProperty(issue.key, E2E_RUN_ID_PROPERTY)).toBe("run-abc");
+  });
+
+  it("still deletes a page whose marker write failed", async () => {
+    // An unmarked orphan would be invisible to the marker-gated sweeper — i.e.
+    // permanent residue — so the ID is tracked before the marker is stamped.
+    const confluence = new MemoryConfluence();
+    confluence.failNextPropertyWrite = true;
+    const tracker = new E2eResourceTracker({ confluence }, "run-abc");
+
+    await expect(tracker.createPage("scope-tree", { now: AT })).rejects.toThrow(/HTTP 403/);
+    expect(tracker.trackedPages).toHaveLength(1);
+
+    await tracker.cleanup();
+    expect(confluence.pages.size).toBe(0);
+  });
+
+  it("deletes tracked resources newest-first and reports what it removed", async () => {
+    const confluence = new MemoryConfluence();
+    const jira = new MemoryJira();
+    const tracker = new E2eResourceTracker({ confluence, jira }, "run-abc");
+
+    const first = await tracker.createPage("first", { now: AT });
+    const second = await tracker.createPage("second", { now: AT });
+    const issue = await tracker.createIssue("third", { now: AT });
+
+    const summary = await tracker.cleanup();
+
+    expect(summary.deletedPages).toEqual([second.id, first.id]);
+    expect(summary.deletedIssues).toEqual([issue.key]);
+    expect(summary.failures).toEqual([]);
+    expect(confluence.pages.size).toBe(0);
+    expect(jira.issues.size).toBe(0);
+  });
+
+  it("never throws from cleanup, and reports failures instead", async () => {
+    // cleanup() runs inside `finally`; throwing there would replace the test's
+    // real failure with a cleanup error.
+    const confluence = new MemoryConfluence();
+    const tracker = new E2eResourceTracker({ confluence }, "run-abc");
+    const doomed = await tracker.createPage("doomed", { now: AT });
+    const fine = await tracker.createPage("fine", { now: AT });
+    confluence.failDeletesFor.add(doomed.id);
+
+    const summary = await tracker.cleanup();
+
+    expect(summary.failures).toEqual([
+      { kind: "page", id: doomed.id, error: `HTTP 500 deleting page ${doomed.id}` },
+    ]);
+    // The healthy resource is still removed.
+    expect(summary.deletedPages).toEqual([fine.id]);
+  });
+
+  it("tracks resources created by something else (e.g. the CLI under test)", async () => {
+    const confluence = new MemoryConfluence();
+    const external = confluence.seed({ title: "atlcli-e2e-cli-made-1789000000", spaceKey: E2E_SPACE_KEY });
+    const tracker = new E2eResourceTracker({ confluence }, "run-abc");
+
+    tracker.trackPage(external.id);
+    tracker.trackPage(external.id); // idempotent
+    expect(tracker.trackedPages).toEqual([external.id]);
+
+    await tracker.cleanup();
+    expect(confluence.pages.size).toBe(0);
+  });
+});
+
+describe("withE2eResources", () => {
+  it("deletes everything the body created", async () => {
+    const confluence = new MemoryConfluence();
+
+    await withE2eResources({ confluence }, async (tracker) => {
+      await tracker.createPage("happy-path", { now: AT });
+      expect(confluence.pages.size).toBe(1);
+    });
+
+    expect(confluence.pages.size).toBe(0);
+  });
+
+  it("deletes everything even when the body throws", async () => {
+    // This is the property that makes the nightly sweeper a recovery mechanism
+    // rather than the primary one: a failing test still leaves a clean tenant.
+    const confluence = new MemoryConfluence();
+    const jira = new MemoryJira();
+
+    await expect(
+      withE2eResources({ confluence, jira }, async (tracker) => {
+        await tracker.createPage("exploding", { now: AT });
+        await tracker.createIssue("exploding", { now: AT });
+        throw new Error("assertion failed inside the E2E body");
+      })
+    ).rejects.toThrow("assertion failed inside the E2E body");
+
+    expect(confluence.pages.size).toBe(0);
+    expect(jira.issues.size).toBe(0);
+  });
+
+  it("surfaces leftover resources to the caller without masking the body's error", async () => {
+    const confluence = new MemoryConfluence();
+    const summaries: Array<{ failures: unknown[] }> = [];
+
+    await expect(
+      withE2eResources(
+        { confluence },
+        async (tracker) => {
+          const page = await tracker.createPage("stuck", { now: AT });
+          confluence.failDeletesFor.add(page.id);
+          throw new Error("body failure wins");
+        },
+        { onCleanup: (summary) => summaries.push(summary) }
+      )
+    ).rejects.toThrow("body failure wins");
+
+    expect(summaries).toHaveLength(1);
+    expect(summaries[0]!.failures).toHaveLength(1);
+  });
+});
+
+describe("module registry is intact for later test files", () => {
+  /**
+   * Regression: `auth.test.ts`, `helloworld.test.ts` and `session-guard.test.ts`
+   * all call `mock.module(...)`, which mutates the registry for the WHOLE
+   * process. Without an `afterAll` that puts the real barrels back, their stubs
+   * leaked into every file that runs after them — `getLogger()` came back with
+   * only an `auth` method, so any later test touching a real API client died on
+   * `logger.api is not a function`, and the real clients threw on construction.
+   *
+   * This file sorts after `src/commands/`, so it is exactly where such a leak
+   * shows up. Asserting it here keeps the restores honest.
+   */
+  it("hands later files the real @atlcli/core logger, not a test stub", async () => {
+    const { getLogger } = await import("@atlcli/core");
+    const logger = getLogger();
+    // `api` is the method the leaked stub omitted, which is what broke the
+    // Confluence/Jira clients for every file that ran after the mock.
+    expect(typeof logger.api).toBe("function");
+    expect(typeof logger.auth).toBe("function");
+  });
+
+  it("hands later files constructible API clients", async () => {
+    const { ConfluenceClient } = await import("@atlcli/confluence");
+    const { JiraClient } = await import("@atlcli/jira");
+    const profile: Profile = {
+      name: "registry-probe",
+      baseUrl: "https://probe.example.com",
+      deploymentType: "data-center",
+      auth: { type: "bearer", pat: "probe-token" },
+    };
+    expect(() => new ConfluenceClient(profile)).not.toThrow();
+    expect(() => new JiraClient(profile)).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// REST adapter against a real local HTTP server
+// ---------------------------------------------------------------------------
+
+describe("REST ports against a local stand-in REST API", () => {
+  let server: ReturnType<typeof Bun.serve>;
+  let profile: Profile;
+  const unmatched: string[] = [];
+  const authHeaders: string[] = [];
+
+  // Server-side state, so the adapter is exercised end to end rather than
+  // against canned responses.
+  const pages = new Map<string, { id: string; title: string; spaceKey: string }>();
+  const pageProperties = new Map<string, { value: unknown; version: number }>();
+  const issueProperties = new Map<string, unknown>();
+  const deletedPages: string[] = [];
+  const deletedIssues: string[] = [];
+  let nextPageId = 900;
+
+  beforeAll(() => {
+    server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        const url = new URL(req.url);
+        const { pathname } = url;
+        const auth = req.headers.get("authorization");
+        if (auth) authHeaders.push(auth);
+
+        // --- Confluence: content properties -------------------------------
+        const propMatch = pathname.match(/^\/rest\/api\/content\/([^/]+)\/property(?:\/([^/]+))?$/);
+        if (propMatch) {
+          const [, pageId, key] = propMatch;
+          if (req.method === "GET" && key) {
+            const stored = pageProperties.get(`${pageId}:${key}`);
+            if (!stored) return new Response("{}", { status: 404 });
+            return Response.json({ key, value: stored.value, version: { number: stored.version } });
+          }
+          if (req.method === "POST") {
+            const body = (await req.json()) as { key: string; value: unknown };
+            pageProperties.set(`${pageId}:${body.key}`, { value: body.value, version: 1 });
+            return Response.json({ key: body.key, value: body.value, version: { number: 1 } });
+          }
+          if (req.method === "PUT" && key) {
+            const body = (await req.json()) as { value: unknown; version: { number: number } };
+            pageProperties.set(`${pageId}:${key}`, { value: body.value, version: body.version.number });
+            return Response.json({ key, value: body.value, version: body.version });
+          }
+        }
+
+        // --- Confluence: content CRUD -------------------------------------
+        if (pathname === "/rest/api/content" && req.method === "POST") {
+          const body = (await req.json()) as { title: string; space: { key: string } };
+          const id = String(nextPageId++);
+          pages.set(id, { id, title: body.title, spaceKey: body.space.key });
+          return Response.json({ id, title: body.title, space: { key: body.space.key }, version: { number: 1 } });
+        }
+        const contentMatch = pathname.match(/^\/rest\/api\/content\/([^/]+)$/);
+        if (contentMatch && req.method === "DELETE") {
+          deletedPages.push(contentMatch[1]!);
+          pages.delete(contentMatch[1]!);
+          return new Response(null, { status: 204 });
+        }
+
+        // --- Confluence: paginated CQL search ------------------------------
+        // Two pages, the first one SHORT but carrying a live next-link, so a
+        // `results.length < limit` early break would visibly lose results.
+        if (pathname === "/rest/api/content/search") {
+          const cursor = url.searchParams.get("cursor");
+          if (!cursor) {
+            return Response.json({
+              results: [
+                {
+                  id: "p1",
+                  title: "atlcli-e2e-page-one-1789000000",
+                  type: "page",
+                  space: { key: "DOCSY" },
+                },
+              ],
+              start: 0,
+              limit: 100,
+              size: 1,
+              _links: { next: "/rest/api/content/search?cql=x&cursor=page2" },
+            });
+          }
+          return Response.json({
+            results: [
+              {
+                id: "p2",
+                title: "atlcli-e2e-page-two-1789000000",
+                type: "page",
+                space: { key: "DOCSY" },
+              },
+              { id: "p3", title: "M1 Abnahme 42", type: "page", space: { key: "DOCSY" } },
+            ],
+            start: 1,
+            limit: 100,
+            size: 2,
+            _links: {},
+          });
+        }
+
+        // --- Jira: issue properties ----------------------------------------
+        const issuePropMatch = pathname.match(/^\/rest\/api\/2\/issue\/([^/]+)\/properties\/([^/]+)$/);
+        if (issuePropMatch) {
+          const [, issueKey, key] = issuePropMatch;
+          if (req.method === "PUT") {
+            issueProperties.set(`${issueKey}:${key}`, await req.json());
+            return new Response(null, { status: 201 });
+          }
+          if (req.method === "GET") {
+            const stored = issueProperties.get(`${issueKey}:${key}`);
+            if (stored === undefined) return new Response("{}", { status: 404 });
+            return Response.json({ key, value: stored });
+          }
+        }
+
+        // --- Jira: issue CRUD ----------------------------------------------
+        if (pathname === "/rest/api/2/issue" && req.method === "POST") {
+          const body = (await req.json()) as { fields: { summary: string; project: { key: string } } };
+          return Response.json({ id: "9001", key: `${body.fields.project.key}-1` });
+        }
+        const issueMatch = pathname.match(/^\/rest\/api\/2\/issue\/([^/]+)$/);
+        if (issueMatch && req.method === "GET") {
+          return Response.json({
+            id: "9001",
+            key: issueMatch[1],
+            self: url.href,
+            fields: { summary: "atlcli-e2e-jira-1789000000", project: { key: "ATLCLI", id: "1" } },
+          });
+        }
+        if (issueMatch && req.method === "DELETE") {
+          deletedIssues.push(issueMatch[1]!);
+          return new Response(null, { status: 204 });
+        }
+
+        // --- Jira: paginated JQL search -------------------------------------
+        if (pathname === "/rest/api/2/search/jql") {
+          const body = (await req.json().catch(() => ({}))) as { nextPageToken?: string };
+          if (!body.nextPageToken) {
+            return Response.json({
+              issues: [
+                {
+                  id: "1",
+                  key: "ATLCLI-1",
+                  fields: { summary: "atlcli-e2e-first-1789000000", project: { key: "ATLCLI" } },
+                },
+              ],
+              nextPageToken: "token-2",
+              maxResults: 100,
+            });
+          }
+          return Response.json({
+            issues: [
+              {
+                id: "2",
+                key: "ATLCLI-2",
+                fields: { summary: "atlcli-e2e-second-1789000000", project: { key: "ATLCLI" } },
+              },
+            ],
+            maxResults: 100,
+          });
+        }
+
+        unmatched.push(`${req.method} ${pathname}`);
+        return new Response(JSON.stringify({ message: `stub: no route for ${pathname}` }), {
+          status: 404,
+          headers: { "content-type": "application/json" },
+        });
+      },
+    });
+
+    // Bearer/data-center so the Confluence base URL is used verbatim (no /wiki)
+    // and the token resolves from the profile without touching the keychain.
+    profile = {
+      name: "e2e-stub",
+      baseUrl: server.url.origin,
+      deploymentType: "data-center",
+      auth: { type: "bearer", pat: "stub-token" },
+    };
+  });
+
+  afterAll(() => {
+    server?.stop(true);
+  });
+
+  it("creates a page, stamps the marker, reads it back and deletes it", async () => {
+    const port = createConfluencePort(profile);
+
+    const page = await port.createPage({
+      spaceKey: E2E_SPACE_KEY,
+      title: "atlcli-e2e-rest-1789000000",
+      storage: "<p>fixture</p>",
+    });
+    await port.setPageProperty(page.id, E2E_RUN_ID_PROPERTY, "gha-777");
+
+    expect(await port.getPageProperty(page.id, E2E_RUN_ID_PROPERTY)).toBe("gha-777");
+
+    await port.deletePage(page.id);
+    expect(deletedPages).toContain(page.id);
+    expect(authHeaders).toContain("Bearer stub-token");
+  });
+
+  it("reports no marker when the property does not exist", async () => {
+    const port = createConfluencePort(profile);
+    expect(await port.getPageProperty("does-not-exist", E2E_RUN_ID_PROPERTY)).toBeUndefined();
+  });
+
+  it("overwrites an existing marker with an incremented property version", async () => {
+    const port = createConfluencePort(profile);
+    const page = await port.createPage({ spaceKey: E2E_SPACE_KEY, title: "atlcli-e2e-v-1789000000", storage: "" });
+
+    await port.setPageProperty(page.id, E2E_RUN_ID_PROPERTY, "gha-1");
+    await port.setPageProperty(page.id, E2E_RUN_ID_PROPERTY, "gha-2");
+
+    expect(await port.getPageProperty(page.id, E2E_RUN_ID_PROPERTY)).toBe("gha-2");
+    expect(pageProperties.get(`${page.id}:${E2E_RUN_ID_PROPERTY}`)?.version).toBe(2);
+  });
+
+  it("drains every page of the Confluence listing, including a short first page", async () => {
+    const port = createConfluencePort(profile);
+    const records = await port.listPages("DOCSY");
+
+    expect(records.map((r) => r.id)).toEqual(["p1", "p2", "p3"]);
+    // The retained "M1 Abnahme" fixture is listed but never gets a marker,
+    // because its name does not follow the convention.
+    expect(records.find((r) => r.id === "p3")?.runId).toBeUndefined();
+  });
+
+  it("drains every page of the Jira listing", async () => {
+    const port = createJiraPort(profile);
+    const records = await port.listIssues("ATLCLI");
+    expect(records.map((r) => r.key)).toEqual(["ATLCLI-1", "ATLCLI-2"]);
+  });
+
+  it("stamps and reads a Jira issue property, then deletes the issue", async () => {
+    const port = createJiraPort(profile);
+    const issue = await port.createIssue({ projectKey: E2E_PROJECT_KEY, summary: "atlcli-e2e-jira-1789000000", issueType: "Task" });
+
+    await port.setIssueProperty(issue.key, E2E_RUN_ID_PROPERTY, "gha-777");
+    expect(await port.getIssueProperty(issue.key, E2E_RUN_ID_PROPERTY)).toBe("gha-777");
+
+    await port.deleteIssue(issue.key);
+    expect(deletedIssues).toContain(issue.key);
+  });
+
+  it("routed every request the adapters made", () => {
+    expect(unmatched).toEqual([]);
+  });
+});

--- a/apps/cli/src/e2e/resources.ts
+++ b/apps/cli/src/e2e/resources.ts
@@ -64,6 +64,16 @@ export function makeE2eTitle(feature: string, now: Date = new Date()): string {
     );
   }
   const seconds = Math.floor(now.getTime() / 1000);
+  // The clock must produce a timestamp `parseE2eTitle` will accept. An injected
+  // epoch-0 or otherwise bogus `now` would otherwise mint a name that parses as
+  // null forever — a resource no sweeper can ever recover, which is the exact
+  // failure this validation exists to prevent.
+  if (!Number.isSafeInteger(seconds) || seconds < MIN_TIMESTAMP_SECONDS) {
+    throw new Error(
+      `E2E timestamp must be epoch seconds >= ${MIN_TIMESTAMP_SECONDS}, got ${seconds} (from epoch ms ${now.getTime()}). ` +
+        "A name outside the convention can never be swept."
+    );
+  }
   return `${E2E_NAME_PREFIX}-${feature}-${seconds}`;
 }
 

--- a/apps/cli/src/e2e/resources.ts
+++ b/apps/cli/src/e2e/resources.ts
@@ -1,0 +1,358 @@
+/**
+ * Shared naming + ownership conventions for **live** E2E test resources
+ * (spec 011 "E2E resource discipline").
+ *
+ * Three rules, in force for every live E2E script and agent run:
+ *
+ *  1. **Naming** — every resource is named `atlcli-e2e-<feature>-<timestamp>`
+ *     (epoch *seconds*). Confluence pages live exclusively in space `DOCSY`,
+ *     Jira issues exclusively in project `ATLCLI` (summary prefix).
+ *
+ *  2. **Machine-readable ownership marker** — a visible title prefix proves
+ *     nothing: a user page can happen to share the name, and two E2E runs can
+ *     race inside the same second. So at creation every page also gets a
+ *     content property `atlcli-e2e-run-id` (and every issue the equivalent
+ *     issue property) holding the CI run ID or a local UUID. **That property,
+ *     not the title, is the ownership proof any deletion path checks.**
+ *
+ *  3. **Per-test cleanup first** — each test records what it created and
+ *     deletes it in a `finally` block ({@link withE2eResources}), so the tenant
+ *     is clean after *every single run*. The nightly sweeper
+ *     (`apps/cli/src/e2e/cleanup.ts`) is recovery for what a crashed or killed
+ *     run missed — never the primary mechanism.
+ *
+ * @see src/content/docs/contributing.md — "E2E resources"
+ * @module
+ */
+
+import { randomUUID } from "node:crypto";
+
+/** Content/issue property key holding the owning run's ID. The ownership proof. */
+export const E2E_RUN_ID_PROPERTY = "atlcli-e2e-run-id";
+
+/** Fixed prefix of every live E2E resource name. */
+export const E2E_NAME_PREFIX = "atlcli-e2e";
+
+/** The ONLY Confluence space live E2E resources may be created in or swept from. */
+export const E2E_SPACE_KEY = "DOCSY";
+
+/** The ONLY Jira project live E2E resources may be created in or swept from. */
+export const E2E_PROJECT_KEY = "ATLCLI";
+
+/** Resources younger than this are never swept — a running E2E is never deleted. */
+export const E2E_TTL_MS = 24 * 60 * 60 * 1000;
+
+/** Feature slugs are lowercase alphanumerics joined by single dashes. */
+const FEATURE_SLUG = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+/** Epoch seconds crossed 1e9 in 2001; anything shorter is not a timestamp. */
+const MIN_TIMESTAMP_SECONDS = 1_000_000_000;
+
+/**
+ * Build the canonical name for a live E2E resource.
+ *
+ * @param feature - Lowercase slug naming the feature under test (e.g. `scope-tree`).
+ * @param now - Clock injection point; defaults to the current time.
+ * @returns e.g. `atlcli-e2e-scope-tree-1789000000`
+ * @throws If `feature` is not a lowercase dash-joined slug — an out-of-convention
+ *   name would produce a resource the sweeper can never recover.
+ */
+export function makeE2eTitle(feature: string, now: Date = new Date()): string {
+  if (!FEATURE_SLUG.test(feature)) {
+    throw new Error(
+      `E2E feature slug must match ${FEATURE_SLUG} (lowercase, dash-separated), got: ${JSON.stringify(feature)}`
+    );
+  }
+  const seconds = Math.floor(now.getTime() / 1000);
+  return `${E2E_NAME_PREFIX}-${feature}-${seconds}`;
+}
+
+/** The parts recovered from a conventional E2E resource name. */
+export interface ParsedE2eTitle {
+  feature: string;
+  /** Creation time as epoch **seconds**, exactly as encoded in the name. */
+  timestampSeconds: number;
+}
+
+/**
+ * Recover `{ feature, timestampSeconds }` from a resource name.
+ *
+ * @returns `null` for anything that does not follow the convention — including
+ *   every human-authored page title. Callers treat `null` as "not ours".
+ */
+export function parseE2eTitle(title: string): ParsedE2eTitle | null {
+  if (typeof title !== "string") return null;
+  const segments = title.trim().split("-");
+  // `atlcli` + `e2e` + at least one feature segment + timestamp.
+  if (segments.length < 4) return null;
+  if (segments[0] !== "atlcli" || segments[1] !== "e2e") return null;
+
+  const last = segments[segments.length - 1];
+  if (!/^\d+$/.test(last)) return null;
+  const timestampSeconds = Number.parseInt(last, 10);
+  if (!Number.isSafeInteger(timestampSeconds) || timestampSeconds < MIN_TIMESTAMP_SECONDS) return null;
+
+  const feature = segments.slice(2, -1).join("-");
+  if (!FEATURE_SLUG.test(feature)) return null;
+
+  return { feature, timestampSeconds };
+}
+
+/**
+ * The run ID stamped into every resource this process creates.
+ *
+ * Prefers the CI run identity (so a nightly sweep can attribute residue to a
+ * specific workflow run); falls back to a fresh UUID locally.
+ */
+export function resolveRunId(env: Record<string, string | undefined> = process.env): string {
+  const runId = env.GITHUB_RUN_ID?.trim();
+  const attempt = env.GITHUB_RUN_ATTEMPT?.trim();
+  if (runId) return attempt ? `gha-${runId}-${attempt}` : `gha-${runId}`;
+  return `local-${randomUUID()}`;
+}
+
+// ---------------------------------------------------------------------------
+// Ports
+// ---------------------------------------------------------------------------
+//
+// The tracker and the sweeper talk to Confluence/Jira only through these two
+// narrow interfaces. Production wiring supplies REST-backed implementations
+// (`apps/cli/src/e2e/rest-ports.ts`); tests supply in-memory implementations.
+// Nothing here is ever mocked at the `fetch` level.
+
+/** A Confluence page as the sweeper needs to see it. */
+export interface E2ePageRecord {
+  id: string;
+  title: string;
+  spaceKey: string;
+  /** Value of the {@link E2E_RUN_ID_PROPERTY} content property, if present. */
+  runId?: string;
+}
+
+/** A Jira issue as the sweeper needs to see it. */
+export interface E2eIssueRecord {
+  key: string;
+  summary: string;
+  projectKey: string;
+  /** Value of the {@link E2E_RUN_ID_PROPERTY} issue property, if present. */
+  runId?: string;
+}
+
+export interface E2eConfluencePort {
+  createPage(input: {
+    spaceKey: string;
+    title: string;
+    storage: string;
+    parentId?: string;
+  }): Promise<{ id: string; title: string }>;
+  deletePage(pageId: string): Promise<void>;
+  setPageProperty(pageId: string, key: string, value: string): Promise<void>;
+  getPageProperty(pageId: string, key: string): Promise<string | undefined>;
+  /** MUST fully paginate. A short page carrying a next-cursor is not the last page. */
+  listPages(spaceKey: string): Promise<E2ePageRecord[]>;
+}
+
+export interface E2eJiraPort {
+  createIssue(input: {
+    projectKey: string;
+    summary: string;
+    issueType: string;
+  }): Promise<{ id: string; key: string }>;
+  deleteIssue(issueKey: string): Promise<void>;
+  setIssueProperty(issueKey: string, key: string, value: string): Promise<void>;
+  getIssueProperty(issueKey: string, key: string): Promise<string | undefined>;
+  /** MUST fully paginate. */
+  listIssues(projectKey: string): Promise<E2eIssueRecord[]>;
+}
+
+export interface E2ePorts {
+  confluence?: E2eConfluencePort;
+  jira?: E2eJiraPort;
+}
+
+// ---------------------------------------------------------------------------
+// Per-test tracking + cleanup
+// ---------------------------------------------------------------------------
+
+/** What a {@link E2eResourceTracker.cleanup} pass actually managed to remove. */
+export interface E2eCleanupSummary {
+  deletedPages: string[];
+  deletedIssues: string[];
+  /** Deletions that failed. Never thrown — reported, so a `finally` cannot mask the real error. */
+  failures: Array<{ kind: "page" | "issue"; id: string; error: string }>;
+}
+
+/**
+ * Records every live resource a test creates and deletes them again.
+ *
+ * Two invariants worth stating, because both exist to keep the tenant clean
+ * even when things go wrong:
+ *
+ *  - The ID is recorded **before** the ownership marker is written. If stamping
+ *    the marker fails, the resource is already tracked and this run's `finally`
+ *    still deletes it — otherwise it would be orphaned *and* invisible to the
+ *    marker-gated sweeper, i.e. permanent residue.
+ *  - {@link cleanup} never throws. It runs inside `finally` blocks, where a
+ *    throw would replace the test's actual failure with a cleanup error.
+ */
+export class E2eResourceTracker {
+  readonly runId: string;
+  private readonly pageIds: string[] = [];
+  private readonly issueKeys: string[] = [];
+
+  constructor(
+    private readonly ports: E2ePorts,
+    runId: string = resolveRunId()
+  ) {
+    this.runId = runId;
+  }
+
+  /** IDs of pages created through (or handed to) this tracker, creation order. */
+  get trackedPages(): readonly string[] {
+    return [...this.pageIds];
+  }
+
+  /** Keys of issues created through (or handed to) this tracker, creation order. */
+  get trackedIssues(): readonly string[] {
+    return [...this.issueKeys];
+  }
+
+  /**
+   * Record a page created by something else (e.g. the CLI under test) so it is
+   * still deleted in `finally`. Prefer {@link createPage}, which also stamps
+   * the ownership marker.
+   */
+  trackPage(pageId: string): void {
+    if (!this.pageIds.includes(pageId)) this.pageIds.push(pageId);
+  }
+
+  /** Record an issue created by something else. Prefer {@link createIssue}. */
+  trackIssue(issueKey: string): void {
+    if (!this.issueKeys.includes(issueKey)) this.issueKeys.push(issueKey);
+  }
+
+  /**
+   * Create a conventionally named DOCSY page carrying the ownership marker.
+   *
+   * @param feature - Feature slug for the name (see {@link makeE2eTitle}).
+   */
+  async createPage(
+    feature: string,
+    options: { storage?: string; parentId?: string; now?: Date } = {}
+  ): Promise<{ id: string; title: string }> {
+    const confluence = this.requireConfluence();
+    const title = makeE2eTitle(feature, options.now);
+    const page = await confluence.createPage({
+      spaceKey: E2E_SPACE_KEY,
+      title,
+      storage: options.storage ?? `<p>atlcli E2E fixture (run ${this.runId}). Safe to delete.</p>`,
+      parentId: options.parentId,
+    });
+    // Track BEFORE stamping: an unmarked orphan is worse than a tracked failure.
+    this.trackPage(page.id);
+    await confluence.setPageProperty(page.id, E2E_RUN_ID_PROPERTY, this.runId);
+    return { id: page.id, title };
+  }
+
+  /** Create a conventionally named ATLCLI issue carrying the ownership marker. */
+  async createIssue(
+    feature: string,
+    options: { issueType?: string; now?: Date } = {}
+  ): Promise<{ id: string; key: string; summary: string }> {
+    const jira = this.requireJira();
+    const summary = makeE2eTitle(feature, options.now);
+    const issue = await jira.createIssue({
+      projectKey: E2E_PROJECT_KEY,
+      summary,
+      issueType: options.issueType ?? "Task",
+    });
+    this.trackIssue(issue.key);
+    await jira.setIssueProperty(issue.key, E2E_RUN_ID_PROPERTY, this.runId);
+    return { ...issue, summary };
+  }
+
+  /**
+   * Delete everything recorded, newest first.
+   *
+   * Best-effort and non-throwing: a failed deletion is collected into
+   * {@link E2eCleanupSummary.failures} and the remaining resources are still
+   * attempted. Whatever survives is the sweeper's problem — it carries the
+   * marker, so the sweeper can prove ownership.
+   */
+  async cleanup(): Promise<E2eCleanupSummary> {
+    const summary: E2eCleanupSummary = { deletedPages: [], deletedIssues: [], failures: [] };
+
+    for (const pageId of [...this.pageIds].reverse()) {
+      try {
+        await this.ports.confluence?.deletePage(pageId);
+        summary.deletedPages.push(pageId);
+      } catch (error) {
+        summary.failures.push({ kind: "page", id: pageId, error: errorMessage(error) });
+      }
+    }
+    this.pageIds.length = 0;
+
+    for (const issueKey of [...this.issueKeys].reverse()) {
+      try {
+        await this.ports.jira?.deleteIssue(issueKey);
+        summary.deletedIssues.push(issueKey);
+      } catch (error) {
+        summary.failures.push({ kind: "issue", id: issueKey, error: errorMessage(error) });
+      }
+    }
+    this.issueKeys.length = 0;
+
+    return summary;
+  }
+
+  private requireConfluence(): E2eConfluencePort {
+    if (!this.ports.confluence) throw new Error("E2eResourceTracker: no Confluence port configured");
+    return this.ports.confluence;
+  }
+
+  private requireJira(): E2eJiraPort {
+    if (!this.ports.jira) throw new Error("E2eResourceTracker: no Jira port configured");
+    return this.ports.jira;
+  }
+}
+
+/**
+ * Run `fn` with a tracker and delete everything it created — **always**,
+ * including when `fn` throws.
+ *
+ * This is the shape every live E2E case should use; it is what makes the
+ * nightly sweeper a recovery mechanism instead of the primary one.
+ *
+ * @example
+ * ```ts
+ * await withE2eResources({ confluence }, async (t) => {
+ *   const page = await t.createPage("scope-tree");
+ *   await runCli(["wiki", "export", page.id]);
+ * });
+ * ```
+ */
+export async function withE2eResources<T>(
+  ports: E2ePorts,
+  fn: (tracker: E2eResourceTracker) => Promise<T>,
+  options: { runId?: string; onCleanup?: (summary: E2eCleanupSummary) => void } = {}
+): Promise<T> {
+  const tracker = new E2eResourceTracker(ports, options.runId);
+  try {
+    return await fn(tracker);
+  } finally {
+    const summary = await tracker.cleanup();
+    if (options.onCleanup) {
+      options.onCleanup(summary);
+    } else if (summary.failures.length > 0) {
+      // Surface, never throw: the nightly sweeper is the backstop for these.
+      console.warn(
+        `[e2e] cleanup left ${summary.failures.length} resource(s) behind (run ${tracker.runId}); ` +
+          `the nightly sweeper will recover them: ${summary.failures.map((f) => `${f.kind}:${f.id}`).join(", ")}`
+      );
+    }
+  }
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/apps/cli/src/e2e/rest-ports.ts
+++ b/apps/cli/src/e2e/rest-ports.ts
@@ -1,0 +1,242 @@
+/**
+ * REST-backed implementations of the E2E ports (spec 011 "E2E resource
+ * discipline").
+ *
+ * Page/issue CRUD and listing go through `ConfluenceClient` / `JiraClient` so
+ * live E2E traffic uses the same retry, auth and pagination code paths the
+ * product does. The two **property** endpoints are the exception: neither
+ * client wraps content properties / issue properties today, so those are issued
+ * directly against the same base URL with the same `Authorization` header
+ * rather than growing the shared clients' public API for a test-only need.
+ *
+ * @module
+ */
+
+import { buildAuthHeader, getConfluenceBaseUrl, type Profile } from "@atlcli/core";
+import { ConfluenceClient, escapeCqlValue } from "@atlcli/confluence";
+import { JiraClient } from "@atlcli/jira";
+import {
+  E2E_NAME_PREFIX,
+  E2E_RUN_ID_PROPERTY,
+  parseE2eTitle,
+  type E2eConfluencePort,
+  type E2eIssueRecord,
+  type E2eJiraPort,
+  type E2ePageRecord,
+} from "./resources.js";
+
+/** Shape stored in the marker property. An object, so hosts that reject scalar property values still work. */
+interface RunIdPropertyValue {
+  runId: string;
+  createdAt: string;
+}
+
+function encodeRunId(runId: string): RunIdPropertyValue {
+  return { runId, createdAt: new Date().toISOString() };
+}
+
+/** Tolerates both the object shape written by {@link encodeRunId} and a bare string. */
+function decodeRunId(value: unknown): string | undefined {
+  if (typeof value === "string") return value.trim() || undefined;
+  if (value && typeof value === "object") {
+    const runId = (value as { runId?: unknown }).runId;
+    if (typeof runId === "string") return runId.trim() || undefined;
+  }
+  return undefined;
+}
+
+/**
+ * Jira's API path, mirroring `JiraClient`'s private `apiPath` getter — Cloud
+ * sites get v3, everything else v2.
+ */
+function jiraApiPath(profile: Profile): string {
+  return profile.baseUrl.includes(".atlassian.net") ? "/rest/api/3" : "/rest/api/2";
+}
+
+async function readJson(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (!text) return undefined;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return undefined;
+  }
+}
+
+/** Build a REST-backed Confluence port for live E2E resource handling. */
+export function createConfluencePort(profile: Profile): E2eConfluencePort {
+  const client = new ConfluenceClient(profile);
+  const baseUrl = getConfluenceBaseUrl(profile);
+
+  const propertyHeaders = (): Record<string, string> => ({
+    Authorization: buildAuthHeader(profile),
+    Accept: "application/json",
+    "Content-Type": "application/json",
+  });
+
+  const propertyUrl = (pageId: string, key?: string): string =>
+    `${baseUrl}/rest/api/content/${encodeURIComponent(pageId)}/property${key ? `/${encodeURIComponent(key)}` : ""}`;
+
+  return {
+    async createPage(input) {
+      const page = await client.createPage(input);
+      return { id: page.id, title: page.title };
+    },
+
+    async deletePage(pageId) {
+      await client.deletePage(pageId);
+    },
+
+    async setPageProperty(pageId, key, value) {
+      // Mirrors the client's own `setEditorVersion` dance: read the current
+      // version to PUT over it, POST when the property does not exist yet.
+      const existing = await fetch(propertyUrl(pageId, key), { headers: propertyHeaders() });
+      const body = { key, value: encodeRunId(value) };
+
+      if (existing.ok) {
+        const current = (await readJson(existing)) as { version?: { number?: number } } | undefined;
+        const next = (current?.version?.number ?? 0) + 1;
+        const put = await fetch(propertyUrl(pageId, key), {
+          method: "PUT",
+          headers: propertyHeaders(),
+          body: JSON.stringify({ ...body, version: { number: next } }),
+        });
+        if (!put.ok) {
+          throw new Error(`Failed to update content property ${key} on page ${pageId}: HTTP ${put.status}`);
+        }
+        return;
+      }
+
+      const post = await fetch(propertyUrl(pageId), {
+        method: "POST",
+        headers: propertyHeaders(),
+        body: JSON.stringify(body),
+      });
+      if (!post.ok) {
+        throw new Error(`Failed to create content property ${key} on page ${pageId}: HTTP ${post.status}`);
+      }
+    },
+
+    async getPageProperty(pageId, key) {
+      const response = await fetch(propertyUrl(pageId, key), { headers: propertyHeaders() });
+      // A missing property is the common case, not an error — and it means
+      // "not ours", which the sweeper treats as do-not-delete.
+      if (!response.ok) return undefined;
+      const data = (await readJson(response)) as { value?: unknown } | undefined;
+      return decodeRunId(data?.value);
+    },
+
+    async listPages(spaceKey) {
+      // `searchPages` drains cursor pagination through `drainPaginated`, so a
+      // short page carrying a live next-link is never mistaken for the last one.
+      // The title filter only bounds the candidate set; ownership is still
+      // decided by the marker property below.
+      const cql = `space = "${escapeCqlValue(spaceKey)}" and type = page and title ~ "${E2E_NAME_PREFIX}*"`;
+      const results = await client.searchPages(cql, 100);
+
+      const records: E2ePageRecord[] = [];
+      for (const result of results) {
+        const record: E2ePageRecord = {
+          id: result.id,
+          title: result.title,
+          // Left undefined when the API omits it — an unknown space fails the
+          // scope guard rather than defaulting into it.
+          spaceKey: result.spaceKey ?? "",
+        };
+        // Only pay a property round-trip for names that could ever be swept.
+        if (parseE2eTitle(result.title)) {
+          record.runId = await this.getPageProperty(result.id, E2E_RUN_ID_PROPERTY);
+        }
+        records.push(record);
+      }
+      return records;
+    },
+  };
+}
+
+/** Build a REST-backed Jira port for live E2E resource handling. */
+export function createJiraPort(profile: Profile): E2eJiraPort {
+  const client = new JiraClient(profile);
+  const baseUrl = profile.baseUrl.replace(/\/+$/, "");
+  const apiPath = jiraApiPath(profile);
+
+  const propertyHeaders = (): Record<string, string> => ({
+    Authorization: buildAuthHeader(profile),
+    Accept: "application/json",
+    "Content-Type": "application/json",
+  });
+
+  const propertyUrl = (issueKey: string, key: string): string =>
+    `${baseUrl}${apiPath}/issue/${encodeURIComponent(issueKey)}/properties/${encodeURIComponent(key)}`;
+
+  return {
+    async createIssue(input) {
+      const issue = await client.createIssue({
+        fields: {
+          project: { key: input.projectKey },
+          issuetype: { name: input.issueType },
+          summary: input.summary,
+        },
+      });
+      return { id: issue.id, key: issue.key };
+    },
+
+    async deleteIssue(issueKey) {
+      await client.deleteIssue(issueKey);
+    },
+
+    async setIssueProperty(issueKey, key, value) {
+      const response = await fetch(propertyUrl(issueKey, key), {
+        method: "PUT",
+        headers: propertyHeaders(),
+        body: JSON.stringify(encodeRunId(value)),
+      });
+      if (!response.ok) {
+        throw new Error(`Failed to set issue property ${key} on ${issueKey}: HTTP ${response.status}`);
+      }
+    },
+
+    async getIssueProperty(issueKey, key) {
+      const response = await fetch(propertyUrl(issueKey, key), { headers: propertyHeaders() });
+      if (!response.ok) return undefined;
+      const data = (await readJson(response)) as { value?: unknown } | undefined;
+      return decodeRunId(data?.value);
+    },
+
+    async listIssues(projectKey) {
+      const jql = `project = "${projectKey.replace(/"/g, '\\"')}" AND summary ~ "${E2E_NAME_PREFIX}" ORDER BY created ASC`;
+      const issues: E2eIssueRecord[] = [];
+
+      // Token pagination: keep going while the server hands back a next token.
+      let nextPageToken: string | undefined;
+      const seenTokens = new Set<string>();
+      do {
+        const page = await client.search(jql, {
+          maxResults: 100,
+          fields: ["summary", "project"],
+          nextPageToken,
+        });
+        for (const issue of page.issues) {
+          const record: E2eIssueRecord = {
+            key: issue.key,
+            summary: issue.fields.summary,
+            projectKey: issue.fields.project?.key ?? "",
+          };
+          if (parseE2eTitle(issue.fields.summary)) {
+            record.runId = await this.getIssueProperty(issue.key, E2E_RUN_ID_PROPERTY);
+          }
+          issues.push(record);
+        }
+        nextPageToken = page.nextPageToken;
+        if (nextPageToken) {
+          if (seenTokens.has(nextPageToken)) {
+            throw new Error(`Jira pagination loop: token ${nextPageToken} repeated`);
+          }
+          seenTokens.add(nextPageToken);
+        }
+      } while (nextPageToken);
+
+      return issues;
+    },
+  };
+}

--- a/specs/export-expansion/011-quality-gates/PLAN.md
+++ b/specs/export-expansion/011-quality-gates/PLAN.md
@@ -941,13 +941,18 @@ budget).**
 
 ### E2E resource discipline
 
-- [x] Naming convention: every live test resource is named
+- [~] Naming convention: every live test resource is named
       `atlcli-e2e-<feature>-<timestamp>` (epoch seconds; e.g.
       `atlcli-e2e-scope-tree-1789000000`) — Confluence pages in space
       `DOCSY`, Jira issues in project `ATLCLI` (summary prefix). Helper
       `makeE2eTitle(feature)` in a new shared test helper
       `apps/cli/src/e2e/resources.ts` used by all live E2E scripts
       (including `scripts/e2e-template-test.sh` successors).
+      *(Helper landed and fully tested; ADOPTION still pending. Nothing
+      outside `apps/cli/src/e2e/` imports it yet — no live E2E script calls
+      `makeE2eTitle` today. Sequencing is intentional: folders 001/003/004
+      deferred converting their live cases until this helper existed, so the
+      call sites land with those folders' own E2E cases.)*
 - [x] **Machine-readable ownership marker, not name/timestamp alone**: at
       creation, every E2E-created page also gets a content property
       (`atlcli-e2e-run-id` → the CI run ID or a local UUID) and every
@@ -956,12 +961,17 @@ budget).**
       against a same-named user page or two E2E runs racing in the same
       window — the property is the actual ownership proof a deletion path
       checks before deleting.
-- [x] **Per-test cleanup first, sweeper as recovery only**: each E2E test
+- [~] **Per-test cleanup first, sweeper as recovery only**: each E2E test
       records the IDs it creates and deletes them itself in a `finally`
       block (`apps/cli/src/e2e/resources.ts`) — the tenant is clean after
       every single run, not just after the nightly sweep. This is on top
       of, not instead of, the existing "clean up test resources" workflow
       rule in `CLAUDE.md`.
+      *(`withE2eResources` + `E2eResourceTracker` landed, with tests proving
+      the `finally` path runs when the body throws. No live E2E case uses
+      them yet — the only existing one (`export-pdf.e2e.test.ts`) reads
+      env-provided fixture IDs and creates nothing. Adoption lands with
+      folders 001/003/004.)*
 - [x] Cleanup helper task in the CLI test suite:
       `apps/cli/src/e2e/cleanup.ts` — using `ConfluenceClient`/`JiraClient`
       with profile `mayflower`, list `DOCSY` pages / `ATLCLI` issues that
@@ -978,7 +988,7 @@ budget).**
       marker-match, circuit-breaker threshold) in
       `apps/cli/src/e2e/cleanup.test.ts`; the deletion path is exercised
       only against the live tenant.
-- [x] CI wiring, nightly only: `.github/workflows/e2e-nightly.yml`
+- [~] CI wiring, nightly only: `.github/workflows/e2e-nightly.yml`
       (`schedule` + `workflow_dispatch`, main branch only) runs the new
       scope/macro E2E cases (T4.8 scope) and then `cleanup.ts --force` as
       **recovery for whatever per-test cleanup missed** (a crashed run, a
@@ -988,6 +998,12 @@ budget).**
       history, credentials are repo secrets that must not be exposed to
       fork PRs — therefore **never** per-PR, never on forks; the sweeper
       also runs even when the E2E step fails (`if: always()`).
+      *(Workflow landed with the schedule/dispatch/main/fork guards and the
+      `if: always()` recovery sweep. The "new scope/macro E2E cases (T4.8
+      scope)" it is meant to run DO NOT EXIST yet — its
+      `apps/cli/src/commands/*.e2e.test.ts` glob currently matches only the
+      pre-existing `export-pdf.e2e.test.ts`. The workflow is the landing pad;
+      folders 001/003/004 add the cases.)*
 - [x] Documentation: add an "E2E resources" section to
       `src/content/docs/contributing.md` (naming convention, run-id marker
       property, 24 h TTL, per-test cleanup-in-`finally` expectation,

--- a/specs/export-expansion/011-quality-gates/PLAN.md
+++ b/specs/export-expansion/011-quality-gates/PLAN.md
@@ -941,14 +941,14 @@ budget).**
 
 ### E2E resource discipline
 
-- [ ] Naming convention: every live test resource is named
+- [x] Naming convention: every live test resource is named
       `atlcli-e2e-<feature>-<timestamp>` (epoch seconds; e.g.
       `atlcli-e2e-scope-tree-1789000000`) — Confluence pages in space
       `DOCSY`, Jira issues in project `ATLCLI` (summary prefix). Helper
       `makeE2eTitle(feature)` in a new shared test helper
       `apps/cli/src/e2e/resources.ts` used by all live E2E scripts
       (including `scripts/e2e-template-test.sh` successors).
-- [ ] **Machine-readable ownership marker, not name/timestamp alone**: at
+- [x] **Machine-readable ownership marker, not name/timestamp alone**: at
       creation, every E2E-created page also gets a content property
       (`atlcli-e2e-run-id` → the CI run ID or a local UUID) and every
       Jira issue gets an equivalent issue property. A visible-title prefix
@@ -956,13 +956,13 @@ budget).**
       against a same-named user page or two E2E runs racing in the same
       window — the property is the actual ownership proof a deletion path
       checks before deleting.
-- [ ] **Per-test cleanup first, sweeper as recovery only**: each E2E test
+- [x] **Per-test cleanup first, sweeper as recovery only**: each E2E test
       records the IDs it creates and deletes them itself in a `finally`
       block (`apps/cli/src/e2e/resources.ts`) — the tenant is clean after
       every single run, not just after the nightly sweep. This is on top
       of, not instead of, the existing "clean up test resources" workflow
       rule in `CLAUDE.md`.
-- [ ] Cleanup helper task in the CLI test suite:
+- [x] Cleanup helper task in the CLI test suite:
       `apps/cli/src/e2e/cleanup.ts` — using `ConfluenceClient`/`JiraClient`
       with profile `mayflower`, list `DOCSY` pages / `ATLCLI` issues that
       carry the `atlcli-e2e-run-id` marker property **and** whose title/
@@ -978,7 +978,7 @@ budget).**
       marker-match, circuit-breaker threshold) in
       `apps/cli/src/e2e/cleanup.test.ts`; the deletion path is exercised
       only against the live tenant.
-- [ ] CI wiring, nightly only: `.github/workflows/e2e-nightly.yml`
+- [x] CI wiring, nightly only: `.github/workflows/e2e-nightly.yml`
       (`schedule` + `workflow_dispatch`, main branch only) runs the new
       scope/macro E2E cases (T4.8 scope) and then `cleanup.ts --force` as
       **recovery for whatever per-test cleanup missed** (a crashed run, a
@@ -988,7 +988,7 @@ budget).**
       history, credentials are repo secrets that must not be exposed to
       fork PRs — therefore **never** per-PR, never on forks; the sweeper
       also runs even when the E2E step fails (`if: always()`).
-- [ ] Documentation: add an "E2E resources" section to
+- [x] Documentation: add an "E2E resources" section to
       `src/content/docs/contributing.md` (naming convention, run-id marker
       property, 24 h TTL, per-test cleanup-in-`finally` expectation,
       sweeper usage `bun apps/cli/src/e2e/cleanup.ts`, circuit-breaker

--- a/src/content/docs/contributing.md
+++ b/src/content/docs/contributing.md
@@ -121,21 +121,49 @@ It deletes a resource only when **all four** hold:
 2. Its name matches `atlcli-e2e-<feature>-<timestamp>`.
 3. It is **older than 24 h** — so a running E2E is never swept out from under
    itself.
-4. It lives in space `DOCSY` / project `ATLCLI`. There is no flag to widen this.
+4. It lives in space `DOCSY` / project `ATLCLI`.
+
+Every gate is re-checked immediately before each delete, not just when the plan
+is built.
+
+#### Options
+
+| Flag | Default | Constraint |
+| --- | --- | --- |
+| `--force` | off | Without it, nothing is deleted |
+| `--profile <name>` | `mayflower` | Selects the **tenant** — see the warning below |
+| `--ttl-hours <n>` | `24` | May only be **raised**. Values below `1` are rejected: the TTL gate cannot be switched off |
+| `--max-deletes <n>` | `50` | May only be **lowered**. `50` is a hard ceiling, not a default |
+
+The two directional limits are deliberate. `--ttl-hours 0` would delete a page a
+*different*, still-running E2E created seconds ago — the exact thing the TTL
+exists to prevent. And raising `--max-deletes` is the obvious reflex right after
+seeing an abort, which is precisely the moment a bad query is the likeliest
+explanation.
 
 :::caution[Circuit breaker]
 If a single run selects more than **50** resources, the sweeper aborts the whole
 sweep with a non-zero exit and deletes **nothing at all** — not even up to the
 limit. A selection that large means the query is wrong, not that the tenant is
-dirty. Investigate before re-running.
+dirty. Investigate before re-running; if a sweep legitimately needs to remove
+more, run it repeatedly.
+:::
+
+:::danger[`--profile` selects the tenant]
+The `DOCSY`/`ATLCLI` lock constrains which space and project are swept, **not
+which site**. Point `--profile` (or the `ATLCLI_BASE_URL` fallback) at the wrong
+instance and the sweeper will happily sweep *that* instance's `DOCSY`.
 :::
 
 Listings are fully paginated: a short result page carrying a live next-cursor is
 not the last page.
 
 DOCSY also holds deliberately retained fixtures (the DOCX feature zoo, the
-spec-005 logo/image page, the "M1 Abnahme …" set). None of them carries the
-marker, so the sweeper is structurally incapable of touching them.
+spec-005 logo/image page, the "M1 Abnahme …" set). What protects them is the
+**naming gate**: their titles do not parse as `atlcli-e2e-<feature>-<timestamp>`,
+so they are rejected even if something stamps a valid-looking marker on them.
+That is a structural property of their names, not the contingent fact that they
+happen to carry no marker today.
 
 ### Nightly workflow
 

--- a/src/content/docs/contributing.md
+++ b/src/content/docs/contributing.md
@@ -47,6 +47,104 @@ atlcli/
 └── spec/                 # Internal specs and roadmaps
 ```
 
+## E2E Resources
+
+End-to-end tests create real pages and issues in a shared Atlassian tenant.
+These rules keep that tenant clean and make every resource's ownership
+decidable. They apply to CI **and** to local agent runs — they are the concrete
+form of the "clean up test resources" rule in `CLAUDE.md`.
+
+Helpers live in `apps/cli/src/e2e/`.
+
+### Naming convention
+
+Every live E2E resource is named `atlcli-e2e-<feature>-<timestamp>`, where
+`<feature>` is a lowercase dash-separated slug and `<timestamp>` is epoch
+**seconds**:
+
+```
+atlcli-e2e-scope-tree-1789000000
+```
+
+Confluence pages go **only** in space `DOCSY`; Jira issues go **only** in
+project `ATLCLI` (the summary carries the prefix). Build the name with
+`makeE2eTitle(feature)` rather than by hand — it validates the slug, because an
+off-convention name is one the sweeper can never recover.
+
+### The run-id ownership marker
+
+A title prefix is **not** proof of ownership. A real user page can share the
+name, and two E2E runs can race inside the same second. So at creation every
+page also gets a content property and every issue an issue property:
+
+| Property key        | Value                                    |
+| ------------------- | ---------------------------------------- |
+| `atlcli-e2e-run-id` | The CI run ID (`gha-<run>-<attempt>`), or a local UUID |
+
+**That property, not the name, is what any deletion path checks.** Anything
+without it is treated as someone else's content and is never deleted.
+
+### Clean up in `finally` — every run, not every night
+
+Each test records what it creates and deletes it in a `finally` block, so the
+tenant is clean after *every single run*. Use `withE2eResources`, which does the
+tracking, the marker stamping and the `finally` for you:
+
+```ts
+import { withE2eResources } from "../e2e/resources.js";
+import { createConfluencePort } from "../e2e/rest-ports.js";
+
+await withE2eResources({ confluence: createConfluencePort(profile) }, async (t) => {
+  const page = await t.createPage("scope-tree");   // named + marked + tracked
+  await runCli(["wiki", "export", page.id]);
+  // deleted on the way out, including when this body throws
+});
+```
+
+Use `t.trackPage(id)` / `t.trackIssue(key)` for resources the CLI under test
+created, so they are deleted too.
+
+### The sweeper is recovery, not cleanup
+
+`apps/cli/src/e2e/cleanup.ts` exists for the runs that could not clean up after
+themselves — a crashed process, a cancelled CI job. It is not the primary
+mechanism, and a test that relies on it is a broken test.
+
+```bash
+bun apps/cli/src/e2e/cleanup.ts            # dry run: lists what it would delete
+bun apps/cli/src/e2e/cleanup.ts --force    # actually deletes
+```
+
+It deletes a resource only when **all four** hold:
+
+1. It carries the `atlcli-e2e-run-id` marker.
+2. Its name matches `atlcli-e2e-<feature>-<timestamp>`.
+3. It is **older than 24 h** — so a running E2E is never swept out from under
+   itself.
+4. It lives in space `DOCSY` / project `ATLCLI`. There is no flag to widen this.
+
+:::caution[Circuit breaker]
+If a single run selects more than **50** resources, the sweeper aborts the whole
+sweep with a non-zero exit and deletes **nothing at all** — not even up to the
+limit. A selection that large means the query is wrong, not that the tenant is
+dirty. Investigate before re-running.
+:::
+
+Listings are fully paginated: a short result page carrying a live next-cursor is
+not the last page.
+
+DOCSY also holds deliberately retained fixtures (the DOCX feature zoo, the
+spec-005 logo/image page, the "M1 Abnahme …" set). None of them carries the
+marker, so the sweeper is structurally incapable of touching them.
+
+### Nightly workflow
+
+`.github/workflows/e2e-nightly.yml` runs the live cases on a schedule (and via
+`workflow_dispatch`), on `main` only, then runs the sweeper with `--force` under
+`if: always()` as recovery. It never runs per-PR and never on forks: live REST
+calls spend the tenant's rate budget and pollute space history, and the tenant
+token is a repository secret that must not be exposed to fork PRs.
+
 ## Coding Standards
 
 ### TypeScript


### PR DESCRIPTION
Implements the **E2E resource discipline** section of spec 011-quality-gates.

## Scope
- Naming convention `atlcli-e2e-<feature>-<epoch>` + helpers, with timestamp validation so a minted name always parses back
- **Machine-readable ownership marker** (`atlcli-e2e-run-id` content/issue property) — a title prefix alone is not decidable
- Per-test cleanup in `finally` (`withE2eResources`), sweeper as recovery only
- Recovery sweeper (`apps/cli/src/e2e/cleanup.ts`) + nightly workflow + contributing docs

## The sweeper is destructive code — four gates, all adversarially probed
An Opus review executed attacks against the real planner/executor and found **no path to an unintended deletion**:
- **Marker required** — `planSweep` is the only producer of `SweepTarget` (required `runId`); `assertSweepable` re-runs the *full* classification at the delete site, so a hand-built plan with a forged marker on a retained fixture throws instead of deleting
- **Scope locked** — hardcoded `DOCSY`/`ATLCLI`, no widening flag, fails closed on absent/blank/case-variant space keys
- **TTL** — floored at 1 h (cannot be disabled); rounds toward keeping; future-dated resources kept
- **Circuit breaker** — >50 aborts the *whole* sweep before the first delete; `--max-deletes` may only be lowered
- Dry-run default; `--force` required

Retained fixtures (DOCX feature-zoo, Spec-005 logo page, the 57 "M1 Abnahme" pages) are protected **structurally by the naming gate**, which holds even if something stamps a marker on them — verified by test with their real titles.

## Note
Helper infrastructure landed; adoption by live E2E scripts is deferred to folders 001/003/004 per their own plans — the three affected checkboxes are annotated `[~]` accordingly rather than claiming adoption.

Also fixes a pre-existing cross-file bug: three test files mutated the module registry via `mock.module` without restoring, polluting later suites. Restoration added (snapshot before mocking) with a subprocess-based regression test.

`bun test`: 2892 pass, 0 fail · typecheck (incl. uncached extension) · check:browser green

🤖 Generated with [Claude Code](https://claude.com/claude-code)