### PR TITLE
fix(docs): emit exactly one JSON document per --json invocation

### DIFF
--- a/apps/cli/src/commands/docs-json-single-document.test.ts
+++ b/apps/cli/src/commands/docs-json-single-document.test.ts
@@ -257,6 +257,20 @@ describe("docs check --json: one document, pass or fail", () => {
     );
   }, 60_000);
 
+  it("emits one error-only document when there is nothing to validate", async () => {
+    // `check` refuses to pass an empty tree (a CI gate that validated nothing).
+    // That failure happens before the report exists, so the document carries
+    // only `error` - and it must still be exactly one document.
+    const json = await runCli(["wiki", "docs", "check", ".", "--json"], checkDir);
+    expect(json.exitCode).toBe(1);
+
+    const parsed = parseSingleDocument(json.stdout);
+    const error = parsed.error as Record<string, unknown>;
+    expect(error.code).toBe("ATLCLI_ERR_USAGE");
+    expect(error.message).toContain("nothing was validated");
+    expect((error.details as Record<string, unknown>).filesChecked).toBe(0);
+  }, 60_000);
+
   it("does not emit an error field without --strict when only warnings exist", async () => {
     await mkdir(join(checkDir, "guides"), { recursive: true });
     await writeFile(join(checkDir, "guides", "one.md"), "# One\n\nFine.\n");

--- a/apps/cli/src/commands/docs-json-single-document.test.ts
+++ b/apps/cli/src/commands/docs-json-single-document.test.ts
@@ -1,0 +1,342 @@
+/**
+ * Regression: several `wiki docs` subcommands wrote MORE THAN ONE JSON document
+ * to stdout under `--json`, so `JSON.parse(stdout)` threw for scripted callers.
+ *
+ *   - `docs pull --json` printed the markdown skip notice through an unguarded
+ *     output(), which JSON-stringifies a bare string: stdout became
+ *     `"Skipping foo.md (local modifications, use --force)"` followed by the
+ *     real result object.
+ *   - `docs check --json` printed the report document and then called fail(),
+ *     which prints a second `{"error": ...}` document. Same for
+ *     `docs push --validate --json`, which additionally emitted the
+ *     human-readable report as a JSON string.
+ *   - `docs resolve --json` emitted one or two bare human-readable strings and
+ *     never a structured document at all.
+ *
+ * Every assertion below parses the WHOLE of stdout as a single document - that
+ * is the contract, and a per-line parse would pass against the bug.
+ *
+ * Runs the real CLI against a local Bun HTTP server standing in for the
+ * Confluence REST API: no fetch mocking, no Atlassian traffic, and a sandboxed
+ * HOME so the developer's own ~/.atlcli/config.json is never read.
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtemp, mkdir, rm, writeFile, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const CLI = fileURLToPath(new URL("../index.ts", import.meta.url));
+const PAGE_ID = "88101";
+/** `docs pull` slugifies the page title into the on-disk filename. */
+const PAGE_SLUG = "json-contract-fixture";
+
+/** Two hard errors: a broken relative link and an unclosed macro. */
+const TWO_ERRORS = `# Broken
+
+See [the missing page](./does-not-exist.md).
+
+:::info
+Never closed.
+`;
+
+const PAGE = {
+  id: PAGE_ID,
+  type: "page",
+  title: "JSON Contract Fixture",
+  space: { key: "DOCSY" },
+  version: { number: 3, when: "2026-07-20T00:00:00.000Z" },
+  ancestors: [],
+  history: {
+    createdDate: "2026-07-19T00:00:00.000Z",
+    createdBy: { accountId: "acc-1", displayName: "Fixture Author" },
+    lastUpdated: { when: "2026-07-20T00:00:00.000Z", by: { accountId: "acc-1", displayName: "Fixture Author" } },
+  },
+  metadata: { labels: { results: [] }, properties: {} },
+  body: { storage: { value: "<p>Remote body.</p>", representation: "storage" } },
+  _links: { base: "http://stub.invalid", webui: `/pages/${PAGE_ID}` },
+};
+
+let server: ReturnType<typeof Bun.serve>;
+let home: string;
+let tree: string;
+/** Any non-GET request would mean the test wrote to "Confluence". */
+let writes: string[] = [];
+
+const pagePath = () => join(tree, `${PAGE_SLUG}.md`);
+
+beforeAll(async () => {
+  server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      const { pathname } = new URL(req.url);
+      if (req.method !== "GET") writes.push(`${req.method} ${pathname}`);
+
+      // Data-center shape (bearer auth => no /wiki prefix).
+      if (pathname === `/rest/api/content/${PAGE_ID}`) return Response.json(PAGE);
+      if (pathname === `/rest/api/content/${PAGE_ID}/child/attachment`) {
+        return Response.json({ results: [], size: 0 });
+      }
+
+      // Folder/comment discovery is best-effort in pull and tolerates 404s.
+      return new Response(JSON.stringify({ message: `stub: no route for ${pathname}` }), {
+        status: 404,
+        headers: { "content-type": "application/json" },
+      });
+    },
+  });
+
+  home = await mkdtemp(join(tmpdir(), "atlcli-jsondoc-home-"));
+  await mkdir(join(home, ".atlcli"), { recursive: true });
+  await writeFile(
+    join(home, ".atlcli", "config.json"),
+    JSON.stringify({
+      currentProfile: "stub",
+      profiles: {
+        stub: {
+          name: "stub",
+          baseUrl: server.url.origin,
+          deploymentType: "data-center",
+          auth: { type: "bearer" },
+          space: "DOCSY",
+        },
+      },
+    })
+  );
+});
+
+afterAll(async () => {
+  server?.stop(true);
+  if (home) await rm(home, { recursive: true, force: true });
+  if (tree) await rm(tree, { recursive: true, force: true });
+});
+
+async function runCli(args: string[], cwd = tree): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const proc = Bun.spawn([process.execPath, "--conditions=development", "run", CLI, ...args], {
+    cwd,
+    env: {
+      ...process.env,
+      HOME: home,
+      USERPROFILE: home,
+      ATLCLI_API_TOKEN: "stub-token",
+      ATLCLI_DISABLE_UPDATE_CHECK: "1",
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  return { stdout, stderr, exitCode };
+}
+
+/**
+ * The assertion this whole file exists for: the ENTIRE stdout must be one JSON
+ * document. A second document (or a stray stringified log line) makes
+ * JSON.parse throw, exactly as it does for a scripted consumer.
+ */
+function parseSingleDocument(stdout: string): Record<string, unknown> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    throw new Error(`stdout is not a single JSON document (${reason}).\n--- stdout ---\n${stdout}`);
+  }
+  // A bare `"Skipping ..."` string parses fine on its own, so reject it too:
+  // the contract is a result object, not whatever human line came out first.
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new Error(`stdout parsed to a ${typeof parsed}, expected an object.\n--- stdout ---\n${stdout}`);
+  }
+  return parsed as Record<string, unknown>;
+}
+
+/** Fresh tree with the fixture page pulled and tracked. */
+async function freshTree(): Promise<void> {
+  if (tree) await rm(tree, { recursive: true, force: true });
+  tree = await mkdtemp(join(tmpdir(), "atlcli-jsondoc-tree-"));
+  writes = [];
+
+  const init = await runCli(["wiki", "docs", "init", ".", "--page-id", PAGE_ID, "--space", "DOCSY"]);
+  expect(init.exitCode, init.stderr).toBe(0);
+
+  const pull = await runCli(["wiki", "docs", "pull", "--skip-user-check"]);
+  expect(pull.exitCode, `${pull.stdout}${pull.stderr}`).toBe(0);
+  expect(await readFile(pagePath(), "utf8")).toContain("Remote body.");
+}
+
+describe("docs pull --json: one document even when a file is skipped", () => {
+  beforeEach(async () => {
+    await freshTree();
+    // Local edit => the "local modifications, use --force" skip path.
+    await writeFile(pagePath(), `${await readFile(pagePath(), "utf8")}\n\nLocal edit.\n`);
+  });
+
+  it("emits a single parseable document reporting the skip", async () => {
+    const pull = await runCli(["wiki", "docs", "pull", "--skip-user-check", "--json"]);
+    expect(pull.exitCode, `${pull.stdout}${pull.stderr}`).toBe(0);
+
+    const parsed = parseSingleDocument(pull.stdout);
+    expect(parsed.schemaVersion).toBe("1");
+    const results = parsed.results as Record<string, number>;
+    expect(results.skipped).toBe(1);
+    expect(results.pulled).toBe(0);
+
+    // The human line must not have leaked into the JSON stream in any form.
+    expect(pull.stdout).not.toContain("local modifications, use --force");
+    expect(writes).toEqual([]);
+  }, 60_000);
+
+  it("still prints the skip notice in human mode", async () => {
+    const pull = await runCli(["wiki", "docs", "pull", "--skip-user-check"]);
+    expect(pull.exitCode, `${pull.stdout}${pull.stderr}`).toBe(0);
+    expect(pull.stdout).toMatch(/Skipping .*\(local modifications, use --force\)/);
+  }, 60_000);
+});
+
+describe("docs check --json: one document, pass or fail", () => {
+  let checkDir: string;
+
+  beforeEach(async () => {
+    checkDir = await mkdtemp(join(tmpdir(), "atlcli-jsondoc-check-"));
+  });
+
+  it("folds the failure into the report instead of printing a second document", async () => {
+    await writeFile(join(checkDir, "broken.md"), TWO_ERRORS);
+
+    const check = await runCli(["wiki", "docs", "check", "."], checkDir);
+    expect(check.exitCode).toBe(1); // sanity: the fixture really does fail
+
+    const json = await runCli(["wiki", "docs", "check", ".", "--json"], checkDir);
+    expect(json.exitCode).toBe(1);
+
+    const parsed = parseSingleDocument(json.stdout);
+    expect(parsed.schemaVersion).toBe("1");
+    expect(parsed.passed).toBe(false);
+    expect(parsed.totalErrors).toBe(2);
+    expect(parsed.filesWithIssues).toBe(1);
+    expect(parsed.error).toEqual({
+      code: "ATLCLI_ERR_VALIDATION",
+      message: "Validation failed",
+      details: {},
+    });
+
+    // The human report must not be in the JSON stream.
+    expect(json.stdout).not.toContain("Summary:");
+  }, 60_000);
+
+  it("reports no error field when validation passes", async () => {
+    await writeFile(join(checkDir, "fine.md"), "# Fine\n\nNothing wrong here.\n");
+
+    const json = await runCli(["wiki", "docs", "check", ".", "--json"], checkDir);
+    expect(json.exitCode, json.stderr).toBe(0);
+
+    const parsed = parseSingleDocument(json.stdout);
+    expect(parsed.passed).toBe(true);
+    expect(parsed.totalErrors).toBe(0);
+    expect(parsed.error).toBeUndefined();
+  }, 60_000);
+
+  it("still emits one document when --strict turns warnings into a failure", async () => {
+    // A subdirectory of pages without an index.md is a warning, not an error:
+    // passed stays true while the process exits 1.
+    await mkdir(join(checkDir, "guides"), { recursive: true });
+    await writeFile(join(checkDir, "guides", "one.md"), "# One\n\nFine.\n");
+
+    const json = await runCli(["wiki", "docs", "check", ".", "--json", "--strict"], checkDir);
+    expect(json.exitCode).toBe(1);
+
+    const parsed = parseSingleDocument(json.stdout);
+    expect(parsed.passed).toBe(true);
+    expect(parsed.totalErrors).toBe(0);
+    expect(parsed.totalWarnings).toBeGreaterThan(0);
+    expect((parsed.error as Record<string, string>).message).toBe(
+      "Validation failed (strict mode: warnings are errors)"
+    );
+  }, 60_000);
+
+  it("does not emit an error field without --strict when only warnings exist", async () => {
+    await mkdir(join(checkDir, "guides"), { recursive: true });
+    await writeFile(join(checkDir, "guides", "one.md"), "# One\n\nFine.\n");
+
+    const json = await runCli(["wiki", "docs", "check", ".", "--json"], checkDir);
+    expect(json.exitCode, json.stderr).toBe(0);
+
+    const parsed = parseSingleDocument(json.stdout);
+    expect(parsed.totalWarnings).toBeGreaterThan(0);
+    expect(parsed.error).toBeUndefined();
+  }, 60_000);
+});
+
+describe("docs push --validate --json: one document when validation aborts the push", () => {
+  beforeEach(async () => {
+    await freshTree();
+    await writeFile(join(tree, "broken.md"), TWO_ERRORS);
+  });
+
+  it("emits only the error document, with the report in details", async () => {
+    const push = await runCli(["wiki", "docs", "push", ".", "--validate", "--json"]);
+    expect(push.exitCode).toBe(1);
+
+    const parsed = parseSingleDocument(push.stdout);
+    const error = parsed.error as Record<string, unknown>;
+    expect(error.code).toBe("ATLCLI_ERR_VALIDATION");
+    expect(error.message).toBe("Validation failed - push aborted");
+
+    // Machine-readable issues replace the stringified human report.
+    const details = error.details as Record<string, unknown>;
+    expect(details.totalErrors).toBe(2);
+    expect((details.files as unknown[]).length).toBe(1);
+
+    expect(push.stdout).not.toContain("Summary:");
+    expect(writes).toEqual([]);
+  }, 60_000);
+});
+
+describe("docs resolve --json: one document, structured", () => {
+  const META = {
+    id: PAGE_ID,
+    title: "JSON Contract Fixture",
+    spaceKey: "DOCSY",
+    version: 3,
+    lastSyncedAt: "2026-07-20T00:00:00.000Z",
+    localHash: "local",
+    remoteHash: "remote",
+    baseHash: "base",
+    syncState: "conflict",
+  };
+
+  beforeEach(async () => {
+    await freshTree();
+    await writeFile(`${pagePath()}.meta.json`, JSON.stringify(META));
+  });
+
+  it("returns an object, not a bare string, when there is nothing to resolve", async () => {
+    const resolve = await runCli(["wiki", "docs", "resolve", pagePath(), "--json"]);
+    expect(resolve.exitCode, `${resolve.stdout}${resolve.stderr}`).toBe(0);
+
+    const parsed = parseSingleDocument(resolve.stdout);
+    expect(parsed.resolved).toBe(false);
+    expect(parsed.staleConflict).toBe(true);
+  }, 60_000);
+
+  it("emits one document (not two lines) after a successful resolve", async () => {
+    await writeFile(
+      pagePath(),
+      "# Conflicted\n\n<<<<<<< LOCAL\nmine\n=======\ntheirs\n>>>>>>> REMOTE\n"
+    );
+
+    const resolve = await runCli(["wiki", "docs", "resolve", pagePath(), "--accept", "local", "--json"]);
+    expect(resolve.exitCode, `${resolve.stdout}${resolve.stderr}`).toBe(0);
+
+    const parsed = parseSingleDocument(resolve.stdout);
+    expect(parsed.resolved).toBe(true);
+    expect(parsed.accept).toBe("local");
+
+    const after = await readFile(pagePath(), "utf8");
+    expect(after).toContain("mine");
+    expect(after).not.toContain("<<<<<<< LOCAL");
+  }, 60_000);
+});

--- a/apps/cli/src/commands/docs.ts
+++ b/apps/cli/src/commands/docs.ts
@@ -185,6 +185,22 @@ function formatTimeAgo(isoDate: string): string {
 }
 
 /**
+ * Machine-readable form of a validation run, shared by `docs check --json` and
+ * `docs push --validate --json` so both report issues in the same shape.
+ */
+function validationPayload(result: ValidationResult): Record<string, unknown> {
+  const filesWithIssues = result.files.filter((f) => f.issues.length > 0);
+  return {
+    passed: result.passed,
+    totalErrors: result.totalErrors,
+    totalWarnings: result.totalWarnings,
+    filesChecked: result.filesChecked,
+    filesWithIssues: filesWithIssues.length,
+    files: filesWithIssues.map((f) => ({ path: f.path, issues: f.issues })),
+  };
+}
+
+/**
  * Check if a path is inside the atlcli source tree.
  * Used to warn about stale test data that might interfere with operations.
  */
@@ -988,7 +1004,9 @@ async function handlePull(args: string[], flags: Record<string, string | boolean
     // Get computed path for this page
     const computed = pathMap.get(detail.id);
     if (!computed) {
-      output(`Warning: Could not compute path for page ${detail.id}`, opts);
+      if (!opts.json) {
+        output(`Warning: Could not compute path for page ${detail.id}`, opts);
+      }
       skipped++;
       continue;
     }
@@ -1051,7 +1069,9 @@ async function handlePull(args: string[], flags: Record<string, string | boolean
 
         if (localHash !== existingState.baseHash) {
           // Local has modifications, skip unless --force
-          output(`Skipping ${relativePath} (local modifications, use --force)`, opts);
+          if (!opts.json) {
+            output(`Skipping ${relativePath} (local modifications, use --force)`, opts);
+          }
           skipped++;
           getLogger().sync({
             eventType: "status",
@@ -1791,6 +1811,10 @@ async function handlePush(args: string[], flags: Record<string, string | boolean
   }
 
 
+  // Validation carried into the final push document so `--json` consumers see
+  // the warnings we pushed through instead of a stray human-readable report.
+  let validation: Record<string, unknown> | null = null;
+
   // Run validation if --validate flag is set.
   //
   // Validation covers exactly the files this push will send - a single file for
@@ -1808,19 +1832,32 @@ async function handlePush(args: string[], flags: Record<string, string | boolean
       maxPageSizeKb: 500,
     });
 
+    // In JSON mode the report goes into the single result/error document, never
+    // as its own stringified document ahead of it.
+    const reportIfHuman = () => {
+      if (!opts.json) output(formatValidationReport(result), opts);
+    };
+
     if (!result.passed) {
-      output(formatValidationReport(result), opts);
-      fail(opts, 1, ERROR_CODES.VALIDATION, "Validation failed - push aborted");
+      reportIfHuman();
+      fail(opts, 1, ERROR_CODES.VALIDATION, "Validation failed - push aborted", validationPayload(result));
     }
 
     if (result.totalWarnings > 0) {
-      output(formatValidationReport(result), opts);
+      reportIfHuman();
       if (strict) {
-        fail(opts, 1, ERROR_CODES.VALIDATION, "Validation failed (strict mode: warnings are errors) - push aborted");
+        fail(
+          opts,
+          1,
+          ERROR_CODES.VALIDATION,
+          "Validation failed (strict mode: warnings are errors) - push aborted",
+          validationPayload(result)
+        );
       }
       if (!opts.json) {
         output("Proceeding with push despite warnings...\n", opts);
       }
+      validation = validationPayload(result);
     }
   }
 
@@ -1975,7 +2012,7 @@ atlcli:
     const result = updated > 0 ? "updated" : created > 0 ? "created" : "skipped";
     output(
       opts.json
-        ? { schemaVersion: "1", file: files[0], result }
+        ? { schemaVersion: "1", file: files[0], result, ...(validation ? { validation } : {}) }
         : `${basename(files[0])}: ${result}`,
       opts
     );
@@ -1988,6 +2025,7 @@ atlcli:
       {
         schemaVersion: "1",
         results,
+        ...(validation ? { validation } : {}),
         note: "Frontmatter stripped before push. State saved to .atlcli/",
       },
       opts
@@ -3295,12 +3333,17 @@ async function handleResolve(args: string[], flags: Record<string, string | bool
                      content.includes(">>>>>>> REMOTE");
 
   if (!hasMarkers) {
-    if (isEnhancedMeta(meta) && meta.syncState === "conflict") {
-      // No markers but marked as conflict - might have been manually edited
-      output("File was marked as conflict but has no conflict markers.", opts);
-    } else {
-      output("File has no conflicts to resolve.", opts);
-    }
+    // No markers but marked as conflict - might have been manually edited
+    const staleConflict = isEnhancedMeta(meta) && meta.syncState === "conflict";
+    const message = staleConflict
+      ? "File was marked as conflict but has no conflict markers."
+      : "File has no conflicts to resolve.";
+    output(
+      opts.json
+        ? { schemaVersion: "1", file: filePath, resolved: false, staleConflict, message }
+        : message,
+      opts
+    );
     return;
   }
 
@@ -3325,6 +3368,11 @@ async function handleResolve(args: string[], flags: Record<string, string | bool
       localHash: hashContent(normalizeMarkdown(resolved)),
     };
     await writeMeta(filePath, updatedMeta);
+  }
+
+  if (opts.json) {
+    output({ schemaVersion: "1", file: filePath, resolved: true, accept }, opts);
+    return;
   }
 
   output(`Resolved conflicts in ${filePath} using ${accept} version.`, opts);
@@ -3495,33 +3543,33 @@ async function handleCheck(args: string[], flags: Record<string, string | boolea
     }
   }
 
-  // JSON output
+  // Reason for a non-zero exit, if any: errors always fail, warnings only in
+  // strict mode.
+  const failureMessage = !result.passed
+    ? "Validation failed"
+    : strict && result.totalWarnings > 0
+      ? "Validation failed (strict mode: warnings are errors)"
+      : null;
+
+  // JSON output. The error is folded into the report so `--json` always emits
+  // exactly one document that JSON.parse() can read - calling fail() here would
+  // print a second, separate {"error": ...} document to the same stream.
   if (opts.json) {
     output({
       schemaVersion: "1",
-      passed: result.passed,
-      totalErrors: result.totalErrors,
-      totalWarnings: result.totalWarnings,
-      filesChecked: result.filesChecked,
-      filesWithIssues: result.files.filter((f) => f.issues.length > 0).length,
-      files: result.files.filter((f) => f.issues.length > 0).map((f) => ({
-        path: f.path,
-        issues: f.issues,
-      })),
+      ...validationPayload(result),
+      ...(failureMessage
+        ? { error: { code: ERROR_CODES.VALIDATION, message: failureMessage, details: {} } }
+        : {}),
     }, opts);
-  } else {
-    // Human-readable output
-    output(formatValidationReport(result), opts);
+    if (failureMessage) process.exit(1);
+    return;
   }
 
-  // Exit with error if validation failed
-  if (!result.passed) {
-    fail(opts, 1, ERROR_CODES.VALIDATION, "Validation failed");
-  }
-
-  // Exit with error in strict mode if there are warnings
-  if (strict && result.totalWarnings > 0) {
-    fail(opts, 1, ERROR_CODES.VALIDATION, "Validation failed (strict mode: warnings are errors)");
+  // Human-readable output
+  output(formatValidationReport(result), opts);
+  if (failureMessage) {
+    fail(opts, 1, ERROR_CODES.VALIDATION, failureMessage);
   }
 }
 

--- a/src/content/docs/confluence/sync.md
+++ b/src/content/docs/confluence/sync.md
@@ -767,7 +767,11 @@ atlcli represents folders as directories with an `index.md` file containing `typ
 
 ## JSON Output
 
-Most commands support `--json` for scripting:
+Most commands support `--json` for scripting. Apart from the two streaming
+commands noted below, `--json` writes **exactly one JSON document** to stdout —
+`JSON.parse(stdout)` is always safe. Progress notes, skip messages and warnings
+are suppressed in this mode; the counters in the result document report the same
+information (a skipped file shows up in `results.skipped`, not as a log line).
 
 ```bash
 atlcli wiki docs status ./docs --json
@@ -788,7 +792,11 @@ atlcli wiki docs status ./docs --json
 }
 ```
 
-Sync command emits JSON lines (one event per line):
+### Streaming commands
+
+`sync` and `watch` are the exception: they run until done (or until you stop
+them) and emit **JSON Lines** — one complete document per line. Parse these line
+by line, not as a whole.
 
 ```bash
 atlcli wiki docs sync ./docs --json
@@ -799,6 +807,12 @@ atlcli wiki docs sync ./docs --json
 {"schemaVersion":"1","type":"pull","file":"api-reference.md","pageId":"12345","message":"Pulled: API Reference"}
 {"schemaVersion":"1","type":"push","file":"guide.md","pageId":"12346","message":"Pushed: Guide"}
 ```
+
+### Failures
+
+A command that exits non-zero reports the reason in an `error` object. For
+`docs check` this is folded into the report document so there is still only one
+document to parse — see [Validation](validation.md#json-output).
 
 ## Best Practices
 

--- a/src/content/docs/confluence/validation.md
+++ b/src/content/docs/confluence/validation.md
@@ -195,6 +195,23 @@ and exit code `1`. Branch on the exit code (or on the presence of `error`), not
 on `passed`.
 :::
 
+The two failures that stop `check` before it validates anything — a path that
+does not exist, and a path with no markdown files in it — emit a document that
+carries only the `error` field, with `code` set to `ATLCLI_ERR_USAGE` rather
+than `ATLCLI_ERR_VALIDATION`:
+
+```json
+{
+  "error": {
+    "code": "ATLCLI_ERR_USAGE",
+    "message": "No markdown files found in /work/docs - nothing was validated. Pass the directory explicitly (path argument or --dir).",
+    "details": { "path": "/work/docs", "filesChecked": 0 }
+  }
+}
+```
+
+So a consumer should read `error` first and only then the report fields.
+
 ## Pre-Push Validation
 
 Use the `--validate` flag with push to run checks before pushing:

--- a/src/content/docs/confluence/validation.md
+++ b/src/content/docs/confluence/validation.md
@@ -138,6 +138,63 @@ Exit codes:
 atlcli wiki docs check ./docs --json
 ```
 
+`--json` writes **exactly one JSON document** to stdout, so `JSON.parse(stdout)`
+always works. The human-readable report is never printed in this mode.
+
+Minimal example — validation passed:
+
+```json
+{
+  "schemaVersion": "1",
+  "passed": true,
+  "totalErrors": 0,
+  "totalWarnings": 0,
+  "filesChecked": 24,
+  "filesWithIssues": 0,
+  "files": []
+}
+```
+
+When the command exits non-zero, the error is folded into the **same** document
+as an `error` field rather than emitted as a second document:
+
+```json
+{
+  "schemaVersion": "1",
+  "passed": false,
+  "totalErrors": 1,
+  "totalWarnings": 0,
+  "filesChecked": 24,
+  "filesWithIssues": 1,
+  "files": [
+    {
+      "path": "getting-started.md",
+      "issues": [
+        {
+          "severity": "error",
+          "code": "LINK_FILE_NOT_FOUND",
+          "message": "Broken link to \"./setup.md\"",
+          "file": "getting-started.md",
+          "line": 45
+        }
+      ]
+    }
+  ],
+  "error": {
+    "code": "ATLCLI_ERR_VALIDATION",
+    "message": "Validation failed",
+    "details": {}
+  }
+}
+```
+
+:::caution[`passed` is not the exit code]
+`passed` reports whether any **errors** were found, not the exit code. In
+`--strict` mode a run with warnings only has `passed: true`, an `error` field,
+and exit code `1`. Branch on the exit code (or on the presence of `error`), not
+on `passed`.
+:::
+
 ## Pre-Push Validation
 
 Use the `--validate` flag with push to run checks before pushing:
@@ -154,6 +211,29 @@ file for a file/`--page-id` push, and the collected (ignore-filtered) set for a
 directory push. An unrelated file's errors will not block your push, and the
 flag works outside an initialized directory too - it validates the named file
 rather than silently doing nothing.
+
+With `--json`, an aborted push emits a single error document carrying the same
+issue list under `error.details`:
+
+```json
+{
+  "error": {
+    "code": "ATLCLI_ERR_VALIDATION",
+    "message": "Validation failed - push aborted",
+    "details": {
+      "passed": false,
+      "totalErrors": 1,
+      "totalWarnings": 0,
+      "filesChecked": 24,
+      "filesWithIssues": 1,
+      "files": [{ "path": "getting-started.md", "issues": [] }]
+    }
+  }
+}
+```
+
+If the push proceeds despite warnings, the warnings are reported under a
+`validation` field on the normal push result document.
 
 ## CI Integration
 


### PR DESCRIPTION
`JSON.parse(stdout)` failed for scripted consumers of several `wiki docs` subcommands, which wrote two or more JSON documents to the same stream.

## What was wrong

| Command | Before | After |
|---|---|---|
| `docs pull --json` (skipped file) | skip notice + result | one result document |
| `docs check --json` (failing) | report + `{"error"}` | one document, `error` folded in |
| `docs push --validate --json` | stringified human report + `{"error"}` | one error document |
| `docs resolve --json` | one or two bare strings, never structured | one result object |

The markdown skip message went through an unguarded `output()`, which JSON-stringifies a bare string, so stdout became `"Skipping foo.md (local modifications, use --force)"` followed by the real result document. The "could not compute path" warning had the same problem.

## Decisions

**`docs check`** — the error is folded into the report document rather than emitted as a second one. `passed` keeps its old meaning (errors only), so under `--strict` a warnings-only run is `passed: true` **with** an `error` field and exit 1. That quirk pre-dates this change; it is now documented rather than silently redefined.

**`docs push --validate`** — the human report was leaking into JSON on both the abort and the proceed-anyway path. It now travels as machine-readable `error.details` on abort, and as a `validation` field on the push result when warnings are pushed through — previously JSON consumers got a stringified report or nothing at all.

**`sync` / `watch`** — left as JSON Lines. They are streaming by design; the distinction is documented instead.

A shared `validationPayload()` keeps `check` and `push --validate` reporting issues in the same shape.

## Audit

Every `output()` call in `docs.ts` was checked with a brace-tracking script plus manual review of each hit. The remaining unguarded string outputs are all fine: either in the `else` of `if (opts.json)`, or after an `if (opts.json) { …; return }` early return. Re-run after rebasing onto #76/#77 — those PRs introduced no new offenders, and their attachment skip messages are correctly guarded.

## Interaction with #76

`docs check` now refuses to pass a tree with no markdown files. That failure happens before the report exists, so `--json` emits an `error`-only document with `ATLCLI_ERR_USAGE` — still exactly one document, but a different shape. Pinned down by a test and documented, so consumers know to read `error` before the report fields.

## Testing

- 10 regression tests in `apps/cli/src/commands/docs-json-single-document.test.ts`. Each parses **all** of stdout as one document — a per-line parse would pass against the bug — and rejects a bare string, since `"Skipping …"` alone parses fine on its own.
- **6 of 9 failed on the unfixed code** (verified by stashing the fix), with the multi-document stdout visible in each failure.
- Real CLI driven against a local `Bun.serve` stub, sandboxed HOME, no Atlassian traffic, asserts zero non-GET requests.
- Full suite 3241 pass / 0 fail, `bun run typecheck` clean, Astro docs build green.
- E2E against DOCSY (profile `mayflower`, page 1117356071, read-only into a temp dir): live skip path emits a single document with `results.skipped: 1`, human mode still prints the notice, `check` / empty-`check` / `push --validate` each emit one document with exit 1. No Confluence writes — the push aborts at validation. Temp dir removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)