### PR TITLE
docs: refresh README developer experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,162 +1,189 @@
-[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
-[![Build](https://github.com/BjoernSchotte/atlcli/actions/workflows/ci.yml/badge.svg)](https://github.com/BjoernSchotte/atlcli/actions)
-[![Version](https://img.shields.io/github/v/release/BjoernSchotte/atlcli)](https://github.com/BjoernSchotte/atlcli/releases)
-[![Docs](https://img.shields.io/badge/docs-online-brightgreen)](https://atlcli.sh/)
-
-```
-         _   _      _ _
-   __ _ | |_| | ___| (_)
-  / _` || __| |/ __| | |
- | (_| || |_| | (__| | |
-  \__,_| \__|_|\___|_|_|
-
-  Extensible CLI for Atlassian products
-```
-
 # atlcli
 
-A blazingly fast CLI for Atlassian products. Sync Confluence pages as markdown, manage Jira issues from your terminal. Works with both Atlassian Cloud and Data Center (on-premises) deployments.
+**Bring Confluence and Jira into your terminal, editor, browser, and CI pipeline.**
 
-## Key Features
+Sync Confluence spaces as Markdown, export pages and page trees to DOCX or PDF,
+and automate Jira workflows. Use the CLI for repeatable work or the Chrome side
+panel for private, local exports with a visual preview.
 
-**Confluence**
-- Bidirectional markdown sync with conflict detection
-- Macro support (info, note, warning, expand, toc)
-- Page templates with Handlebars-style variables
-- Attachment sync with smart change detection
+[Documentation](https://atlcli.sh/) ·
+[Getting started](https://atlcli.sh/getting-started/) ·
+[CLI reference](https://atlcli.sh/reference/cli-commands/)
 
-**Jira**
-- Full issue lifecycle from the command line
-- JQL search with convenient shortcuts
-- Sprint analytics (velocity, burndown, predictability)
-- Timer-based time tracking
-- Issue templates for quick reuse
+[![Build](https://github.com/BjoernSchotte/atlcli/actions/workflows/ci.yml/badge.svg)](https://github.com/BjoernSchotte/atlcli/actions)
+[![Version](https://img.shields.io/github/v/release/BjoernSchotte/atlcli)](https://github.com/BjoernSchotte/atlcli/releases)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
+[![Docs](https://img.shields.io/badge/docs-atlcli.sh-brightgreen)](https://atlcli.sh/)
 
-**General**
-- Multiple auth profiles
-- Plugin system for extensibility
-- Comprehensive JSONL logging
+## What you can do
 
-## Installation
+### Confluence as code
 
-### Quick Install (macOS/Linux)
+Pull pages into a local Markdown workspace, edit them with your usual tools,
+inspect changes, and push them back with conflict detection. Page hierarchy,
+attachments, macros, labels, comments, and frontmatter stay part of the
+workflow.
+
+[Explore Confluence workflows →](https://atlcli.sh/confluence/)
+
+### Publication-ready exports
+
+Turn one page, a page tree, or an entire space into a single DOCX or PDF. Use
+reusable templates, label filters, deterministic macro handling, durable export
+jobs, and machine-readable reports for repeatable publishing and CI.
+
+[Explore DOCX and PDF export →](https://atlcli.sh/confluence/export/)
+
+### Browser-native exports
+
+Open the Chrome side panel on any Confluence Cloud page and export it to Word or
+PDF using the session you are already signed in with. Preview PDFs, configure
+document branding, manage per-space template sets, and leave long-running
+exports in the Activity view.
+
+Compilation happens locally in your browser: the extension bundles its PDF
+compiler, WebAssembly module, fonts, and export engines. Page content is not
+sent to an external rendering service.
+
+The extension currently installs from a local build and requires Chrome 140 or
+newer.
+
+### Jira from the terminal
+
+Search, create, update, and transition issues without leaving your current
+workflow. Work with attachments, boards, sprints, epics, bulk operations,
+templates, analytics, and timer-based time tracking.
+
+[Explore Jira workflows →](https://atlcli.sh/jira/)
+
+## Get started
+
+### Install
+
+macOS or Linux:
 
 ```bash
 curl -fsSL https://atlcli.sh/install.sh | bash
 ```
 
-### Homebrew
+With Homebrew:
 
 ```bash
 brew install bjoernschotte/tap/atlcli
 ```
 
-### Windows
+Windows binaries, manual downloads, checksums, and platform-specific setup are
+covered in the [installation guide](https://atlcli.sh/getting-started/#installation).
 
-Download `atlcli-windows-x64.zip` from the [latest release](https://github.com/BjoernSchotte/atlcli/releases/latest), extract it, and add the folder containing `atlcli.exe` to your `PATH`. The binary is unsigned, so Windows SmartScreen may show a warning on first run — click **More info** → **Run anyway**.
-
-### From Source
-
-```bash
-git clone https://github.com/BjoernSchotte/atlcli.git
-cd atlcli
-bun install && bun run build
-```
-
-## Requirements
-
-- macOS, Linux, or Windows (x64)
-- Atlassian Cloud **or** Data Center (on-premises) instance
-- API token from [id.atlassian.com](https://id.atlassian.com/manage-profile/security/api-tokens) (Cloud) or a Personal Access Token from your Data Center instance
-
-See [Getting Started](https://atlcli.sh/getting-started/) for detailed setup instructions.
-
-## Quick Example
+### Connect your Atlassian site
 
 ```bash
-# Authenticate
 atlcli auth init
-
-# Sync Confluence docs
-atlcli wiki docs init ./my-docs --space TEAM
-atlcli wiki docs pull ./my-docs
-# Edit locally...
-atlcli wiki docs push ./my-docs
-
-# Search Jira issues
-atlcli jira search --assignee me --status "In Progress"
-
-# Track time on an issue
-atlcli jira worklog timer start PROJ-123
-# ... work ...
-atlcli jira worklog timer stop PROJ-123
+atlcli doctor
 ```
+
+`auth init` guides you through creating a profile. `doctor` checks the
+configuration, credentials, connectivity, and permissions before you start.
+atlcli supports named profiles for multiple Atlassian sites.
+
+## Your first Confluence workspace
+
+```bash
+# Create a Markdown workspace for a Confluence space
+atlcli wiki docs init ./team-docs --space TEAM
+
+cd team-docs
+atlcli wiki docs pull
+
+# Edit Markdown files, then inspect and publish the changes
+atlcli wiki docs status
+atlcli wiki docs push --validate
+```
+
+Try an export or query Jira next:
+
+```bash
+# Export a page tree as one PDF
+atlcli wiki export 12345 --scope tree --output handbook.pdf
+
+# Find your current Jira work
+atlcli jira search --assignee me --status "In Progress"
+```
+
+## Built for terminals, scripts, and agents
+
+- Human-readable output by default
+- Stable machine-readable results with `--json`
+- Validation and strict modes for CI
+- Classified exit codes and export reports
+- Named profiles for multiple Atlassian sites
+- Bash and Zsh completion
+- Diagnostic checks through `atlcli doctor`
+- An extensible plugin system
+
+| Workflow | Start here |
+| --- | --- |
+| Sync Confluence and Markdown | `atlcli wiki docs --help` |
+| Manage pages and spaces | `atlcli wiki --help` |
+| Export DOCX or PDF | `atlcli wiki export --help` |
+| Export visually in Chrome | Open the atlcli side panel on a Confluence page |
+| Search and manage Jira | `atlcli jira --help` |
+| Diagnose configuration | `atlcli doctor` |
+| Automate in CI | `--json`, `--strict`, and documented exit codes |
+| Extend atlcli | `atlcli plugin --help` |
+
+## CLI or browser extension?
+
+Both use the same Confluence, DOCX, and PDF engines.
+
+| Use the CLI when you need… | Use the browser extension when you need… |
+| --- | --- |
+| Repeatable, scriptable exports | A one-off export from the page you are viewing |
+| CI and headless automation | PDF preview before download |
+| JSON reports and classified exit codes | Visual PDF settings and branding |
+| Cloud or Data Center support | Your existing Confluence Cloud browser session |
+| Git-based Markdown workflows | Background activity you can leave and revisit |
 
 ## Documentation
 
-Full documentation: **https://atlcli.sh/**
+The complete and maintained documentation lives at
+**[atlcli.sh](https://atlcli.sh/)**.
 
-- [Getting Started](https://atlcli.sh/getting-started/)
-- [Confluence Guide](https://atlcli.sh/confluence/)
-- [Jira Guide](https://atlcli.sh/jira/)
-- [CLI Reference](https://atlcli.sh/reference/cli-commands/)
-- [Plugin Development](https://atlcli.sh/plugins/)
-- [Contributing](https://atlcli.sh/contributing/)
-- [Changelog](CHANGELOG.md)
+- [Getting started](https://atlcli.sh/getting-started/)
+- [Authentication](https://atlcli.sh/authentication/)
+- [Confluence](https://atlcli.sh/confluence/)
+- [DOCX and PDF export](https://atlcli.sh/confluence/export/)
+- [Jira](https://atlcli.sh/jira/)
+- [Recipes](https://atlcli.sh/recipes/)
+- [CLI reference](https://atlcli.sh/reference/cli-commands/)
+- [Troubleshooting](https://atlcli.sh/reference/troubleshooting/)
 
 ## Development
 
-```bash
-bun install        # Install dependencies
-bun run build      # Build all packages
-bun run start      # Run development version
-bun test           # Run tests
-```
-
-See [Contributing Guide](https://atlcli.sh/contributing/) for detailed development setup.
-
-### Documentation development
-
-The Astro documentation site requires Node.js 22.12.0 or newer. Use the
-repository's declared Bun version (`1.3.14`) to install dependencies and run the
-documentation commands:
+atlcli is a Bun workspace monorepo.
 
 ```bash
-bun install --frozen-lockfile
-bun run docs:dev      # Start the local development server
-bun run docs:check    # Run Astro diagnostics and type checking
-bun run docs:build    # Build the production documentation site
+bun install
+bun run build
+bun run test
+bun run typecheck
 ```
 
-### Project Structure
+Run the CLI directly from source:
 
+```bash
+bun --conditions=development run --cwd apps/cli src/index.ts --help
 ```
-atlcli/
-├── apps/
-│   ├── browser-export-harness/ # Vite/Chromium DOCX + PDF conformance app
-│   ├── cli/                    # CLI entry point and commands
-│   ├── extension/              # Chrome MV3 export host
-│   └── uno-dashboard/          # UNO dashboard web app
-├── packages/
-│   ├── core/                   # Shared utilities (config, logging, templates)
-│   ├── confluence/             # Confluence client, conversion, shared export blocks
-│   ├── docx/                   # Isomorphic DOCX engine + browser runtime
-│   ├── jira/                   # Jira API client
-│   ├── pdf/                    # Host-neutral PDF preparation and runner contracts
-│   ├── pdf-compiler-browser/   # Private Typst-WASM browser adapter
-│   └── plugin-api/             # Plugin type definitions
-├── plugins/              # Built-in plugins (git, example)
-├── scripts/              # Build and release scripts
-├── services/             # Background services (UNO)
-├── specs/                # Feature specifications and implementation plans
-└── src/content/docs/     # Documentation (Astro Starlight)
-```
+
+See the [contributing guide](https://atlcli.sh/contributing/) for repository
+structure, testing conventions, documentation development, and release
+procedures.
 
 ## License
 
-Apache License 2.0 - see [LICENSE](LICENSE) and [NOTICE](NOTICE)
+Licensed under the [Apache License 2.0](LICENSE). See [NOTICE](NOTICE) for
+additional attribution.
 
----
-
-Jira and Confluence are trademarks of Atlassian Corporation Plc, registered in the US and other countries.
-atlcli is not affiliated with, endorsed by, or sponsored by Atlassian.
+Jira and Confluence are trademarks of Atlassian Corporation Plc, registered in
+the US and other countries. atlcli is not affiliated with, endorsed by, or
+sponsored by Atlassian.


### PR DESCRIPTION
## Summary

- rewrite the repository README around a focused five-minute developer journey
- present Confluence sync, publication-ready DOCX/PDF export, the Chrome side panel, and Jira as first-class product paths
- add clearer CLI vs. browser-extension guidance and automation-oriented capabilities
- keep unpublished browser-extension documentation unlinked until it is deployed
- simplify contributor guidance and correct the test command to `bun run test`

## Why

The previous README mixed end-user onboarding, feature inventory, and
contributor details while underrepresenting the export stack and browser
extension. This revision makes the repository landing page a concise entry
point and routes deeper documentation to atlcli.sh.

## User and developer impact

New users get a shorter path from installation to a successful Confluence
workflow, plus clear guidance on when to use the CLI or browser extension.
Contributors get the correct repository commands without duplicating the full
documentation site.

## Validation

- `git diff --check`
- staged diff check

No runtime tests were run because this PR changes only `README.md`.
