### PR TITLE
fix(ci): validate README media routing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
       code: ${{ steps.routes.outputs.code }}
       consumer: ${{ steps.routes.outputs.consumer }}
       docs: ${{ steps.routes.outputs.docs }}
+      readmeMedia: ${{ steps.routes.outputs.readmeMedia }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -93,6 +94,23 @@ jobs:
 
       - name: Build docs
         run: bun run docs:build
+
+  readme-media:
+    name: README media
+    needs: changes
+    if: needs.changes.outputs.readmeMedia == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Validate README media
+        run: bun run check:readme-media
 
   test:
     name: Product quality
@@ -233,6 +251,7 @@ jobs:
     needs:
       - changes
       - docs
+      - readme-media
       - test
       - consumer-smoke
       - pdf-cli-macos
@@ -245,13 +264,19 @@ jobs:
         env:
           CHANGES: ${{ needs.changes.result }}
           DOCS: ${{ needs.docs.result }}
+          README_MEDIA_REQUIRED: ${{ needs.changes.outputs.readmeMedia }}
+          README_MEDIA: ${{ needs.readme-media.result }}
           TEST: ${{ needs.test.result }}
           CONSUMER: ${{ needs.consumer-smoke.result }}
           MACOS: ${{ needs.pdf-cli-macos.result }}
           WINDOWS: ${{ needs.pdf-sink-windows.result }}
           BROWSER: ${{ needs.browser-export-harness.result }}
         run: |
-          for result in "$CHANGES" "$DOCS" "$TEST" "$CONSUMER" "$MACOS" "$WINDOWS" "$BROWSER"; do
+          if [[ "$README_MEDIA_REQUIRED" == "true" && "$README_MEDIA" != "success" ]]; then
+            echo "::error::The selected README media gate finished with result: $README_MEDIA"
+            exit 1
+          fi
+          for result in "$CHANGES" "$DOCS" "$README_MEDIA" "$TEST" "$CONSUMER" "$MACOS" "$WINDOWS" "$BROWSER"; do
             if [[ "$result" != "success" && "$result" != "skipped" ]]; then
               echo "::error::A selected CI gate finished with result: $result"
               exit 1

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "test": "bun --conditions=development test",
     "typecheck": "bunx tsc --noEmit && bun run typecheck:extension && bun run typecheck:pdf-compiler-browser && bun run typecheck:browser-export-harness",
     "check:browser": "bun scripts/check-browser-build.ts",
+    "check:readme-media": "bun scripts/ci/validate-readme-media.ts",
     "typecheck:extension": "turbo run typecheck --filter=@atlcli/extension",
     "typecheck:pdf-compiler-browser": "turbo run typecheck --filter=@atlcli/pdf-compiler-browser",
     "typecheck:browser-export-harness": "turbo run typecheck --filter=@atlcli/browser-export-harness",

--- a/scripts/ci/classify-changes.test.ts
+++ b/scripts/ci/classify-changes.test.ts
@@ -7,6 +7,7 @@ describe("classifyChanges", () => {
       code: false,
       consumer: false,
       docs: true,
+      readmeMedia: false,
     });
   });
 
@@ -15,6 +16,7 @@ describe("classifyChanges", () => {
       code: false,
       consumer: false,
       docs: false,
+      readmeMedia: true,
     });
   });
 
@@ -23,21 +25,37 @@ describe("classifyChanges", () => {
       code: true,
       consumer: true,
       docs: false,
+      readmeMedia: false,
     });
   });
 
   it("routes root dependency changes through every dependent gate", () => {
-    expect(classifyChanges(["bun.lock"])).toEqual({ code: true, consumer: true, docs: true });
+    expect(classifyChanges(["bun.lock"])).toEqual({
+      code: true,
+      consumer: true,
+      docs: true,
+      readmeMedia: false,
+    });
   });
 
   it("fails open for workflow and unknown top-level paths", () => {
-    expect(classifyChanges([".github/workflows/ci.yml"])).toEqual({ code: true, consumer: true, docs: true });
-    expect(classifyChanges(["new-runtime/config.toml"])).toEqual({ code: true, consumer: true, docs: true });
+    expect(classifyChanges([".github/workflows/ci.yml"])).toEqual({
+      code: true,
+      consumer: true,
+      docs: true,
+      readmeMedia: true,
+    });
+    expect(classifyChanges(["new-runtime/config.toml"])).toEqual({
+      code: true,
+      consumer: true,
+      docs: true,
+      readmeMedia: true,
+    });
   });
 
   it("runs every gate for manual, scheduled, or indeterminate changes", () => {
-    expect(classifyChanges([], true)).toEqual({ code: true, consumer: true, docs: true });
-    expect(classifyChanges([])).toEqual({ code: true, consumer: true, docs: true });
+    expect(classifyChanges([], true)).toEqual({ code: true, consumer: true, docs: true, readmeMedia: true });
+    expect(classifyChanges([])).toEqual({ code: true, consumer: true, docs: true, readmeMedia: true });
   });
 
   it("unions independent route decisions", () => {
@@ -45,6 +63,39 @@ describe("classifyChanges", () => {
       code: true,
       consumer: false,
       docs: true,
+      readmeMedia: false,
+    });
+  });
+
+  it("routes only the exact README media prefix through its lightweight gate", () => {
+    expect(
+      classifyChanges([
+        "README.md",
+        "assets/readme/example.png",
+        "assets/readme/reference.pdf",
+      ])
+    ).toEqual({ code: false, consumer: false, docs: false, readmeMedia: true });
+
+    expect(classifyChanges(["assets/runtime/example.png"])).toEqual({
+      code: true,
+      consumer: true,
+      docs: true,
+      readmeMedia: true,
+    });
+    expect(classifyChanges(["assets/readme-preview/example.png"])).toEqual({
+      code: true,
+      consumer: true,
+      docs: true,
+      readmeMedia: true,
+    });
+  });
+
+  it("keeps product-owned assets on product gates", () => {
+    expect(classifyChanges(["apps/extension/assets/example.png"])).toEqual({
+      code: true,
+      consumer: false,
+      docs: false,
+      readmeMedia: false,
     });
   });
 });

--- a/scripts/ci/classify-changes.ts
+++ b/scripts/ci/classify-changes.ts
@@ -10,6 +10,7 @@ export interface CiRoutes {
   code: boolean;
   consumer: boolean;
   docs: boolean;
+  readmeMedia: boolean;
 }
 
 const SITE_DOC_PREFIXES = ["src/content/", "src/components/", "src/styles/", "public/"];
@@ -17,6 +18,7 @@ const SITE_DOC_FILES = new Set(["astro.config.mjs", "src/content.config.ts", "ts
 const GLOBAL_FILES = new Set(["package.json", "bun.lock", "turbo.json", "tsconfig.json"]);
 const DOCUMENTATION_PREFIXES = ["docs/", "spec/", "specs/", ".github/ISSUE_TEMPLATE/"];
 const DOCUMENTATION_FILES = new Set(["README.md", "CHANGELOG.md", "LICENSE", "NOTICE", ".impeccable.md"]);
+const README_MEDIA_PREFIX = "assets/readme/";
 const PRODUCT_PREFIXES = ["apps/", "packages/", "patches/", "plugins/", "scripts/", "services/"];
 
 function normalized(path: string): string {
@@ -28,7 +30,13 @@ function startsWithAny(path: string, prefixes: readonly string[]): boolean {
 }
 
 function isDocumentationOnly(path: string): boolean {
-  if (DOCUMENTATION_FILES.has(path) || startsWithAny(path, DOCUMENTATION_PREFIXES)) return true;
+  if (
+    DOCUMENTATION_FILES.has(path) ||
+    path.startsWith(README_MEDIA_PREFIX) ||
+    startsWithAny(path, DOCUMENTATION_PREFIXES)
+  ) {
+    return true;
+  }
   return path.endsWith(".md") && !startsWithAny(path, PRODUCT_PREFIXES);
 }
 
@@ -47,17 +55,20 @@ function affectsConsumers(path: string): boolean {
 }
 
 export function classifyChanges(paths: readonly string[], full = false): CiRoutes {
-  if (full || paths.length === 0) return { code: true, consumer: true, docs: true };
+  if (full || paths.length === 0) {
+    return { code: true, consumer: true, docs: true, readmeMedia: true };
+  }
 
-  const routes: CiRoutes = { code: false, consumer: false, docs: false };
+  const routes: CiRoutes = { code: false, consumer: false, docs: false, readmeMedia: false };
   for (const rawPath of paths) {
     const path = normalized(rawPath);
     if (!path) continue;
 
     if (path.startsWith(".github/workflows/")) {
-      return { code: true, consumer: true, docs: true };
+      return { code: true, consumer: true, docs: true, readmeMedia: true };
     }
 
+    if (path === "README.md" || path.startsWith(README_MEDIA_PREFIX)) routes.readmeMedia = true;
     if (affectsSiteDocs(path)) routes.docs = true;
     if (affectsConsumers(path)) routes.consumer = true;
 
@@ -70,7 +81,7 @@ export function classifyChanges(paths: readonly string[], full = false): CiRoute
 
     // Unknown paths are deliberately fail-open. A new top-level build surface
     // must receive full CI until this policy explicitly classifies it.
-    return { code: true, consumer: true, docs: true };
+    return { code: true, consumer: true, docs: true, readmeMedia: true };
   }
 
   return routes;

--- a/scripts/ci/validate-readme-media.test.ts
+++ b/scripts/ci/validate-readme-media.test.ts
@@ -1,0 +1,155 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  README_MEDIA_POLICY,
+  validateReadmeMedia,
+  type ReadmeMediaIssue,
+} from "./validate-readme-media.js";
+
+const roots: string[] = [];
+
+async function fixture(
+  readme: string,
+  files: Record<string, Uint8Array | string>,
+  tracked = Object.keys(files)
+): Promise<ReadmeMediaIssue[]> {
+  const root = await mkdtemp(join(tmpdir(), "atlcli-readme-media-"));
+  roots.push(root);
+  await writeFile(join(root, "README.md"), readme);
+  for (const [path, contents] of Object.entries(files)) {
+    await mkdir(join(root, path, ".."), { recursive: true });
+    await writeFile(join(root, path), contents);
+  }
+  return validateReadmeMedia({
+    repoRoot: root,
+    trackedFiles: new Set(["README.md", ...tracked]),
+  });
+}
+
+function png(width: number, height: number): Uint8Array {
+  const bytes = new Uint8Array(24);
+  bytes.set([137, 80, 78, 71, 13, 10, 26, 10]);
+  bytes.set(new TextEncoder().encode("IHDR"), 12);
+  new DataView(bytes.buffer).setUint32(16, width);
+  new DataView(bytes.buffer).setUint32(20, height);
+  return bytes;
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe("README media validation", () => {
+  it("accepts committed local Markdown and HTML PNG/PDF references", async () => {
+    const issues = await fixture(
+      [
+        "![Screenshot](assets/readme/example.png)",
+        '<img src="assets/readme/example.png" alt="Screenshot">',
+        "[Reference](assets/readme/reference.pdf)",
+      ].join("\n"),
+      {
+        "assets/readme/example.png": png(1200, 800),
+        "assets/readme/reference.pdf": "%PDF-1.7\n1 0 obj <</Type /Page>> endobj\n%%EOF",
+      }
+    );
+    expect(issues).toEqual([]);
+  });
+
+  it("reports missing, uncommitted, and unsupported image references", async () => {
+    const issues = await fixture(
+      [
+        "![Missing](assets/readme/missing.png)",
+        "![Uncommitted](assets/readme/uncommitted.png)",
+        "![JPEG](assets/readme/example.jpg)",
+      ].join("\n"),
+      {
+        "assets/readme/uncommitted.png": png(100, 100),
+        "assets/readme/example.jpg": "jpeg",
+      },
+      ["assets/readme/example.jpg", "assets/readme/missing.png"]
+    );
+    expect(issues.map((issue) => issue.message)).toEqual([
+      "referenced README media does not exist",
+      "referenced README media is not committed",
+      "unsupported media extension .jpg; allowed: .png, .pdf",
+    ]);
+  });
+
+  it("reports actionable per-file size limits", async () => {
+    const oversized = new Uint8Array(README_MEDIA_POLICY.maxFileBytes + 1);
+    oversized.set(png(100, 100));
+    const issues = await fixture("![Large](assets/readme/large.png)", {
+      "assets/readme/large.png": oversized,
+    });
+    expect(issues).toContainEqual({
+      file: "assets/readme/large.png",
+      message: expect.stringContaining("exceeds the per-file limit 10.0 MiB"),
+    });
+  });
+
+  it("bounds PNG dimensions and detectable PDF page counts", async () => {
+    const pages = Array.from(
+      { length: README_MEDIA_POLICY.maxPdfPages + 1 },
+      (_, index) => `${index + 1} 0 obj <</Type /Page>> endobj`
+    ).join("\n");
+    const issues = await fixture(
+      [
+        "![Wide](assets/readme/wide.png)",
+        "[Long PDF](assets/readme/long.pdf)",
+      ].join("\n"),
+      {
+        "assets/readme/wide.png": png(README_MEDIA_POLICY.maxPngWidth + 1, 10),
+        "assets/readme/long.pdf": `%PDF-1.7\n${pages}\n%%EOF`,
+      }
+    );
+    expect(issues.map((issue) => issue.message)).toEqual([
+      expect.stringContaining("PNG dimensions 4097x10"),
+      expect.stringContaining("detectable PDF page count 21"),
+    ]);
+  });
+
+  it("rejects invalid PNG and PDF headers", async () => {
+    const issues = await fixture(
+      [
+        "![Broken PNG](assets/readme/broken.png)",
+        "[Broken PDF](assets/readme/broken.pdf)",
+      ].join("\n"),
+      {
+        "assets/readme/broken.png": "not a png",
+        "assets/readme/broken.pdf": "not a pdf",
+      }
+    );
+    expect(issues.map((issue) => issue.message)).toEqual([
+      "invalid PNG signature or IHDR header",
+      "invalid PDF header; expected %PDF-",
+    ]);
+  });
+
+  it("counts duplicate links once and enforces the aggregate size limit", async () => {
+    const first = new Uint8Array(README_MEDIA_POLICY.maxFileBytes);
+    const second = new Uint8Array(README_MEDIA_POLICY.maxFileBytes);
+    const third = new Uint8Array(README_MEDIA_POLICY.maxFileBytes);
+    for (const bytes of [first, second, third]) bytes.set(png(100, 100));
+    const issues = await fixture(
+      [
+        "![First](assets/readme/first.png)",
+        "![First again](assets/readme/first.png)",
+        "![Second](assets/readme/second.png)",
+        "![Third](assets/readme/third.png)",
+      ].join("\n"),
+      {
+        "assets/readme/first.png": first,
+        "assets/readme/second.png": second,
+        "assets/readme/third.png": third,
+      }
+    );
+    expect(issues).toEqual([
+      {
+        file: "README.md",
+        message: expect.stringContaining("exceeding the aggregate limit 25.0 MiB"),
+      },
+    ]);
+  });
+});

--- a/scripts/ci/validate-readme-media.ts
+++ b/scripts/ci/validate-readme-media.ts
@@ -1,0 +1,179 @@
+import { readFile, stat } from "node:fs/promises";
+import { dirname, extname, isAbsolute, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const README_MEDIA_POLICY = {
+  allowedExtensions: new Set([".png", ".pdf"]),
+  maxFileBytes: 10 * 1024 * 1024,
+  maxAggregateBytes: 25 * 1024 * 1024,
+  maxPngWidth: 4_096,
+  maxPngHeight: 4_096,
+  maxPdfPages: 20,
+} as const;
+
+const PNG_SIGNATURE = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10]);
+const EXTERNAL = /^(?:[a-z][a-z\d+.-]*:|#|\/\/)/iu;
+
+export interface ReadmeMediaIssue {
+  file: string;
+  message: string;
+}
+
+export interface ValidateReadmeMediaOptions {
+  repoRoot: string;
+  readme?: string;
+  trackedFiles: ReadonlySet<string>;
+}
+
+function localMediaLinks(markdown: string): string[] {
+  const links: string[] = [];
+  for (const match of markdown.matchAll(/(!?)\[[^\]]*\]\(\s*(?:<([^>]+)>|([^) \t]+))(?:\s+["'][^"']*["'])?\s*\)/gu)) {
+    const link = match[2] ?? match[3]!;
+    if (match[1] === "!" || extname(link.split(/[?#]/u, 1)[0]!).toLowerCase() === ".pdf") {
+      links.push(link);
+    }
+  }
+  for (const match of markdown.matchAll(/<(img|a)\b[^>]+(?:src|href)=["']([^"']+)["'][^>]*>/giu)) {
+    const link = match[2]!;
+    if (match[1]!.toLowerCase() === "img" || extname(link.split(/[?#]/u, 1)[0]!).toLowerCase() === ".pdf") {
+      links.push(link);
+    }
+  }
+  return links.filter((link) => !EXTERNAL.test(link));
+}
+
+function displayBytes(bytes: number): string {
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MiB`;
+}
+
+function pngDimensions(bytes: Uint8Array): { width: number; height: number } | null {
+  if (bytes.length < 24 || !PNG_SIGNATURE.every((byte, index) => bytes[index] === byte)) return null;
+  if (new TextDecoder().decode(bytes.subarray(12, 16)) !== "IHDR") return null;
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  return { width: view.getUint32(16), height: view.getUint32(20) };
+}
+
+function detectablePdfPages(bytes: Uint8Array): number {
+  const text = new TextDecoder("latin1").decode(bytes);
+  return text.match(/\/Type\s*\/Page\b/gu)?.length ?? 0;
+}
+
+export async function validateReadmeMedia(
+  options: ValidateReadmeMediaOptions
+): Promise<ReadmeMediaIssue[]> {
+  const readme = resolve(options.repoRoot, options.readme ?? "README.md");
+  const markdown = await readFile(readme, "utf8");
+  const issues: ReadmeMediaIssue[] = [];
+  let aggregateBytes = 0;
+
+  for (const href of [...new Set(localMediaLinks(markdown))]) {
+    let cleanHref: string;
+    try {
+      cleanHref = decodeURIComponent(href.split(/[?#]/u, 1)[0]!);
+    } catch {
+      issues.push({ file: href, message: "README media link contains invalid percent-encoding" });
+      continue;
+    }
+    const absolute = resolve(dirname(readme), cleanHref);
+    const repoPath = relative(options.repoRoot, absolute).replaceAll("\\", "/");
+    const extension = extname(repoPath).toLowerCase();
+
+    if (isAbsolute(cleanHref) || repoPath.startsWith("../") || repoPath === "..") {
+      issues.push({ file: href, message: "local README media must stay inside the repository" });
+      continue;
+    }
+    if (!README_MEDIA_POLICY.allowedExtensions.has(extension)) {
+      issues.push({
+        file: repoPath,
+        message: `unsupported media extension ${extension || "(none)"}; allowed: .png, .pdf`,
+      });
+      continue;
+    }
+    if (!options.trackedFiles.has(repoPath)) {
+      issues.push({ file: repoPath, message: "referenced README media is not committed" });
+      continue;
+    }
+
+    let bytes: Uint8Array;
+    try {
+      const info = await stat(absolute);
+      if (!info.isFile()) throw new Error("not a regular file");
+      bytes = new Uint8Array(await readFile(absolute));
+    } catch {
+      issues.push({ file: repoPath, message: "referenced README media does not exist" });
+      continue;
+    }
+
+    aggregateBytes += bytes.byteLength;
+    if (bytes.byteLength > README_MEDIA_POLICY.maxFileBytes) {
+      issues.push({
+        file: repoPath,
+        message:
+          `size ${displayBytes(bytes.byteLength)} exceeds the per-file limit ` +
+          `${displayBytes(README_MEDIA_POLICY.maxFileBytes)}`,
+      });
+    }
+
+    if (extension === ".png") {
+      const dimensions = pngDimensions(bytes);
+      if (!dimensions) {
+        issues.push({ file: repoPath, message: "invalid PNG signature or IHDR header" });
+      } else if (
+        dimensions.width === 0 ||
+        dimensions.height === 0 ||
+        dimensions.width > README_MEDIA_POLICY.maxPngWidth ||
+        dimensions.height > README_MEDIA_POLICY.maxPngHeight
+      ) {
+        issues.push({
+          file: repoPath,
+          message:
+            `PNG dimensions ${dimensions.width}x${dimensions.height} exceed the non-zero ` +
+            `${README_MEDIA_POLICY.maxPngWidth}x${README_MEDIA_POLICY.maxPngHeight} limit`,
+        });
+      }
+    } else {
+      const header = new TextDecoder("ascii").decode(bytes.subarray(0, 5));
+      if (header !== "%PDF-") {
+        issues.push({ file: repoPath, message: "invalid PDF header; expected %PDF-" });
+      }
+      const pages = detectablePdfPages(bytes);
+      if (pages > README_MEDIA_POLICY.maxPdfPages) {
+        issues.push({
+          file: repoPath,
+          message: `detectable PDF page count ${pages} exceeds the ${README_MEDIA_POLICY.maxPdfPages}-page limit`,
+        });
+      }
+    }
+  }
+
+  if (aggregateBytes > README_MEDIA_POLICY.maxAggregateBytes) {
+    issues.push({
+      file: "README.md",
+      message:
+        `referenced media totals ${displayBytes(aggregateBytes)}, exceeding the aggregate limit ` +
+        `${displayBytes(README_MEDIA_POLICY.maxAggregateBytes)}`,
+    });
+  }
+  return issues;
+}
+
+async function trackedFiles(repoRoot: string): Promise<ReadonlySet<string>> {
+  const result = Bun.spawnSync(["git", "ls-files", "-z"], { cwd: repoRoot, stdout: "pipe", stderr: "pipe" });
+  if (result.exitCode !== 0) {
+    throw new Error(`git ls-files failed: ${result.stderr.toString().trim()}`);
+  }
+  return new Set(result.stdout.toString().split("\0").filter(Boolean));
+}
+
+async function main(): Promise<void> {
+  const repoRoot = fileURLToPath(new URL("../..", import.meta.url));
+  const issues = await validateReadmeMedia({ repoRoot, trackedFiles: await trackedFiles(repoRoot) });
+  if (issues.length > 0) {
+    for (const issue of issues) console.error(`README media: ${issue.file}: ${issue.message}`);
+    process.exitCode = 1;
+    return;
+  }
+  console.log("README media: all local PNG and PDF references are valid");
+}
+
+if (import.meta.main) await main();

--- a/scripts/ci/workflow-policy.test.ts
+++ b/scripts/ci/workflow-policy.test.ts
@@ -34,6 +34,16 @@ describe("CI workflow policy", () => {
     expect(ci).toContain("if: always()");
     expect(ci).toContain("uses: ./.github/workflows/reusable-quality.yml");
     expect(ci).toContain("uses: ./.github/workflows/reusable-consumer-smoke.yml");
+    const readmeMedia = ci.slice(ci.indexOf("  readme-media:"), ci.indexOf("  test:"));
+    expect(readmeMedia).toContain("needs: changes");
+    expect(readmeMedia).toContain("if: needs.changes.outputs.readmeMedia == 'true'");
+    expect(readmeMedia).toContain("bun run check:readme-media");
+    const required = ci.slice(ci.indexOf("  required:"));
+    expect(required).toContain("- readme-media");
+    expect(required).toContain("README_MEDIA_REQUIRED: ${{ needs.changes.outputs.readmeMedia }}");
+    expect(required).toContain("README_MEDIA: ${{ needs.readme-media.result }}");
+    expect(required).toContain('[[ "$README_MEDIA_REQUIRED" == "true" && "$README_MEDIA" != "success" ]]');
+    expect(required).toContain('"$README_MEDIA" "$TEST"');
   });
 
   it("cancels superseded PR work but retains main and scheduled evidence", async () => {

--- a/src/content/docs/contributing.md
+++ b/src/content/docs/contributing.md
@@ -53,6 +53,24 @@ Superseded pull-request runs and Pages deployments are cancelled. Product CI
 on `main`, nightly runs, and release evidence are never cancelled by a newer
 commit.
 
+### README media
+
+Store repository-owned screenshots and downloadable PDF references used by the
+root `README.md` under `assets/readme/`. Keep each file below 10 MiB and the
+referenced set below 25 MiB. PNG images must have non-zero dimensions no larger
+than 4096×4096; PDFs may contain at most 20 detectable pages.
+
+Run the lightweight validation before committing README presentation changes:
+
+```bash
+bun run check:readme-media
+```
+
+The check rejects missing or untracked files, unsupported local image formats,
+invalid PNG/PDF headers, and media over the configured limits. Other `assets/`
+subdirectories remain product or unknown surfaces and do not inherit this
+documentation-only CI policy.
+
 ### Project Structure
 
 ```


### PR DESCRIPTION
## Summary

- classify only the exact `assets/readme/` prefix as documentation-only
- add a lightweight README media gate for committed links, formats, sizes, PNG dimensions, and PDF structure/page bounds
- wire the selected gate into the stable required-check aggregator while preserving fail-open routing for unknown asset paths
- document the repository-owned README media policy

## Root cause

The conservative changed-surface classifier recognized the root `README.md` as documentation-only but treated its adjacent versioned media under `assets/readme/` as an unknown top-level surface. README-only presentation changes therefore enabled every product and consumer gate.

## Impact

README screenshots and linked PDFs under `assets/readme/` now run a focused validation gate instead of the full product matrix. Unknown siblings such as `assets/runtime/` and product-owned assets under `apps/**` continue to use the conservative product routing.

## Validation

- `bun run check:readme-media`
- `bun run test scripts/ci/validate-readme-media.test.ts scripts/ci/classify-changes.test.ts scripts/ci/workflow-policy.test.ts` (25 pass)
- `bun run typecheck`
- `bun run docs:check`
- `bun run test` (5,425 pass, 12 expected skips, 0 failures)
- `git diff --check`

Closes #104