### PR TITLE
perf(docx): prepare complete render runtime after export intent

### DIFF
--- a/apps/browser-export-harness/scripts/check-output.ts
+++ b/apps/browser-export-harness/scripts/check-output.ts
@@ -29,6 +29,8 @@ const ONIGURUMA_RUNTIME_RES = [
   /\bfindNextOnigScannerMatch\b/g,
   /Must invoke loadWasm first[.]/g,
 ];
+const DOCX_CODE_FONT_SHA256 =
+  "a0bf60ef0f83c5ed4d7a75d45838548b1f6873372dfac88f71804491898d138f";
 
 export interface OutputFinding {
   file: string;
@@ -148,6 +150,12 @@ export function validateHarnessInventory(artifacts: OutputArtifact[]): string[] 
     artifacts,
     "Typst compiler WASM",
     /(?:^|\/)assets\/typst_ts_web_compiler_bg-[^/]+\.wasm$/,
+  ));
+  issues.push(...requireOne(
+    artifacts,
+    "DOCX code font",
+    /(?:^|\/)assets\/JetBrainsMono-Regular-[^/]+\.ttf$/,
+    DOCX_CODE_FONT_SHA256,
   ));
   for (const font of PDF_RUNTIME_ASSETS.fonts) {
     issues.push(...requireOne(artifacts, font.fileName, hashedAssetPattern(font.fileName), font.sha256));

--- a/apps/browser-export-harness/src/highlight-benchmark.ts
+++ b/apps/browser-export-harness/src/highlight-benchmark.ts
@@ -3,7 +3,7 @@ import type { ExportBlock } from "@atlcli/confluence";
 import { runExport } from "@atlcli/docx/browser";
 import {
   memoryTemplateSource,
-  prepareDocxCodeHighlighting,
+  prepareDocxExportRuntime,
 } from "@atlcli/docx/browser-runtime";
 import { DOCX_TEMPLATE_BYTES } from "@atlcli/export-fixtures";
 import { sha256Hex } from "./digest.js";
@@ -34,14 +34,49 @@ const REPRESENTATIVE_CODE = [
   ["markdown", "# Answer\n\n42"],
 ] as const;
 
-const HIGHLIGHT_BLOCKS: ExportBlock[] = REPRESENTATIVE_CODE.map(
+const FLAT_HIGHLIGHT_BLOCKS: ExportBlock[] = REPRESENTATIVE_CODE.map(
   ([language, code]) => ({ type: "codeBlock", language, code }),
 );
+const HIGHLIGHT_BLOCKS: ExportBlock[] = [
+  {
+    type: "callout",
+    kind: "info",
+    content: [FLAT_HIGHLIGHT_BLOCKS[0]!],
+  },
+  {
+    type: "table",
+    rows: [{
+      cells: [{
+        header: false,
+        colspan: 1,
+        rowspan: 1,
+        content: [FLAT_HIGHLIGHT_BLOCKS[1]!],
+      }],
+    }],
+  },
+  {
+    type: "paragraph",
+    content: [{
+      type: "text",
+      text: "Inline code also needs the bundled face: INLINE_TOKEN",
+      marks: ["code"],
+    }],
+  },
+  ...FLAT_HIGHLIGHT_BLOCKS.slice(2),
+];
 
 export interface HighlightBenchmarkResult {
   engine: string | null;
   preloadMs: number;
   exportMs: number;
+  preparation: Awaited<ReturnType<typeof prepareDocxExportRuntime>> | null;
+  phases: {
+    runtimeReadyAt: number;
+    preloadStartedAt: number;
+    preloadEndedAt: number;
+    exportStartedAt: number;
+    exportEndedAt: number;
+  };
   digest: string;
   byteLength: number;
   base64: string;
@@ -67,8 +102,11 @@ async function runHighlightBenchmark(
   preload: boolean,
 ): Promise<HighlightBenchmarkResult> {
   const preloadStartedAt = performance.now();
-  if (preload) await prepareDocxCodeHighlighting(HIGHLIGHT_BLOCKS);
-  const preloadMs = preload ? performance.now() - preloadStartedAt : 0;
+  const preparation = preload
+    ? await prepareDocxExportRuntime(HIGHLIGHT_BLOCKS)
+    : null;
+  const preloadEndedAt = performance.now();
+  const preloadMs = preload ? preloadEndedAt - preloadStartedAt : 0;
 
   const output = new MemoryOutputSink();
   const exportStartedAt = performance.now();
@@ -92,12 +130,22 @@ async function runHighlightBenchmark(
       output,
     },
   );
-  const exportMs = performance.now() - exportStartedAt;
+  const exportEndedAt = performance.now();
+  const exportMs = exportEndedAt - exportStartedAt;
   const bytes = output.single.bytes;
   return {
     engine: getCodeHighlightEngineId(),
     preloadMs,
     exportMs,
+    preparation,
+    phases: {
+      runtimeReadyAt:
+        window.__ATLCLI_DOCX_BROWSER_RUNTIME_READY_AT ?? 0,
+      preloadStartedAt,
+      preloadEndedAt,
+      exportStartedAt,
+      exportEndedAt,
+    },
     digest: await sha256Hex(bytes),
     byteLength: bytes.byteLength,
     base64: toBase64(bytes),
@@ -113,6 +161,7 @@ async function runHighlightBenchmark(
 
 declare global {
   interface Window {
+    __ATLCLI_DOCX_BROWSER_RUNTIME_READY_AT?: number;
     __ATLCLI_DOCX_HIGHLIGHT_BENCHMARK?: (
       preload: boolean,
     ) => Promise<HighlightBenchmarkResult>;

--- a/apps/browser-export-harness/src/main.ts
+++ b/apps/browser-export-harness/src/main.ts
@@ -2,4 +2,8 @@
 // The actual application graph is therefore loaded dynamically, not statically.
 import "@atlcli/docx/browser-runtime";
 
+(globalThis as typeof globalThis & {
+  __ATLCLI_DOCX_BROWSER_RUNTIME_READY_AT?: number;
+}).__ATLCLI_DOCX_BROWSER_RUNTIME_READY_AT = performance.now();
+
 await import("./app.js");

--- a/apps/browser-export-harness/tests/highlight-performance.e2e.ts
+++ b/apps/browser-export-harness/tests/highlight-performance.e2e.ts
@@ -11,11 +11,15 @@ const RESULT_DIR = resolve(
 const HARNESS_URL = "http://127.0.0.1:4179/browser-export-harness/";
 const INITIALIZATION_CHUNK_RE =
   /^(?:core|engine-javascript|github-light)-[^/]+[.]js$/;
+const CODE_FONT_RE = /^JetBrainsMono-Regular-[^/]+[.]ttf$/;
 
 interface HighlightResourceTiming {
+  url: string;
   name: string;
   startTime: number;
   responseEnd: number;
+  transferSize: number;
+  decodedBodySize: number;
 }
 
 async function runInFreshContext(
@@ -25,6 +29,8 @@ async function runInFreshContext(
   benchmark: HighlightBenchmarkResult;
   beforeIntentResources: string[];
   resources: HighlightResourceTiming[];
+  repeat?: HighlightBenchmarkResult;
+  repeatResources: HighlightResourceTiming[];
 }> {
   const context = await browser.newContext();
   try {
@@ -34,6 +40,18 @@ async function runInFreshContext(
       () => typeof window.__ATLCLI_DOCX_HIGHLIGHT_BENCHMARK === "function",
     );
     return await page.evaluate(async (shouldPreload) => {
+      const resources = (): HighlightResourceTiming[] => performance
+        .getEntriesByType("resource")
+        .map((entry) => entry as PerformanceResourceTiming)
+        .filter(({ name }) => /[.](?:js|ttf)$/u.test(new URL(name).pathname))
+        .map(({ name: url, startTime, responseEnd, transferSize, decodedBodySize }) => ({
+          url,
+          name: new URL(url).pathname.split("/").at(-1) ?? url,
+          startTime,
+          responseEnd,
+          transferSize,
+          decodedBodySize,
+        }));
       const beforeIntentResources = performance
         .getEntriesByType("resource")
         .map(({ name }) => new URL(name).pathname.split("/").at(-1) ?? name);
@@ -41,16 +59,21 @@ async function runInFreshContext(
       const run = window.__ATLCLI_DOCX_HIGHLIGHT_BENCHMARK;
       if (!run) throw new Error("highlight benchmark hook is unavailable");
       const benchmark = await run(shouldPreload);
-      const resources = performance
-        .getEntriesByType("resource")
-        .map((entry) => entry as PerformanceResourceTiming)
-        .filter(({ name }) => name.endsWith(".js"))
-        .map(({ name, startTime, responseEnd }) => ({
-          name: new URL(name).pathname.split("/").at(-1) ?? name,
-          startTime,
-          responseEnd,
-        }));
-      return { benchmark, beforeIntentResources, resources };
+      const firstResources = resources();
+      let repeat: HighlightBenchmarkResult | undefined;
+      let repeatResources: HighlightResourceTiming[] = [];
+      if (shouldPreload) {
+        performance.clearResourceTimings();
+        repeat = await run(true);
+        repeatResources = resources();
+      }
+      return {
+        benchmark,
+        beforeIntentResources,
+        resources: firstResources,
+        ...(repeat ? { repeat } : {}),
+        repeatResources,
+      };
     }, preload);
   } finally {
     await context.close();
@@ -65,19 +88,28 @@ test("DOCX highlighting is JavaScript-only and deterministic across fresh cold/p
     beforeIntentResources,
     resources: coldResources,
   } = await runInFreshContext(browser, false);
-  const { benchmark: preloaded } = await runInFreshContext(browser, true);
+  const {
+    benchmark: preloaded,
+    resources: preloadedResources,
+    repeat,
+    repeatResources,
+  } = await runInFreshContext(browser, true);
 
-  const initializationResources = coldResources.filter(({ name }) =>
+  const initializationResources = preloadedResources.filter(({ name }) =>
     INITIALIZATION_CHUNK_RE.test(name),
   );
-  const grammarResources = coldResources.filter(
-    ({ name }) => !INITIALIZATION_CHUNK_RE.test(name),
+  const grammarResources = preloadedResources.filter(
+    ({ name }) => name.endsWith(".js") && !INITIALIZATION_CHUNK_RE.test(name),
   );
+  const coldFonts = coldResources.filter(({ name }) => CODE_FONT_RE.test(name));
+  const preloadedFonts = preloadedResources.filter(({ name }) => CODE_FONT_RE.test(name));
   expect(initializationResources.length).toBeGreaterThan(0);
   expect(grammarResources.length).toBeGreaterThanOrEqual(22);
+  expect(coldFonts).toHaveLength(1);
+  expect(preloadedFonts).toHaveLength(1);
   const beforeIntentNames = new Set(beforeIntentResources);
   expect(
-    [...initializationResources, ...grammarResources].some(({ name }) =>
+    [...initializationResources, ...grammarResources, ...preloadedFonts].some(({ name }) =>
       beforeIntentNames.has(name),
     ),
   ).toBe(false);
@@ -90,6 +122,23 @@ test("DOCX highlighting is JavaScript-only and deterministic across fresh cold/p
   expect(earliestGrammarRequestStart).toBeLessThan(
     latestInitializationResponseEnd,
   );
+  const preloadedFont = preloadedFonts[0]!;
+  const coldFont = coldFonts[0]!;
+  expect(new URL(preloadedFont.url).origin).toBe(new URL(HARNESS_URL).origin);
+  expect(preloadedFont.decodedBodySize).toBe(273_900);
+  expect(preloadedFont.startTime).toBeLessThan(preloaded.phases.preloadEndedAt);
+  expect(preloadedFont.responseEnd).toBeLessThanOrEqual(
+    preloaded.phases.exportStartedAt,
+  );
+  expect(coldFont.startTime).toBeGreaterThanOrEqual(cold.phases.exportStartedAt);
+  expect(coldFont.responseEnd).toBeLessThanOrEqual(cold.phases.exportEndedAt);
+  const latestPreparationJavaScriptEnd = Math.max(
+    ...[...initializationResources, ...grammarResources].map(({ responseEnd }) => responseEnd),
+  );
+  expect(preloadedFont.startTime).toBeLessThan(latestPreparationJavaScriptEnd);
+  expect(
+    Math.min(...[...initializationResources, ...grammarResources].map(({ startTime }) => startTime)),
+  ).toBeLessThan(preloadedFont.responseEnd);
 
   expect(cold.engine).toBe("javascript");
   expect(preloaded.engine).toBe("javascript");
@@ -97,6 +146,12 @@ test("DOCX highlighting is JavaScript-only and deterministic across fresh cold/p
   expect(cold.timings.highlightGrammarLoadMs).toBeGreaterThan(0);
   expect(cold.timings.highlightTokenizeMs).toBeGreaterThan(0);
   expect(preloaded.preloadMs).toBeGreaterThan(0);
+  expect(preloaded.preparation?.codeFontBytes).toBe(273_900);
+  expect(preloaded.preparation?.highlightingMs).toBeGreaterThan(0);
+  expect(preloaded.preparation?.codeFontMs).toBeGreaterThan(0);
+  expect(preloaded.phases.runtimeReadyAt).toBeLessThan(
+    preloaded.phases.preloadStartedAt,
+  );
   expect(preloaded.timings.highlightEngineInitMs).toBe(0);
   expect(preloaded.timings.highlightGrammarLoadMs).toBe(0);
   expect(preloaded.timings.highlightTokenizeMs).toBeGreaterThan(0);
@@ -106,6 +161,10 @@ test("DOCX highlighting is JavaScript-only and deterministic across fresh cold/p
   expect(preloaded.timings.highlightLanguageCount).toBe(22);
   expect(preloaded.digest).toBe(cold.digest);
   expect(preloaded.byteLength).toBe(cold.byteLength);
+  expect(repeat?.digest).toBe(preloaded.digest);
+  expect(repeat?.byteLength).toBe(preloaded.byteLength);
+  expect(repeat?.preparation?.codeFontBytes).toBe(273_900);
+  expect(repeatResources.filter(({ name }) => CODE_FONT_RE.test(name))).toEqual([]);
 
   mkdirSync(RESULT_DIR, { recursive: true });
   writeFileSync(
@@ -121,9 +180,13 @@ test("DOCX highlighting is JavaScript-only and deterministic across fresh cold/p
     `${JSON.stringify({
       cold: { ...cold, base64: undefined },
       preloaded: { ...preloaded, base64: undefined },
+      repeat: repeat ? { ...repeat, base64: undefined } : undefined,
       resourceTrace: {
         initializationRequests: initializationResources.map(({ name }) => name),
         grammarRequestCount: grammarResources.length,
+        coldFont: coldFont,
+        preloadedFont: preloadedFont,
+        repeatRequests: repeatResources.map(({ name }) => name),
         earliestGrammarRequestStart,
         latestInitializationResponseEnd,
         overlapMs:
@@ -131,4 +194,41 @@ test("DOCX highlighting is JavaScript-only and deterministic across fresh cold/p
       },
     }, null, 2)}\n`,
   );
+});
+
+test("a failed DOCX code-font request is retryable in the same browser realm", async ({
+  browser,
+}) => {
+  const context = await browser.newContext();
+  try {
+    const page = await context.newPage();
+    let fontRequests = 0;
+    await page.route("**/JetBrainsMono-Regular-*.ttf", async (route) => {
+      fontRequests += 1;
+      if (fontRequests === 1) {
+        await route.abort("failed");
+      } else {
+        await route.continue();
+      }
+    });
+    await page.goto(HARNESS_URL);
+    await page.waitForFunction(
+      () => typeof window.__ATLCLI_DOCX_HIGHLIGHT_BENCHMARK === "function",
+    );
+    await expect(page.evaluate(async () => {
+      const run = window.__ATLCLI_DOCX_HIGHLIGHT_BENCHMARK;
+      if (!run) throw new Error("highlight benchmark hook is unavailable");
+      return run(true);
+    })).rejects.toThrow();
+    const retry = await page.evaluate(async () => {
+      const run = window.__ATLCLI_DOCX_HIGHLIGHT_BENCHMARK;
+      if (!run) throw new Error("highlight benchmark hook is unavailable");
+      return run(true);
+    });
+    expect(fontRequests).toBe(2);
+    expect(retry.preparation?.codeFontBytes).toBe(273_900);
+    expect(retry.byteLength).toBeGreaterThan(100_000);
+  } finally {
+    await context.close();
+  }
 });

--- a/apps/browser-export-harness/tests/output-scan.test.ts
+++ b/apps/browser-export-harness/tests/output-scan.test.ts
@@ -64,6 +64,11 @@ function completeInventory(): OutputArtifact[] {
     { path: "index.html", size: 100 },
     { path: "assets/pdf-worker-abc.js", size: 100 },
     { path: "assets/typst_ts_web_compiler_bg-abc.wasm", size: 25_000_000 },
+    {
+      path: "assets/JetBrainsMono-Regular-abc.ttf",
+      size: 273_900,
+      sha256: "a0bf60ef0f83c5ed4d7a75d45838548b1f6873372dfac88f71804491898d138f",
+    },
   ];
   for (const font of PDF_RUNTIME_ASSETS.fonts) {
     const extension = font.fileName.slice(font.fileName.lastIndexOf("."));
@@ -93,6 +98,25 @@ describe("harness runtime inventory", () => {
       artifact.path.includes(font!.fileName.split(".")[0]!) ? { ...artifact, sha256: "tampered" } : artifact,
     );
     expect(validateHarnessInventory(tampered).join("\n")).toContain("SHA-256");
+  });
+
+  it("requires one pinned DOCX code font", () => {
+    const missing = completeInventory().filter(
+      (artifact) => !artifact.path.includes("JetBrainsMono-Regular"),
+    );
+    expect(validateHarnessInventory(missing).join("\n")).toContain("DOCX code font");
+
+    const duplicate = [
+      ...completeInventory(),
+      {
+        path: "assets/JetBrainsMono-Regular-duplicate.ttf",
+        size: 273_900,
+        sha256: "a0bf60ef0f83c5ed4d7a75d45838548b1f6873372dfac88f71804491898d138f",
+      },
+    ];
+    expect(validateHarnessInventory(duplicate).join("\n")).toContain(
+      "expected exactly one artifact",
+    );
   });
 
   it("rejects an emitted Oniguruma engine chunk by inventory", () => {

--- a/apps/cli/src/commands/export-code-font-smoke-entry.ts
+++ b/apps/cli/src/commands/export-code-font-smoke-entry.ts
@@ -3,11 +3,27 @@
  * Bun bundle, and compiled executable must all receive the same committed sfnt
  * bytes even when launched from a foreign working directory.
  */
+import { prepareDocxExportRuntime } from "@atlcli/docx";
+import { configureBundledCodeFontLoader } from "@atlcli/docx/internal";
 import { loadDocxCodeFont } from "./export-code-font.js";
 
 async function main(): Promise<void> {
+  let loads = 0;
+  configureBundledCodeFontLoader(async () => {
+    loads += 1;
+    return loadDocxCodeFont();
+  });
+  const [first, second] = await Promise.all([
+    prepareDocxExportRuntime([]),
+    prepareDocxExportRuntime([]),
+  ]);
+  const warm = await prepareDocxExportRuntime([]);
   const bytes = await loadDocxCodeFont();
   const sfnt =
+    first.codeFontBytes === bytes.byteLength &&
+    second.codeFontBytes === bytes.byteLength &&
+    warm.codeFontBytes === bytes.byteLength &&
+    loads === 1 &&
     bytes.byteLength > 250_000 &&
     bytes[0] === 0x00 &&
     bytes[1] === 0x01 &&

--- a/apps/cli/src/commands/export.ts
+++ b/apps/cli/src/commands/export.ts
@@ -1014,6 +1014,23 @@ interface OrdinaryDocxJobArgs {
   opts: OutputOptions;
 }
 
+let cliDocxCodeFontLoaderInstallation:
+  | Promise<void>
+  | undefined;
+
+/**
+ * Install the single-file CLI's embedded asset bridge once. Ordinary Node/Bun
+ * consumers keep the package-relative loader installed by @atlcli/docx.
+ */
+function ensureCliDocxCodeFontLoader(): Promise<void> {
+  return cliDocxCodeFontLoaderInstallation ??= Promise.all([
+    import("@atlcli/docx/internal"),
+    import("./export-code-font.js"),
+  ]).then(([{ configureBundledCodeFontLoader }, { loadDocxCodeFont }]) => {
+    configureBundledCodeFontLoader(loadDocxCodeFont);
+  });
+}
+
 /** Queue-backed DOCX command; no direct-engine fallback is reachable here. */
 async function exportDocxAsOrdinaryJob(
   args: OrdinaryDocxJobArgs,
@@ -1030,6 +1047,7 @@ async function exportDocxAsOrdinaryJob(
   const cliNotes: string[] = [];
 
   try {
+    await ensureCliDocxCodeFontLoader();
     // Executor construction is local-only; runOrdinaryExportJobV1 performs the
     // durable create before this resolver can reach Confluence.
     const sourcePolicyKey = args.profile.deploymentType === "data-center"

--- a/apps/extension/components/export/DocxExportPanel.tsx
+++ b/apps/extension/components/export/DocxExportPanel.tsx
@@ -83,9 +83,6 @@ export function DocxExportPanel({
       .then((current) => {
         if (cancelled || !current) return;
         setTemplate(current);
-        // A stored template means an export is likely: warm the heavy chunks now
-        // so the first Export click does not pay the cold import. Pure warm-up.
-        port.warm?.();
       })
       .catch(() => {
         if (!cancelled) setDocxError(t("docx.error.storedUnreadable"));
@@ -95,6 +92,20 @@ export function DocxExportPanel({
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [port, store]);
+
+  // A stored/uploaded Word template is explicit DOCX intent. Warm the
+  // productive host realm (offscreen in MV3) without making readiness depend on
+  // this optimization; the export path retains its own retry/fallback.
+  useEffect(() => {
+    if (!template || !port.warm) return;
+    void port.warm({
+      ...(scopeRequest?.codeTheme
+        ? { codeTheme: scopeRequest.codeTheme }
+        : {}),
+    }).catch(() => {
+      // Pure warm-up: the export path retries its own imports/assets.
+    });
+  }, [port, scopeRequest?.codeTheme, template]);
 
   async function onFile(event: React.ChangeEvent<HTMLInputElement>): Promise<void> {
     const file = event.target.files?.[0];
@@ -116,7 +127,6 @@ export function DocxExportPanel({
       const buffer = await file.arrayBuffer();
       // Validate + scan BEFORE persisting — store nothing on failure.
       const scan = await port.scan(new Uint8Array(buffer));
-      port.warm?.();
       const stored = await store.put({ name: file.name, bytes: buffer });
       setTemplate({
         name: stored.name,

--- a/apps/extension/entrypoints/background.ts
+++ b/apps/extension/entrypoints/background.ts
@@ -12,6 +12,7 @@ import { defineBackground } from "wxt/utils/define-background";
 // resolves the `browser` export condition (PLAN §6 risk 4); the Task 6 output
 // scan then proves this pulls in zero node:/bun: specifiers.
 import { extractEntityFromUrl } from "@atlcli/core";
+import type { CodeThemeId } from "@atlcli/code-highlight/registry";
 import {
   type EntityChanged,
   type EntityDetection,
@@ -282,6 +283,20 @@ async function runPdfCancel(jobId: string): Promise<boolean> {
   );
 }
 
+async function prepareDocxRuntime(codeTheme?: CodeThemeId) {
+  offscreenActivity.touch();
+  await ensureOffscreen();
+  const response = (await chrome.runtime.sendMessage({
+    kind: "offscreen:docx-prepare-runtime",
+    ...(codeTheme ? { codeTheme } : {}),
+  })) as OffscreenResponse | undefined;
+  if (!response || response.kind !== "offscreen:docx-prepare-runtime-result") {
+    throw new Error("Offscreen DOCX runtime returned no preparation result.");
+  }
+  if (!response.ok) throw new Error(response.error);
+  return response.preparation;
+}
+
 async function runJobsWake(
   jobIds?: string[],
   options?: { resumeWaiting?: boolean },
@@ -416,6 +431,7 @@ export default defineBackground({
       getCurrentEntity,
       runPdfCompile,
       runPdfCancel,
+      prepareDocxRuntime,
       runJobsWake,
     });
     if (handled) {

--- a/apps/extension/entrypoints/offscreen/main.ts
+++ b/apps/extension/entrypoints/offscreen/main.ts
@@ -109,6 +109,14 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) =>
       return result.ok ? { ok: true } : { ok: false, error: result.error };
     },
     runPdfCancel: (jobId) => pdfHost.cancel(jobId),
+    prepareDocxRuntime: async (codeTheme) => {
+      const { prepareDocxExportRuntime } = await import(
+        "@atlcli/docx/browser-runtime"
+      );
+      return prepareDocxExportRuntime([], {
+        ...(codeTheme ? { codeTheme } : {}),
+      });
+    },
     runJobsWake: (jobIds, options) => exportQueue.wake(jobIds, options),
   })
 );

--- a/apps/extension/entrypoints/sidepanel/ports/docx.ts
+++ b/apps/extension/entrypoints/sidepanel/ports/docx.ts
@@ -105,10 +105,20 @@ export function chromeDocxExportPort(): DocxExportPort {
       return scanTemplate(bytes);
     },
 
-    warm() {
-      void loadRun().catch(() => {
-        // Pure warm-up: the export path retries its own imports.
-      });
+    async warm(options) {
+      const responsePromise = chrome.runtime.sendMessage({
+        kind: "docx:prepare-runtime",
+        ...(options?.codeTheme ? { codeTheme: options.codeTheme } : {}),
+      }) as Promise<
+        | { kind: "docx:prepare-runtime-result"; ok: true }
+        | { kind: "docx:prepare-runtime-result"; ok: false; error: string }
+        | undefined
+      >;
+      const [, response] = await Promise.all([loadRun(), responsePromise]);
+      if (!response || response.kind !== "docx:prepare-runtime-result") {
+        throw new Error("DOCX runtime preparation returned no result.");
+      }
+      if (!response.ok) throw new Error(response.error);
     },
 
     async run(request) {

--- a/apps/extension/scripts/check-output-build.ts
+++ b/apps/extension/scripts/check-output-build.ts
@@ -12,7 +12,7 @@
  *   3. zero bare node/Bun GLOBALS (`Buffer.`, `process.env`, `__dirname`, `Bun.`),
  *   4. zero string-to-code constructors (`Function(...)`, `eval(...)`) that
  *      violate Manifest V3's extension-page CSP, and
- *   5. a complete, locally bundled PDF runtime (worker, WASM and eleven fonts).
+ *   5. complete, locally bundled PDF and DOCX render assets.
  *
  * Bare node globals are
  *      invisible to an import-specifier scan — nothing is imported, the symbol is
@@ -136,6 +136,11 @@ const REQUIRED_PDF_ARTIFACTS = [
     pattern: /(?:^|\/)assets\/typst_ts_web_compiler_bg-[^/]+\.wasm$/,
     minimumSize: 20_000_000,
     sha256: "1fc968438a672366dfec39c96c842c26ed29caff4eb1bcaab19a6c60867de5fd",
+  },
+  {
+    label: "DOCX code font",
+    pattern: /(?:^|\/)assets\/JetBrainsMono-Regular-[^/]+\.ttf$/,
+    sha256: "a0bf60ef0f83c5ed4d7a75d45838548b1f6873372dfac88f71804491898d138f",
   },
   {
     label: "Source Sans 3 Regular",
@@ -296,7 +301,7 @@ export function scanText(text: string): string[] {
   return findings;
 }
 
-/** Verify that every runtime asset needed for a browser-only PDF export exists. */
+/** Verify that every binary runtime asset needed for browser exports exists. */
 export function validatePdfArtifactInventory(artifacts: OutputArtifact[]): string[] {
   const issues: string[] = [];
   for (const requirement of REQUIRED_PDF_ARTIFACTS) {
@@ -389,7 +394,7 @@ async function main(): Promise<void> {
 
   if (leaks.length === 0 && artifactIssues.length === 0) {
     console.log(
-      `✓ extension output clean — CSP-safe and complete PDF runtime in ${root}`
+      `✓ extension output clean — CSP-safe and complete export runtime in ${root}`
     );
     return;
   }
@@ -402,7 +407,7 @@ async function main(): Promise<void> {
     }
   }
   if (artifactIssues.length > 0) {
-    console.error("  incomplete PDF runtime:");
+    console.error("  incomplete export runtime:");
     for (const issue of artifactIssues) console.error(`    ${issue}`);
   }
   process.exit(1);

--- a/apps/extension/tests/docx/export-panel.test.tsx
+++ b/apps/extension/tests/docx/export-panel.test.tsx
@@ -27,6 +27,7 @@ const SCAN: ScanResult = {
 describe("DocxExportPanel — honest preview wiring", () => {
   it("places the Word-rendering explanation beside the persisted template scan", async () => {
     const bytes = new ArrayBuffer(8);
+    const warmOptions: unknown[] = [];
     const store: DocxTemplateStore = {
       async get() {
         return { name: "report.docx", uploadedAt: 1, bytes };
@@ -43,6 +44,9 @@ describe("DocxExportPanel — honest preview wiring", () => {
       async run() {
         throw new Error("export is not part of this view test");
       },
+      async warm(options) {
+        warmOptions.push(options);
+      },
     };
 
     await dom.render(
@@ -53,6 +57,7 @@ describe("DocxExportPanel — honest preview wiring", () => {
             store={store}
             page={null}
             pageUrl={null}
+            scopeRequest={{ codeTheme: "github-dark" }}
           />
         </ExportRunsProvider>
       </I18nProvider>
@@ -63,5 +68,6 @@ describe("DocxExportPanel — honest preview wiring", () => {
     expect(dom.find("docx-preview-explanation").textContent).toContain(
       "Word renders the final document"
     );
+    expect(warmOptions).toEqual([{ codeTheme: "github-dark" }]);
   });
 });

--- a/apps/extension/tests/jobs/packed/job-recovery.e2e.ts
+++ b/apps/extension/tests/jobs/packed/job-recovery.e2e.ts
@@ -431,6 +431,34 @@ async function ensureCatalog(): Promise<void> {
   await expect(sendWake()).resolves.toEqual({ kind: "jobs:wake-result" });
 }
 
+async function preparePackedDocxRuntime(): Promise<{
+  kind: string;
+  preparation?: {
+    totalMs: number;
+    highlightingMs: number;
+    codeFontMs: number;
+    codeFontBytes: number;
+  };
+}> {
+  return page.evaluate(async () => {
+    const chromeApi = (globalThis as unknown as {
+      chrome: { runtime: { sendMessage(value: unknown): Promise<unknown> } };
+    }).chrome;
+    return chromeApi.runtime.sendMessage({
+      kind: "docx:prepare-runtime",
+      codeTheme: "github-dark",
+    }) as Promise<{
+      kind: string;
+      preparation?: {
+        totalMs: number;
+        highlightingMs: number;
+        codeFontMs: number;
+        codeFontBytes: number;
+      };
+    }>;
+  });
+}
+
 interface PackedBadgeSnapshot {
   text: string;
   color: number[];
@@ -1469,6 +1497,14 @@ test("packed Retry and Run again preserve originals and replay retained requests
 
 test("a packed offscreen DOCX runs PizZip, docxtemplater, and canvas diagram rasterization", async () => {
   await ensureCatalog();
+  const preparation = await preparePackedDocxRuntime();
+  expect(preparation.kind).toBe("docx:prepare-runtime-result");
+  expect(preparation.preparation).toMatchObject({
+    codeFontBytes: 273_900,
+    totalMs: expect.any(Number),
+    highlightingMs: expect.any(Number),
+    codeFontMs: expect.any(Number),
+  });
   const storage =
     '<p>before</p><ac:structured-macro ac:name="code">' +
     '<ac:parameter ac:name="language">mermaid</ac:parameter>' +

--- a/apps/extension/tests/listeners.test.ts
+++ b/apps/extension/tests/listeners.test.ts
@@ -7,17 +7,25 @@ import {
 import type { ExtResponse, OffscreenResponse } from "../utils/messages.js";
 import type { RouterDeps } from "../utils/router.js";
 
+const preparation = {
+  totalMs: 12,
+  highlightingMs: 8,
+  codeFontMs: 10,
+  codeFontBytes: 273_900,
+};
 const okRouterDeps: RouterDeps = {
   runWasmSmoke: async (a, b) => a + b,
   getCurrentEntity: async (windowId) => ({ windowId, url: null, entity: null, seq: 0 }),
   runPdfCompile: async () => ({ ok: true }),
   runPdfCancel: async () => true,
+  prepareDocxRuntime: async () => preparation,
   runJobsWake: async (jobIds) => jobIds?.[0],
 };
 const okOffscreenDeps: OffscreenListenerDeps = {
   runWasmAdd: async (a, b) => a + b,
   runPdfCompile: async () => ({ ok: true }),
   runPdfCancel: async () => true,
+  prepareDocxRuntime: async () => preparation,
   runJobsWake: async (jobIds) => jobIds?.[0],
 };
 
@@ -111,6 +119,21 @@ describe("handleExtMessage (background listener adapter)", () => {
     await cap.called;
     expect(cap.values).toEqual([{ kind: "jobs:wake-result", claimedJobId: jobId }]);
   });
+
+  it("returns true and responds to DOCX runtime preparation", async () => {
+    const cap = captureResponse<ExtResponse>();
+    expect(handleExtMessage(
+      { kind: "docx:prepare-runtime", codeTheme: "github-dark" },
+      cap.sendResponse,
+      okRouterDeps,
+    )).toBe(true);
+    await cap.called;
+    expect(cap.values).toEqual([{
+      kind: "docx:prepare-runtime-result",
+      ok: true,
+      preparation,
+    }]);
+  });
 });
 
 describe("handleOffscreenMessage (offscreen listener adapter)", () => {
@@ -178,6 +201,21 @@ describe("handleOffscreenMessage (offscreen listener adapter)", () => {
     )).toBe(true);
     await cap.called;
     expect(cap.values).toEqual([{ kind: "offscreen:jobs-wake-result", claimedJobId: jobId }]);
+  });
+
+  it("returns true and responds to offscreen DOCX runtime preparation", async () => {
+    const cap = captureResponse<OffscreenResponse>();
+    expect(handleOffscreenMessage(
+      { kind: "offscreen:docx-prepare-runtime", codeTheme: "github-light" },
+      cap.sendResponse,
+      okOffscreenDeps,
+    )).toBe(true);
+    await cap.called;
+    expect(cap.values).toEqual([{
+      kind: "offscreen:docx-prepare-runtime-result",
+      ok: true,
+      preparation,
+    }]);
   });
 
   it("keeps an offscreen queue wake failure distinct from an empty queue", async () => {

--- a/apps/extension/tests/messages.test.ts
+++ b/apps/extension/tests/messages.test.ts
@@ -19,6 +19,19 @@ describe("message guards", () => {
     expect(isExtRequest({ kind: "get-current-entity", windowId: 1.5 })).toBe(false);
     expect(isExtRequest({ kind: "pdf:compile", jobId })).toBe(true);
     expect(isExtRequest({ kind: "pdf:cancel", jobId })).toBe(true);
+    expect(isExtRequest({ kind: "docx:prepare-runtime" })).toBe(true);
+    expect(isExtRequest({
+      kind: "docx:prepare-runtime",
+      codeTheme: "github-dark",
+    })).toBe(true);
+    expect(isExtRequest({
+      kind: "docx:prepare-runtime",
+      codeTheme: "remote-theme",
+    })).toBe(false);
+    expect(isExtRequest({
+      kind: "docx:prepare-runtime",
+      blocks: [{ type: "codeBlock", code: "secret" }],
+    })).toBe(false);
     expect(isExtRequest({ kind: "jobs:wake", jobIds: [jobId] })).toBe(true);
     expect(isExtRequest({ kind: "jobs:wake", jobIds: [jobId], resumeWaiting: true })).toBe(true);
     expect(isExtRequest({ kind: "jobs:wake", resumeWaiting: true })).toBe(false);
@@ -94,6 +107,14 @@ describe("message guards", () => {
     expect(isOffscreenRequest({ kind: "offscreen:wasm-add", a: 1, b: 2 })).toBe(true);
     expect(isOffscreenRequest({ kind: "offscreen:pdf-compile", jobId })).toBe(true);
     expect(isOffscreenRequest({ kind: "offscreen:pdf-cancel", jobId })).toBe(true);
+    expect(isOffscreenRequest({
+      kind: "offscreen:docx-prepare-runtime",
+      codeTheme: "github-light",
+    })).toBe(true);
+    expect(isOffscreenRequest({
+      kind: "offscreen:docx-prepare-runtime",
+      codeTheme: "remote-theme",
+    })).toBe(false);
     expect(isOffscreenRequest({ kind: "offscreen:jobs-wake", jobIds: [jobId] })).toBe(true);
     expect(isOffscreenRequest({
       kind: "offscreen:jobs-wake",

--- a/apps/extension/tests/output-scan.test.ts
+++ b/apps/extension/tests/output-scan.test.ts
@@ -145,6 +145,7 @@ describe("PDF artifact inventory", () => {
     { path: "assets/pdf.min-abc.mjs", size: 452_000, sha256: "4ba2f15599b03fde8755ad91349920c21dadd3e8fd6b6460a7663d46d4cf21b5" },
     { path: "assets/pdf.worker.min-abc.mjs", size: 1_260_000, sha256: "2ab9e09667296dab1a618868b3ce6e6c23d5b8f48120ae7c5b34e7e335ed01fa" },
     { path: "assets/typst_ts_web_compiler_bg-abc.wasm", size: 28_000_000, sha256: "1fc968438a672366dfec39c96c842c26ed29caff4eb1bcaab19a6c60867de5fd" },
+    { path: "assets/JetBrainsMono-Regular-abc.ttf", size: 273_900, sha256: "a0bf60ef0f83c5ed4d7a75d45838548b1f6873372dfac88f71804491898d138f" },
     { path: "assets/SourceSans3-Regular-abc.ttf", size: 100_000, sha256: "4644c81b86ec9caaa76b634889968ed3c4f4f52f054855933acc7c2b21e53b0f" },
     { path: "assets/SourceSans3-It-abc.ttf", size: 100_000, sha256: "192afd78f0f54a3c69eaf02d43f4d9a821e9d6110e41d3d25d61a7385cd580e4" },
     { path: "assets/SourceSans3-Semibold-abc.ttf", size: 100_000, sha256: "a3f4f8dcf343a8f24dc61951de93f3ba1558b15cd250ba24af8a40e957081b7d" },
@@ -186,6 +187,27 @@ describe("PDF artifact inventory", () => {
       artifact.path.includes("SourceSans3-Regular") ? { ...artifact, sha256: "tampered" } : artifact
     );
     expect(validatePdfArtifactInventory(tampered).join("\n")).toContain("SHA-256");
+  });
+
+  it("requires exactly one pinned DOCX code font", () => {
+    const missing = complete.filter(
+      (artifact) => !artifact.path.includes("JetBrainsMono-Regular"),
+    );
+    expect(validatePdfArtifactInventory(missing).join("\n")).toContain(
+      "DOCX code font",
+    );
+
+    const duplicate = [
+      ...complete,
+      {
+        path: "assets/JetBrainsMono-Regular-duplicate.ttf",
+        size: 273_900,
+        sha256: "a0bf60ef0f83c5ed4d7a75d45838548b1f6873372dfac88f71804491898d138f",
+      },
+    ];
+    expect(validatePdfArtifactInventory(duplicate).join("\n")).toContain(
+      "expected exactly one bundled artifact",
+    );
   });
 
   /**

--- a/apps/extension/tests/router.test.ts
+++ b/apps/extension/tests/router.test.ts
@@ -3,12 +3,19 @@ import { routeMessage, type RouterDeps } from "../utils/router.js";
 import type { EntityDetection } from "../utils/messages.js";
 
 const noEntity: EntityDetection = { windowId: 7, url: null, entity: null, seq: 0 };
+const preparation = {
+  totalMs: 12,
+  highlightingMs: 8,
+  codeFontMs: 10,
+  codeFontBytes: 273_900,
+};
 
 const okDeps: RouterDeps = {
   runWasmSmoke: async (a, b) => a + b,
   getCurrentEntity: async () => noEntity,
   runPdfCompile: async () => ({ ok: true }),
   runPdfCancel: async () => true,
+  prepareDocxRuntime: async () => preparation,
   runJobsWake: async (jobIds) => jobIds?.[0],
 };
 
@@ -119,6 +126,30 @@ describe("routeMessage (pure router)", () => {
     );
     expect(response).toEqual({
       kind: "pdf:compile-result", jobId, ok: false, error: "compiler offline",
+    });
+  });
+
+  it("routes bounded DOCX runtime preparation and captures failures", async () => {
+    expect(await routeMessage({
+      kind: "docx:prepare-runtime",
+      codeTheme: "github-dark",
+    }, okDeps)).toEqual({
+      kind: "docx:prepare-runtime-result",
+      ok: true,
+      preparation,
+    });
+    expect(await routeMessage(
+      { kind: "docx:prepare-runtime" },
+      {
+        ...okDeps,
+        prepareDocxRuntime: async () => {
+          throw new Error("font unavailable");
+        },
+      },
+    )).toEqual({
+      kind: "docx:prepare-runtime-result",
+      ok: false,
+      error: "font unavailable",
     });
   });
 

--- a/apps/extension/utils/listeners.ts
+++ b/apps/extension/utils/listeners.ts
@@ -12,10 +12,12 @@
 import {
   isExtRequest,
   isOffscreenRequest,
+  type DocxRuntimePreparationMessage,
   type ExtResponse,
   type OffscreenResponse,
   type PdfCompileHints,
 } from "./messages.js";
+import type { CodeThemeId } from "@atlcli/code-highlight/registry";
 import { routeMessage, type RouterDeps } from "./router.js";
 import { runWasmAdd } from "./wasm-smoke.js";
 
@@ -27,6 +29,9 @@ export interface OffscreenListenerDeps {
     hints?: PdfCompileHints
   ) => Promise<{ ok: true } | { ok: false; error: string }>;
   runPdfCancel: (jobId: string) => Promise<boolean>;
+  prepareDocxRuntime?: (
+    codeTheme?: CodeThemeId,
+  ) => Promise<DocxRuntimePreparationMessage>;
   runJobsWake?: (
     jobIds?: string[],
     options?: { resumeWaiting?: boolean },
@@ -64,6 +69,13 @@ export function handleExtMessage(
         case "jobs:wake":
           sendResponse({ kind: "jobs:wake-result", error: toMessage(err) });
           break;
+        case "docx:prepare-runtime":
+          sendResponse({
+            kind: "docx:prepare-runtime-result",
+            ok: false,
+            error: toMessage(err),
+          });
+          break;
         case "ping":
         case "wasm-smoke":
         case "get-current-entity":
@@ -87,6 +99,9 @@ export function handleOffscreenMessage(
     runWasmAdd,
     runPdfCompile: async () => ({ ok: false, error: "PDF compiler host is not configured." }),
     runPdfCancel: async () => false,
+    prepareDocxRuntime: async () => {
+      throw new Error("DOCX runtime preparation is not configured.");
+    },
     runJobsWake: async () => undefined,
   }
 ): boolean {
@@ -109,6 +124,21 @@ export function handleOffscreenMessage(
       deps.runPdfCancel(message.jobId)
         .then((cancelled) => sendResponse({ kind: "offscreen:pdf-cancel-result", jobId: message.jobId, cancelled }))
         .catch(() => sendResponse({ kind: "offscreen:pdf-cancel-result", jobId: message.jobId, cancelled: false }));
+      break;
+    case "offscreen:docx-prepare-runtime":
+      (deps.prepareDocxRuntime
+        ? deps.prepareDocxRuntime(message.codeTheme)
+        : Promise.reject(new Error("DOCX runtime preparation is not configured.")))
+        .then((preparation) => sendResponse({
+          kind: "offscreen:docx-prepare-runtime-result",
+          ok: true,
+          preparation,
+        }))
+        .catch((error) => sendResponse({
+          kind: "offscreen:docx-prepare-runtime-result",
+          ok: false,
+          error: toMessage(error),
+        }));
       break;
     case "offscreen:jobs-wake":
       (deps.runJobsWake?.(message.jobIds, {

--- a/apps/extension/utils/messages.ts
+++ b/apps/extension/utils/messages.ts
@@ -12,6 +12,10 @@
  */
 
 import type { AtlassianEntity } from "@atlcli/core";
+import {
+  isCodeThemeId,
+  type CodeThemeId,
+} from "@atlcli/code-highlight/registry";
 
 /**
  * Detection payload shared by the SW push (`entity-changed`) and the
@@ -60,6 +64,14 @@ export interface PdfCompileHints {
   pages?: number;
 }
 
+/** Bounded timing/result projection for cross-realm DOCX runtime preparation. */
+export interface DocxRuntimePreparationMessage {
+  totalMs: number;
+  highlightingMs: number;
+  codeFontMs: number;
+  codeFontBytes: number;
+}
+
 /** Request messages sent from the panel to the service worker. */
 export type ExtRequest =
   | { kind: "ping" }
@@ -67,6 +79,7 @@ export type ExtRequest =
   | { kind: "get-current-entity"; windowId: number }
   | ({ kind: "pdf:compile"; jobId: string } & PdfCompileHints)
   | { kind: "pdf:cancel"; jobId: string }
+  | { kind: "docx:prepare-runtime"; codeTheme?: CodeThemeId }
   | { kind: "jobs:wake"; jobIds?: string[]; resumeWaiting?: boolean };
 
 /** Response messages returned to the panel. */
@@ -78,6 +91,8 @@ export type ExtResponse =
   | { kind: "pdf:compile-result"; jobId: string; ok: true }
   | { kind: "pdf:compile-result"; jobId: string; ok: false; error: string }
   | { kind: "pdf:cancel-result"; jobId: string; cancelled: boolean }
+  | { kind: "docx:prepare-runtime-result"; ok: true; preparation: DocxRuntimePreparationMessage }
+  | { kind: "docx:prepare-runtime-result"; ok: false; error: string }
   | { kind: "jobs:wake-result"; claimedJobId?: string; error?: never }
   | { kind: "jobs:wake-result"; error: string; claimedJobId?: never };
 
@@ -100,6 +115,7 @@ export type OffscreenRequest =
   | { kind: "offscreen:wasm-add"; a: number; b: number }
   | ({ kind: "offscreen:pdf-compile"; jobId: string } & PdfCompileHints)
   | { kind: "offscreen:pdf-cancel"; jobId: string }
+  | { kind: "offscreen:docx-prepare-runtime"; codeTheme?: CodeThemeId }
   | { kind: "offscreen:jobs-wake"; jobIds?: string[]; resumeWaiting?: boolean };
 export type OffscreenResponse =
   | { kind: "offscreen:wasm-add-result"; ok: true; result: number }
@@ -107,6 +123,8 @@ export type OffscreenResponse =
   | { kind: "offscreen:pdf-compile-result"; jobId: string; ok: true }
   | { kind: "offscreen:pdf-compile-result"; jobId: string; ok: false; error: string }
   | { kind: "offscreen:pdf-cancel-result"; jobId: string; cancelled: boolean }
+  | { kind: "offscreen:docx-prepare-runtime-result"; ok: true; preparation: DocxRuntimePreparationMessage }
+  | { kind: "offscreen:docx-prepare-runtime-result"; ok: false; error: string }
   | { kind: "offscreen:jobs-wake-result"; claimedJobId?: string; error?: never }
   | { kind: "offscreen:jobs-wake-result"; error: string; claimedJobId?: never };
 
@@ -132,6 +150,7 @@ export interface ResponseMap {
   "get-current-entity": Extract<ExtResponse, { kind: "current-entity" }>;
   "pdf:compile": Extract<ExtResponse, { kind: "pdf:compile-result" }>;
   "pdf:cancel": Extract<ExtResponse, { kind: "pdf:cancel-result" }>;
+  "docx:prepare-runtime": Extract<ExtResponse, { kind: "docx:prepare-runtime-result" }>;
   "jobs:wake": Extract<ExtResponse, { kind: "jobs:wake-result" }>;
 }
 
@@ -144,6 +163,11 @@ export function isExtRequest(value: unknown): value is ExtRequest {
   const kind = candidate.kind;
   if (kind === "pdf:compile") return hasOnlyKeys(value, ["kind", "jobId", "job", "pages"]) && isPdfJobId(candidate.jobId) && hasValidCompileHints(value);
   if (kind === "pdf:cancel") return hasOnlyKeys(value, ["kind", "jobId"]) && isPdfJobId(candidate.jobId);
+  if (kind === "docx:prepare-runtime") {
+    const preparation = value as { codeTheme?: unknown };
+    return hasOnlyKeys(value, ["kind", "codeTheme"]) &&
+      (preparation.codeTheme === undefined || isCodeThemeId(preparation.codeTheme));
+  }
   if (kind === "jobs:wake") {
     const wake = value as { jobIds?: unknown; resumeWaiting?: unknown };
     return hasOnlyKeys(value, ["kind", "jobIds", "resumeWaiting"]) &&
@@ -189,6 +213,11 @@ export function isOffscreenRequest(value: unknown): value is OffscreenRequest {
     return hasOnlyKeys(value, ["kind", "jobId", "job", "pages"]) && isPdfJobId(candidate.jobId) && hasValidCompileHints(value);
   }
   if (candidate.kind === "offscreen:pdf-cancel") return hasOnlyKeys(value, ["kind", "jobId"]) && isPdfJobId(candidate.jobId);
+  if (candidate.kind === "offscreen:docx-prepare-runtime") {
+    const preparation = value as { codeTheme?: unknown };
+    return hasOnlyKeys(value, ["kind", "codeTheme"]) &&
+      (preparation.codeTheme === undefined || isCodeThemeId(preparation.codeTheme));
+  }
   if (candidate.kind === "offscreen:jobs-wake") {
     const wake = value as { jobIds?: unknown; resumeWaiting?: unknown };
     return hasOnlyKeys(value, ["kind", "jobIds", "resumeWaiting"]) &&

--- a/apps/extension/utils/ports/export.ts
+++ b/apps/extension/utils/ports/export.ts
@@ -236,8 +236,9 @@ export interface DocxExportPort {
   run(request: DocxExportRequest): Promise<ExportReport>;
 
   /**
-   * Optional: pre-fetch the heavy engine chunks because an export is likely
-   * (a template already exists). Pure warm-up — failures must be swallowed.
+   * Optional: prepare deterministic runtime assets because an export is likely
+   * (a template already exists). Hosts must run this in the productive realm.
+   * Callers treat failure as a pure warm-up miss; the export retries normally.
    */
-  warm?(): void;
+  warm?(options?: { codeTheme?: CodeThemeId }): Promise<void>;
 }

--- a/apps/extension/utils/router.ts
+++ b/apps/extension/utils/router.ts
@@ -8,11 +8,13 @@
  * the result onto `chrome.runtime.onMessage`.
  */
 import type {
+  DocxRuntimePreparationMessage,
   EntityDetection,
   ExtRequest,
   ExtResponse,
   PdfCompileHints,
 } from "./messages.js";
+import type { CodeThemeId } from "@atlcli/code-highlight/registry";
 
 /** Injected side effects the router needs to fulfil requests. */
 export interface RouterDeps {
@@ -31,6 +33,10 @@ export interface RouterDeps {
   ) => Promise<{ ok: true } | { ok: false; error: string }>;
   /** Cancels a queued or active PDF job. */
   runPdfCancel: (jobId: string) => Promise<boolean>;
+  /** Warms deterministic DOCX runtime assets in the productive offscreen realm. */
+  prepareDocxRuntime?: (
+    codeTheme?: CodeThemeId,
+  ) => Promise<DocxRuntimePreparationMessage>;
   /** Wakes the common offscreen queue using opaque job ids only. */
   runJobsWake?: (
     jobIds?: string[],
@@ -84,6 +90,25 @@ export async function routeMessage(
     case "pdf:cancel": {
       const cancelled = await deps.runPdfCancel(msg.jobId).catch(() => false);
       return { kind: "pdf:cancel-result", jobId: msg.jobId, cancelled };
+    }
+    case "docx:prepare-runtime": {
+      if (!deps.prepareDocxRuntime) {
+        return {
+          kind: "docx:prepare-runtime-result",
+          ok: false,
+          error: "DOCX runtime preparation is not configured.",
+        };
+      }
+      try {
+        const preparation = await deps.prepareDocxRuntime(msg.codeTheme);
+        return { kind: "docx:prepare-runtime-result", ok: true, preparation };
+      } catch (error) {
+        return {
+          kind: "docx:prepare-runtime-result",
+          ok: false,
+          error: error instanceof Error ? error.message : String(error),
+        };
+      }
     }
     case "jobs:wake": {
       if (!deps.runJobsWake) {

--- a/packages/docx/README.md
+++ b/packages/docx/README.md
@@ -12,7 +12,7 @@ browser and under Node/Bun; hosts inject template/asset/output seams via
   - `./browser` — the same engine without Node adapters.
   - `./browser-runtime` — browser bootstrap (installs the byte helpers;
     import before PizZip/docxtemplater run in a browser host), the
-    JavaScript-only Shiki engine, and `prepareDocxCodeHighlighting`.
+    JavaScript-only Shiki engine, and the runtime-preparation API.
   - `./vite` — build-time define map for browser bundlers.
   - `./scan` — template scanning (`scanTemplate`, `unzipDocx`).
   - `./fixtures` — programmatic minimal-docx builders (dev/test API).
@@ -35,7 +35,7 @@ await runExport(
 Full engine reference: [DOCX export engine](https://atlcli.sh/reference/docx-engine/).
 Versioning: [package versioning](https://atlcli.sh/reference/versioning/).
 
-## Browser code-highlighting preload
+## Intent-time runtime preparation
 
 Browser entrypoints must import the runtime before any static DOCX dependency:
 
@@ -43,22 +43,27 @@ Browser entrypoints must import the runtime before any static DOCX dependency:
 import "@atlcli/docx/browser-runtime";
 ```
 
-After the user has expressed DOCX intent, a host may preload only the known
-languages present in the resolved block tree:
+After the user has expressed DOCX intent, a host can warm the complete
+first-render runtime:
 
 ```ts
-const { prepareDocxCodeHighlighting } =
+const { prepareDocxExportRuntime } =
   await import("@atlcli/docx/browser-runtime");
 
-await prepareDocxCodeHighlighting(blocks, { codeTheme: "github-light" });
+const preparation = await prepareDocxExportRuntime(blocks, {
+  codeTheme: "github-light",
+  signal: dialogSignal,
+});
 ```
 
-The call is awaitable, concurrent-safe, and idempotent. Starting it from a
-DOCX modal or explicit export action keeps ordinary page loads untouched.
-Browser builds use Shiki's JavaScript RegExp engine; Node/Bun imports use
-Oniguruma. `ExportReport.timings` separates one-time engine initialization,
-grammar load/compile, and real-source tokenization, and records code-block and
-distinct-language counts.
+The call warms known Shiki grammars and validates the bundled
+`JetBrainsMono-Regular.ttf` concurrently. It is awaitable, concurrent-safe,
+retryable, and idempotent. Cancellation stops only that caller's wait; shared
+initialization continues for the next caller. Starting it from a DOCX modal,
+Word-template selection, or explicit export action keeps ordinary page loads
+untouched. The returned timings cover only intent-to-ready preparation;
+`ExportReport.timings` still describes render work. Browser builds use Shiki's
+JavaScript RegExp engine; Node/Bun imports use Oniguruma.
 
 ## Queued export engine seam
 

--- a/packages/docx/etc/docx.api.md
+++ b/packages/docx/etc/docx.api.md
@@ -27,6 +27,14 @@ export interface CurrentUser {
     email?: string;
 }
 
+// export: DocxExportRuntimePreparation
+export interface DocxExportRuntimePreparation {
+    totalMs: number;
+    highlightingMs: number;
+    codeFontMs: number;
+    codeFontBytes: number;
+}
+
 // export: DocxRenderError
 export declare class DocxRenderError extends Error {
     readonly details: string[];
@@ -237,6 +245,15 @@ export interface PreparedDocxRenderStateV1 {
 // export: prepareDocxExport
 export declare function prepareDocxExport(input: ExportInput): Promise<PreparedDocxExportV1>;
 
+// export: prepareDocxExportRuntime
+export declare function prepareDocxExportRuntime(blocks: readonly ExportBlock[], options?: PrepareDocxExportRuntimeOptions): Promise<DocxExportRuntimePreparation>;
+
+// export: PrepareDocxExportRuntimeOptions
+export interface PrepareDocxExportRuntimeOptions {
+    codeTheme?: CodeThemeId;
+    signal?: AbortSignal;
+}
+
 // export: renderPreparedDocxExport
 export declare function renderPreparedDocxExport(prepared: PreparedDocxExportV1, input?: RenderPreparedDocxExportInput): Promise<ExportResult>;
 
@@ -329,6 +346,14 @@ export interface CurrentUser {
     accountId: string;
     displayName: string;
     email?: string;
+}
+
+// export: DocxExportRuntimePreparation
+export interface DocxExportRuntimePreparation {
+    totalMs: number;
+    highlightingMs: number;
+    codeFontMs: number;
+    codeFontBytes: number;
 }
 
 // export: DocxRenderError
@@ -547,6 +572,15 @@ export interface PreparedDocxRenderStateV1 {
 // export: prepareDocxExport
 export declare function prepareDocxExport(input: ExportInput): Promise<PreparedDocxExportV1>;
 
+// export: prepareDocxExportRuntime
+export declare function prepareDocxExportRuntime(blocks: readonly ExportBlock[], options?: PrepareDocxExportRuntimeOptions): Promise<DocxExportRuntimePreparation>;
+
+// export: PrepareDocxExportRuntimeOptions
+export interface PrepareDocxExportRuntimeOptions {
+    codeTheme?: CodeThemeId;
+    signal?: AbortSignal;
+}
+
 // export: renderPreparedDocxExport
 export declare function renderPreparedDocxExport(prepared: PreparedDocxExportV1, input?: RenderPreparedDocxExportInput): Promise<ExportResult>;
 
@@ -649,6 +683,14 @@ export interface CurrentUser {
     accountId: string;
     displayName: string;
     email?: string;
+}
+
+// export: DocxExportRuntimePreparation
+export interface DocxExportRuntimePreparation {
+    totalMs: number;
+    highlightingMs: number;
+    codeFontMs: number;
+    codeFontBytes: number;
 }
 
 // export: DocxRenderError
@@ -861,6 +903,15 @@ export interface PreparedDocxRenderStateV1 {
 // export: prepareDocxExport
 export declare function prepareDocxExport(input: ExportInput): Promise<PreparedDocxExportV1>;
 
+// export: prepareDocxExportRuntime
+export declare function prepareDocxExportRuntime(blocks: readonly ExportBlock[], options?: PrepareDocxExportRuntimeOptions): Promise<DocxExportRuntimePreparation>;
+
+// export: PrepareDocxExportRuntimeOptions
+export interface PrepareDocxExportRuntimeOptions {
+    codeTheme?: CodeThemeId;
+    signal?: AbortSignal;
+}
+
 // export: renderPreparedDocxExport
 export declare function renderPreparedDocxExport(prepared: PreparedDocxExportV1, input?: RenderPreparedDocxExportInput): Promise<ExportResult>;
 
@@ -956,6 +1007,14 @@ export interface DocxByteHelpers {
     isBuffer(value: unknown): boolean;
 }
 
+// export: DocxExportRuntimePreparation
+export interface DocxExportRuntimePreparation {
+    totalMs: number;
+    highlightingMs: number;
+    codeFontMs: number;
+    codeFontBytes: number;
+}
+
 // export: installDocxBrowserRuntime
 export declare function installDocxBrowserRuntime(): void;
 
@@ -966,6 +1025,15 @@ export declare function memoryTemplateSource(bytes: ArrayBuffer | Uint8Array): T
 export declare function prepareDocxCodeHighlighting(blocks: readonly ExportBlock[], options?: {
     codeTheme?: CodeThemeId;
 }): Promise<void>;
+
+// export: prepareDocxExportRuntime
+export declare function prepareDocxExportRuntime(blocks: readonly ExportBlock[], options?: PrepareDocxExportRuntimeOptions): Promise<DocxExportRuntimePreparation>;
+
+// export: PrepareDocxExportRuntimeOptions
+export interface PrepareDocxExportRuntimeOptions {
+    codeTheme?: CodeThemeId;
+    signal?: AbortSignal;
+}
 ```
 
 ### Entry point `./fixtures`
@@ -2042,6 +2110,14 @@ export interface CurrentUser {
     email?: string;
 }
 
+// export: DocxExportRuntimePreparation
+export interface DocxExportRuntimePreparation {
+    totalMs: number;
+    highlightingMs: number;
+    codeFontMs: number;
+    codeFontBytes: number;
+}
+
 // export: DocxRenderError
 export declare class DocxRenderError extends Error {
     readonly details: string[];
@@ -2257,6 +2333,15 @@ export interface PreparedDocxRenderStateV1 {
 
 // export: prepareDocxExport
 export declare function prepareDocxExport(input: ExportInput): Promise<PreparedDocxExportV1>;
+
+// export: prepareDocxExportRuntime
+export declare function prepareDocxExportRuntime(blocks: readonly ExportBlock[], options?: PrepareDocxExportRuntimeOptions): Promise<DocxExportRuntimePreparation>;
+
+// export: PrepareDocxExportRuntimeOptions
+export interface PrepareDocxExportRuntimeOptions {
+    codeTheme?: CodeThemeId;
+    signal?: AbortSignal;
+}
 
 // export: renderPreparedDocxExport
 export declare function renderPreparedDocxExport(prepared: PreparedDocxExportV1, input?: RenderPreparedDocxExportInput): Promise<ExportResult>;

--- a/packages/docx/etc/docx.closure.md
+++ b/packages/docx/etc/docx.closure.md
@@ -10,8 +10,8 @@
 
 ### Entry point `. (browser)` — stable
 
-- exported symbols (33): AssetFetcher, AssetRef, CurrentUser, DocxRenderError, ExportEnv, ExportInput, ExportReport, ExportResult, ExportTimings, HostCallContext, IncludeLookupOutcome, IncludePageDetails, IncludePageRef, NumberingAllocator, NumberingBase, NumberingXml, OutputSink, PageOwner, PlaceholderStatus, PreparedDocxExportV1, PreparedDocxRenderStateV1, RenderPreparedDocxExportInput, ResolveDeps, RunExportInput, ScanHit, ScanResult, SvgRasterizer, TemplateMeta, TemplateSource, exportDocx, prepareDocxExport, renderPreparedDocxExport, runExport
-- same-package closure references: 27
+- exported symbols (36): AssetFetcher, AssetRef, CurrentUser, DocxExportRuntimePreparation, DocxRenderError, ExportEnv, ExportInput, ExportReport, ExportResult, ExportTimings, HostCallContext, IncludeLookupOutcome, IncludePageDetails, IncludePageRef, NumberingAllocator, NumberingBase, NumberingXml, OutputSink, PageOwner, PlaceholderStatus, PrepareDocxExportRuntimeOptions, PreparedDocxExportV1, PreparedDocxRenderStateV1, RenderPreparedDocxExportInput, ResolveDeps, RunExportInput, ScanHit, ScanResult, SvgRasterizer, TemplateMeta, TemplateSource, exportDocx, prepareDocxExport, prepareDocxExportRuntime, renderPreparedDocxExport, runExport
+- same-package closure references: 29
 - reaches `@atlcli/code-highlight` (0.x — frozen-by-closure): CodeThemeId
 - reaches `@atlcli/confluence` (frozen): AdfMediaAttachment, ConfluencePageDetails, ConfluenceSpace, ExportBlock, ExportNote, ExportPageSource, ExportProgressCallback, InlineComment
 - reaches `@atlcli/diagram` (0.x — frozen-by-closure): DiagramTheme
@@ -20,8 +20,8 @@
 
 ### Entry point `. (default)` — stable
 
-- exported symbols (39): AssetFetcher, AssetRef, CurrentUser, DocxRenderError, ExportEnv, ExportInput, ExportReport, ExportResult, ExportTimings, HostCallContext, IncludeLookupOutcome, IncludePageDetails, IncludePageRef, NumberingAllocator, NumberingBase, NumberingXml, OutputSink, PageOwner, PlaceholderStatus, PreparedDocxExportV1, PreparedDocxRenderStateV1, RenderPreparedDocxExportInput, ResolveDeps, ResvgRasterizerAssets, RunExportInput, ScanHit, ScanResult, SvgRasterizer, TemplateMeta, TemplateSource, bundledDiagramFonts, exportDocx, fileOutputSink, fileTemplateSource, prepareDocxExport, renderPreparedDocxExport, resvgSvgRasterizer, runExport, unsupportedAssetFetcher
-- same-package closure references: 28
+- exported symbols (42): AssetFetcher, AssetRef, CurrentUser, DocxExportRuntimePreparation, DocxRenderError, ExportEnv, ExportInput, ExportReport, ExportResult, ExportTimings, HostCallContext, IncludeLookupOutcome, IncludePageDetails, IncludePageRef, NumberingAllocator, NumberingBase, NumberingXml, OutputSink, PageOwner, PlaceholderStatus, PrepareDocxExportRuntimeOptions, PreparedDocxExportV1, PreparedDocxRenderStateV1, RenderPreparedDocxExportInput, ResolveDeps, ResvgRasterizerAssets, RunExportInput, ScanHit, ScanResult, SvgRasterizer, TemplateMeta, TemplateSource, bundledDiagramFonts, exportDocx, fileOutputSink, fileTemplateSource, prepareDocxExport, prepareDocxExportRuntime, renderPreparedDocxExport, resvgSvgRasterizer, runExport, unsupportedAssetFetcher
+- same-package closure references: 30
 - reaches `@atlcli/code-highlight` (0.x — frozen-by-closure): CodeThemeId
 - reaches `@atlcli/confluence` (frozen): AdfMediaAttachment, ConfluencePageDetails, ConfluenceSpace, ExportBlock, ExportNote, ExportPageSource, ExportProgressCallback, InlineComment
 - reaches `@atlcli/diagram` (0.x — frozen-by-closure): DiagramTheme
@@ -30,8 +30,8 @@
 
 ### Entry point `./browser` — stable
 
-- exported symbols (33): AssetFetcher, AssetRef, CurrentUser, DocxRenderError, ExportEnv, ExportInput, ExportReport, ExportResult, ExportTimings, HostCallContext, IncludeLookupOutcome, IncludePageDetails, IncludePageRef, NumberingAllocator, NumberingBase, NumberingXml, OutputSink, PageOwner, PlaceholderStatus, PreparedDocxExportV1, PreparedDocxRenderStateV1, RenderPreparedDocxExportInput, ResolveDeps, RunExportInput, ScanHit, ScanResult, SvgRasterizer, TemplateMeta, TemplateSource, exportDocx, prepareDocxExport, renderPreparedDocxExport, runExport
-- same-package closure references: 27
+- exported symbols (36): AssetFetcher, AssetRef, CurrentUser, DocxExportRuntimePreparation, DocxRenderError, ExportEnv, ExportInput, ExportReport, ExportResult, ExportTimings, HostCallContext, IncludeLookupOutcome, IncludePageDetails, IncludePageRef, NumberingAllocator, NumberingBase, NumberingXml, OutputSink, PageOwner, PlaceholderStatus, PrepareDocxExportRuntimeOptions, PreparedDocxExportV1, PreparedDocxRenderStateV1, RenderPreparedDocxExportInput, ResolveDeps, RunExportInput, ScanHit, ScanResult, SvgRasterizer, TemplateMeta, TemplateSource, exportDocx, prepareDocxExport, prepareDocxExportRuntime, renderPreparedDocxExport, runExport
+- same-package closure references: 29
 - reaches `@atlcli/code-highlight` (0.x — frozen-by-closure): CodeThemeId
 - reaches `@atlcli/confluence` (frozen): AdfMediaAttachment, ConfluencePageDetails, ConfluenceSpace, ExportBlock, ExportNote, ExportPageSource, ExportProgressCallback, InlineComment
 - reaches `@atlcli/diagram` (0.x — frozen-by-closure): DiagramTheme
@@ -40,7 +40,7 @@
 
 ### Entry point `./browser-runtime` — experimental
 
-- exported symbols (7): CanvasRasterizerTiming, CanvasSvgRasterizerOptions, DocxByteHelpers, canvasSvgRasterizer, installDocxBrowserRuntime, memoryTemplateSource, prepareDocxCodeHighlighting
+- exported symbols (10): CanvasRasterizerTiming, CanvasSvgRasterizerOptions, DocxByteHelpers, DocxExportRuntimePreparation, PrepareDocxExportRuntimeOptions, canvasSvgRasterizer, installDocxBrowserRuntime, memoryTemplateSource, prepareDocxCodeHighlighting, prepareDocxExportRuntime
 
 ### Entry point `./fixtures` — internal
 
@@ -52,8 +52,8 @@
 
 ### Entry point `./node` — stable
 
-- exported symbols (39): AssetFetcher, AssetRef, CurrentUser, DocxRenderError, ExportEnv, ExportInput, ExportReport, ExportResult, ExportTimings, HostCallContext, IncludeLookupOutcome, IncludePageDetails, IncludePageRef, NumberingAllocator, NumberingBase, NumberingXml, OutputSink, PageOwner, PlaceholderStatus, PreparedDocxExportV1, PreparedDocxRenderStateV1, RenderPreparedDocxExportInput, ResolveDeps, ResvgRasterizerAssets, RunExportInput, ScanHit, ScanResult, SvgRasterizer, TemplateMeta, TemplateSource, bundledDiagramFonts, exportDocx, fileOutputSink, fileTemplateSource, prepareDocxExport, renderPreparedDocxExport, resvgSvgRasterizer, runExport, unsupportedAssetFetcher
-- same-package closure references: 28
+- exported symbols (42): AssetFetcher, AssetRef, CurrentUser, DocxExportRuntimePreparation, DocxRenderError, ExportEnv, ExportInput, ExportReport, ExportResult, ExportTimings, HostCallContext, IncludeLookupOutcome, IncludePageDetails, IncludePageRef, NumberingAllocator, NumberingBase, NumberingXml, OutputSink, PageOwner, PlaceholderStatus, PrepareDocxExportRuntimeOptions, PreparedDocxExportV1, PreparedDocxRenderStateV1, RenderPreparedDocxExportInput, ResolveDeps, ResvgRasterizerAssets, RunExportInput, ScanHit, ScanResult, SvgRasterizer, TemplateMeta, TemplateSource, bundledDiagramFonts, exportDocx, fileOutputSink, fileTemplateSource, prepareDocxExport, prepareDocxExportRuntime, renderPreparedDocxExport, resvgSvgRasterizer, runExport, unsupportedAssetFetcher
+- same-package closure references: 30
 - reaches `@atlcli/code-highlight` (0.x — frozen-by-closure): CodeThemeId
 - reaches `@atlcli/confluence` (frozen): AdfMediaAttachment, ConfluencePageDetails, ConfluenceSpace, ExportBlock, ExportNote, ExportPageSource, ExportProgressCallback, InlineComment
 - reaches `@atlcli/diagram` (0.x — frozen-by-closure): DiagramTheme

--- a/packages/docx/src/browser-runtime.test.ts
+++ b/packages/docx/src/browser-runtime.test.ts
@@ -8,6 +8,7 @@ import {
   installDocxBrowserRuntime,
   memoryTemplateSource,
   prepareDocxCodeHighlighting,
+  prepareDocxExportRuntime,
   type DocxByteHelpers,
 } from "./browser-runtime.js";
 import type { ExportBlock } from "@atlcli/confluence";
@@ -68,6 +69,24 @@ describe("DOCX browser byte helpers", () => {
       prepareDocxCodeHighlighting(blocks),
     ]);
     await prepareDocxCodeHighlighting(blocks);
+  });
+
+  it("warms highlighting and the validated bundled code font through one public contract", async () => {
+    const prepared = await prepareDocxExportRuntime([
+      {
+        type: "callout",
+        kind: "info",
+        content: [{ type: "codeBlock", language: "ts", code: "const x = 1;" }],
+      },
+      {
+        type: "paragraph",
+        content: [{ type: "text", text: "INLINE_TOKEN", marks: ["code"] }],
+      },
+    ]);
+    expect(prepared.codeFontBytes).toBe(273_900);
+    expect(prepared.totalMs).toBeGreaterThanOrEqual(0);
+    expect(prepared.highlightingMs).toBeGreaterThanOrEqual(0);
+    expect(prepared.codeFontMs).toBeGreaterThanOrEqual(0);
   });
 
   it("exports the exact frozen Vite define map", () => {

--- a/packages/docx/src/browser-runtime.ts
+++ b/packages/docx/src/browser-runtime.ts
@@ -15,6 +15,11 @@ import {
 import type { SvgRasterizer, TemplateSource } from "./env.js";
 
 export type { DocxByteHelpers } from "./browser-runtime-bootstrap.js";
+export {
+  prepareDocxExportRuntime,
+  type DocxExportRuntimePreparation,
+  type PrepareDocxExportRuntimeOptions,
+} from "./runtime-preparation.js";
 
 /** Install the namespaced byte helpers once without defining a fake Buffer. */
 export function installDocxBrowserRuntime(): void {

--- a/packages/docx/src/font-embedding.test.ts
+++ b/packages/docx/src/font-embedding.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { afterAll, describe, expect, it } from "bun:test";
 import {
   CODE_FONT_FAMILY,
   CODE_FONT_KEY,
@@ -6,10 +6,13 @@ import {
   DocxFontEmbeddingError,
   assertBundledCodeFont,
   assertEmbeddableSfnt,
+  configureBundledCodeFontLoader,
   ensureEmbeddedCodeFont,
+  loadBundledCodeFont,
   obfuscateFont,
 } from "./font-embedding.js";
 import { buildDocx, para } from "./fixtures.js";
+import { prepareDocxExportRuntime } from "./runtime-preparation.js";
 import { unzipDocx } from "./scan.js";
 
 const fontUrl = new URL("../fonts/JetBrainsMono-Regular.ttf", import.meta.url);
@@ -17,6 +20,10 @@ const fontUrl = new URL("../fonts/JetBrainsMono-Regular.ttf", import.meta.url);
 async function codeFont(): Promise<Uint8Array> {
   return new Uint8Array(await Bun.file(fontUrl).arrayBuffer());
 }
+
+afterAll(() => {
+  configureBundledCodeFontLoader(codeFont);
+});
 
 function reverseObfuscation(bytes: Uint8Array, fontKey: string): Uint8Array {
   const compact = fontKey.replace(/[{}-]/gu, "");
@@ -129,5 +136,76 @@ describe("DOCX code-font embedding", () => {
     await expect(assertBundledCodeFont(changed)).rejects.toThrow(
       DocxFontEmbeddingError,
     );
+  });
+
+  it("shares concurrent and repeated loads, then retries after rejection", async () => {
+    const source = await codeFont();
+    let calls = 0;
+    configureBundledCodeFontLoader(async () => {
+      calls += 1;
+      if (calls === 1) throw new Error("transient font read");
+      return source;
+    });
+
+    await expect(loadBundledCodeFont()).rejects.toThrow("transient font read");
+    const [first, second] = await Promise.all([
+      loadBundledCodeFont(),
+      loadBundledCodeFont(),
+    ]);
+    expect(first).toBe(second);
+    expect(await loadBundledCodeFont()).toBe(first);
+    expect(calls).toBe(2);
+  });
+
+  it("does not let an obsolete rejection clear a replacement loader promise", async () => {
+    const source = await codeFont();
+    let rejectOld: (error: Error) => void = () => {};
+    configureBundledCodeFontLoader(
+      () => new Promise<Uint8Array>((_resolve, reject) => {
+        rejectOld = reject;
+      }),
+    );
+    const obsolete = loadBundledCodeFont();
+
+    let replacementCalls = 0;
+    configureBundledCodeFontLoader(async () => {
+      replacementCalls += 1;
+      return source;
+    });
+    const replacement = loadBundledCodeFont();
+    rejectOld(new Error("obsolete loader failed"));
+    await expect(obsolete).rejects.toThrow("obsolete loader failed");
+    expect(await replacement).toEqual(source);
+    expect(await loadBundledCodeFont()).toBe(await replacement);
+    expect(replacementCalls).toBe(1);
+  });
+
+  it("cancels only one preflight wait while shared initialization completes", async () => {
+    const source = await codeFont();
+    let resolveFont = (_bytes: Uint8Array): void => {};
+    const pendingFont = new Promise<Uint8Array>((resolve) => {
+      resolveFont = resolve;
+    });
+    let markLoaderStarted = (): void => {};
+    const loaderStarted = new Promise<void>((resolve) => {
+      markLoaderStarted = resolve;
+    });
+    let calls = 0;
+    configureBundledCodeFontLoader(() => {
+      calls += 1;
+      markLoaderStarted();
+      return pendingFont;
+    });
+
+    const controller = new AbortController();
+    const cancelled = prepareDocxExportRuntime([], { signal: controller.signal });
+    await loaderStarted;
+    controller.abort(new Error("dialog dismissed"));
+    await expect(cancelled).rejects.toThrow("dialog dismissed");
+
+    resolveFont(source);
+    const warm = await prepareDocxExportRuntime([]);
+    expect(warm.codeFontBytes).toBe(source.byteLength);
+    expect(calls).toBe(1);
   });
 });

--- a/packages/docx/src/font-embedding.ts
+++ b/packages/docx/src/font-embedding.ts
@@ -292,7 +292,8 @@ export function configureBundledCodeFontLoader(loader: BundledCodeFontLoader): v
  * bundler's `new URL(..., import.meta.url)` asset transform.
  */
 export function loadBundledCodeFont(): Promise<Uint8Array> {
-  bundledCodeFontPromise ??= (async () => {
+  if (bundledCodeFontPromise) return bundledCodeFontPromise;
+  const promise = (async () => {
     if (hostCodeFontLoader) return hostCodeFontLoader();
     // Keep this path literal so browser bundlers can discover and copy the asset.
     const url = new URL("../fonts/JetBrainsMono-Regular.ttf", import.meta.url);
@@ -304,8 +305,11 @@ export function loadBundledCodeFont(): Promise<Uint8Array> {
     }
     return new Uint8Array(await response.arrayBuffer());
   })();
-  bundledCodeFontPromise.catch(() => {
-    bundledCodeFontPromise = undefined;
+  bundledCodeFontPromise = promise;
+  promise.catch(() => {
+    // A host may install a replacement loader while an older request is still
+    // in flight. Only the promise that still owns the cache may clear it.
+    if (bundledCodeFontPromise === promise) bundledCodeFontPromise = undefined;
   });
-  return bundledCodeFontPromise;
+  return promise;
 }

--- a/packages/docx/src/index.browser.ts
+++ b/packages/docx/src/index.browser.ts
@@ -43,6 +43,11 @@ export type {
   PreparedDocxRenderStateV1,
   RenderPreparedDocxExportInput,
 } from "./export.js";
+export { prepareDocxExportRuntime } from "./runtime-preparation.js";
+export type {
+  DocxExportRuntimePreparation,
+  PrepareDocxExportRuntimeOptions,
+} from "./runtime-preparation.js";
 
 // --- Types transitively required by the seams above (closure-enforced) but
 // whose implementation modules stay behind ./scan and ./internal. ---

--- a/packages/docx/src/runtime-preparation.ts
+++ b/packages/docx/src/runtime-preparation.ts
@@ -1,0 +1,103 @@
+import type { CodeThemeId } from "@atlcli/code-highlight/registry";
+import type { ExportBlock } from "@atlcli/confluence";
+
+export interface PrepareDocxExportRuntimeOptions {
+  codeTheme?: CodeThemeId;
+  /**
+   * Cancels only this caller's wait. Shared highlighter/font initialization
+   * continues so one dismissed dialog cannot poison another caller's cache.
+   */
+  signal?: AbortSignal;
+}
+
+/** Local intent-to-ready evidence. Export/render timing remains in ExportReport. */
+export interface DocxExportRuntimePreparation {
+  totalMs: number;
+  highlightingMs: number;
+  codeFontMs: number;
+  codeFontBytes: number;
+}
+
+function nowMs(): number {
+  return typeof performance === "undefined" ? Date.now() : performance.now();
+}
+
+function abortReason(signal: AbortSignal): unknown {
+  return signal.reason ??
+    new DOMException("DOCX runtime preparation was cancelled.", "AbortError");
+}
+
+/**
+ * Race one caller against cancellation without passing its signal into shared
+ * package initialization. The owned promise keeps rejection handlers attached
+ * even when the caller leaves early.
+ */
+function waitForCaller<T>(operation: Promise<T>, signal?: AbortSignal): Promise<T> {
+  if (!signal) return operation;
+  if (signal.aborted) return Promise.reject(abortReason(signal));
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = (): void => {
+      cleanup();
+      reject(abortReason(signal));
+    };
+    const cleanup = (): void => signal.removeEventListener("abort", onAbort);
+    signal.addEventListener("abort", onAbort, { once: true });
+    operation.then(
+      (value) => {
+        cleanup();
+        resolve(value);
+      },
+      (error) => {
+        cleanup();
+        reject(error);
+      },
+    );
+  });
+}
+
+/**
+ * Warm the complete deterministic DOCX render runtime after explicit intent.
+ *
+ * Highlighting is conditional on the known block tree. The bundled code font
+ * is deliberately unconditional: inline code and included content can require
+ * it without appearing in the initial code-block scan. Rendering still embeds
+ * the font only when the produced OOXML uses it.
+ */
+export async function prepareDocxExportRuntime(
+  blocks: readonly ExportBlock[],
+  options: PrepareDocxExportRuntimeOptions = {},
+): Promise<DocxExportRuntimePreparation> {
+  const startedAt = nowMs();
+  options.signal?.throwIfAborted();
+
+  let highlightingMs = 0;
+  let codeFontMs = 0;
+  let codeFontBytes = 0;
+
+  const highlighting = (async () => {
+    const phaseStartedAt = nowMs();
+    const module = await import("./code-highlighting.js");
+    await module.prepareDocxCodeHighlighting(blocks, {
+      ...(options.codeTheme ? { codeTheme: options.codeTheme } : {}),
+    });
+    highlightingMs = nowMs() - phaseStartedAt;
+  })();
+  const codeFont = (async () => {
+    const phaseStartedAt = nowMs();
+    const module = await import("./font-embedding.js");
+    const bytes = await module.loadBundledCodeFont();
+    await module.assertBundledCodeFont(bytes);
+    codeFontBytes = bytes.byteLength;
+    codeFontMs = nowMs() - phaseStartedAt;
+  })();
+  const operation = Promise.all([highlighting, codeFont]);
+
+  await waitForCaller(operation, options.signal);
+  options.signal?.throwIfAborted();
+  return {
+    totalMs: nowMs() - startedAt,
+    highlightingMs,
+    codeFontMs,
+    codeFontBytes,
+  };
+}

--- a/packages/export-wiring/src/jobs/typescript-docx-job-executor.ts
+++ b/packages/export-wiring/src/jobs/typescript-docx-job-executor.ts
@@ -11,6 +11,7 @@ import {
   type ResourceEstimateV1,
 } from "@atlcli/export-jobs";
 import {
+  prepareDocxExportRuntime,
   prepareDocxExport,
   renderPreparedDocxExport,
   type AssetFetcher,
@@ -755,6 +756,21 @@ export function createTypescriptDocxExportJobExecutor(
         if (!checkpoint) {
           // The heavy reservation deliberately precedes template bytes, PizZip,
           // asset fetch/decode, rasterization, and prepared-archive generation.
+          // Runtime preparation is intentionally outside PizZip state. Start it
+          // from the fully resolved block tree while the pinned template is
+          // read/hashed below; the font and known grammars are then warm before
+          // prepareDocxExport reaches serialization in this same host realm.
+          const runtimePreparation = prepareDocxExportRuntime(
+            resolvedInput!.blocks ?? [],
+            {
+              codeTheme: resolveCodeThemeId(request.options.codeTheme),
+              signal: context.signal,
+            },
+          );
+          // Template resolution can fail before the preparation is awaited.
+          // Keep a handler attached so that independent failure never becomes
+          // an unhandled rejection.
+          runtimePreparation.catch(() => {});
           let pinned = await options.templates.resolve({
             jobId: context.jobId,
             recordKey: request.template.recordKey,
@@ -774,6 +790,8 @@ export function createTypescriptDocxExportJobExecutor(
           };
           validateTemplateBinding(template, request);
           await reservation.reconcile({ templateBytes: template.byteLength, signal: context.signal });
+          await runtimePreparation;
+          throwIfAborted(context.signal);
 
           const progressChannel = engineProgress(context, now);
           let prepared: PreparedDocxExportV1 | undefined;

--- a/scripts/consumer-smoke.ts
+++ b/scripts/consumer-smoke.ts
@@ -125,7 +125,7 @@ export function packAll(destDir: string): Map<string, string> {
  * result to assert the heading landed in word/document.xml.
  */
 export const DOCX_SMOKE_MJS = `
-import { runExport } from "@atlcli/docx";
+import { prepareDocxExportRuntime, runExport } from "@atlcli/docx";
 import { buildDocx, para, readPart } from "@atlcli/docx/fixtures";
 import { unzipDocx } from "@atlcli/docx/scan";
 import { storageToBlocks } from "@atlcli/confluence";
@@ -152,6 +152,29 @@ if (!Array.isArray(blocks) || blocks.length < 2) {
   throw new Error(\`storageToBlocks produced \${blocks?.length} blocks, expected >= 2\`);
 }
 if (!Array.isArray(notes)) throw new Error("storageToBlocks returned no notes array");
+
+// The public Node contract must use the package-relative font loader, never a
+// browser/global fetch. Concurrent and repeated calls share that one load.
+const originalFetch = globalThis.fetch;
+globalThis.fetch = async () => {
+  throw new Error("DOCX Node preparation attempted a network fetch");
+};
+let prepared;
+try {
+  const concurrent = await Promise.all([
+    prepareDocxExportRuntime(blocks),
+    prepareDocxExportRuntime(blocks),
+  ]);
+  prepared = await prepareDocxExportRuntime(blocks);
+  if (concurrent.some((result) => result.codeFontBytes !== 273900)) {
+    throw new Error("concurrent DOCX preparation did not load the committed code font");
+  }
+} finally {
+  globalThis.fetch = originalFetch;
+}
+if (prepared.codeFontBytes !== 273900) {
+  throw new Error("warm DOCX preparation did not retain the committed code font");
+}
 
 const templateBytes = buildDocx({ body: para("$scroll.title") + para("$scroll.content") });
 

--- a/specs/issue-110-docx-runtime-preparation/EVIDENCE.md
+++ b/specs/issue-110-docx-runtime-preparation/EVIDENCE.md
@@ -1,0 +1,46 @@
+# Issue 110 verification evidence
+
+Verified on 2026-07-27.
+
+## Runtime contract
+
+- Focused DOCX font/runtime tests: 19 passed. Covers single-flight loading,
+  rejection retry, loader replacement race, caller-only cancellation, nested
+  grammar discovery, and warm repeated preparation.
+- Browser Chromium trace: 2 passed. A fresh context emitted one same-origin
+  `JetBrainsMono-Regular-*.ttf` request after intent and before export; the
+  export and warm repeat emitted none. Cold/prepared DOCX bytes were equal.
+  A failed first font request was retryable in the same realm.
+- Full workspace suite: 5,475 passed, 12 environment-gated tests skipped,
+  0 failed.
+
+## Host boundaries
+
+- Production build: all 17 build tasks passed. Harness and MV3 output each
+  contained exactly one 273,900-byte DOCX code-font asset.
+- Browser/isomorphism gate: all 21 entry points passed.
+- Harness and MV3 output scans passed with the code-font count and SHA-256
+  inventory requirement.
+- Packed MV3 Chromium test passed through side panel message, service worker,
+  productive offscreen preparation, durable DOCX execution, PizZip,
+  docxtemplater, Mermaid/canvas rasterization, and syntax highlighting.
+- Workspace, extension, PDF compiler, and browser-harness typechecks passed.
+
+## Package and CLI consumers
+
+- Frozen API report and transitive closure guards passed from fresh `dist/`.
+- A packed npm project under Node 22.18 imported every supported entry point,
+  passed NodeNext typechecking with `skipLibCheck: false`, prepared DOCX
+  runtime without a network fetch, and produced real DOCX/PDF files.
+- A packed Bun project performed the same real DOCX/PDF consumer smoke.
+- Source, bundled, and compiled-executable CLI font modes all passed.
+
+## Live E2E
+
+- A read-only single-page export from the required DOCSY environment completed
+  through the durable TypeScript DOCX job with the requested dark code theme.
+  The job fetched, composed, rendered, validated, staged, delivered, and
+  acknowledged one real DOCX with no warnings.
+- `unzip -t` accepted every generated part. The no-code page correctly omitted
+  font parts even though runtime preparation warmed the font unconditionally.
+- No remote resource was created or modified, so no tenant cleanup was needed.

--- a/specs/issue-110-docx-runtime-preparation/PLAN.md
+++ b/specs/issue-110-docx-runtime-preparation/PLAN.md
@@ -1,0 +1,47 @@
+# Issue 110: complete DOCX runtime preparation
+
+## Goal
+
+Add one public, isomorphic intent-time contract that prepares every
+deterministic DOCX runtime asset before the first render: known Shiki grammars
+and the committed JetBrains Mono code font. Page attachment bytes remain
+generation-bound.
+
+## Decisions
+
+1. `prepareDocxExportRuntime(blocks, options)` is additive and available from
+   the Node, browser, and browser-runtime entry points.
+2. Highlighting is prepared from the supplied nested block tree. The code font
+   is warmed and checksum-validated unconditionally after explicit DOCX intent.
+   Actual OOXML embedding remains conditional on rendered code semantics.
+3. Highlighting and font preparation start concurrently. The existing
+   `loadBundledCodeFont()` promise remains the only font cache.
+4. Caller cancellation stops only that caller's wait. Shared preparation keeps
+   running and remains usable by later calls.
+5. `prepareDocxExport()` retains its render-time font check as the correctness
+   fallback for included or otherwise later-discovered content.
+6. Durable jobs call the same public contract in their productive render realm.
+   The extension also sends a bounded intent hint to its offscreen realm; it
+   never sends page or attachment bytes through runtime messaging.
+
+## Implementation order
+
+1. Add the engine API, timings, cache-race fix, and focused regression tests.
+2. Wire durable DOCX jobs, compiled CLI loading, and the MV3 offscreen intent
+   path.
+3. Extend browser/consumer/MV3 proofs for cold, warm, retry, output parity, and
+   browser boundaries.
+4. Regenerate API reports and update package/reference documentation.
+
+## Verification
+
+- Focused DOCX, export-wiring, CLI, extension protocol, and consumer tests.
+- Browser build and boundary scans for Node builtins and remote assets.
+- Browser export harness resource timing with one same-origin TTF request before
+  render, no repeat request, retry after a failed request, and byte parity.
+- Packed MV3 side-panel/offscreen and durable-job proof.
+- Workspace typecheck and a real `mayflower` / `DOCSY` CLI export before commit.
+
+## Unresolved questions
+
+None.

--- a/src/content/docs/reference/asset-contract.md
+++ b/src/content/docs/reference/asset-contract.md
@@ -5,14 +5,16 @@ description: "Stable @atlcli/* asset subpaths (wasm, fonts, licenses) and how bu
 
 # Export Asset Contract (`?url` subpaths)
 
-The PDF and DOCX engines never bundle their binary runtime assets. Instead the packages expose
-them at **stable subpaths**, and every host — CLI, extension, harness, or an external bundler —
-loads bytes itself and injects them through the engine seams
-(`BrowserPdfCompilerAssets`, `ExportEnv`). This page is the contract those subpaths follow.
+The export packages expose binary runtime assets at **stable subpaths**. PDF
+hosts load and inject compiler/font bytes through `BrowserPdfCompilerAssets`.
+The DOCX package owns its code-font loader: Node reads the installed package
+file, browser bundlers emit a same-origin asset, and the compiled CLI injects
+its embedded copy. This page is the contract those subpaths follow.
 
 ## In this page
 
 - [Stable subpaths](#stable-subpaths)
+- [DOCX code-font loading](#docx-code-font-loading)
 - [`BrowserPdfCompilerAssets`](#browserpdfcompilerassets)
 - [Vite `?url` example](#vite-url-example)
 - [Ambient type declarations](#ambient-type-declarations)
@@ -27,11 +29,25 @@ loads bytes itself and injects them through the engine seams
 | `@atlcli/pdf-compiler-browser/wasm` | The vendored, CSP-patched typst.ts compiler wasm (`typst_ts_web_compiler_bg.wasm`) |
 | `@atlcli/pdf/fonts/<file>.ttf` | The ten sha256-pinned Source Sans 3 / Source Serif 4 / Source Code Pro TTFs |
 | `@atlcli/pdf/licenses/<file>` | The SIL OFL 1.1 license texts accompanying those fonts |
-| `@atlcli/docx/fonts/<file>` | The committed Inter / JetBrains Mono TTFs used by the CLI's SVG rasterizer |
+| `@atlcli/docx/fonts/<file>` | The committed Inter TTFs used by SVG rasterization and the JetBrains Mono face embedded for inline/block code |
 
 The canonical font/license list lives in code — `PDF_RUNTIME_ASSETS` (exported from
 `@atlcli/pdf`) — and `scripts/pack-check.test.ts` asserts the shipped tarball matches it
 exactly. Never hardcode a font list; iterate `PDF_RUNTIME_ASSETS.fonts`.
+
+## DOCX code-font loading
+
+`prepareDocxExportRuntime(blocks, options?)` resolves and validates the
+committed `JetBrainsMono-Regular.ttf` after explicit DOCX intent. The loader is
+single-flight and retryable. Browser bundlers discover the package-relative
+`new URL(..., import.meta.url)` and emit exactly one local asset; callers do
+not pass a font URL or fetch callback. Node/Bun resolve the installed package
+file instead. The browser harness and MV3 output scans pin the asset's SHA-256
+and require exactly one emitted copy.
+
+Preparation loads the font unconditionally because included content or inline
+code may need it after the initial block scan. The render path still embeds
+the font into OOXML only when the final document contains code.
 
 ## `BrowserPdfCompilerAssets`
 

--- a/src/content/docs/reference/docx-engine.md
+++ b/src/content/docs/reference/docx-engine.md
@@ -70,21 +70,32 @@ an unused WASM chunk. Once the first highlighter initializes, the engine is
 locked because its grammar and highlighter caches cannot safely be reused by a
 different implementation.
 
-After explicit DOCX intent, a browser host can start an awaitable preload:
+After explicit DOCX intent, every host can start an awaitable preparation of
+the complete first-render runtime:
 
 ```ts
 import "@atlcli/docx/browser-runtime";
-import { prepareDocxCodeHighlighting } from "@atlcli/docx/browser-runtime";
+import { prepareDocxExportRuntime } from "@atlcli/docx/browser-runtime";
 
-await prepareDocxCodeHighlighting(blocks, { codeTheme: "github-light" });
+const preparation = await prepareDocxExportRuntime(blocks, {
+  codeTheme: "github-light",
+  signal: dialogSignal,
+});
 ```
 
-The walker includes nested callouts, lists, layouts, tables, block quotes,
+The preparation walks nested callouts, lists, layouts, tables, block quotes,
 expands, and orientation regions. It canonicalizes aliases, ignores unknown
-languages and Mermaid, and loads each known grammar once. Concurrent and
-repeated calls share the same cache promises. A modal can therefore start the
-preload when it opens and enable export after the promise settles, without
-adding Shiki work to ordinary Confluence page views.
+languages and Mermaid, and loads each known grammar once. In parallel it loads,
+validates, and caches the pinned `JetBrainsMono-Regular.ttf`, even when the
+initial block scan contains no code; included content or inline code can still
+need it. Rendering embeds the font only when the produced document uses code.
+
+Concurrent and repeated calls share the same cache promises. A failed load is
+retryable. Aborting `signal` cancels only that caller's wait, not shared
+initialization. `preparation` reports `totalMs`, `highlightingMs`, `codeFontMs`,
+and `codeFontBytes`; these local intent-to-ready timings are separate from
+`ExportReport.timings`. Start this from a DOCX modal, Word-template selection,
+or explicit export action. Do not run it on ordinary page attachment.
 
 Hosts must pin the resolved theme in durable requests before preparation.
 Historical prepared `/1` checkpoints without the additive field resume as
@@ -364,10 +375,11 @@ therefore does not need a system copy of JetBrains Mono. Documents without code
 omit those parts.
 
 The package entry point loads the face from `@atlcli/docx/fonts/` under
-Node/Bun; browser bundlers emit it as a local asset, and the compiled CLI passes
-its embedded copy into the same engine. Inline code keeps its distinct
-background and exact text, while block code retains the separate full-width
-style and syntax coloring.
+Node/Bun; browser bundlers emit one same-origin local asset, and the compiled
+CLI passes its embedded copy into the same engine. `prepareDocxExportRuntime`
+warms and validates that exact loader before rendering. Inline code keeps its
+distinct background and exact text, while block code retains the separate
+full-width style and syntax coloring.
 
 ### Logo placeholders
 

--- a/src/content/docs/reference/export-api.md
+++ b/src/content/docs/reference/export-api.md
@@ -63,6 +63,9 @@ entrypoint's full symbol list and transitive type closure is committed and CI-gu
 `@atlcli/docx` (spec 006).
 
 - `runExport(input: RunExportInput, env: ExportEnv)` → `ExportReport`.
+- `prepareDocxExportRuntime(blocks, options?)` → `DocxExportRuntimePreparation` — intent-time,
+  isomorphic preparation of known highlighting grammars plus the bundled code font. Concurrent
+  and repeated calls share work; cancellation stops only the requesting wait.
 - `ExportEnv` seams: `TemplateSource`, `AssetFetcher`, `OutputSink`, `SvgRasterizer` — hosts
   inject them; nothing assumes a browser or Node.
 - Node adapters (stable, exported from the barrel): `fileTemplateSource`, `fileOutputSink`,
@@ -206,8 +209,8 @@ Explicitly **not** part of the freeze:
   are not); export-macros' concrete renderer instances + helpers.
 - `@atlcli/docx/scan` and `@atlcli/docx/fixtures` (dev/test API), `@atlcli/pdf/template`
   (raw Typst template), `./browser-runtime` and `./vite` (host bootstrap, experimental).
-  The browser runtime also exports the awaitable, idempotent
-  `prepareDocxCodeHighlighting(blocks, options?)` intent-time preload.
+  The browser runtime also re-exports stable `prepareDocxExportRuntime`; its narrower
+  `prepareDocxCodeHighlighting(blocks, options?)` compatibility helper remains experimental.
 - The 0.x packages: `@atlcli/core`, `@atlcli/diagram`, `@atlcli/jira`, `@atlcli/plugin-api`,
   `@atlcli/template-pack`, `@atlcli/export-node` — see the freeze table in
   [Package Versioning](/reference/versioning/) for the per-package reasoning. Types owned by

--- a/src/content/docs/reference/package-consumption.md
+++ b/src/content/docs/reference/package-consumption.md
@@ -130,8 +130,14 @@ The engine is driven through injected host seams (`ExportEnv`) — no filesystem
 assumptions:
 
 ```ts
-import { runExport } from "@atlcli/docx";
+import { prepareDocxExportRuntime, runExport } from "@atlcli/docx";
+import { storageToBlocks } from "@atlcli/confluence";
 import { readFile, writeFile } from "node:fs/promises";
+
+// Start after explicit DOCX intent. Node loads the font from the installed
+// package; no browser fetch or system font is involved.
+const { blocks } = storageToBlocks(pageDetails.storage ?? "");
+await prepareDocxExportRuntime(blocks);
 
 const report = await runExport(
   {


### PR DESCRIPTION
## Summary

- add the public, isomorphic `prepareDocxExportRuntime` contract to warm known Shiki grammars and validate the bundled code font after explicit DOCX intent
- wire the durable CLI, Node/Bun, browser harness, and MV3 offscreen hosts without sending page or attachment bytes over runtime messaging
- harden single-flight retry, cancellation, and cache replacement while pinning browser output inventory, docs, and API snapshots

Closes #110

## Why

The first DOCX render could still pay for the code-font load after highlighting preload, and browser hosts lacked one awaitable complete-runtime contract. The preflight is now intent-scoped: ordinary page attachment remains unchanged, and font embedding stays conditional on rendered code.

## Validation

- `bun run test` — 5,475 passed, 12 skipped, 0 failed
- `bun run build` — 17 tasks passed
- `bun run typecheck`
- `bun run check:browser`
- Chromium resource trace — one same-origin preflight TTF request, no render or repeat request, retry and byte parity verified
- packed MV3 offscreen DOCX test
- isolated npm/Node 22 and Bun tarball consumers
- live read-only Confluence DOCX export; no remote resource created