### PR TITLE
ci: run CI when a pull request leaves draft

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,13 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    # Spelled out rather than inherited from the GitHub default. Without
+    # `ready_for_review` a PR can sit in draft for days and then be marked
+    # ready — the moment a human is asked to trust the checks — while the
+    # newest run still points at an outdated moment in time. Every
+    # `pull_request`-triggered workflow in this repo carries this same list;
+    # scripts/ci/workflow-policy.test.ts enforces it.
+    types: [opened, synchronize, reopened, ready_for_review]
   schedule:
     # Full unfiltered drift guard. Path routing must never become the only proof.
     - cron: "33 5 * * 6"

--- a/scripts/ci/workflow-policy.test.ts
+++ b/scripts/ci/workflow-policy.test.ts
@@ -4,7 +4,26 @@ import { fileURLToPath } from "node:url";
 import { join } from "node:path";
 
 const REPO_ROOT = fileURLToPath(new URL("../..", import.meta.url));
-const workflow = (name: string) => readFile(join(REPO_ROOT, ".github", "workflows", name), "utf8");
+const WORKFLOW_DIR = join(REPO_ROOT, ".github", "workflows");
+const workflow = (name: string) => readFile(join(WORKFLOW_DIR, name), "utf8");
+const workflowNames = async () =>
+  (await readdir(WORKFLOW_DIR)).filter((entry) => entry.endsWith(".yml"));
+
+/** Body of an indented YAML block, ending at the next key of the same depth. */
+const block = (source: string, header: RegExp, indent: number): string | null => {
+  const lines = source.split("\n");
+  const start = lines.findIndex((line) => header.test(line));
+  if (start === -1) return null;
+  const rest = lines.slice(start + 1);
+  const end = rest.findIndex((line) => new RegExp(`^ {${indent}}\\S`).test(line));
+  return (end === -1 ? rest : rest.slice(0, end)).join("\n");
+};
+
+/** The `pull_request:` trigger body of a workflow, or null when it has none. */
+const pullRequestTrigger = (source: string): string | null => {
+  const triggers = block(source, /^on:\s*$/, 0);
+  return triggers === null ? null : block(triggers, /^ {2}pull_request:\s*$/, 2);
+};
 
 describe("CI workflow policy", () => {
   it("keeps one stable required check around selectively skipped jobs", async () => {
@@ -22,6 +41,26 @@ describe("CI workflow policy", () => {
     expect(ci).toContain("group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}");
     expect(ci).toContain("cancel-in-progress: ${{ github.event_name == 'pull_request' }}");
     expect(ci).toMatch(/schedule:\n\s+# Full unfiltered drift guard/);
+  });
+
+  it("revalidates a pull request when it leaves draft", async () => {
+    const ci = await workflow("ci.yml");
+    const trigger = pullRequestTrigger(ci);
+    expect(trigger).not.toBeNull();
+    expect(trigger).toContain("types: [opened, synchronize, reopened, ready_for_review]");
+  });
+
+  it("spells out the same trigger types on every pull_request workflow", async () => {
+    for (const name of await workflowNames()) {
+      const trigger = pullRequestTrigger(await workflow(name));
+      if (trigger === null) continue;
+      const types = trigger.match(/^\s*types:\s*\[(.+)\]\s*$/m);
+      expect(types, `${name} inherits the default pull_request types`).not.toBeNull();
+      const listed = types![1]!.split(",").map((entry) => entry.trim());
+      for (const action of ["opened", "synchronize", "reopened", "ready_for_review"]) {
+        expect(listed, `${name} does not listen for ${action}`).toContain(action);
+      }
+    }
   });
 
   it("runs the browser gate in parallel with product quality", async () => {


### PR DESCRIPTION
Fixes #94.

## Problem

`ci.yml` subscribed to `pull_request` without a `types:` list, so it inherited the GitHub default — `opened`, `synchronize`, `reopened`. `ready_for_review` was not in that set and no other workflow listened for it, so taking a PR out of draft started no run: the checks shown on the ready PR were whatever the draft last produced, arbitrarily old.

## Change

`.github/workflows/ci.yml` now spells the list out:

```yaml
  pull_request:
    branches: [main]
    types: [opened, synchronize, reopened, ready_for_review]
```

`concurrency` is already keyed on `github.event.pull_request.number` with `cancel-in-progress` for pull requests, so a ready transition landing while a run is in flight supersedes the older run instead of doubling the load. The `changes` job needs no adjustment — `github.event.pull_request.base.sha` and `.head.sha` are both populated on a `ready_for_review` payload, so path classification resolves the same range it does on `synchronize`.

Draft PRs keep running the full matrix; this change does not add an `if: !draft` condition. It only makes the ready transition a revalidation point, which is also the precondition for ever skipping drafts safely.

## Regression tests

`scripts/ci/workflow-policy.test.ts` gains two cases, both of which fail against the pre-fix `ci.yml`:

- `revalidates a pull request when it leaves draft` — pins the exact type list on `ci.yml`.
- `spells out the same trigger types on every pull_request workflow` — walks every workflow file and fails any `pull_request` trigger that inherits the default types or omits one of the four actions. This answers the open question in the issue about future workflows: the convention is enforced mechanically rather than by comment alone.

The block-extraction helpers parse the `on:` mapping by indentation, so a `types:` line inside a job (rather than the trigger) cannot satisfy the assertion.

## Verification

- `bun run test scripts/ci/` — 17 pass.
- With the `types:` line removed, both new cases fail with `ci.yml inherits the default pull_request types`; restored, they pass.
- `bun run typecheck` — clean.
- End-to-end: this PR was opened as a draft and marked ready without a push, confirming a fresh run appears for the head SHA with `github.event.action == 'ready_for_review'`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EjVJbNmXiVdJqPUoxKsMzd)_