### PR TITLE
perf(code-highlight): overlap grammar and highlighter imports

### DIFF
--- a/apps/browser-export-harness/tests/highlight-performance.e2e.ts
+++ b/apps/browser-export-harness/tests/highlight-performance.e2e.ts
@@ -9,11 +9,23 @@ const RESULT_DIR = resolve(
   "../test-results/highlight-performance",
 );
 const HARNESS_URL = "http://127.0.0.1:4179/browser-export-harness/";
+const INITIALIZATION_CHUNK_RE =
+  /^(?:core|engine-javascript|github-light)-[^/]+[.]js$/;
+
+interface HighlightResourceTiming {
+  name: string;
+  startTime: number;
+  responseEnd: number;
+}
 
 async function runInFreshContext(
   browser: Browser,
   preload: boolean,
-): Promise<HighlightBenchmarkResult> {
+): Promise<{
+  benchmark: HighlightBenchmarkResult;
+  beforeIntentResources: string[];
+  resources: HighlightResourceTiming[];
+}> {
   const context = await browser.newContext();
   try {
     const page = await context.newPage();
@@ -22,9 +34,23 @@ async function runInFreshContext(
       () => typeof window.__ATLCLI_DOCX_HIGHLIGHT_BENCHMARK === "function",
     );
     return await page.evaluate(async (shouldPreload) => {
+      const beforeIntentResources = performance
+        .getEntriesByType("resource")
+        .map(({ name }) => new URL(name).pathname.split("/").at(-1) ?? name);
+      performance.clearResourceTimings();
       const run = window.__ATLCLI_DOCX_HIGHLIGHT_BENCHMARK;
       if (!run) throw new Error("highlight benchmark hook is unavailable");
-      return run(shouldPreload);
+      const benchmark = await run(shouldPreload);
+      const resources = performance
+        .getEntriesByType("resource")
+        .map((entry) => entry as PerformanceResourceTiming)
+        .filter(({ name }) => name.endsWith(".js"))
+        .map(({ name, startTime, responseEnd }) => ({
+          name: new URL(name).pathname.split("/").at(-1) ?? name,
+          startTime,
+          responseEnd,
+        }));
+      return { benchmark, beforeIntentResources, resources };
     }, preload);
   } finally {
     await context.close();
@@ -34,8 +60,36 @@ async function runInFreshContext(
 test("DOCX highlighting is JavaScript-only and deterministic across fresh cold/preloaded contexts", async ({
   browser,
 }) => {
-  const cold = await runInFreshContext(browser, false);
-  const preloaded = await runInFreshContext(browser, true);
+  const {
+    benchmark: cold,
+    beforeIntentResources,
+    resources: coldResources,
+  } = await runInFreshContext(browser, false);
+  const { benchmark: preloaded } = await runInFreshContext(browser, true);
+
+  const initializationResources = coldResources.filter(({ name }) =>
+    INITIALIZATION_CHUNK_RE.test(name),
+  );
+  const grammarResources = coldResources.filter(
+    ({ name }) => !INITIALIZATION_CHUNK_RE.test(name),
+  );
+  expect(initializationResources.length).toBeGreaterThan(0);
+  expect(grammarResources.length).toBeGreaterThanOrEqual(22);
+  const beforeIntentNames = new Set(beforeIntentResources);
+  expect(
+    [...initializationResources, ...grammarResources].some(({ name }) =>
+      beforeIntentNames.has(name),
+    ),
+  ).toBe(false);
+  const latestInitializationResponseEnd = Math.max(
+    ...initializationResources.map(({ responseEnd }) => responseEnd),
+  );
+  const earliestGrammarRequestStart = Math.min(
+    ...grammarResources.map(({ startTime }) => startTime),
+  );
+  expect(earliestGrammarRequestStart).toBeLessThan(
+    latestInitializationResponseEnd,
+  );
 
   expect(cold.engine).toBe("javascript");
   expect(preloaded.engine).toBe("javascript");
@@ -67,6 +121,14 @@ test("DOCX highlighting is JavaScript-only and deterministic across fresh cold/p
     `${JSON.stringify({
       cold: { ...cold, base64: undefined },
       preloaded: { ...preloaded, base64: undefined },
+      resourceTrace: {
+        initializationRequests: initializationResources.map(({ name }) => name),
+        grammarRequestCount: grammarResources.length,
+        earliestGrammarRequestStart,
+        latestInitializationResponseEnd,
+        overlapMs:
+          latestInitializationResponseEnd - earliestGrammarRequestStart,
+      },
     }, null, 2)}\n`,
   );
 });

--- a/packages/code-highlight/README.md
+++ b/packages/code-highlight/README.md
@@ -30,7 +30,8 @@ Aliases are canonicalized, unknown languages are ignored, and concurrent or
 repeated calls share the same initialization/grammar promises. `highlightCode`
 and `prepareCodeHighlighting` accept an `onTiming` callback that reports newly
 performed engine initialization, grammar load/compile, and source
-tokenization. Warm cache work is reported as zero.
+tokenization. Cold engine initialization and grammar loading overlap, so those
+two wall-time metrics are not additive. Warm cache work is reported as zero.
 
 After upgrading Shiki, regenerate and verify the checked-in catalogue:
 

--- a/packages/code-highlight/src/highlight.ts
+++ b/packages/code-highlight/src/highlight.ts
@@ -164,9 +164,13 @@ async function loadLanguage(
   if (!promise) {
     created = true;
     promise = (async () => {
-      const { highlighter, initMs } = await getHighlighter(theme);
       const startedAt = nowMs();
-      const grammarModule = await bundledLanguages[language]();
+      const highlighterPromise = getHighlighter(theme);
+      const grammarPromise = bundledLanguages[language]();
+      const [{ highlighter, initMs }, grammarModule] = await Promise.all([
+        highlighterPromise,
+        grammarPromise,
+      ]);
       const grammar =
         "default" in grammarModule ? grammarModule.default : grammarModule;
       await highlighter.loadLanguage(grammar as LanguageInput);
@@ -176,6 +180,8 @@ async function loadLanguage(
       highlighter.codeToTokens("0;", { lang: language, theme });
       return {
         engineInitMs: initMs,
+        // This is the grammar's wall time from import request through ready
+        // state. On a cold theme it intentionally overlaps engineInitMs.
         grammarLoadMs: nowMs() - startedAt,
         tokenizeMs: 0,
       };

--- a/packages/code-highlight/src/index.test.ts
+++ b/packages/code-highlight/src/index.test.ts
@@ -122,9 +122,11 @@ describe("highlightCode", () => {
     expect(timing!.engineInitMs).toBeGreaterThan(0);
     expect(timing!.grammarLoadMs).toBeGreaterThan(0);
     expect(timing!.tokenizeMs).toBe(0);
-    expect(timing!.engineInitMs + timing!.grammarLoadMs).toBeLessThanOrEqual(
-      elapsedMs + 5,
-    );
+    // Cold engine and grammar work overlap. Each phase reports its own wall
+    // time, so they are individually bounded but are no longer additive.
+    expect(
+      Math.max(timing!.engineInitMs, timing!.grammarLoadMs),
+    ).toBeLessThanOrEqual(elapsedMs + 5);
   });
 });
 

--- a/specs/issue-108-shiki-import-overlap/EVIDENCE.md
+++ b/specs/issue-108-shiki-import-overlap/EVIDENCE.md
@@ -1,0 +1,40 @@
+# Issue 108: Shiki grammar import overlap
+
+Baseline: `52a5abb` (`origin/main`), 2026-07-26
+
+The production Vite browser-export harness ran the same 22-language DOCX
+fixture in fresh Chromium contexts before and after the scheduling change.
+Resource Timing entries were cleared immediately before explicit export intent.
+The generated artifacts stayed byte-identical.
+
+| Measurement | Before | After |
+| --- | ---: | ---: |
+| Cold export wall time | 891.8 ms | 871.3 ms |
+| Explicit preload wall time | 738.2 ms | 655.5 ms |
+| Export after preload | 223.7 ms | 207.9 ms |
+| Cold engine initialization | 6.4 ms | 17.1 ms |
+| Cold grammar-ready wall time | 784.5 ms | 792.5 ms |
+| Cold source tokenization | 183.4 ms | 172.2 ms |
+| First grammar request relative to final initialization response | 3.7 ms after | 9.9 ms before |
+| Grammar JavaScript requests | 47 | 47 |
+| DOCX size | 132,165 bytes | 132,165 bytes |
+
+Both versions produced SHA-256
+`099d9a72e42221982ea79f2c5157e2066a8c83d05a07565b1d4da41d98baaf66`.
+The wall times are single local runs and are not a performance budget. The
+acceptance signal is the resource ordering: before the change, the first
+grammar request began only after core, JavaScript engine, and theme responses
+completed; after the change, it began while those responses were still in
+flight.
+
+The permanent Playwright regression also verifies that none of the observed
+runtime, theme, or requested grammar chunks loaded before explicit highlighting
+intent.
+
+## Commands
+
+```bash
+bun run test packages/code-highlight/src/index.test.ts
+bun run build:browser-export-harness -- --force
+bun run --cwd apps/browser-export-harness test:e2e -- highlight-performance.e2e.ts
+```

--- a/src/content/docs/reference/docx-engine.md
+++ b/src/content/docs/reference/docx-engine.md
@@ -96,10 +96,13 @@ Historical prepared `/1` checkpoints without the additive field resume as
 | Field | Meaning |
 |-------|---------|
 | `highlightEngineInitMs` | Newly performed Shiki core, theme, and RegExp-engine initialization |
-| `highlightGrammarLoadMs` | Wall time of newly imported, loaded, and deterministically compiled grammar batches |
+| `highlightGrammarLoadMs` | Wall time from the first requested grammar import through the newly loaded and deterministically compiled grammar batch; this overlaps cold engine initialization |
 | `highlightTokenizeMs` | Real source-code tokenization only |
 | `highlightCodeBlocks` | Non-Mermaid code blocks seen across the body and included pages |
 | `highlightLanguageCount` | Distinct known canonical languages across the export |
+
+`highlightEngineInitMs` and `highlightGrammarLoadMs` are independent wall-time
+diagnostics. Cold requests start both phases together, so do not add them.
 
 Preloaded engine/grammar time is zero during the later export; tokenization
 remains measured because every code block still produces tokens. The


### PR DESCRIPTION
## Summary

- start the requested Shiki grammar import in parallel with cold highlighter, engine, and theme initialization
- preserve lazy loading, per-language/theme promise deduplication, and explicit highlighting intent
- add a production Chromium resource-order regression plus before/after evidence and timing documentation

## Root cause

`loadLanguage()` awaited `getHighlighter()` before invoking the bundled language loader. In browser hosts, grammar chunks therefore formed a second request wave after core, JavaScript engine, and theme initialization completed.

## Impact

The requested grammar now begins loading while initialization is still in flight. No observed runtime, theme, or requested grammar chunk loads before explicit highlighting intent. DOCX output remains byte-identical for the 22-language fixture (132,165 bytes; SHA-256 `099d9a72e42221982ea79f2c5157e2066a8c83d05a07565b1d4da41d98baaf66`).

## Verification

- `bun run test` — 5,466 pass, 12 environment-dependent skips, 0 fail
- `bun run typecheck`
- `bun run check:browser` — 21 entrypoints passed
- `bun run build:browser-export-harness -- --force`
- `bun run check:browser-export-harness`
- `bun run test:browser-export-harness` — 2 passed
- production Chromium trace confirms grammar/init request overlap and unchanged DOCX bytes

Closes #108