### PR TITLE
fix(extension): preserve ADF captions in PDF preview

### DIFF
--- a/apps/extension/tests/confluence/tree-source.test.ts
+++ b/apps/extension/tests/confluence/tree-source.test.ts
@@ -282,6 +282,58 @@ describe("sessionTreeSource — behavior inherited from ConfluenceClient", () =>
 });
 
 describe("sessionTreeSource — injectable client seam", () => {
+  it("uses the representation-aware export read when preview requests ADF-primary", async () => {
+    const seen: string[] = [];
+    const fake: TreeSourceClient = {
+      getExportPageDetailsWithMedia: async (id) => {
+        seen.push(`export:${id}`);
+        return {
+          id,
+          title: "ADF preview",
+          storage: "<p>Storage sidecar</p>",
+          version: 4,
+          exportSource: {
+            primary: {
+              representation: "atlas_doc_format",
+              value: JSON.stringify({
+                type: "doc",
+                version: 1,
+                content: [{ type: "paragraph", content: [{ type: "text", text: "ADF body" }] }],
+              }),
+            },
+            storageSidecar: "<p>Storage sidecar</p>",
+            sourceVersion: 4,
+          },
+        };
+      },
+      getPageDetails: async (id) => {
+        seen.push(`details:${id}`);
+        return { id, title: "Storage preview", storage: "<p>Storage body</p>", version: 4 };
+      },
+      getPageVersion: async () => ({ title: "ADF preview", version: 4 }),
+      getChildrenWithPosition: async () => [],
+      getPageDirectChildren: async () => [],
+      getFolderChildren: async () => [],
+      getSpaceHomepageId: async () => null,
+      searchPages: async () => [],
+    };
+
+    const page = await sessionTreeSource(PAGE_URL, {
+      exportSourcePolicy: "adf-primary",
+      makeClient: () => fake,
+    }).getPage("42", {});
+
+    expect(page).toMatchObject({
+      id: "42",
+      title: "ADF preview",
+      exportSource: {
+        primary: { representation: "atlas_doc_format" },
+        sourceVersion: 4,
+      },
+    });
+    expect(seen).toEqual(["export:42"]);
+  });
+
   it("uses the supplied client factory and the tab's origin as base URL", async () => {
     const seen: string[] = [];
     const fake: TreeSourceClient = {

--- a/apps/extension/tests/pdf/preview.test.ts
+++ b/apps/extension/tests/pdf/preview.test.ts
@@ -220,6 +220,109 @@ const loadedPage = {
 const report = { filename: "T.pdf" } as unknown as PdfExportReport;
 
 describe("runPagePdfPreview", () => {
+  it("refreshes ADF-primary source so a media caption absent from Storage remains visible", async () => {
+    const caption = "Abstract document-flow symbol";
+    const adf = JSON.stringify({
+      type: "doc",
+      version: 1,
+      content: [
+        {
+          type: "mediaSingle",
+          attrs: { layout: "center" },
+          content: [
+            {
+              type: "media",
+              attrs: {
+                type: "file",
+                id: "media-1",
+                collection: "contentId-1",
+                alt: "Architecture",
+              },
+            },
+            {
+              type: "caption",
+              content: [{ type: "text", text: caption }],
+            },
+          ],
+        },
+      ],
+    });
+    const source: TreeSource = {
+      async getPage() {
+        return {
+          id: "1",
+          title: "T",
+          storage: "<p><ac:image><ri:attachment ri:filename=\"image.png\" /></ac:image></p>",
+          version: 2,
+          labels: [],
+          spaceKey: "DOCSY",
+          exportSource: {
+            primary: { representation: "atlas_doc_format", value: adf },
+            storageSidecar:
+              "<p><ac:image><ri:attachment ri:filename=\"image.png\" /></ac:image></p>",
+            sourceVersion: 2,
+          },
+          mediaAttachments: [
+            { fileId: "media-1", filename: "image.png", pageId: "1" },
+          ],
+          mediaAttachmentsComplete: true,
+        };
+      },
+      async getPageVersion() {
+        return { title: "T", version: 2 };
+      },
+      async getChildren() {
+        return [];
+      },
+      async getSpaceHomepageId() {
+        return "1";
+      },
+    };
+    let previewBlocks: ExportBlock[] = [];
+
+    await runPagePdfPreview(
+      { page: loadedPage, pageUrl: "https://x.atlassian.net/wiki/p/1" },
+      {
+        runExport: async (input, overrides) => {
+          const composition = await overrides!.resolveComposition!(
+            {
+              root: {
+                id: input.page.details.id,
+                title: input.page.details.title,
+                version: input.page.details.version,
+                storage: input.page.details.storage,
+              },
+              pageUrl: input.pageUrl,
+              exporter: "pdf",
+            },
+            { createTreeSource: () => source }
+          );
+          previewBlocks = composition.blocks;
+          await overrides?.output?.emit(
+            "T.pdf",
+            pdfBytesFromUint8Array(new Uint8Array([1]))
+          );
+          return report;
+        },
+      }
+    );
+
+    expect(previewBlocks).toEqual([
+      expect.objectContaining({
+        type: "image",
+        source: {
+          kind: "attachment",
+          filename: "image.png",
+          pageId: "1",
+        },
+        caption: {
+          kind: "figure",
+          content: [{ type: "text", text: caption }],
+        },
+      }),
+    ]);
+  });
+
   it("runs the REAL export pipeline with a capture sink and a preview-tagged port", async () => {
     let sawPreviewPort = false;
     let emitted: string | undefined;

--- a/apps/extension/utils/confluence/export-composition.ts
+++ b/apps/extension/utils/confluence/export-composition.ts
@@ -76,6 +76,12 @@ export interface ExportCompositionInput {
   pageUrl: string;
   /** Absent → single page (today's behaviour). */
   scope?: ExportScope;
+  /**
+   * Re-read a single page through the injected {@link TreeSource} instead of
+   * walking the panel's already-loaded Storage body. PDF preview enables this
+   * so its published source representation matches durable ADF-primary export.
+   */
+  refreshPageSource?: boolean;
   labels?: LabelFilter;
   /** Which engine's walker dialect to use for the single-page walk. */
   exporter: "pdf" | "word";
@@ -160,11 +166,9 @@ function externalUrlResolver(profile: Profile): NonNullable<ComposeOptions["reso
 /**
  * Resolve the requested scope into one composed document.
  *
- * Single page: walks the already-loaded storage — with `pageContext`, so
- * attachment `ImageSource`s carry `pageId` and `unknown` blocks carry
- * `sourcePage` exactly as they do in a tree export. That uniformity is what
- * lets the asset resolvers and the macro `contextFor` take ONE code path for
- * both scopes rather than special-casing the root.
+ * Single page normally walks the already-loaded storage. A preview can set
+ * `refreshPageSource` to read the page through the injected representation-
+ * aware source instead, preserving ADF-only semantics such as media captions.
  *
  * Tree/space: folder 002's `fetchExportTree` (label filter, ordering,
  * completeness, `onProgress`, `signal`) followed by `composeChapters`. The
@@ -178,7 +182,7 @@ export async function resolveExportComposition(
   const deps = { ...defaultDeps, ...overrides };
   input.signal?.throwIfAborted();
 
-  if (!isTreeScope(input.scope)) {
+  if (!isTreeScope(input.scope) && input.refreshPageSource !== true) {
     const walked = storageToBlocks(input.root.storage ?? "", {
       exporter: input.exporter,
       pageContext: {
@@ -207,7 +211,8 @@ export async function resolveExportComposition(
   if (!profile) throw new Error(NOT_ATLASSIAN_HOST_MESSAGE);
 
   const source = deps.createTreeSource(input.pageUrl, input.signal);
-  const tree = await fetchExportTree(source, input.scope, {
+  const scope = input.scope ?? { kind: "page" as const, pageId: input.root.id };
+  const tree = await fetchExportTree(source, scope, {
     ...(input.labels ? { labels: input.labels } : {}),
     ...(input.completenessMode ? { completenessMode: input.completenessMode } : {}),
     ...(input.maxPages !== undefined ? { maxPages: input.maxPages } : {}),
@@ -216,6 +221,33 @@ export async function resolveExportComposition(
     ...(input.onProgress ? { onProgress: input.onProgress } : {}),
   });
   input.signal?.throwIfAborted();
+
+  if (scope.kind === "page") {
+    const page = tree.nodes.find((node) => node.kind === "page");
+    if (!page || page.kind !== "page") {
+      throw new Error("The refreshed preview source did not contain its root page.");
+    }
+    if (
+      input.root.version !== undefined &&
+      page.meta.version !== undefined &&
+      page.meta.version !== input.root.version
+    ) {
+      throw new Error("The published page changed while its preview source was being read.");
+    }
+    return {
+      kind: "page",
+      blocks: page.blocks,
+      notes: [...tree.notes, ...page.notes],
+      complete: tree.complete,
+      root: {
+        id: page.pageId,
+        title: page.title,
+        ...(page.meta.version !== undefined ? { version: page.meta.version } : {}),
+        ...(page.meta.spaceKey !== undefined ? { spaceKey: page.meta.spaceKey } : {}),
+      },
+      pageCount: 1,
+    };
+  }
 
   const selectedNodes = input.selectNodes ? input.selectNodes(tree.nodes) : tree.nodes;
   const selectedPageIds = new Set(

--- a/apps/extension/utils/confluence/tree-source.ts
+++ b/apps/extension/utils/confluence/tree-source.ts
@@ -31,6 +31,7 @@
 import {
   ConfluenceClient,
   confluenceTreeSource,
+  type ExportSourcePolicy,
   type TreeFetchContext,
   type TreeSource,
   type TreeSourceClient,
@@ -47,6 +48,12 @@ export const NOT_ATLASSIAN_HOST_MESSAGE =
   "The active page is not on an approved Atlassian host.";
 
 export interface SessionTreeSourceOptions {
+  /**
+   * Body representation used by export reads. The legacy panel-owned export
+   * path stays Storage-primary by default; PDF preview opts into ADF-primary so
+   * it renders the same published source as the durable Download path.
+   */
+  exportSourcePolicy?: ExportSourcePolicy;
   /**
    * The export-level abort signal. Combined with (not replaced by) whatever
    * signal `fetchExportTree` threads into each call's {@link TreeFetchContext},
@@ -122,8 +129,19 @@ export function sessionTreeSourceForProfile(
   profile: Profile,
   options: SessionTreeSourceOptions = {}
 ): TreeSource {
-  const makeClient = options.makeClient ?? ((p: Profile) => new ConfluenceClient(p));
+  const makeClient =
+    options.makeClient ??
+    ((p: Profile) =>
+      new ConfluenceClient(
+        p,
+        options.exportSourcePolicy
+          ? { exportSourcePolicy: options.exportSourcePolicy }
+          : {}
+      ));
   const client = makeClient(profile);
+  if (options.exportSourcePolicy === "adf-primary") {
+    return withExportSignal(confluenceTreeSource(client), options.signal);
+  }
   // The current panel-owned export path remains explicitly Storage-primary
   // until the background-job resolver owns the complete dual-read lifecycle.
   // Hiding the optional export read here is a routing policy, not a parser

--- a/apps/extension/utils/pdf/preview.ts
+++ b/apps/extension/utils/pdf/preview.ts
@@ -58,6 +58,7 @@ import {
 import type { LoadedPage } from "../read-path.js";
 import { exportScopeIdentity } from "../scope-state.js";
 import { resolveExportComposition } from "../confluence/export-composition.js";
+import { sessionTreeSource } from "../confluence/tree-source.js";
 import { extensionPdfCompilePort } from "./compile-port.js";
 import { isPreviewSupersededError } from "./compiler-host.js";
 import {
@@ -418,6 +419,13 @@ const UNTRUNCATED: PreviewTruncationPlan = {
   reason: "none",
 };
 
+function previewTreeSource(pageUrl: string, signal?: AbortSignal) {
+  return sessionTreeSource(pageUrl, {
+    ...(signal ? { signal } : {}),
+    exportSourcePolicy: "adf-primary",
+  });
+}
+
 /** Preview of the loaded page (whole document, never truncated). */
 export async function runPagePdfPreview(
   input: PdfPagePreviewInput,
@@ -437,7 +445,20 @@ export async function runPagePdfPreview(
         signal: input.signal,
         onPhase: input.onPhase,
       },
-      { output: captured.sink, createCompilePort: deps.createCompilePort, now: deps.now }
+      {
+        output: captured.sink,
+        createCompilePort: deps.createCompilePort,
+        now: deps.now,
+        resolveComposition: (compositionInput, compositionOverrides) =>
+          resolveExportComposition(
+            { ...compositionInput, refreshPageSource: true },
+            {
+              ...compositionOverrides,
+              createTreeSource:
+                compositionOverrides?.createTreeSource ?? previewTreeSource,
+            }
+          ),
+      }
     );
     return {
       status: "ready",
@@ -458,7 +479,8 @@ export async function runPagePdfPreview(
 /**
  * Preview the Studio's selected scope through the same host pipeline as
  * Download. Tree/space scopes fetch the complete shared tree, then compose only
- * the bounded chapter prefix; page scope stays on the cheap loaded-page path.
+ * the bounded chapter prefix; page scope refreshes exactly one published source
+ * so ADF-only semantics match Download without paying for a tree walk.
  */
 export async function runScopedPdfPreview(
   input: PdfScopedPreviewInput,
@@ -503,7 +525,11 @@ export async function runScopedPdfPreview(
                 return truncation.nodes;
               },
             },
-            compositionOverrides
+            {
+              ...compositionOverrides,
+              createTreeSource:
+                compositionOverrides?.createTreeSource ?? previewTreeSource,
+            }
           ),
       }
     );


### PR DESCRIPTION
## What changed

- route extension PDF preview source loading through the ADF-primary export path
- refresh page-preview composition through the injected tree source while guarding against version drift
- keep the existing storage-source compatibility behavior as the default for other callers
- add regression coverage for captions that exist in ADF media nodes but not in the storage image representation

## Root cause

Downloaded PDF/DOCX exports already used the ADF-primary representation and therefore preserved the media caption. The extension PDF preview still composed the page from the storage representation, where the image caption was absent, so preview and export diverged.

## User impact

Image captions shown in Confluence now also appear in the extension PDF preview, matching the downloaded PDF/DOCX output.

## Validation

- live Confluence export E2E against DOCSY page `1140457478` with profile `mayflower`; rendered PDF contained the expected figure caption
- `bun run test apps/extension/tests/pdf/preview.test.ts apps/extension/tests/confluence/tree-source.test.ts apps/extension/tests/pdf/run-export-scope.test.ts` — 93 passed
- `bun run typecheck` — passed
- `bun run check:browser` — passed for 20 entrypoints
- extension production build plus `check:extension-output` — passed
- Chromium browser export conformance harness — 1 passed