### PR TITLE
fix(docs): keep a pulled page on its own filename

### DIFF
--- a/apps/cli/src/commands/docs-pull-path-stability.test.ts
+++ b/apps/cli/src/commands/docs-pull-path-stability.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Regression: repeated `docs pull` renamed a tracked page's local file and
+ * eventually duplicated it on disk.
+ *
+ * The write loop reuses `existingState.path` for a page that has not moved, but
+ * the sync.db upsert at the end of `handlePull` stored `computed.relativePath`
+ * from `buildPathMap()`. `buildPathMap()` seeds its `usedPaths` set from the
+ * paths already recorded in state, without knowing that `<slug>.md` belongs to
+ * the very page being placed, so it handed out `<slug>-2.md`. sync.db (which
+ * `readState()` prefers over state.json) then claimed the page lived at
+ * `<slug>-2.md`, and the next pull wrote a second markdown file plus a second
+ * `.attachments/` directory there - forever alternating between the two names.
+ *
+ * Everything runs through the real CLI against a real Bun HTTP server standing
+ * in for the Confluence REST API - no fetch mocking, no Atlassian traffic, and
+ * a sandboxed HOME so the developer's own ~/.atlcli/config.json is never read.
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtemp, mkdir, rm, writeFile, readdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createSyncDb, getAtlcliPath, readState } from "@atlcli/confluence/internal";
+
+const CLI = fileURLToPath(new URL("../index.ts", import.meta.url));
+const PAGE_ID = "78001";
+const PAGE_TITLE = "Path Stability Fixture";
+const SLUG = "path-stability-fixture";
+const ATTACHMENT_ID = "att78001";
+const ATTACHMENT_NAME = "diagram.png";
+const DOWNLOAD_PATH = `/download/attachments/${PAGE_ID}/${ATTACHMENT_NAME}`;
+
+const ATTACHMENT_BYTES = new Uint8Array(Buffer.from("PNG stub payload ".repeat(16)));
+
+const PAGE = {
+  id: PAGE_ID,
+  type: "page",
+  title: PAGE_TITLE,
+  space: { key: "DOCSY" },
+  version: { number: 3, when: "2026-07-20T00:00:00.000Z" },
+  ancestors: [],
+  history: {
+    createdDate: "2026-07-19T00:00:00.000Z",
+    createdBy: { accountId: "acc-1", displayName: "Fixture Author" },
+    lastUpdated: { when: "2026-07-20T00:00:00.000Z", by: { accountId: "acc-1", displayName: "Fixture Author" } },
+  },
+  metadata: { labels: { results: [] }, properties: {} },
+  body: { storage: { value: "<p>Stable body.</p>", representation: "storage" } },
+  _links: { base: "http://stub.invalid", webui: `/pages/${PAGE_ID}` },
+};
+
+const ATTACHMENTS = {
+  results: [
+    {
+      id: ATTACHMENT_ID,
+      type: "attachment",
+      title: ATTACHMENT_NAME,
+      version: { number: 1, when: "2026-07-20T00:00:00.000Z" },
+      extensions: { mediaType: "image/png", fileSize: ATTACHMENT_BYTES.byteLength },
+      metadata: { mediaType: "image/png" },
+      _links: { download: DOWNLOAD_PATH },
+    },
+  ],
+  size: 1,
+};
+
+let server: ReturnType<typeof Bun.serve>;
+let home: string;
+let tree: string;
+
+/** Any non-GET request would mean the test wrote to "Confluence". */
+let writes: string[] = [];
+
+beforeAll(async () => {
+  server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      const { pathname } = new URL(req.url);
+      if (req.method !== "GET") writes.push(`${req.method} ${pathname}`);
+
+      // Data-center shape (bearer auth => no /wiki prefix).
+      if (pathname === `/rest/api/content/${PAGE_ID}`) return Response.json(PAGE);
+      if (pathname === `/rest/api/content/${PAGE_ID}/child/attachment`) return Response.json(ATTACHMENTS);
+      if (pathname === DOWNLOAD_PATH) {
+        return new Response(ATTACHMENT_BYTES, { headers: { "content-type": "image/png" } });
+      }
+
+      // Folder discovery (v2 API) is best-effort in pull and tolerates 404s.
+      return new Response(JSON.stringify({ message: `stub: no route for ${pathname}` }), {
+        status: 404,
+        headers: { "content-type": "application/json" },
+      });
+    },
+  });
+
+  home = await mkdtemp(join(tmpdir(), "atlcli-path-home-"));
+  await mkdir(join(home, ".atlcli"), { recursive: true });
+  await writeFile(
+    join(home, ".atlcli", "config.json"),
+    JSON.stringify({
+      currentProfile: "stub",
+      profiles: {
+        stub: {
+          name: "stub",
+          baseUrl: server.url.origin,
+          deploymentType: "data-center",
+          auth: { type: "bearer" },
+          space: "DOCSY",
+        },
+      },
+    })
+  );
+});
+
+afterAll(async () => {
+  server?.stop(true);
+  if (home) await rm(home, { recursive: true, force: true });
+  if (tree) await rm(tree, { recursive: true, force: true });
+});
+
+async function runCli(args: string[]): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const proc = Bun.spawn([process.execPath, "--conditions=development", "run", CLI, ...args], {
+    cwd: tree,
+    env: {
+      ...process.env,
+      HOME: home,
+      USERPROFILE: home,
+      ATLCLI_API_TOKEN: "stub-token",
+      ATLCLI_DISABLE_UPDATE_CHECK: "1",
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  return { stdout, stderr, exitCode };
+}
+
+/** Every markdown file in the tree, excluding the .atlcli metadata directory. */
+async function markdownFiles(): Promise<string[]> {
+  const found: string[] = [];
+  const walk = async (dir: string, prefix = "") => {
+    for (const entry of await readdir(dir, { withFileTypes: true })) {
+      if (entry.name.startsWith(".")) continue;
+      const rel = prefix ? `${prefix}/${entry.name}` : entry.name;
+      if (entry.isDirectory()) await walk(join(dir, entry.name), rel);
+      else if (entry.name.endsWith(".md")) found.push(rel);
+    }
+  };
+  await walk(tree);
+  return found.sort();
+}
+
+/** Every `*.attachments` directory in the tree. */
+async function attachmentDirs(): Promise<string[]> {
+  const entries = await readdir(tree, { withFileTypes: true });
+  return entries
+    .filter((e) => e.isDirectory() && e.name.endsWith(".attachments"))
+    .map((e) => e.name)
+    .sort();
+}
+
+async function pull(): Promise<void> {
+  const result = await runCli(["wiki", "docs", "pull", "--skip-user-check"]);
+  expect(result.exitCode, `${result.stdout}${result.stderr}`).toBe(0);
+}
+
+describe("docs pull: a tracked page keeps its filename across repeated pulls", () => {
+  beforeEach(async () => {
+    if (tree) await rm(tree, { recursive: true, force: true });
+    tree = await mkdtemp(join(tmpdir(), "atlcli-path-tree-"));
+    writes = [];
+
+    const init = await runCli(["wiki", "docs", "init", ".", "--page-id", PAGE_ID, "--space", "DOCSY"]);
+    expect(init.exitCode, init.stderr).toBe(0);
+  });
+
+  it("writes exactly one markdown file after three pulls", async () => {
+    await pull();
+    expect(await markdownFiles()).toEqual([`${SLUG}.md`]);
+
+    await pull();
+    expect(await markdownFiles()).toEqual([`${SLUG}.md`]);
+
+    // The third pull is where the mis-recorded sync.db path used to surface as
+    // a real second file on disk.
+    await pull();
+    expect(await markdownFiles()).toEqual([`${SLUG}.md`]);
+
+    expect(writes).toEqual([]);
+  }, 90_000);
+
+  it("does not spawn a second attachments directory", async () => {
+    await pull();
+    await pull();
+    await pull();
+
+    expect(await attachmentDirs()).toEqual([`${SLUG}.attachments`]);
+  }, 90_000);
+
+  it("records the path it actually wrote in sync.db", async () => {
+    await pull();
+    expect((await readState(tree)).pages[PAGE_ID].path).toBe(`${SLUG}.md`);
+
+    // After pull #2 the tree still looks right on disk; the damage was purely
+    // in sync.db, which readState() prefers over state.json. That stale path is
+    // what pull #3 then treats as the page's home.
+    await pull();
+    expect((await readState(tree)).pages[PAGE_ID].path).toBe(`${SLUG}.md`);
+
+    const status = await runCli(["wiki", "docs", "status", "--json"]);
+    expect(status.exitCode, status.stderr).toBe(0);
+
+    const parsed = JSON.parse(status.stdout);
+    expect(parsed.stats.synced).toBe(1);
+    expect(parsed.stats.untracked).toBe(0);
+    expect(parsed.stats.localModified).toBe(0);
+  }, 90_000);
+
+  it("recovers a tree whose sync.db already points at the alias", async () => {
+    await pull();
+
+    // Reproduce what a pre-fix pull left behind: the record names a file that
+    // was never written. Upgrading must not make the next pull create it.
+    const adapter = await createSyncDb(getAtlcliPath(tree), { autoMigrate: false });
+    const record = await adapter.getPage(PAGE_ID);
+    await adapter.upsertPage({ ...record!, path: `${SLUG}-2.md` });
+    await adapter.close();
+
+    await pull();
+
+    expect(await markdownFiles()).toEqual([`${SLUG}.md`]);
+    expect((await readState(tree)).pages[PAGE_ID].path).toBe(`${SLUG}.md`);
+  }, 90_000);
+});

--- a/apps/cli/src/commands/docs.ts
+++ b/apps/cli/src/commands/docs.ts
@@ -296,6 +296,22 @@ export async function findMarkdownFileByFrontmatterId(
   return null;
 }
 
+/**
+ * @internal
+ * Check whether one specific markdown file carries a given page ID.
+ *
+ * The cheap counterpart to findMarkdownFileByFrontmatterId() for when a
+ * candidate path is already known - no tree walk, no ignore-file loading.
+ */
+async function markdownFileHasPageId(absolutePath: string, pageId: string): Promise<boolean> {
+  try {
+    const { frontmatter } = parseFrontmatter(await readTextFile(absolutePath));
+    return frontmatter?.id === pageId;
+  } catch {
+    return false;
+  }
+}
+
 
 /**
  * Subcommands that render their own `--help` text instead of the shared
@@ -927,11 +943,23 @@ async function handlePull(args: string[], flags: Record<string, string | boolean
     }
   }
 
-  // Compute nested paths
+  // Compute nested paths. pathOwners keeps an already-tracked page on the path
+  // it is stored at instead of uniquifying it against its own file.
   const pathMap = buildPathMap(hierarchyPages, {
     existingPaths,
     rootAncestorId: homePageId,
+    pathOwners: state?.pathIndex,
   });
+
+  /**
+   * Path each page/folder was actually written to, keyed by ID.
+   *
+   * The computed path is only a proposal: a page that has not moved keeps the
+   * path it already has. sync.db must record what the pull did, not what
+   * buildPathMap() suggested - otherwise the next pull looks for the page at a
+   * path that has no file and writes a duplicate there.
+   */
+  const resolvedPaths = new Map<string, string>();
 
   let pulled = 0;
   let skipped = 0;
@@ -995,31 +1023,46 @@ async function handlePull(args: string[], flags: Record<string, string | boolean
       } else {
         // Keep existing path if not moved
         relativePath = existingState.path;
-      }
 
-      // Check if local has modifications
-      if (!force) {
-        const localPath = join(atlcliDir!, relativePath);
-        try {
-          const localContent = await readTextFile(localPath);
-          const { content: localWithoutFrontmatter } = parseFrontmatter(localContent);
-          const localHash = hashContent(normalizeMarkdown(localWithoutFrontmatter));
-
-          if (localHash !== existingState.baseHash) {
-            // Local has modifications, skip unless --force
-            output(`Skipping ${relativePath} (local modifications, use --force)`, opts);
-            skipped++;
-            getLogger().sync({
-              eventType: "status",
-              file: relativePath,
-              pageId: detail.id,
-              title: `Skipped: local modifications`,
-            });
-            continue;
-          }
-        } catch {
-          // File doesn't exist, will be re-created
+        // Heal a stale record: earlier versions stored a uniquified alias
+        // ({slug}-2.md) for pages that never moved. If the recorded file is
+        // gone but the computed path holds this very page, adopt it instead of
+        // writing a duplicate next to it.
+        if (
+          relativePath !== computed.relativePath &&
+          !existsSync(join(outDir, toPlatformPath(relativePath))) &&
+          (await markdownFileHasPageId(join(outDir, toPlatformPath(computed.relativePath)), detail.id))
+        ) {
+          relativePath = computed.relativePath;
         }
+      }
+    }
+
+    // Record the path this pull settled on, before any early exit below.
+    resolvedPaths.set(detail.id, relativePath);
+
+    // Check if local has modifications
+    if (existingState && !force) {
+      const localPath = join(atlcliDir!, relativePath);
+      try {
+        const localContent = await readTextFile(localPath);
+        const { content: localWithoutFrontmatter } = parseFrontmatter(localContent);
+        const localHash = hashContent(normalizeMarkdown(localWithoutFrontmatter));
+
+        if (localHash !== existingState.baseHash) {
+          // Local has modifications, skip unless --force
+          output(`Skipping ${relativePath} (local modifications, use --force)`, opts);
+          skipped++;
+          getLogger().sync({
+            eventType: "status",
+            file: relativePath,
+            pageId: detail.id,
+            title: `Skipped: local modifications`,
+          });
+          continue;
+        }
+      } catch {
+        // File doesn't exist, will be re-created
       }
     }
 
@@ -1349,6 +1392,8 @@ async function handlePull(args: string[], flags: Record<string, string | boolean
       folderRelativePath = existingFolderState.path;
     }
 
+    resolvedPaths.set(folder.id, folderRelativePath);
+
     // Recompute folderPath and folderDir based on final path
     const finalFolderPath = join(outDir, folderRelativePath);
     const finalFolderDir = dirname(finalFolderPath);
@@ -1410,27 +1455,28 @@ async function handlePull(args: string[], flags: Record<string, string | boolean
     try {
       // Upsert all pages to sync.db (populates last_modified for stale detection)
       for (const detail of pageDetails) {
-        const computed = pathMap.get(detail.id);
-        if (!computed) continue;
+        // The path the pull used, not the one buildPathMap proposed.
+        const pagePath = resolvedPaths.get(detail.id) ?? pathMap.get(detail.id)?.relativePath;
+        if (!pagePath) continue;
 
         const pageRecord = createPageRecord({
           pageId: detail.id,
-          path: computed.relativePath,
+          path: pagePath,
           title: detail.title,
           spaceKey: detail.spaceKey,
           version: detail.version,
           lastSyncedAt: new Date().toISOString(),
           localHash: hashContent(normalizeMarkdown(replaceAttachmentPaths(
             storageToMarkdown(detail.storage, buildConversionOptions(dirConfig?.baseUrl)),
-            basename(computed.relativePath, ".md")
+            basename(pagePath, ".md")
           ))),
           remoteHash: hashContent(normalizeMarkdown(replaceAttachmentPaths(
             storageToMarkdown(detail.storage, buildConversionOptions(dirConfig?.baseUrl)),
-            basename(computed.relativePath, ".md")
+            basename(pagePath, ".md")
           ))),
           baseHash: hashContent(normalizeMarkdown(replaceAttachmentPaths(
             storageToMarkdown(detail.storage, buildConversionOptions(dirConfig?.baseUrl)),
-            basename(computed.relativePath, ".md")
+            basename(pagePath, ".md")
           ))),
           syncState: "synced",
           parentId: detail.parentId,
@@ -1448,12 +1494,12 @@ async function handlePull(args: string[], flags: Record<string, string | boolean
 
       // Upsert folder records to sync.db
       for (const folder of folders) {
-        const computed = pathMap.get(folder.id);
-        if (!computed) continue;
+        const folderPath = resolvedPaths.get(folder.id) ?? pathMap.get(folder.id)?.relativePath;
+        if (!folderPath) continue;
 
         const folderRecord = createPageRecord({
           pageId: folder.id,
-          path: computed.relativePath,
+          path: folderPath,
           title: folder.title,
           spaceKey: space!,
           version: 1,

--- a/apps/cli/src/commands/sync.ts
+++ b/apps/cli/src/commands/sync.ts
@@ -886,6 +886,8 @@ class SyncEngine {
       const computed = computeFilePath(pageInfo, ancestorTitles, {
         existingPaths,
         rootAncestorId: this.homePageId,
+        // A page's own stored path is not a collision.
+        pathOwners: this.state?.pathIndex,
       });
       let filePath = join(this.opts.dir, computed.relativePath);
 
@@ -1038,6 +1040,8 @@ class SyncEngine {
       const computed = computeFilePath(folderInfo, ancestorTitles, {
         existingPaths,
         rootAncestorId: this.homePageId,
+        // A folder's own stored path is not a collision.
+        pathOwners: this.state?.pathIndex,
       });
 
       let filePath = join(this.opts.dir, computed.relativePath);

--- a/packages/confluence/etc/confluence.api.md
+++ b/packages/confluence/etc/confluence.api.md
@@ -4372,6 +4372,7 @@ export declare function buildPathMap(pages: PageHierarchyInfo[], options?: Build
 export interface BuildPathMapOptions {
     existingPaths?: Set<string>;
     rootAncestorId?: string;
+    pathOwners?: Record<string, string> | Map<string, string>;
 }
 
 // export: BulkOperationResult
@@ -4446,6 +4447,7 @@ export declare function computeFilePath(page: PageHierarchyInfo, ancestorTitles:
 export interface ComputeFilePathOptions {
     existingPaths?: Set<string>;
     rootAncestorId?: string;
+    pathOwners?: Record<string, string> | Map<string, string>;
 }
 
 // export: computeSyncState

--- a/packages/confluence/src/hierarchy.test.ts
+++ b/packages/confluence/src/hierarchy.test.ts
@@ -105,6 +105,43 @@ describe("hierarchy utilities", () => {
       expect(result.relativePath).toBe("test-2.md");
     });
 
+    test("keeps a path the page itself already owns", () => {
+      // Regression: re-computing the path of an already-synced page treated its
+      // own file as a collision and aliased it to `test-2.md`, which then got
+      // recorded as the page's location.
+      const page: PageHierarchyInfo = {
+        id: "100",
+        title: "Test",
+        parentId: null,
+        ancestors: [],
+      };
+      const ancestorTitles = new Map([["100", "Test"]]);
+
+      const result = computeFilePath(page, ancestorTitles, {
+        existingPaths: new Set(["test.md"]),
+        pathOwners: { "test.md": "100" },
+      });
+
+      expect(result.relativePath).toBe("test.md");
+    });
+
+    test("still avoids a path owned by a different page", () => {
+      const page: PageHierarchyInfo = {
+        id: "100",
+        title: "Test",
+        parentId: null,
+        ancestors: [],
+      };
+      const ancestorTitles = new Map([["100", "Test"]]);
+
+      const result = computeFilePath(page, ancestorTitles, {
+        existingPaths: new Set(["test.md"]),
+        pathOwners: { "test.md": "999" },
+      });
+
+      expect(result.relativePath).toBe("test-2.md");
+    });
+
     test("handles empty title", () => {
       const page: PageHierarchyInfo = {
         id: "100",
@@ -262,6 +299,53 @@ describe("hierarchy utilities", () => {
       const pathMap = buildPathMap(pages, existingPaths);
 
       expect(pathMap.get("100")?.relativePath).toBe("test-2.md");
+    });
+
+    test("leaves an already-tracked page on its own path", () => {
+      const pages: PageHierarchyInfo[] = [
+        { id: "100", title: "Test", parentId: null, ancestors: [] },
+      ];
+
+      const pathMap = buildPathMap(pages, {
+        existingPaths: new Set(["test.md"]),
+        pathOwners: { "test.md": "100" },
+      });
+
+      expect(pathMap.get("100")?.relativePath).toBe("test.md");
+    });
+
+    test("gives a new page a unique path next to the owner of the slug", () => {
+      const pages: PageHierarchyInfo[] = [
+        { id: "100", title: "Test", parentId: null, ancestors: [] },
+        // Same title, not yet tracked - must not land on the owner's path.
+        { id: "101", title: "Test", parentId: null, ancestors: [] },
+      ];
+
+      const pathMap = buildPathMap(pages, {
+        existingPaths: new Set(["test.md"]),
+        pathOwners: { "test.md": "100" },
+      });
+
+      expect(pathMap.get("100")?.relativePath).toBe("test.md");
+      expect(pathMap.get("101")?.relativePath).toBe("test-2.md");
+    });
+
+    test("does not hand two pages the same path when one owns it", () => {
+      // Ordering matters: the untracked page is placed first, so path claims
+      // made during the run must block later pages just like stored ones do.
+      const pages: PageHierarchyInfo[] = [
+        { id: "101", title: "Test", parentId: null, ancestors: [] },
+        { id: "100", title: "Test", parentId: null, ancestors: [] },
+      ];
+
+      const pathMap = buildPathMap(pages, {
+        existingPaths: new Set(["test.md"]),
+        pathOwners: { "test.md": "100" },
+      });
+
+      const paths = [pathMap.get("100")!.relativePath, pathMap.get("101")!.relativePath];
+      expect(pathMap.get("100")?.relativePath).toBe("test.md");
+      expect(new Set(paths).size).toBe(2);
     });
   });
 

--- a/packages/confluence/src/hierarchy.ts
+++ b/packages/confluence/src/hierarchy.ts
@@ -70,6 +70,24 @@ export interface ComputeFilePathOptions {
    * in the directory path. Used to flatten space home page children.
    */
   rootAncestorId?: string;
+  /**
+   * Map of path to the ID of the page/folder that already owns it
+   * (typically `state.pathIndex`).
+   *
+   * A path in `existingPaths` that this very page owns is not a collision:
+   * without this, re-computing the path of an already-synced page hands out a
+   * `{slug}-2.md` alias for the file it is already stored at.
+   */
+  pathOwners?: Record<string, string> | Map<string, string>;
+}
+
+/** Look up the current owner of a path, accepting either map shape. */
+function ownerOf(
+  owners: Record<string, string> | Map<string, string> | undefined,
+  path: string
+): string | undefined {
+  if (!owners) return undefined;
+  return owners instanceof Map ? owners.get(path) : owners[path];
 }
 
 /**
@@ -98,6 +116,9 @@ export function computeFilePath(
     options instanceof Set ? { existingPaths: options } : options;
   const existingPaths = opts.existingPaths ?? new Set<string>();
   const rootAncestorId = opts.rootAncestorId;
+  /** A path is only taken if somebody *else* owns it. */
+  const isTaken = (path: string) =>
+    existingPaths.has(path) && ownerOf(opts.pathOwners, path) !== page.id;
 
   const slug = slugifyTitle(page.title) || "page";
   const contentType = page.contentType ?? "page";
@@ -141,7 +162,7 @@ export function computeFilePath(
   let relativePath = directory ? `${directory}/${filename}` : filename;
   let counter = 2;
 
-  while (existingPaths.has(relativePath)) {
+  while (isTaken(relativePath)) {
     if (isIndex) {
       // For index files, modify the directory instead
       const newSlug = `${slug}-${counter}`;
@@ -313,6 +334,12 @@ export interface BuildPathMapOptions {
    * Children of this page will be placed at the root level.
    */
   rootAncestorId?: string;
+  /**
+   * Map of path to the ID of the page/folder that already owns it
+   * (typically `state.pathIndex`). Keeps an already-synced page on the path it
+   * is stored at instead of aliasing it to `{slug}-2.md`.
+   */
+  pathOwners?: Record<string, string> | Map<string, string>;
 }
 
 /**
@@ -346,13 +373,28 @@ export function buildPathMap(
   const pathMap = new Map<string, ComputedPath>();
   const usedPaths = new Set(existingPaths);
 
+  // Ownership grows as pages claim paths, so a path taken earlier in this run
+  // still blocks later pages while staying free for the page that owns it.
+  const owners = new Map<string, string>();
+  if (opts.pathOwners) {
+    const entries =
+      opts.pathOwners instanceof Map
+        ? opts.pathOwners.entries()
+        : Object.entries(opts.pathOwners);
+    for (const [path, pageId] of entries) {
+      owners.set(path, pageId);
+    }
+  }
+
   for (const page of sorted) {
     const computed = computeFilePath(page, titleMap, {
       existingPaths: usedPaths,
       rootAncestorId,
+      pathOwners: owners,
     });
     pathMap.set(page.id, computed);
     usedPaths.add(computed.relativePath);
+    owners.set(computed.relativePath, page.id);
   }
 
   return pathMap;

--- a/src/content/docs/reference/troubleshooting.md
+++ b/src/content/docs/reference/troubleshooting.md
@@ -100,6 +100,30 @@ Conflict: file.md was modified both locally and on Confluence
 2. Merge manually
 3. Force push: `atlcli wiki docs push --force`
 
+### Duplicate `-2.md` Files After Pulling
+
+A page you pull repeatedly shows up twice: `page.md` **and** `page-2.md`, each with the
+same `id` in its frontmatter, plus a second `page-2.attachments/` directory.
+
+**Cause:**
+Older versions recorded a uniquified filename in `.atlcli/sync.db` for pages that had
+not moved, so the next `pull` treated that alias as the page's location.
+
+**Solutions:**
+1. Upgrade and pull again — `atlcli wiki docs pull` re-adopts the original file and
+   corrects the recorded path, as long as only one of the two files exists.
+2. If both files are already on disk, delete the `-2` copy (and its
+   `-2.attachments/` directory) after checking it holds no edits of yours, then pull
+   again:
+   ```bash
+   atlcli wiki docs diff page-2.md   # confirm there is nothing to keep
+   rm -r page-2.md page-2.attachments
+   atlcli wiki docs pull
+   ```
+
+Note that a genuine `-2` suffix is also how atlcli keeps two *different* pages with the
+same title apart — check the `id` in the frontmatter before deleting anything.
+
 ### Page Not Found
 
 ```


### PR DESCRIPTION
`atlcli wiki docs pull` renamed a tracked page's local file on every repeated pull and eventually wrote a second copy of it. Pull #2 recorded `<slug>-2.md`, pull #3 created that file for real — along with a second `<slug>-2.attachments/` directory. The tree then alternates between the two names forever, one duplicate per pull cycle.

## Root cause

The write loop correctly reuses `existingState.path` for a page that has not moved. The sync.db upsert at the end of `handlePull` did not: it stored `computed.relativePath` from `buildPathMap()`.

`buildPathMap()` seeds its used-path set from the paths already recorded in state, without knowing that `<slug>.md` belongs to the very page it is placing — so it dutifully handed out `<slug>-2.md` as a "collision-free" alias.

The reason that mis-recorded path becomes real damage: `readState()` prefers `sync.db` over `state.json`, so on the next pull the alias *is* `existingState.path`. The page's file is written there, and the original is left behind.

## The fix

1. **Record what the pull did, not what it proposed** — a `resolvedPaths` map tracks the path each page and folder was actually written to (moved, kept, or healed); both sync.db upserts use it. The local-modification guard was de-nested so skipped pages record their path too, before the `continue`.
2. **Ownership-aware uniquification** — `computeFilePath()`/`buildPathMap()` take a `pathOwners` map (`state.pathIndex`); a path is only a collision if *someone else* owns it. `buildPathMap()` also registers claims made during the run, so two pages with the same title still get distinct paths regardless of iteration order. Passed from both `docs pull` and `sync`.
3. **Recovery for trees already poisoned** — if the recorded file is gone but the computed path holds a file with this page's frontmatter ID, the pull adopts it. Without this, anyone whose sync.db already carries the alias would still get one duplicate after upgrading.

## Verification

- New `apps/cli/src/commands/docs-pull-path-stability.test.ts`: four tests driving the real CLI against a local Bun stub server — three pulls leave exactly one markdown file and one attachments directory, sync.db keeps recording `<slug>.md`, and a hand-poisoned record heals. All four fail on the unfixed code (`path-stability-fixture-2.md`, `-2.attachments`, recorded path `-2.md`); the recovery test was mutation-checked separately by disabling its branch.
- Five unit tests for `pathOwners` in `hierarchy.test.ts`, including that a second same-titled page still gets a distinct path.
- Full suite **3232 pass / 14 skip / 0 fail**, `bun run typecheck` clean. `confluence.api.md` regenerated for the two new optional fields (additive only).
- Live E2E, read-only, against DOCSY (profile `mayflower`): init page-scoped tree, three pulls — one file, stable name, `status` reports 1 synced, zero writes to Confluence. Rebased onto #76 and re-verified.

## Notes

- Docs: a "Duplicate `-2.md` Files After Pulling" entry in `reference/troubleshooting.md`, including manual cleanup for trees where both files are already on disk (the recovery deliberately does not delete anything) and a warning that a genuine `-2` also distinguishes two different pages with the same title.
- Rebased on top of #76; both touch `handlePull`, and the merge was re-read by hand — the attachment guard and this path fix act at different points in the loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)