### PR TITLE
fix(template-pack): refuse implausible declared sizes before inflating

### DIFF
--- a/packages/template-pack/etc/template-pack.api.md
+++ b/packages/template-pack/etc/template-pack.api.md
@@ -292,7 +292,7 @@ export declare class TemplatePackError extends Error {
 }
 
 // export: TemplatePackErrorKind
-export type TemplatePackErrorKind = "too-large-archive" | "not-zip" | "too-many-entries" | "path-traversal" | "invalid-path" | "symlink" | "file-too-large" | "uncompressed-too-large" | "missing-manifest" | "bad-manifest" | "missing-entry";
+export type TemplatePackErrorKind = "too-large-archive" | "not-zip" | "too-many-entries" | "path-traversal" | "invalid-path" | "symlink" | "file-too-large" | "uncompressed-too-large" | "suspicious-compression" | "corrupt-entry" | "missing-manifest" | "bad-manifest" | "missing-entry";
 
 // export: TemplateProvenance
 export interface TemplateProvenance {
@@ -708,7 +708,7 @@ export declare class TemplatePackError extends Error {
 }
 
 // export: TemplatePackErrorKind
-export type TemplatePackErrorKind = "too-large-archive" | "not-zip" | "too-many-entries" | "path-traversal" | "invalid-path" | "symlink" | "file-too-large" | "uncompressed-too-large" | "missing-manifest" | "bad-manifest" | "missing-entry";
+export type TemplatePackErrorKind = "too-large-archive" | "not-zip" | "too-many-entries" | "path-traversal" | "invalid-path" | "symlink" | "file-too-large" | "uncompressed-too-large" | "suspicious-compression" | "corrupt-entry" | "missing-manifest" | "bad-manifest" | "missing-entry";
 
 // export: TemplateProvenance
 export interface TemplateProvenance {
@@ -1124,7 +1124,7 @@ export declare class TemplatePackError extends Error {
 }
 
 // export: TemplatePackErrorKind
-export type TemplatePackErrorKind = "too-large-archive" | "not-zip" | "too-many-entries" | "path-traversal" | "invalid-path" | "symlink" | "file-too-large" | "uncompressed-too-large" | "missing-manifest" | "bad-manifest" | "missing-entry";
+export type TemplatePackErrorKind = "too-large-archive" | "not-zip" | "too-many-entries" | "path-traversal" | "invalid-path" | "symlink" | "file-too-large" | "uncompressed-too-large" | "suspicious-compression" | "corrupt-entry" | "missing-manifest" | "bad-manifest" | "missing-entry";
 
 // export: TemplateProvenance
 export interface TemplateProvenance {
@@ -1540,7 +1540,7 @@ export declare class TemplatePackError extends Error {
 }
 
 // export: TemplatePackErrorKind
-export type TemplatePackErrorKind = "too-large-archive" | "not-zip" | "too-many-entries" | "path-traversal" | "invalid-path" | "symlink" | "file-too-large" | "uncompressed-too-large" | "missing-manifest" | "bad-manifest" | "missing-entry";
+export type TemplatePackErrorKind = "too-large-archive" | "not-zip" | "too-many-entries" | "path-traversal" | "invalid-path" | "symlink" | "file-too-large" | "uncompressed-too-large" | "suspicious-compression" | "corrupt-entry" | "missing-manifest" | "bad-manifest" | "missing-entry";
 
 // export: TemplateProvenance
 export interface TemplateProvenance {

--- a/packages/template-pack/src/unpack.test.ts
+++ b/packages/template-pack/src/unpack.test.ts
@@ -6,6 +6,8 @@
  * rejected with the matching typed {@link TemplatePackError.kind}.
  */
 import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import PizZipDefault from "pizzip";
 import {
   unpackTemplate,
@@ -159,5 +161,343 @@ describe("size caps", () => {
     expect(bytes.byteLength).toBeLessThan(1024 * 1024);
     expect(90 * 1024 * 1024).toBeGreaterThan(MAX_TEMPLATE_PACK_UNCOMPRESSED_BYTES);
     expectKind(() => unpackTemplate(bytes), "uncompressed-too-large");
+  });
+});
+
+/* -------------------------------------------------------------------------
+ * Forged central directory: the declared-size bypass.
+ *
+ * The size caps above budget on `_data.uncompressedSize`, which is metadata
+ * the attacker writes. An archive that UNDER-declares slips past every
+ * absolute cap and detonates in the inflation pass instead. These tests forge
+ * that field directly in the zip bytes, which no fixture builder can express.
+ * ---------------------------------------------------------------------- */
+
+/** Zip record signatures and the offset of the uncompressed-size field in each. */
+const CENTRAL_DIR_SIG = 0x02014b50;
+const CENTRAL_DIR_USIZE_OFFSET = 24;
+const LOCAL_HEADER_SIG = 0x04034b50;
+const LOCAL_HEADER_USIZE_OFFSET = 22;
+
+/**
+ * Rewrite a member's declared uncompressed size in BOTH the central-directory
+ * record and the local file header.
+ *
+ * Patching only the central directory would be a weaker adversary than the real
+ * one: readers that cross-check the two headers would notice. Patching both
+ * produces an internally consistent archive whose only flaw is that the
+ * declared size does not match what the DEFLATE stream actually yields — which
+ * is precisely the attack `assertPlausibleCompression` exists to refuse.
+ *
+ * @returns the patched archive; asserts that both records were found.
+ */
+function forgeDeclaredSize(archive: Uint8Array, actual: number, forged: number): Uint8Array {
+  const out = new Uint8Array(archive);
+  const dv = new DataView(out.buffer);
+  let patched = 0;
+  for (let i = 0; i + 4 <= out.length; i++) {
+    const sig = dv.getUint32(i, true);
+    if (
+      sig === CENTRAL_DIR_SIG &&
+      i + CENTRAL_DIR_USIZE_OFFSET + 4 <= out.length &&
+      dv.getUint32(i + CENTRAL_DIR_USIZE_OFFSET, true) === actual
+    ) {
+      dv.setUint32(i + CENTRAL_DIR_USIZE_OFFSET, forged, true);
+      patched++;
+    }
+    if (
+      sig === LOCAL_HEADER_SIG &&
+      i + LOCAL_HEADER_USIZE_OFFSET + 4 <= out.length &&
+      dv.getUint32(i + LOCAL_HEADER_USIZE_OFFSET, true) === actual
+    ) {
+      dv.setUint32(i + LOCAL_HEADER_USIZE_OFFSET, forged, true);
+      patched++;
+    }
+  }
+  // Both the central-directory record and the local header must have been hit.
+  expect(patched).toBe(2);
+  return out;
+}
+
+/** Read back a member's declared/compressed sizes as the reader sees them. */
+function sizesOf(archive: Uint8Array, name: string): { declared: number; compressed: number } {
+  const zip = new PizZipDefault(archive);
+  const files = zip.files as unknown as Record<
+    string,
+    { _data?: { uncompressedSize?: number; compressedSize?: number } }
+  >;
+  const e = files[name];
+  return { declared: e?._data?.uncompressedSize ?? -1, compressed: e?._data?.compressedSize ?? -1 };
+}
+
+describe("forged declared size (under-declaration bypass)", () => {
+  /** Size the bomb inflates to. Far above any plausible GC noise in the RSS check. */
+  const BOMB_UNCOMPRESSED = 256 * 1024 * 1024;
+
+  /** Build the forged archive, keeping the 256 MiB buffer out of the caller's scope. */
+  function buildForgedBomb(): Uint8Array {
+    const honest = buildRaw((z) =>
+      z.file("bomb.bin", new Uint8Array(BOMB_UNCOMPRESSED), { date: DATE })
+    );
+    // Declare 1 KiB for a member that actually inflates to 256 MiB.
+    return forgeDeclaredSize(honest, BOMB_UNCOMPRESSED, 1024);
+  }
+
+  it("refuses a member declaring fewer bytes than its own compressed stream", () => {
+    const forged = buildForgedBomb();
+    const { declared, compressed } = sizesOf(forged, "bomb.bin");
+
+    // The forgery is what makes this lethal: 1 KiB declared passes BOTH the
+    // per-file cap and the cumulative cap, so absolute limits alone let it through.
+    expect(declared).toBe(1024);
+    expect(declared).toBeLessThan(MAX_TEMPLATE_PACK_FILE_BYTES);
+    expect(declared).toBeLessThan(MAX_TEMPLATE_PACK_UNCOMPRESSED_BYTES);
+    // ...yet it declares far less than its own compressed stream, which DEFLATE
+    // can never do. That contradiction is the detection.
+    expect(declared).toBeLessThan(compressed);
+
+    expectKind(() => unpackTemplate(forged), "suspicious-compression");
+  });
+
+  it("refuses the forged bomb WITHOUT inflating it (RSS stays flat)", () => {
+    const forged = buildForgedBomb();
+    Bun.gc(true);
+
+    const before = process.memoryUsage().rss;
+    expectKind(() => unpackTemplate(forged), "suspicious-compression");
+    const after = process.memoryUsage().rss;
+
+    const grewBytes = after - before;
+    // Before the guard this inflated the full 256 MiB payload (measured at
+    // 400 MiB: +819 MiB RSS in 231 ms) and only then threw an untyped PizZip
+    // "uncompressed data size mismatch". Rejecting from metadata alone must
+    // allocate essentially nothing, so a fraction of the payload is a generous
+    // bound that still fails loudly if the pre-inflation guard regresses.
+    expect(grewBytes).toBeLessThan(BOMB_UNCOMPRESSED / 4);
+  });
+
+  it("refuses a member declaring implausibly MORE than its compressed stream", () => {
+    // A bomb that stays under the absolute caps: ~4 KiB of incompressible data
+    // re-declared as 30 MiB. Under the 32 MiB per-file and 64 MiB cumulative
+    // caps, so only the ratio bound can catch it.
+    // xorshift32 — genuinely incompressible, so the member lands ABOVE the
+    // 512-byte floor and the ratio bound is what decides. (A weaker generator
+    // compressed to 303 bytes and skipped the check entirely.)
+    const noise = new Uint8Array(4096);
+    let state = 0x9e3779b9;
+    for (let i = 0; i < noise.length; i++) {
+      state ^= state << 13;
+      state ^= state >>> 17;
+      state ^= state << 5;
+      noise[i] = state & 0xff;
+    }
+    const honest = buildRaw((z) => z.file("padded.bin", noise, { date: DATE }));
+
+    const declaredBig = 30 * 1024 * 1024;
+    const forged = forgeDeclaredSize(honest, noise.length, declaredBig);
+    const { declared, compressed } = sizesOf(forged, "padded.bin");
+
+    expect(declared).toBe(declaredBig);
+    expect(declared).toBeLessThan(MAX_TEMPLATE_PACK_FILE_BYTES);
+    expect(compressed).toBeGreaterThan(512); // above the ratio floor
+    expect(declared / compressed).toBeGreaterThan(500);
+
+    expectKind(() => unpackTemplate(forged), "suspicious-compression");
+  });
+});
+
+describe("inflate failure is typed", () => {
+  it("reports a PizZip size mismatch as `corrupt-entry`, not an untyped Error", () => {
+    // Declared size is forged to a value that is PLAUSIBLE for the compressed
+    // stream (so the ratio guard passes) but still wrong, so the failure lands
+    // where it previously escaped untyped: inside the inflation pass.
+    const body = "#let caption = [Figure]\n".repeat(4096); // ~98 KB, compresses well
+    const actual = new TextEncoder().encode(body).length;
+    const honest = buildRaw((z) => z.file("big.typ", body, { date: DATE }));
+
+    const forgedSize = Math.floor(actual / 2);
+    const forged = forgeDeclaredSize(honest, actual, forgedSize);
+    const { declared, compressed } = sizesOf(forged, "big.typ");
+
+    // Confirm this slips past the ratio band, so the test really exercises the
+    // inflate path rather than being caught earlier by `suspicious-compression`.
+    const ratio = declared / compressed;
+    expect(ratio).toBeGreaterThan(0.9);
+    expect(ratio).toBeLessThan(500);
+
+    expectKind(() => unpackTemplate(forged), "corrupt-entry");
+  });
+});
+
+/* -------------------------------------------------------------------------
+ * Positive controls.
+ *
+ * A guard that rejects ordinary input is the same class of defect as the hole
+ * it closes, so the legitimate shapes are pinned as tightly as the evil ones.
+ * Measured ratios (PizZip, the compressor `packTemplate` itself uses):
+ * PNG ~1.2:1, real TTF ~2.1:1, Typst source ~3.4:1, SVG ~7.1:1,
+ * localization JSON ~11.9:1, 20 000 identical Typst blocks ~335.8:1.
+ * ---------------------------------------------------------------------- */
+
+/** A real TTF shipped by `@atlcli/docx`, resolved through its export map. */
+function realFontBytes(): Uint8Array {
+  const url = import.meta.resolve("@atlcli/docx/fonts/Inter-Regular.ttf");
+  return new Uint8Array(readFileSync(fileURLToPath(url)));
+}
+
+/** CRC-32 over `bytes`, for building a genuine PNG. */
+function crc32(bytes: Uint8Array): number {
+  let crc = 0xffffffff;
+  for (const b of bytes) {
+    crc ^= b;
+    for (let k = 0; k < 8; k++) crc = crc & 1 ? (crc >>> 1) ^ 0xedb88320 : crc >>> 1;
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+/**
+ * Build a genuine, structurally valid PNG (zlib-compressed IDAT).
+ *
+ * A real PNG rather than random bytes because the point of the control is the
+ * COMPRESSION behaviour of the media: PNG's payload is already DEFLATE'd, so
+ * the zip layer can barely shrink it further (~1.2:1 measured).
+ */
+function buildPng(width: number, height: number): Uint8Array {
+  const chunk = (type: string, data: Uint8Array): Uint8Array => {
+    const typeBytes = new TextEncoder().encode(type);
+    const body = new Uint8Array(typeBytes.length + data.length);
+    body.set(typeBytes, 0);
+    body.set(data, typeBytes.length);
+    const out = new Uint8Array(4 + body.length + 4);
+    const dv = new DataView(out.buffer);
+    dv.setUint32(0, data.length, false);
+    out.set(body, 4);
+    dv.setUint32(4 + body.length, crc32(body), false);
+    return out;
+  };
+
+  const ihdrData = new Uint8Array(13);
+  const ihdrView = new DataView(ihdrData.buffer);
+  ihdrView.setUint32(0, width, false);
+  ihdrView.setUint32(4, height, false);
+  ihdrData[8] = 8; // bit depth
+  ihdrData[9] = 2; // colour type: truecolour
+  // Varied pixel data, so the PNG is a plausible photo/diagram rather than a
+  // flat fill that would compress unrealistically well.
+  const raw = new Uint8Array(height * (1 + width * 3));
+  let p = 0;
+  for (let y = 0; y < height; y++) {
+    raw[p++] = 0; // filter: none
+    for (let x = 0; x < width; x++) {
+      raw[p++] = (x * 7 + y * 13) % 256;
+      raw[p++] = (x * 31 + y * 17) % 256;
+      raw[p++] = (x * 3 + y * 101) % 256;
+    }
+  }
+  const idat = Bun.deflateSync(raw);
+
+  const sig = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+  const parts = [
+    sig,
+    chunk("IHDR", ihdrData),
+    chunk("IDAT", idat),
+    chunk("IEND", new Uint8Array(0)),
+  ];
+  const total = parts.reduce((n, part) => n + part.length, 0);
+  const png = new Uint8Array(total);
+  let at = 0;
+  for (const part of parts) {
+    png.set(part, at);
+    at += part.length;
+  }
+  return png;
+}
+
+describe("legitimate packs still unpack (positive controls)", () => {
+  it("accepts a realistic mixed pack: manifest + Typst + real TTF + real PNG", () => {
+    const font = realFontBytes();
+    const png = buildPng(256, 256);
+    expect(font.byteLength).toBeGreaterThan(100_000); // a real font, not a stub
+    expect(png.byteLength).toBeGreaterThan(10_000);
+
+    const typst = [
+      "#let render(meta, body, settings) = {",
+      '  set page(paper: "a4", margin: 2cm)',
+      '  set text(font: "Inter", size: 10pt)',
+      "  heading(meta.title)",
+      "  body",
+      "}",
+    ].join("\n");
+
+    const bytes = buildRaw((z) => {
+      z.file("assets/Inter-Regular.ttf", font, { date: DATE });
+      z.file("assets/cover.png", png, { date: DATE });
+      z.file("partials/body.typ", typst, { date: DATE });
+    });
+
+    const out = unpackTemplate(bytes);
+    expect(out.manifest.engine.entry).toBe("template.typ");
+    expect(out.files["assets/Inter-Regular.ttf"]?.byteLength).toBe(font.byteLength);
+    expect(out.files["assets/cover.png"]?.byteLength).toBe(png.byteLength);
+
+    // The incompressible media must sit comfortably inside the ratio band.
+    for (const name of ["assets/Inter-Regular.ttf", "assets/cover.png"]) {
+      const { declared, compressed } = sizesOf(bytes, name);
+      const ratio = declared / compressed;
+      expect(ratio).toBeGreaterThan(0.9);
+      expect(ratio).toBeLessThan(500);
+    }
+  });
+
+  it("accepts a highly repetitive but legitimate pack (~336:1, just under the cap)", () => {
+    // The template-pack analogue of a long form of identical empty rows. This is
+    // the shape that a naive 100:1 cap would have rejected: measured 335.8:1 at
+    // 20 000 blocks, converging to ~343:1 rather than climbing to DEFLATE's
+    // ceiling, because real Typst syntax needs several distinct bytes per unit.
+    const block = "#block(width: 100%, inset: 8pt)[#text(size: 10pt)[]]";
+    const repetitive = Array.from({ length: 20_000 }, () => block).join("\n");
+
+    const bytes = buildRaw((z) => z.file("form.typ", repetitive, { date: DATE }));
+    const { declared, compressed } = sizesOf(bytes, "form.typ");
+    const ratio = declared / compressed;
+
+    // Pin the measurement: this legitimate shape really is far above 100:1.
+    expect(ratio).toBeGreaterThan(300);
+    expect(ratio).toBeLessThan(500);
+
+    const out = unpackTemplate(bytes);
+    expect(new TextDecoder().decode(out.files["form.typ"]!)).toBe(repetitive);
+  });
+
+  it("accepts ordinary small members below the 512-byte ratio floor", () => {
+    // Zip framing dominates tiny entries — a 4-byte member compresses to ~6
+    // bytes (0.7:1), which is UNDER the lower bound and would be rejected as a
+    // lie were the floor not applied.
+    const bytes = buildRaw((z) => {
+      z.file("tiny.txt", "body", { date: DATE });
+      z.file("small.typ", "#let x = 1\n".repeat(18), { date: DATE });
+      z.file("empty.txt", "", { date: DATE });
+    });
+
+    const tiny = sizesOf(bytes, "tiny.txt");
+    expect(tiny.compressed).toBeLessThan(512); // below the floor
+    expect(tiny.declared).toBeLessThan(tiny.compressed); // would trip the lower bound
+
+    const out = unpackTemplate(bytes);
+    expect(new TextDecoder().decode(out.files["tiny.txt"]!)).toBe("body");
+    expect(out.files["empty.txt"]?.byteLength).toBe(0);
+  });
+
+  it("accepts a manifest carrying a large repetitive localization table", () => {
+    const localization = Object.fromEntries(
+      Array.from({ length: 2000 }, (_, i) => [`key.${i}`, { en: "Continued", de: "Fortsetzung" }])
+    );
+    const bytes = buildRaw((z) =>
+      z.file("i18n.json", JSON.stringify(localization), { date: DATE })
+    );
+
+    const { declared, compressed } = sizesOf(bytes, "i18n.json");
+    expect(declared / compressed).toBeLessThan(500);
+    expect(() => unpackTemplate(bytes)).not.toThrow();
   });
 });

--- a/packages/template-pack/src/unpack.ts
+++ b/packages/template-pack/src/unpack.ts
@@ -14,11 +14,33 @@
  *     *declared* uncompressed size and aborted BEFORE any inflation (zip-bomb
  *     guard), never by counting compressed bytes;
  *   - any single member over {@link MAX_TEMPLATE_PACK_FILE_BYTES};
+ *   - any member whose declared size is implausible for its own compressed
+ *     stream (`suspicious-compression`) — see below;
+ *   - a member that fails to inflate (`corrupt-entry`);
  *   - more than {@link MAX_TEMPLATE_PACK_ENTRIES} entries;
  *   - path traversal (`..` segments, absolute paths, backslashes, drive letters)
  *     and ASCII control characters in member paths (see {@link assertSafePath});
  *   - symlink entries;
  *   - a missing/unreadable manifest, or a missing `engine.entry` member.
+ *
+ * The size caps alone are NOT sufficient, because the declared uncompressed
+ * size they budget on is attacker-controlled central-directory metadata. Two
+ * independent families of check are therefore required:
+ *
+ *  - ABSOLUTE caps refuse an HONEST bomb — one that truthfully declares a huge
+ *    payload.
+ *  - RATIO plausibility ({@link assertPlausibleCompression}) refuses a LYING
+ *    central directory — one that UNDER-declares to slip past those caps and
+ *    detonate at inflation time. Measured before this guard: a member declaring
+ *    1 KiB whose stream inflates to 400 MiB cost +819 MiB RSS in 231 ms.
+ *
+ * Residual risk, stated plainly: a member declaring a size consistent with its
+ * compressed stream but whose DEFLATE data decodes to something else still
+ * inflates before PizZip's own post-hoc size comparison fires. PizZip exposes no
+ * bounded/streaming inflate, so that spike cannot be prevented here; it is
+ * bounded by the ratio cap (at most ~500x the compressed bytes actually shipped)
+ * and surfaces as a typed `corrupt-entry` rather than an untyped crash (see
+ * {@link readEntryBytes}).
  *
  * The inner DOCX cap (`MAX_TEMPLATE_BYTES` = 20 MiB in `@atlcli/docx`) is
  * unrelated and unchanged; it still applies once a `kind: "docx"` container's
@@ -49,6 +71,74 @@ export const MAX_TEMPLATE_PACK_ENTRIES = 2048;
 const S_IFMT = 0xf000;
 const S_IFLNK = 0xa000;
 
+/**
+ * Maximum plausible declared:compressed ratio for a pack member.
+ *
+ * DEFLATE tops out near 1032:1. Measured ratios for REAL template-pack media
+ * (PizZip, the same compressor `packTemplate` uses):
+ *
+ * | Member                                        | ratio    |
+ * |-----------------------------------------------|----------|
+ * | PNG / incompressible image data                |    1.2:1 |
+ * | TTF font (real Inter-Regular, 411 KB)          |    2.1:1 |
+ * | TTF font (real JetBrainsMono-Regular, 274 KB)  |    2.1:1 |
+ * | Typst source (real, 23 KB)                     |    3.4:1 |
+ * | SVG logo/diagram (2000 paths)                  |    7.1:1 |
+ * | Typst table, 100 000 VARYING rows              |    6.4:1 |
+ * | Manifest JSON, 400-key localization table      |   11.9:1 |
+ * | Manifest JSON, 50 000 IDENTICAL entries        |   19.5:1 |
+ * | Typst source, 20 000 IDENTICAL blocks          |  335.8:1 |
+ * | Typst source, 200 000 IDENTICAL blocks         |  342.9:1 |
+ *
+ * The last two rows are why this is 500 and not 100: a highly repetitive but
+ * entirely legitimate template (a long form of identical empty blocks)
+ * compresses far better than prose, and a 100:1 cap would reject it. A limit
+ * that refuses real packs is an availability bug, not a control.
+ *
+ * Critically, that shape CONVERGES rather than approaching DEFLATE's ceiling:
+ * 230:1 at 1000 blocks, 335.8:1 at 20 000, 342.9:1 at 200 000 (10.6 MB
+ * uncompressed). Any real Typst/JSON syntax needs several distinct bytes per
+ * repeated unit, which bounds the ratio a few hundred to one. Only a
+ * single-byte run (e.g. 2 MiB of pure newlines, measured 1023:1) reaches the
+ * ceiling, and that is a degenerate blob rather than a template — a pack member
+ * of that shape has no legitimate function, so the envelope is not fitted to it.
+ *
+ * 500:1 therefore sits ~1.46x above every legitimate shape measured and well
+ * below DEFLATE's ceiling, so it still catches a bomb that stays UNDER the
+ * absolute caps: declaring the full 32 MiB per-file cap now forces an attacker
+ * to ship at least 65.5 KiB of real compressed data instead of 31.8 KiB.
+ */
+const MAX_DECLARED_COMPRESSION_RATIO = 500;
+
+/**
+ * Minimum plausible declared:compressed ratio.
+ *
+ * DEFLATE never meaningfully expands its input: worst case is ~1.0003x plus a
+ * few bytes of framing. A member declaring FEWER bytes than its own compressed
+ * stream is therefore provably lying, which is exactly the shape of the
+ * inflation bypass this guard closes — a member declaring 1 KiB whose stream
+ * inflates to 400 MiB passed both absolute caps and detonated in the inflation
+ * pass (measured: +819 MiB RSS in 231 ms, surfacing as an untyped PizZip
+ * "uncompressed data size mismatch"). 0.9 tolerates framing overhead on small
+ * entries while still catching a lie by orders of magnitude.
+ *
+ * This lower bound is the actual protection; the upper bound only narrows the
+ * remaining sub-cap window.
+ */
+const MIN_DECLARED_COMPRESSION_RATIO = 0.9;
+
+/**
+ * Below this compressed size the ratio checks are skipped.
+ *
+ * Zip framing dominates tiny members, which makes both ratios meaningless and
+ * would reject ordinary small ones — measured here: a 4-byte member compresses
+ * to 6 bytes (0.7:1, under the lower bound) and a 198-byte Typst snippet to
+ * 16 bytes (12.4:1). A member this small cannot inflate to anything dangerous
+ * even at DEFLATE's theoretical maximum (512 B x 1032 = 528 KiB), so skipping
+ * it costs nothing.
+ */
+const COMPRESSION_RATIO_FLOOR_BYTES = 512;
+
 /** Typed rejection kinds carried by {@link TemplatePackError}. */
 export type TemplatePackErrorKind =
   | "too-large-archive"
@@ -59,6 +149,8 @@ export type TemplatePackErrorKind =
   | "symlink"
   | "file-too-large"
   | "uncompressed-too-large"
+  | "suspicious-compression"
+  | "corrupt-entry"
   | "missing-manifest"
   | "bad-manifest"
   | "missing-entry";
@@ -134,6 +226,65 @@ function isSymlink(entry: ReadEntry): boolean {
 }
 
 /**
+ * Reject a member whose declared uncompressed size is implausible for its own
+ * compressed stream (see {@link MAX_DECLARED_COMPRESSION_RATIO} /
+ * {@link MIN_DECLARED_COMPRESSION_RATIO}).
+ *
+ * This deliberately mirrors `assertPlausibleCompression` in `@atlcli/docx`
+ * rather than importing it — exactly as {@link assertSafePath} mirrors that
+ * package's `assertSafeDocxEntryName`. The rule is shared but the ERROR TYPE is
+ * not: callers of {@link unpackTemplate} switch on {@link TemplatePackError} and
+ * its `kind`, so importing the docx helper would throw a `DocxError` straight
+ * through this package's import gate and defeat the typing it exists to
+ * provide. The ratio envelope is re-derived from template-pack media (fonts,
+ * images, Typst, manifest JSON) rather than inherited — see the constants.
+ *
+ * @throws {TemplatePackError} `suspicious-compression`.
+ */
+function assertPlausibleCompression(entry: ReadEntry, declared: number): void {
+  const compressed = entry._data?.compressedSize;
+  if (typeof compressed !== "number" || !Number.isFinite(compressed)) return;
+  if (compressed < COMPRESSION_RATIO_FLOOR_BYTES) return;
+  if (declared > compressed * MAX_DECLARED_COMPRESSION_RATIO) {
+    throw new TemplatePackError(
+      "suspicious-compression",
+      `Member "${entry.name}" declares ${declared} bytes from ${compressed} compressed (ratio ${(declared / compressed).toFixed(1)}:1, limit ${MAX_DECLARED_COMPRESSION_RATIO}:1).`,
+      entry.name
+    );
+  }
+  if (declared < compressed * MIN_DECLARED_COMPRESSION_RATIO) {
+    throw new TemplatePackError(
+      "suspicious-compression",
+      `Member "${entry.name}" declares only ${declared} uncompressed bytes for a ${compressed}-byte compressed stream. DEFLATE never expands its input, so the declared size is false — refusing before inflation.`,
+      entry.name
+    );
+  }
+}
+
+/**
+ * Inflate one member, translating a decompression failure into a typed error.
+ *
+ * PizZip inflates eagerly and only compares sizes afterwards, throwing a bare
+ * `Error("Bug : uncompressed data size mismatch")`. Without this wrapper that
+ * untyped throw escapes {@link unpackTemplate}, so a caller switching on
+ * {@link TemplatePackError.kind} faces an unhandled exception from what is
+ * simply another malformed archive.
+ *
+ * @throws {TemplatePackError} `corrupt-entry`.
+ */
+function readEntryBytes(entry: ReadEntry): Uint8Array {
+  try {
+    return entry.asUint8Array();
+  } catch (err) {
+    throw new TemplatePackError(
+      "corrupt-entry",
+      `Member "${entry.name}" could not be decompressed (${(err as Error).message}); the archive is corrupt or its central directory is falsified.`,
+      entry.name
+    );
+  }
+}
+
+/**
  * Read and validate a `.wiki-pdf-template` archive.
  *
  * @throws {TemplatePackError} on any structural rejection above.
@@ -161,7 +312,8 @@ export function unpackTemplate(bytes: Uint8Array): UnpackedTemplate {
     );
   }
 
-  // First pass: validate paths + declared sizes WITHOUT inflating (zip-bomb guard).
+  // First pass: paths, symlinks and ABSOLUTE size caps, WITHOUT inflating.
+  const sized: { entry: ReadEntry; declared: number }[] = [];
   let cumulative = 0;
   for (const entry of entries) {
     assertSafePath(entry.name);
@@ -192,14 +344,30 @@ export function unpackTemplate(bytes: Uint8Array): UnpackedTemplate {
         entry.name
       );
     }
+    sized.push({ entry, declared });
   }
 
-  // Second pass: inflate now that declared sizes are proven within caps.
+  // Second pass: ratio plausibility, only once the archive fits every absolute
+  // cap. Separated from the pass above rather than folded into it, because the
+  // cumulative budget is a property of the WHOLE archive: three members
+  // honestly declaring 30 MiB of zeros each breach the 64 MiB total, but the
+  // breach is only detectable at the third, while a per-entry ratio test would
+  // fire on the first and misreport an HONEST bomb (nothing in it lied) as
+  // `suspicious-compression`. Checking every absolute cap first keeps the
+  // diagnosis accurate: size kinds for honest bombs, `suspicious-compression`
+  // strictly for a central directory that cannot be telling the truth.
+  // Both passes read metadata only, so nothing is inflated either way.
+  for (const { entry, declared } of sized) {
+    assertPlausibleCompression(entry, declared);
+  }
+
+  // Final pass: inflate, now that declared sizes are both within the absolute
+  // caps and plausible for their own compressed streams.
   const files: Record<string, Uint8Array> = {};
   let manifestBytes: Uint8Array | undefined;
   for (const entry of entries) {
     if (entry.dir) continue;
-    const data = entry.asUint8Array();
+    const data = readEntryBytes(entry);
     if (entry.name === TEMPLATE_PACK_MANIFEST_NAME) {
       manifestBytes = data;
     } else {


### PR DESCRIPTION
Closes the zip-bomb blind spot in `unpackTemplate` — the **import gate for third-party `.wiki-pdf-template` containers** — identical to the one just fixed on the DOCX path in spec 011 (#72).

## The defect
`unpackTemplate` budgeted using `entry._data.uncompressedSize`, the DECLARED size from the zip central directory, which is attacker-controlled. An archive that UNDER-declares (1 KiB for a member whose DEFLATE stream expands to 400 MiB) passed both size caps, got fully inflated in the second pass, and only then did PizZip throw an untyped `Error: Bug : uncompressed data size mismatch`.

**Measured, before → after:** `+819.5 MiB RSS in 231 ms` (untyped Error) → **`+0.6 MiB in 1 ms`** (typed `TemplatePackError` / `suspicious-compression`).

The load-bearing check is the *lower* bound — `declared < compressed × 0.9` is provably a lie, because DEFLATE never expands its input.

## The 500:1 upper bound is validated, not copied
Measured with real repo assets through PizZip (the same compressor `packTemplate` uses):

| Member | ratio |
|---|---|
| PNG / incompressible image | 1.2:1 |
| Real `Inter-Regular.ttf` / `JetBrainsMono-Regular.ttf` | 2.1:1 |
| Real Typst source | 3.4:1 |
| Typst table, 100 000 varying rows | 6.4:1 |
| SVG, 2000 paths | 7.1:1 |
| Localization JSON | 11.9–19.5:1 |
| **20 000 identical Typst blocks** | **335.8:1** |
| 200 000 identical Typst blocks | 342.9:1 |

The decisive finding: the repetitive shape **converges** (230 → 335.8 → 342.9) rather than climbing toward DEFLATE's 1032:1 ceiling, because real Typst/JSON syntax needs several distinct bytes per repeated unit. A 2 MiB blob of pure newlines does hit 1023:1, but that is a degenerate blob rather than a template — fitting the cap to it would have destroyed the upper bound, so it was deliberately excluded. 500 clears every legitimate shape by ~1.46×; 100:1 would have rejected the repetitive pack, matching the DOCX lane's experience.

## Design note
The first implementation put the ratio check inline in the existing loop and broke a pre-existing test plus the shared corpus in `packages/export-fixtures` (out of scope): `zip-bomb-cumulative` flipped from `uncompressed-too-large` to `suspicious-compression`. Rather than edit an out-of-scope fixture, plausibility moved into its own metadata pass that runs *after* the absolute caps — which is also the more correct diagnosis: three members honestly declaring 30 MiB of zeros are not lying about anything; their fault is the size budget. Both passes are metadata-only; nothing inflates either way.

Also: PizZip inflate failures now surface as a typed `corrupt-entry` instead of an untyped exception, so callers switching on `kind` never face an unhandled error.

## Verification
21 tests incl. a `forgeDeclaredSize` helper patching the size field in **both** the central-directory record and the local header (asserting exactly 2 patches, so a partial forgery cannot silently pass), an RSS assertion proving nothing inflates, and positive controls (realistic mixed pack with genuine TTF + structurally valid PNG, a ~336:1 legitimate repetitive pack, small members below the 512-byte floor).

`bun test`: 2825 pass, 0 fail · typecheck (incl. uncached extension) · check:browser green · API report regenerated after build

🤖 Generated with [Claude Code](https://claude.com/claude-code)