### PR TITLE
fix(extension): avoid CORS fetches for external images

### DIFF
--- a/apps/extension/tests/pdf/run-export-scope.test.ts
+++ b/apps/extension/tests/pdf/run-export-scope.test.ts
@@ -545,6 +545,25 @@ describe("PDF env — sink-side trust routing", () => {
     await pdfAssets().resolve({ kind: "attachment", filename: "a.png" }).catch(() => undefined);
     expect(urls.some((url) => url.includes("/download/attachments/1/a.png"))).toBe(true);
   });
+
+  it("blocks a page-authored external image outside host permissions before CORS", async () => {
+    const urls = recordingFetch();
+    const error = await pdfAssets()
+      .resolve({ kind: "external", url: "https://example.com/adf-conformance.svg" })
+      .then(() => undefined, (e: unknown) => e);
+
+    expect(isExternalAssetBlockedError(error)).toBe(true);
+    expect(urls).toEqual([]);
+  });
+
+  it("keeps an absolute page-authored image on the permitted site session path", async () => {
+    const urls = recordingFetch();
+    await pdfAssets()
+      .resolve({ kind: "external", url: `${SITE}/wiki/download/attachments/1/site.png` })
+      .catch(() => undefined);
+
+    expect(urls).toEqual([`${SITE}/wiki/download/attachments/1/site.png`]);
+  });
 });
 
 describe("DOCX env — sink-side trust routing", () => {
@@ -573,6 +592,25 @@ describe("DOCX env — sink-side trust routing", () => {
     const urls = recordingFetch();
     await docxAssets().fetch({ url: "/download/attachments/7/x.png" }).catch(() => undefined);
     expect(urls.some((url) => url.includes(`${SITE}/wiki/download/attachments/7/x.png`))).toBe(true);
+  });
+
+  it("blocks a page-authored external image outside host permissions before CORS", async () => {
+    const urls = recordingFetch();
+    const error = await docxAssets()
+      .fetch({ url: "https://example.com/adf-conformance.svg" })
+      .then(() => undefined, (e: unknown) => e);
+
+    expect(isExternalAssetBlockedError(error)).toBe(true);
+    expect(urls).toEqual([]);
+  });
+
+  it("keeps an absolute page-authored image on the permitted site session path", async () => {
+    const urls = recordingFetch();
+    await docxAssets()
+      .fetch({ url: `${SITE}/wiki/download/attachments/1/site.png` })
+      .catch(() => undefined);
+
+    expect(urls).toEqual([`${SITE}/wiki/download/attachments/1/site.png`]);
   });
 });
 

--- a/apps/extension/utils/docx/env.ts
+++ b/apps/extension/utils/docx/env.ts
@@ -22,6 +22,7 @@ import type { ExternalAssetFetcher, ExternalAssetPolicy } from "@atlcli/export-m
 import { trustRoutingAssetFetcher } from "@atlcli/export-wiring";
 import {
   createExternalAssetFetcher,
+  extensionPageAssetFetcher,
   extensionAssetPolicyFromPageUrl,
 } from "../macros/external-asset-policy.js";
 import {
@@ -237,7 +238,7 @@ export interface SessionDocxAssetsOptions {
   baseUrl?: string;
   /** The active tab's URL — the origin the external-asset policy is built on. */
   pageUrl: string;
-  /** Replaces the session fetch; the trust router is composed around it regardless. */
+  /** Replaces the session fetch; the manifest guard and trust router are composed around it. */
   inner?: AssetFetcher;
   /** Defaults to the extension's manifest-scoped origin allowlist. */
   policy?: ExternalAssetPolicy;
@@ -248,7 +249,7 @@ export interface SessionDocxAssetsOptions {
 
 /**
  * The fetcher the DOCX export env actually gets: {@link sessionAssetFetcher}
- * with the spec-004 trust router already composed around it.
+ * with the manifest-origin guard and spec-004 trust router composed around it.
  *
  * **Every `ExportEnv.assets` this host builds goes through here** — the exact
  * counterpart of `extensionPdfAssets` in `utils/pdf/run-export.ts`, and for the
@@ -258,15 +259,17 @@ export interface SessionDocxAssetsOptions {
  * app's `export_view` HTML would otherwise have been fetched from inside the
  * user's authenticated browser session. The router sends exactly those
  * (`trust: "export-view"`) through the policy-checked, redirect-re-checked,
- * byte-capped, `credentials: "omit"` fetcher; page-author refs keep the
- * session path unchanged, which is what keeps the DOCX and PDF engines
- * embedding the same image for the same page.
+ * byte-capped, `credentials: "omit"` fetcher. Page-author refs keep the
+ * session path when their origin is covered by the extension manifest; other
+ * absolute origins are rejected before Chrome can emit a CORS request. PDF
+ * applies the same host-specific guard, so both engines degrade identically.
  */
 export function sessionDocxAssets(options: SessionDocxAssetsOptions): AssetFetcher {
   const policy = options.policy ?? extensionAssetPolicyFromPageUrl(options.pageUrl);
   const external = options.external ?? createExternalAssetFetcher(policy);
-  const inner =
+  const session =
     options.inner ?? sessionAssetFetcher(options.baseUrl, options.fetchFn ?? fetch);
+  const inner = extensionPageAssetFetcher(session, policy);
   return trustRoutingAssetFetcher(inner, external);
 }
 

--- a/apps/extension/utils/macros/external-asset-policy.ts
+++ b/apps/extension/utils/macros/external-asset-policy.ts
@@ -20,8 +20,11 @@
  */
 import {
   createExternalAssetPolicy,
+  ExternalAssetBlockedError,
   type ExternalAssetPolicy,
 } from "@atlcli/export-wiring";
+import type { AssetFetcher } from "@atlcli/docx/browser";
+import type { PdfAssetResolver } from "@atlcli/pdf/browser";
 
 export {
   createExternalAssetFetcher,
@@ -57,6 +60,65 @@ export interface ExtensionAssetPolicyOptions {
   siteOrigin: string;
   /** Defaults to {@link ATLASSIAN_MEDIA_ORIGINS}. */
   allowedMediaOrigins?: readonly string[];
+}
+
+function isAbsoluteUrl(value: string): boolean {
+  try {
+    new URL(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function assertManifestScopedPageAsset(
+  policy: ExternalAssetPolicy,
+  url: string,
+): void {
+  if (isAbsoluteUrl(url) && !policy.allow(url)) {
+    throw new ExternalAssetBlockedError(
+      url,
+      "the extension has no host permission for this origin",
+    );
+  }
+}
+
+/**
+ * Guard page-authored DOCX assets with the extension's manifest-scoped policy.
+ *
+ * The shared trust router deliberately only diverts `export-view` refs because
+ * non-browser hosts may support arbitrary page-authored external images. The
+ * extension does not: without a matching `host_permissions` entry Chrome falls
+ * back to CORS and emits a console error before the engine can degrade the
+ * image. Rejecting here keeps relative/same-origin attachment traffic on the
+ * authenticated session path while turning unsupported absolute origins into
+ * the engines' existing `image-embed-failed` fallback without a network call.
+ */
+export function extensionPageAssetFetcher(
+  inner: AssetFetcher,
+  policy: ExternalAssetPolicy,
+): AssetFetcher {
+  return {
+    async fetch(ref, context): Promise<Uint8Array> {
+      assertManifestScopedPageAsset(policy, ref.url);
+      return inner.fetch(ref, context);
+    },
+  };
+}
+
+/** PDF counterpart of {@link extensionPageAssetFetcher}. */
+export function extensionPagePdfAssetResolver(
+  inner: PdfAssetResolver,
+  policy: ExternalAssetPolicy,
+): PdfAssetResolver {
+  return {
+    async resolve(ref, context) {
+      if (ref.kind === "external" && ref.url) {
+        assertManifestScopedPageAsset(policy, ref.url);
+      }
+      return inner.resolve(ref, context);
+    },
+  };
 }
 
 /**

--- a/apps/extension/utils/pdf/run-export.ts
+++ b/apps/extension/utils/pdf/run-export.ts
@@ -57,6 +57,7 @@ import {
 import {
   createExternalAssetFetcher,
   extensionAssetPolicyFromPageUrl,
+  extensionPagePdfAssetResolver,
 } from "../macros/external-asset-policy.js";
 import {
   buildSessionMacroResolutionOptions,
@@ -288,11 +289,12 @@ function mimeFromFilename(filename: string): string {
  * what keeps a single-page export — whose refs carry no page id at all —
  * working unchanged.
  *
- * Page-author external images (`trust` absent/`"page"`) are fetched through the
- * same session path the DOCX engine uses, so the two engines embed the same
- * image for the same page. `trust: "export-view"` refs never arrive here: the
- * router in {@link extensionPdfAssets} diverts them to the policy-checked
- * fetcher first.
+ * Page-author external images (`trust` absent/`"page"`) whose origin is covered
+ * by the extension manifest are fetched through the same session path the DOCX
+ * engine uses. Other absolute origins are rejected by the host-specific guard
+ * around this resolver before Chrome can emit a CORS request.
+ * `trust: "export-view"` refs never arrive here: the router in
+ * {@link extensionPdfAssets} diverts them to the policy-checked fetcher first.
  */
 function pageResolver(
   rootPageId: string,
@@ -340,7 +342,7 @@ export interface ExtensionPdfAssetsOptions {
   rootPageId: string;
   pageUrl: string;
   signal?: AbortSignal;
-  /** Replaces the session fetch; the trust router is composed around it regardless. */
+  /** Replaces the session fetch; the manifest guard and trust router are composed around it. */
   inner?: PdfAssetResolver;
   /** Defaults to the extension's manifest-scoped origin allowlist. */
   policy?: ExternalAssetPolicy;
@@ -350,7 +352,7 @@ export interface ExtensionPdfAssetsOptions {
 
 /**
  * The resolver the PDF export env actually gets: the session resolver with the
- * spec-004 trust router already composed around it.
+ * manifest-origin guard and spec-004 trust router already composed around it.
  *
  * **Every `PdfExportEnv.assets` this host builds goes through here.** That is
  * the reason it is a function rather than two inlined lines: the CLI's PDF path
@@ -359,14 +361,16 @@ export interface ExtensionPdfAssetsOptions {
  * path passed no `macros`. This host passes `macros`, so an unwrapped resolver
  * here is a live SSRF — third-party macro HTML naming
  * the cloud metadata service would be fetched from inside the user's
- * authenticated browser session. Composing the router costs nothing for refs
- * without the trust marker: they take the identical inner path.
+ * authenticated browser session. Refs without the trust marker take the inner
+ * path only when the extension manifest covers their origin; unsupported
+ * absolute origins degrade before the browser transport.
  */
 export function extensionPdfAssets(options: ExtensionPdfAssetsOptions): PdfAssetResolver {
   const policy = options.policy ?? extensionAssetPolicyFromPageUrl(options.pageUrl);
   const external = options.external ?? createExternalAssetFetcher(policy);
-  const inner =
+  const session =
     options.inner ?? pageResolver(options.rootPageId, options.pageUrl, options.signal);
+  const inner = extensionPagePdfAssetResolver(session, policy);
   return trustRoutingPdfAssetResolver(inner, external);
 }
 


### PR DESCRIPTION
## What changed

- guard page-authored absolute image URLs against the extension's manifest-scoped origin policy before the browser transport
- apply the same host-specific guard to both PDF and DOCX asset seams
- keep same-site and Atlassian media URLs on the existing session-authenticated path
- add regression coverage for the reported `https://example.com/adf-conformance.svg` URL and permitted same-site URLs

## Root cause

The ADF-primary preview path correctly exposed an external media node. Page-authored external images bypassed the `export-view` trust router and were sent directly through the session fetcher. Because the extension manifest only grants Atlassian and Atlassian Media origins, Chrome attempted a normal cross-origin request and emitted a CORS error before the engines could degrade the image.

## User impact

Unsupported external image origins now degrade directly to the existing image fallback and `image-embed-failed` note without issuing a CORS request. Captions remain visible, and the extension does not widen its host permissions.

## Validation

- user manually confirmed the rebuilt extension fixes the reported preview behavior
- focused PDF/DOCX/policy regression suite — 109 passed
- PDF preview/caption suite — 25 passed
- workspace typecheck — passed
- browser build gate — passed for 20 entrypoints
- MV3 production build and extension-output validator — passed
- packed MV3 PDF-worker Chromium E2E — 2 passed