### PR TITLE
fix(extension): hide export controls outside Atlassian pages

### DIFF
--- a/apps/extension/components/screens/ExportScreen.tsx
+++ b/apps/extension/components/screens/ExportScreen.tsx
@@ -64,6 +64,18 @@ export function ExportScreen(props: ScreenProps): React.JSX.Element {
 }
 
 function ExportScreenBody({ ports, page, retry, navigate }: ScreenProps): React.JSX.Element {
+  if (page.status !== "loaded") {
+    return (
+      <div className="flex flex-col gap-3" data-testid="publishing-studio">
+        <PageSummary state={page} onRetry={retry} />
+      </div>
+    );
+  }
+
+  return <LoadedExportScreenBody ports={ports} page={page} retry={retry} navigate={navigate} />;
+}
+
+function LoadedExportScreenBody({ ports, page, retry, navigate }: ScreenProps): React.JSX.Element {
   const t = useT();
   const loadedPage = page.status === "loaded" ? page.page : null;
   const pageUrl = page.status === "loaded" ? page.ref.url : null;

--- a/apps/extension/tests/app-portability.test.tsx
+++ b/apps/extension/tests/app-portability.test.tsx
@@ -660,18 +660,25 @@ describe("i18n reaches the rendered app", () => {
 });
 
 describe("page states render without a page", () => {
-  it("shows the idle state and still offers the Export screen", async () => {
+  it("shows only the idle state when the active tab is not an Atlassian page", async () => {
     await render(
       <ExportApp
         ports={makePorts(newRecorder(), {
-          watchPageContext: fakePageContext({ url: null, entity: null, seq: 1 }),
+          watchPageContext: fakePageContext({
+            url: "https://www.heise.de/",
+            entity: null,
+            seq: 1,
+          }),
         })}
         localeCandidates={["en"]}
       />
     );
 
     expect(maybeFind("state-idle")).not.toBeNull();
-    expect((find("pdf-export") as unknown as HTMLButtonElement).disabled).toBe(true);
+    expect(maybeFind("studio-step-01")).toBeNull();
+    expect(maybeFind("format-pdf")).toBeNull();
+    expect(maybeFind("pdf-export")).toBeNull();
+    expect(maybeFind("template-export")).toBeNull();
   });
 
   it("shows a classified error with a retry affordance", async () => {


### PR DESCRIPTION
## Summary

- render only the page-status message while no Confluence page is loaded
- keep scope, format, PDF, and Word controls out of the DOM on non-Atlassian tabs
- add a regression case for an active `https://www.heise.de/` tab

## Root cause

The export screen rendered `PageSummary` from the current page state, but mounted the rest of Publishing Studio unconditionally. The idle message was therefore correct while stale, inapplicable export controls remained visible below it.

## User impact

Keeping the side panel open while navigating away from Atlassian now produces a clear empty state instead of showing controls that cannot apply to the active tab. Error and retry states remain available.

## Validation

- `bun run test apps/extension/tests/app-portability.test.tsx` — 18 passed
- `bun run typecheck --filter=@atlcli/extension`
- `bun run --cwd apps/extension build`
- `bun run --cwd apps/extension check:output`
- `bun run --cwd apps/extension test:worker-extension-browser` — 2 Chromium MV3 E2E tests passed
- `git diff --check`