### PR TITLE
test(extension): stabilize restart recovery assertion

### DIFF
--- a/apps/extension/tests/jobs/packed/job-recovery.e2e.ts
+++ b/apps/extension/tests/jobs/packed/job-recovery.e2e.ts
@@ -1854,10 +1854,12 @@ test("a full persistent-browser restart automatically reclaims checkpointed work
   const recovered = await waitForJobState(JOB_N, "succeeded", 45_000);
   expect(recovered.snapshot).toMatchObject({
     state: "succeeded",
-    leaseEpoch: 2,
-    attempt: 2,
-    recoveryCount: 1,
     artifact: { filename: `Packed page ${JOB_N}.pdf` },
     reportSummary: { completeness: "complete" },
   });
+  // A loaded runner may let the reclaimed attempt's lease expire while the
+  // persistent browser, service worker, and offscreen document cold-start.
+  // The contract is eventual recovery, not an exact number of reclaims.
+  expect(recovered.snapshot.recoveryCount).toBeGreaterThanOrEqual(1);
+  expect(recovered.snapshot.leaseEpoch).toBe(recovered.snapshot.attempt);
 });


### PR DESCRIPTION
## What changed

- relax the packed persistent-browser restart test from an exact recovery count to `recoveryCount >= 1`
- preserve the recovery consistency invariant with `leaseEpoch === attempt`
- keep successful completion, artifact filename, and complete report assertions intact
- leave the exact recovery counts in the controlled live-browser cases unchanged

## Why

A loaded CI runner can legitimately expire the reclaimed attempt during Chromium, service-worker, and offscreen-document cold start. The job still converges successfully, but the previous assertion pinned a timing-dependent count and could fail with a second valid reclaim.

This closes #96.

## Validation

- `bun run build`
- `bun run typecheck`
- targeted persistent-browser restart E2E
- full packed MV3 job-recovery suite: 22 passed