### PR TITLE
perf(docx): add ordered browser intent entry

### DIFF
--- a/apps/browser-export-harness/scripts/check-output.ts
+++ b/apps/browser-export-harness/scripts/check-output.ts
@@ -157,6 +157,9 @@ export function validateHarnessInventory(artifacts: OutputArtifact[]): string[] 
   if (!artifacts.some((artifact) => artifact.path === "index.html")) {
     issues.push("entry HTML: missing index.html");
   }
+  if (!artifacts.some((artifact) => artifact.path === "topology.html")) {
+    issues.push("topology HTML: missing topology.html");
+  }
   issues.push(...requireOne(
     artifacts,
     "PDF compiler Worker",

--- a/apps/browser-export-harness/src/adf-source-case.ts
+++ b/apps/browser-export-harness/src/adf-source-case.ts
@@ -1,8 +1,10 @@
 /** Browser conformance that starts with real ADF before either render engine. */
 import type { TreeSource } from "@atlcli/confluence";
-import { runExport } from "@atlcli/docx/browser";
-import { memoryTemplateSource } from "@atlcli/docx/browser-runtime";
-import { unzipDocx } from "@atlcli/docx/scan";
+import {
+  memoryTemplateSource,
+  runExport,
+  unzipDocx,
+} from "@atlcli/docx/browser-entry";
 import {
   ADF_CODE_BLOCK_SOURCE,
   ADF_CONFORMANCE_MEDIA_ATTACHMENTS,

--- a/apps/browser-export-harness/src/app.ts
+++ b/apps/browser-export-harness/src/app.ts
@@ -1,6 +1,14 @@
+import { runExport } from "@atlcli/docx/browser-entry";
 import "./style.css";
 import "./highlight-benchmark.js";
 import { CONFORMANCE_CASES } from "./conformance-registry.js";
+
+if (typeof runExport !== "function") {
+  throw new Error("The canonical DOCX browser entry did not expose runExport.");
+}
+(globalThis as typeof globalThis & {
+  __ATLCLI_DOCX_BROWSER_ENTRY_READY_AT?: number;
+}).__ATLCLI_DOCX_BROWSER_ENTRY_READY_AT = performance.now();
 
 function required<T extends Element>(selector: string): T {
   const element = document.querySelector<T>(selector);

--- a/apps/browser-export-harness/src/blocks-case.ts
+++ b/apps/browser-export-harness/src/blocks-case.ts
@@ -12,9 +12,11 @@
  * Emits a PDF sha256 digest + report projection for the shape-parity gate.
  */
 import { validatePdfOutput, type PdfExportReport } from "@atlcli/pdf/browser";
-import { runExport } from "@atlcli/docx/browser";
-import { memoryTemplateSource } from "@atlcli/docx/browser-runtime";
-import { unzipDocx } from "@atlcli/docx/scan";
+import {
+  memoryTemplateSource,
+  runExport,
+  unzipDocx,
+} from "@atlcli/docx/browser-entry";
 import {
   BLOCKS_ALL_FIELDS,
   BLOCKS_DETAILS,
@@ -52,7 +54,10 @@ export interface BlocksCaseResult {
   digests: Record<string, string>;
 }
 
-async function runDocx(): Promise<{ report: import("@atlcli/docx/browser").ExportReport; bytes: Uint8Array }> {
+async function runDocx(): Promise<{
+  report: import("@atlcli/docx/browser-entry").ExportReport;
+  bytes: Uint8Array;
+}> {
   const output = new MemoryOutputSink();
   const report = await runExport(
     {

--- a/apps/browser-export-harness/src/content-case.ts
+++ b/apps/browser-export-harness/src/content-case.ts
@@ -12,9 +12,11 @@
  * Emits a PDF sha256 digest + report projection for the shape-parity gate.
  */
 import { validatePdfOutput } from "@atlcli/pdf/browser";
-import { runExport } from "@atlcli/docx/browser";
-import { memoryTemplateSource } from "@atlcli/docx/browser-runtime";
-import { unzipDocx } from "@atlcli/docx/scan";
+import {
+  memoryTemplateSource,
+  runExport,
+  unzipDocx,
+} from "@atlcli/docx/browser-entry";
 import {
   CONTENT_COMPAT_DETAILS,
   CONTENT_COMPAT_METADATA,

--- a/apps/browser-export-harness/src/docx-case.ts
+++ b/apps/browser-export-harness/src/docx-case.ts
@@ -1,9 +1,9 @@
 import {
   canvasSvgRasterizer,
   memoryTemplateSource,
-} from "@atlcli/docx/browser-runtime";
-import { runExport } from "@atlcli/docx/browser";
-import { unzipDocx } from "@atlcli/docx/scan";
+  runExport,
+  unzipDocx,
+} from "@atlcli/docx/browser-entry";
 import {
   DOCX_DETAILS,
   DOCX_EXPECTED,

--- a/apps/browser-export-harness/src/docx-job-parity-case.ts
+++ b/apps/browser-export-harness/src/docx-job-parity-case.ts
@@ -2,10 +2,10 @@ import {
   exportDocx,
   prepareDocxExport,
   renderPreparedDocxExport,
+  canvasSvgRasterizer,
   type ExportInput,
   type SvgRasterizer,
-} from "@atlcli/docx/browser";
-import { canvasSvgRasterizer } from "@atlcli/docx/browser-runtime";
+} from "@atlcli/docx/browser-entry";
 import type {
   DocxExportJobRequestV1,
   ExportJobExecutionContext,

--- a/apps/browser-export-harness/src/docx-job-parity.ts
+++ b/apps/browser-export-harness/src/docx-job-parity.ts
@@ -1,5 +1,7 @@
-import type { ExportReport } from "@atlcli/docx/browser";
-import { unzipDocx } from "@atlcli/docx/scan";
+import {
+  unzipDocx,
+  type ExportReport,
+} from "@atlcli/docx/browser-entry";
 
 export interface DocxParityRun {
   bytes: Uint8Array;

--- a/apps/browser-export-harness/src/docx-quality-case.ts
+++ b/apps/browser-export-harness/src/docx-quality-case.ts
@@ -10,9 +10,13 @@
  *     unused-style warning (the level-1 heading emits the referenced style),
  *   - the engine emits no warning notes.
  */
-import { runExport } from "@atlcli/docx/browser";
-import { canvasSvgRasterizer, memoryTemplateSource } from "@atlcli/docx/browser-runtime";
-import { unzipDocx } from "@atlcli/docx/scan";
+import {
+  canvasSvgRasterizer,
+  memoryTemplateSource,
+  runExport,
+  unzipDocx,
+  type AssetFetcher,
+} from "@atlcli/docx/browser-entry";
 import {
   DOCX_QUALITY_BLOCKS,
   DOCX_QUALITY_DETAILS,
@@ -20,7 +24,6 @@ import {
   DOCX_QUALITY_SVG_FILENAME,
   DOCX_QUALITY_TEMPLATE_BYTES,
 } from "@atlcli/export-fixtures";
-import type { AssetFetcher } from "@atlcli/docx/browser";
 import { MemoryOutputSink } from "./memory-output.js";
 
 const svgAssets: AssetFetcher = {

--- a/apps/browser-export-harness/src/highlight-benchmark.ts
+++ b/apps/browser-export-harness/src/highlight-benchmark.ts
@@ -4,11 +4,11 @@ import {
   type CodeThemeId,
 } from "@atlcli/code-highlight";
 import type { ExportBlock } from "@atlcli/confluence";
-import { runExport } from "@atlcli/docx/browser";
 import {
   memoryTemplateSource,
   prepareDocxExportRuntime,
-} from "@atlcli/docx/browser-runtime";
+  runExport,
+} from "@atlcli/docx/browser-entry";
 import { DOCX_TEMPLATE_BYTES } from "@atlcli/export-fixtures";
 import { sha256Hex } from "./digest.js";
 import { MemoryOutputSink } from "./memory-output.js";
@@ -75,7 +75,8 @@ export interface HighlightBenchmarkResult {
   exportMs: number;
   preparation: Awaited<ReturnType<typeof prepareDocxExportRuntime>> | null;
   phases: {
-    runtimeReadyAt: number;
+    intentStartedAt: number;
+    entryReadyAt: number;
     preloadStartedAt: number;
     preloadEndedAt: number;
     exportStartedAt: number;
@@ -159,8 +160,10 @@ async function runHighlightBenchmark(
     exportMs,
     preparation,
     phases: {
-      runtimeReadyAt:
-        window.__ATLCLI_DOCX_BROWSER_RUNTIME_READY_AT ?? 0,
+      intentStartedAt:
+        window.__ATLCLI_DOCX_BROWSER_INTENT_STARTED_AT ?? 0,
+      entryReadyAt:
+        window.__ATLCLI_DOCX_BROWSER_ENTRY_READY_AT ?? 0,
       preloadStartedAt,
       preloadEndedAt,
       exportStartedAt,
@@ -238,7 +241,8 @@ async function prepareHighlightModules(
 
 declare global {
   interface Window {
-    __ATLCLI_DOCX_BROWSER_RUNTIME_READY_AT?: number;
+    __ATLCLI_DOCX_BROWSER_INTENT_STARTED_AT?: number;
+    __ATLCLI_DOCX_BROWSER_ENTRY_READY_AT?: number;
     __ATLCLI_DOCX_HIGHLIGHT_BENCHMARK?: (
       preload: boolean,
     ) => Promise<HighlightBenchmarkResult>;

--- a/apps/browser-export-harness/src/m1-case.ts
+++ b/apps/browser-export-harness/src/m1-case.ts
@@ -19,9 +19,11 @@
  * whichever the CLI side also produces — see `run-m1-acceptance.ts` for how the
  * `digestsMatch` verdict is derived.
  */
-import { runExport } from "@atlcli/docx/browser";
-import { memoryTemplateSource } from "@atlcli/docx/browser-runtime";
-import { unzipDocx } from "@atlcli/docx/scan";
+import {
+  memoryTemplateSource,
+  runExport,
+  unzipDocx,
+} from "@atlcli/docx/browser-entry";
 import {
   runPdfExport,
   validatePdfOutput,

--- a/apps/browser-export-harness/src/macro-case.ts
+++ b/apps/browser-export-harness/src/macro-case.ts
@@ -13,9 +13,11 @@
  * notes) for the shape-parity gate.
  */
 import { validatePdfOutput } from "@atlcli/pdf/browser";
-import { runExport } from "@atlcli/docx/browser";
-import { memoryTemplateSource } from "@atlcli/docx/browser-runtime";
-import { unzipDocx } from "@atlcli/docx/scan";
+import {
+  memoryTemplateSource,
+  runExport,
+  unzipDocx,
+} from "@atlcli/docx/browser-entry";
 import {
   countTables,
   countUnknown,

--- a/apps/browser-export-harness/src/main.ts
+++ b/apps/browser-export-harness/src/main.ts
@@ -1,9 +1,7 @@
-// This side-effect import must evaluate before any PizZip/docxtemplater module.
-// The actual application graph is therefore loaded dynamically, not statically.
-import "@atlcli/docx/browser-runtime";
+export {};
 
 (globalThis as typeof globalThis & {
-  __ATLCLI_DOCX_BROWSER_RUNTIME_READY_AT?: number;
-}).__ATLCLI_DOCX_BROWSER_RUNTIME_READY_AT = performance.now();
+  __ATLCLI_DOCX_BROWSER_INTENT_STARTED_AT?: number;
+}).__ATLCLI_DOCX_BROWSER_INTENT_STARTED_AT = performance.now();
 
 await import("./app.js");

--- a/apps/browser-export-harness/src/placeholder-case.ts
+++ b/apps/browser-export-harness/src/placeholder-case.ts
@@ -9,9 +9,11 @@
  *   - a self-include is caught by cycle protection (`includepage-cycle`),
  *   - the unsupported metadata placeholder degrades visibly (`placeholder-unsupported`).
  */
-import { runExport } from "@atlcli/docx/browser";
-import { memoryTemplateSource } from "@atlcli/docx/browser-runtime";
-import { unzipDocx } from "@atlcli/docx/scan";
+import {
+  memoryTemplateSource,
+  runExport,
+  unzipDocx,
+} from "@atlcli/docx/browser-entry";
 import {
   PLACEHOLDER_ROOT_DETAILS,
   PLACEHOLDER_TEMPLATE_BYTES,

--- a/apps/browser-export-harness/src/scope-case.ts
+++ b/apps/browser-export-harness/src/scope-case.ts
@@ -12,9 +12,11 @@
  * Emits a PDF sha256 digest + report projection for the shape-parity gate.
  */
 import { validatePdfOutput } from "@atlcli/pdf/browser";
-import { runExport } from "@atlcli/docx/browser";
-import { memoryTemplateSource } from "@atlcli/docx/browser-runtime";
-import { unzipDocx } from "@atlcli/docx/scan";
+import {
+  memoryTemplateSource,
+  runExport,
+  unzipDocx,
+} from "@atlcli/docx/browser-entry";
 import {
   composeScopeDocument,
   DOCX_TEMPLATE_BYTES,

--- a/apps/browser-export-harness/src/topology.ts
+++ b/apps/browser-export-harness/src/topology.ts
@@ -1,0 +1,55 @@
+export type DocxEntryTopologyMode = "legacy" | "combined";
+
+export interface DocxEntryTopologyResult {
+  mode: DocxEntryTopologyMode;
+  startedAt: number;
+  runtimeReadyAt?: number;
+  entryReadyAt: number;
+  readyMs: number;
+  hasRunExport: boolean;
+  hasPreparation: boolean;
+}
+
+/**
+ * Isolated production-build probe for #123.
+ *
+ * There are intentionally no static DOCX imports in this page. Navigation is
+ * the discovery baseline; the test invokes this function to create explicit
+ * DOCX intent and compares the old sequential pair with the combined entry.
+ */
+async function loadDocxEntry(
+  mode: DocxEntryTopologyMode,
+): Promise<DocxEntryTopologyResult> {
+  const startedAt = performance.now();
+  let runtimeReadyAt: number | undefined;
+  let api:
+    | typeof import("@atlcli/docx/browser")
+    | typeof import("@atlcli/docx/browser-entry");
+
+  if (mode === "legacy") {
+    await import("@atlcli/docx/browser-runtime");
+    runtimeReadyAt = performance.now();
+    api = await import("@atlcli/docx/browser");
+  } else {
+    api = await import("@atlcli/docx/browser-entry");
+  }
+
+  const entryReadyAt = performance.now();
+  return {
+    mode,
+    startedAt,
+    ...(runtimeReadyAt === undefined ? {} : { runtimeReadyAt }),
+    entryReadyAt,
+    readyMs: entryReadyAt - startedAt,
+    hasRunExport: typeof api.runExport === "function",
+    hasPreparation: typeof api.prepareDocxExportRuntime === "function",
+  };
+}
+
+declare global {
+  interface Window {
+    __ATLCLI_LOAD_DOCX_ENTRY?: typeof loadDocxEntry;
+  }
+}
+
+window.__ATLCLI_LOAD_DOCX_ENTRY = loadDocxEntry;

--- a/apps/browser-export-harness/tests/boundaries.test.ts
+++ b/apps/browser-export-harness/tests/boundaries.test.ts
@@ -18,10 +18,21 @@ function sourceFiles(path: string): string[] {
 }
 
 describe("browser harness boundaries", () => {
-  it("bootstraps the DOCX runtime before dynamically loading the app graph", () => {
-    const source = read("src/main.ts");
-    expect(source.indexOf(`@atlcli/docx/browser-runtime`)).toBeLessThan(source.indexOf(`import("./app.js")`));
-    expect(source).not.toMatch(/from\s+["']@atlcli\/docx\/browser["']/);
+  it("loads one combined DOCX entry inside the explicit app-intent graph", () => {
+    const main = read("src/main.ts");
+    const app = read("src/app.ts");
+    const combined = sourceFiles("src")
+      .map((path) => readFileSync(path, "utf8"))
+      .join("\n");
+    expect(main).toContain(`import("./app.js")`);
+    expect(main).not.toContain("@atlcli/docx/browser-runtime");
+    expect(main).not.toContain("@atlcli/docx/browser-entry");
+    expect(app.split("\n").find((line) => line.startsWith("import "))).toBe(
+      'import { runExport } from "@atlcli/docx/browser-entry";',
+    );
+    expect(combined).not.toMatch(
+      /from\s+["']@atlcli\/docx\/(?:browser|browser-runtime|scan)["']/,
+    );
   });
 
   it("uses relative Vite output and the package-owned DOCX defines", () => {

--- a/apps/browser-export-harness/tests/highlight-performance.e2e.ts
+++ b/apps/browser-export-harness/tests/highlight-performance.e2e.ts
@@ -6,6 +6,10 @@ import type {
   HighlightBenchmarkResult,
   RuntimePreparationBenchmarkResult,
 } from "../src/highlight-benchmark.js";
+import type {
+  DocxEntryTopologyMode,
+  DocxEntryTopologyResult,
+} from "../src/topology.js";
 
 const RESULT_DIR = resolve(
   dirname(fileURLToPath(import.meta.url)),
@@ -60,6 +64,115 @@ async function runRuntimePreparationInFreshContext(
         }));
       return { benchmark, resources };
     }, preloadCodeFont);
+  } finally {
+    await context.close();
+  }
+}
+
+interface EntryTopologyMeasurement {
+  result: DocxEntryTopologyResult;
+  beforeIntentResources: HighlightResourceTiming[];
+  resources: HighlightResourceTiming[];
+  warmResult: DocxEntryTopologyResult;
+  warmResources: HighlightResourceTiming[];
+  baselineJsHeapBytes: number;
+  peakJsHeapBytes: number;
+  readyJsHeapBytes: number;
+}
+
+type EntryTopologyPageMeasurement = Omit<
+  EntryTopologyMeasurement,
+  "baselineJsHeapBytes" | "peakJsHeapBytes" | "readyJsHeapBytes"
+>;
+
+function requestWaveCount(resources: readonly HighlightResourceTiming[]): number {
+  const sorted = [...resources].sort((left, right) => left.startTime - right.startTime);
+  if (sorted.length === 0) return 0;
+  let waves = 1;
+  let activeWaveEnd = sorted[0]!.responseEnd;
+  for (const resource of sorted.slice(1)) {
+    if (resource.startTime >= activeWaveEnd - 0.5) {
+      waves += 1;
+      activeWaveEnd = resource.responseEnd;
+    } else {
+      activeWaveEnd = Math.max(activeWaveEnd, resource.responseEnd);
+    }
+  }
+  return waves;
+}
+
+async function measureEntryTopology(
+  browser: Browser,
+  mode: DocxEntryTopologyMode,
+): Promise<EntryTopologyMeasurement> {
+  const context = await browser.newContext();
+  try {
+    const page = await context.newPage();
+    await page.route("**/*.js", async (route) => {
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      await route.continue();
+    });
+    await page.goto(`${HARNESS_URL}topology.html`);
+    await page.waitForFunction(
+      () => typeof window.__ATLCLI_LOAD_DOCX_ENTRY === "function",
+    );
+    const cdp = await context.newCDPSession(page);
+    await cdp.send("Performance.enable");
+    const jsHeapUsed = async (): Promise<number> => {
+      const { metrics } = await cdp.send("Performance.getMetrics");
+      return metrics.find(({ name }) => name === "JSHeapUsedSize")?.value ?? 0;
+    };
+    const baselineJsHeapBytes = await jsHeapUsed();
+    let peakJsHeapBytes = baselineJsHeapBytes;
+    let sampling = true;
+    const sampler = (async () => {
+      while (sampling) {
+        peakJsHeapBytes = Math.max(peakJsHeapBytes, await jsHeapUsed());
+        await new Promise((resolve) => setTimeout(resolve, 2));
+      }
+    })();
+    let measurement: EntryTopologyPageMeasurement;
+    try {
+      measurement = await page.evaluate(async (requestedMode) => {
+        const resources = (): HighlightResourceTiming[] =>
+          performance
+            .getEntriesByType("resource")
+            .map((entry) => entry as PerformanceResourceTiming)
+            .filter(({ name }) => /[.](?:js|ttf)$/u.test(new URL(name).pathname))
+            .map(({ name: url, startTime, responseEnd, transferSize, decodedBodySize }) => ({
+              url,
+              name: new URL(url).pathname.split("/").at(-1) ?? url,
+              startTime,
+              responseEnd,
+              transferSize,
+              decodedBodySize,
+            }));
+        const beforeIntentResources = resources();
+        performance.clearResourceTimings();
+        const load = window.__ATLCLI_LOAD_DOCX_ENTRY;
+        if (!load) throw new Error("DOCX entry topology hook is unavailable");
+        const result = await load(requestedMode);
+        const firstResources = resources();
+        performance.clearResourceTimings();
+        const warmResult = await load(requestedMode);
+        return {
+          result,
+          beforeIntentResources,
+          resources: firstResources,
+          warmResult,
+          warmResources: resources(),
+        };
+      }, mode);
+    } finally {
+      sampling = false;
+      await sampler;
+    }
+    return {
+      ...measurement,
+      baselineJsHeapBytes,
+      peakJsHeapBytes,
+      readyJsHeapBytes: await jsHeapUsed(),
+    };
   } finally {
     await context.close();
   }
@@ -128,6 +241,89 @@ test("empty DOCX preparation defers the code font unless preload is explicit", a
         warmFontRequestCount: warmExplicitFonts.length,
         sampledPeakJsHeapBytes:
           explicit.benchmark.sampledPeakJsHeapBytes,
+      },
+    }, null, 2)}\n`,
+  );
+});
+
+test("the combined DOCX entry removes the runtime-to-engine request wave", async ({
+  browser,
+}) => {
+  const legacy = await measureEntryTopology(browser, "legacy");
+  const combined = await measureEntryTopology(browser, "combined");
+  const legacyWaves = requestWaveCount(legacy.resources);
+  const combinedWaves = requestWaveCount(combined.resources);
+
+  expect(legacy.result.hasRunExport).toBe(true);
+  expect(legacy.result.hasPreparation).toBe(true);
+  expect(legacy.result.runtimeReadyAt).toBeDefined();
+  expect(combined.result.hasRunExport).toBe(true);
+  expect(combined.result.hasPreparation).toBe(true);
+  expect(combined.result.runtimeReadyAt).toBeUndefined();
+  expect(combinedWaves).toBeLessThan(legacyWaves);
+  expect(legacyWaves).toBeGreaterThanOrEqual(2);
+  expect(combinedWaves).toBe(1);
+  expect(
+    combined.beforeIntentResources.some(({ name }) =>
+      /(?:browser-entry|browser-runtime|index[.]browser|JetBrainsMono-Regular)/u.test(name),
+    ),
+  ).toBe(false);
+  expect(
+    combined.resources.some(({ name }) => CODE_FONT_RE.test(name)),
+  ).toBe(false);
+  expect(combined.warmResources).toEqual([]);
+  expect(legacy.warmResources).toEqual([]);
+  const legacyPeakHeapDelta =
+    legacy.peakJsHeapBytes - legacy.baselineJsHeapBytes;
+  const combinedPeakHeapDelta =
+    combined.peakJsHeapBytes - combined.baselineJsHeapBytes;
+  expect(combinedPeakHeapDelta).toBeLessThanOrEqual(
+    legacyPeakHeapDelta + 1024 * 1024,
+  );
+
+  mkdirSync(RESULT_DIR, { recursive: true });
+  writeFileSync(
+    resolve(RESULT_DIR, "entry-topology.json"),
+    `${JSON.stringify({
+      legacy: {
+        ...legacy.result,
+        requestWaves: legacyWaves,
+        requestCount: legacy.resources.length,
+        transferBytes: legacy.resources.reduce(
+          (total, resource) => total + resource.transferSize,
+          0,
+        ),
+        decodedBytes: legacy.resources.reduce(
+          (total, resource) => total + resource.decodedBodySize,
+          0,
+        ),
+        baselineJsHeapBytes: legacy.baselineJsHeapBytes,
+        peakJsHeapBytes: legacy.peakJsHeapBytes,
+        peakJsHeapDeltaBytes: legacyPeakHeapDelta,
+        readyJsHeapBytes: legacy.readyJsHeapBytes,
+        resources: legacy.resources,
+        warmMs: legacy.warmResult.readyMs,
+        warmResources: legacy.warmResources,
+      },
+      combined: {
+        ...combined.result,
+        requestWaves: combinedWaves,
+        requestCount: combined.resources.length,
+        transferBytes: combined.resources.reduce(
+          (total, resource) => total + resource.transferSize,
+          0,
+        ),
+        decodedBytes: combined.resources.reduce(
+          (total, resource) => total + resource.decodedBodySize,
+          0,
+        ),
+        baselineJsHeapBytes: combined.baselineJsHeapBytes,
+        peakJsHeapBytes: combined.peakJsHeapBytes,
+        peakJsHeapDeltaBytes: combinedPeakHeapDelta,
+        readyJsHeapBytes: combined.readyJsHeapBytes,
+        resources: combined.resources,
+        warmMs: combined.warmResult.readyMs,
+        warmResources: combined.warmResources,
       },
     }, null, 2)}\n`,
   );
@@ -379,7 +575,10 @@ test("DOCX highlighting is JavaScript-only and deterministic across fresh cold/p
   expect(preloaded.preparation?.codeFontBytes).toBe(273_900);
   expect(preloaded.preparation?.highlightingMs).toBeGreaterThan(0);
   expect(preloaded.preparation?.codeFontMs).toBeGreaterThan(0);
-  expect(preloaded.phases.runtimeReadyAt).toBeLessThan(
+  expect(preloaded.phases.intentStartedAt).toBeLessThanOrEqual(
+    preloaded.phases.entryReadyAt,
+  );
+  expect(preloaded.phases.entryReadyAt).toBeLessThan(
     preloaded.phases.preloadStartedAt,
   );
   expect(preloaded.timings.highlightEngineInitMs).toBe(0);

--- a/apps/browser-export-harness/tests/output-scan.test.ts
+++ b/apps/browser-export-harness/tests/output-scan.test.ts
@@ -65,6 +65,7 @@ describe("harness output content policy", () => {
 function completeInventory(): OutputArtifact[] {
   const artifacts: OutputArtifact[] = [
     { path: "index.html", size: 100 },
+    { path: "topology.html", size: 100 },
     { path: "assets/pdf-worker-abc.js", size: 100 },
     { path: "assets/typst_ts_web_compiler_bg-abc.wasm", size: 25_000_000 },
     {

--- a/apps/browser-export-harness/topology.html
+++ b/apps/browser-export-harness/topology.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>DOCX browser entry topology</title>
+  </head>
+  <body>
+    <main>
+      <h1>DOCX browser entry topology</h1>
+      <p>The test driver triggers legacy or combined loading after navigation.</p>
+    </main>
+    <script type="module" src="/src/topology.ts"></script>
+  </body>
+</html>

--- a/apps/browser-export-harness/vite.config.ts
+++ b/apps/browser-export-harness/vite.config.ts
@@ -1,9 +1,13 @@
 import { defineConfig } from "vite";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
 // Relative src import (not "@atlcli/docx/vite"): Vite loads this config with
 // Node-style resolution that does not request the "development" export
 // condition, so the package specifier would resolve to dist/ and break on a
 // fresh clone before any build exists.
 import { DOCX_BROWSER_VITE_DEFINES } from "../../packages/docx/src/vite";
+
+const root = dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
   base: "./",
@@ -24,5 +28,11 @@ export default defineConfig({
     target: "es2022",
     assetsInlineLimit: 0,
     sourcemap: false,
+    rollupOptions: {
+      input: {
+        main: resolve(root, "index.html"),
+        topology: resolve(root, "topology.html"),
+      },
+    },
   },
 });

--- a/apps/extension/entrypoints/offscreen/main.ts
+++ b/apps/extension/entrypoints/offscreen/main.ts
@@ -7,7 +7,6 @@
  * the exported `handleOffscreenMessage` adapter (utils/listeners.ts) so the
  * load-bearing `true` return is unit-tested.
  */
-import "@atlcli/docx/browser-runtime";
 import { handleOffscreenMessage } from "../../utils/listeners.js";
 import type {
   ExportJobExecutor,
@@ -111,7 +110,7 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) =>
     runPdfCancel: (jobId) => pdfHost.cancel(jobId),
     prepareDocxRuntime: async (codeTheme) => {
       const { prepareDocxExportRuntime } = await import(
-        "@atlcli/docx/browser-runtime"
+        "@atlcli/docx/browser-entry"
       );
       return prepareDocxExportRuntime([], {
         ...(codeTheme ? { codeTheme } : {}),

--- a/apps/extension/entrypoints/sidepanel/main.tsx
+++ b/apps/extension/entrypoints/sidepanel/main.tsx
@@ -1,6 +1,3 @@
-// Install the DOCX browser runtime BEFORE anything pulls in PizZip /
-// docxtemplater, whose rewritten byte-helper calls resolve to it (spec 009).
-import "@atlcli/docx/browser-runtime";
 // Tailwind v4 + the CSS-variable theme (spec 010 Phase 0). Imported by the host
 // entrypoint, never by a component, so the portable app layer stays importable
 // in a plain module runner that cannot parse CSS.

--- a/apps/extension/entrypoints/sidepanel/ports/docx.ts
+++ b/apps/extension/entrypoints/sidepanel/ports/docx.ts
@@ -15,7 +15,7 @@
  * (accumulating a library the panel has no UI for). The library UI is wave-2
  * work and replaces this adapter's `get`/`put`/`remove`, not the port.
  */
-import type { ScanResult } from "@atlcli/docx/scan";
+import type { ScanResult } from "@atlcli/docx/browser-entry";
 import { profileFromTabUrl } from "../../../utils/profile.js";
 import { idbTemplateLibrary, type IdbTemplateLibrary, type StoredTemplateEntry } from "../../../utils/templates/library.js";
 import type { DocxExportPort, DocxTemplateStore } from "../../../utils/ports/export.js";
@@ -23,7 +23,7 @@ import type { SiteContext } from "./site-context.js";
 
 // The scan stays panel-local and light. Export itself is a durable observer
 // adapter; PizZip/docxtemplater and canvas load only in the offscreen executor.
-const loadScan = () => import("@atlcli/docx/scan");
+const loadScan = () => import("@atlcli/docx/browser-entry");
 const loadRun = () => import("../../../utils/export-jobs/docx-run.js");
 
 function siteOriginOf(site: SiteContext): string | undefined {

--- a/apps/extension/tests/docx/bootstrap-boundary.test.ts
+++ b/apps/extension/tests/docx/bootstrap-boundary.test.ts
@@ -11,6 +11,10 @@ const offscreenSource = readFileSync(
   join(extensionRoot, "entrypoints", "offscreen", "main.ts"),
   "utf8"
 );
+const executorSource = readFileSync(
+  join(extensionRoot, "utils", "export-jobs", "docx-executor.ts"),
+  "utf8"
+);
 /**
  * The lazy-load boundary moved with the code it guards: spec 010 Phase 0 took
  * the DOCX effect half out of `TemplateSection.tsx` (now a compatibility
@@ -25,27 +29,29 @@ const templateSource = readFileSync(
 );
 
 describe("DOCX browser bootstrap boundary", () => {
-  it("installs the package runtime as the side-panel entry's first import", () => {
-    const firstImport = mainSource.split("\n").find((line) => line.startsWith("import "));
-    expect(firstImport).toBe('import "@atlcli/docx/browser-runtime";');
+  it("keeps the combined DOCX engine out of the discovery side-panel entry", () => {
+    expect(mainSource).not.toContain("@atlcli/docx/browser-entry");
+    expect(mainSource).not.toContain("@atlcli/docx/browser-runtime");
     expect(mainSource).not.toContain("byte-helpers-shim");
   });
 
-  it("installs the package runtime in the productive offscreen DOCX realm", () => {
-    const firstImport = offscreenSource
+  it("loads the combined entry first in the productive DOCX executor graph", () => {
+    const firstImport = executorSource
       .split("\n")
       .find((line) => line.startsWith("import "));
-    expect(firstImport).toBe('import "@atlcli/docx/browser-runtime";');
-    expect(offscreenSource.indexOf("@atlcli/docx/browser-runtime")).toBeLessThan(
-      offscreenSource.indexOf("docx-executor.js"),
+    expect(firstImport).toBe('import "@atlcli/docx/browser-entry";');
+    expect(offscreenSource).not.toMatch(/^import\s+["']@atlcli\/docx\//m);
+    expect(offscreenSource).toMatch(
+      /import\(\s*["']@atlcli\/docx\/browser-entry["']\s*\)/,
     );
+    expect(offscreenSource).toContain('"../../utils/export-jobs/docx-executor.js"');
   });
 
-  it("keeps runtime DOCX engine modules behind dynamic imports", () => {
+  it("keeps the combined DOCX engine behind scan/export intent imports", () => {
     const staticRuntimeImport =
-      /import\s+(?!type\b)[^;]*from\s+["']@atlcli\/docx\/(?:browser|scan)["']/;
+      /import\s+(?!type\b)[^;]*from\s+["']@atlcli\/docx\/browser-entry["']/;
     expect(templateSource).not.toMatch(staticRuntimeImport);
-    expect(templateSource).toContain('import("@atlcli/docx/scan")');
+    expect(templateSource).toContain('import("@atlcli/docx/browser-entry")');
     expect(templateSource).toContain('import("../../../utils/export-jobs/docx-run.js")');
   });
 });

--- a/apps/extension/tests/export-baseline/app.ts
+++ b/apps/extension/tests/export-baseline/app.ts
@@ -12,8 +12,12 @@ import codeBoldUrl from "@atlcli/pdf/fonts/SourceCodePro-Bold.ttf?url";
 import symbolsRegularUrl from "@atlcli/pdf/fonts/NotoSansSymbols2-Regular.ttf?url";
 import emojiRegularUrl from "@atlcli/pdf/fonts/NotoEmoji-wght.ttf?url";
 import { composeChapters, type ExportBlock } from "@atlcli/confluence/browser";
-import { runExport, type AssetFetcher, type OutputSink } from "@atlcli/docx/browser";
-import { memoryTemplateSource } from "@atlcli/docx/browser-runtime";
+import {
+  memoryTemplateSource,
+  runExport,
+  type AssetFetcher,
+  type OutputSink,
+} from "@atlcli/docx/browser-entry";
 import {
   DOCX_TEMPLATE_BYTES,
   digestLargeExportCorpus,

--- a/apps/extension/tests/jobs/docx-executor.test.ts
+++ b/apps/extension/tests/jobs/docx-executor.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "bun:test";
 import { IDBFactory, IDBKeyRange } from "fake-indexeddb";
 import { sha256Hex } from "@atlcli/core";
 import { buildDocx, para } from "@atlcli/docx/fixtures";
-import { prepareDocxExport } from "@atlcli/docx/browser";
+import { prepareDocxExport } from "@atlcli/docx/browser-entry";
 import type {
   DocxExportJobRequestV1,
   ExportJobRequestV1,

--- a/apps/extension/utils/docx/env.ts
+++ b/apps/extension/utils/docx/env.ts
@@ -4,7 +4,7 @@
  * extension's imperative shell: template bytes come from the IndexedDB store,
  * asset bytes ride the user's Atlassian session cookies, and the finished
  * document leaves through a browser download. Neutral memory/canvas support
- * comes from `@atlcli/docx/browser-runtime`; session, storage, cache, download,
+ * comes from `@atlcli/docx/browser-entry`; session, storage, cache, download,
  * and report policy remain here with the extension host.
  */
 import type {
@@ -13,11 +13,11 @@ import type {
   OutputSink,
   SvgRasterizer,
   TemplateSource,
-} from "@atlcli/docx/browser";
+} from "@atlcli/docx/browser-entry";
 import {
   canvasSvgRasterizer as neutralCanvasSvgRasterizer,
   memoryTemplateSource,
-} from "@atlcli/docx/browser-runtime";
+} from "@atlcli/docx/browser-entry";
 import type { ExternalAssetFetcher, ExternalAssetPolicy } from "@atlcli/export-macros";
 import { trustRoutingAssetFetcher } from "@atlcli/export-wiring";
 import {

--- a/apps/extension/utils/export-jobs/docx-executor.ts
+++ b/apps/extension/utils/export-jobs/docx-executor.ts
@@ -1,3 +1,7 @@
+// This is the extension's explicit DOCX-intent entry. Its first dependency
+// installs the browser runtime and pulls the engine into the same ordered graph
+// before export-wiring can evaluate its @atlcli/docx engine imports.
+import "@atlcli/docx/browser-entry";
 import {
   parseDocxExportJobRequestV1,
   type DocxExportJobRequestV1,

--- a/apps/extension/wxt.config.ts
+++ b/apps/extension/wxt.config.ts
@@ -81,7 +81,7 @@ export default defineConfig({
     // Spec 004: PizZip / docxtemplater reference the Node `Buffer.*` globals,
     // which are undefined in the MV3 panel and rejected by the output-scan gate.
     // Rewrite those member expressions to the browser-safe helpers installed by
-    // `@atlcli/docx/browser-runtime` (a real shim, not a scan suppression). Bare
+    // `@atlcli/docx/browser-entry` (a real shim, not a scan suppression). Bare
     // `typeof Buffer` (not a member access) is left alone — it correctly reads
     // as "undefined", keeping the libs on their Uint8Array feature-branch.
     define: { ...DOCX_BROWSER_VITE_DEFINES },

--- a/packages/docx/README.md
+++ b/packages/docx/README.md
@@ -9,7 +9,10 @@ browser and under Node/Bun; hosts inject template/asset/output seams via
   - `.` — `runExport`/`exportDocx`, the `ExportEnv` seams, placeholder
     classification, image handling, plus the Node filesystem adapters
     (`fileTemplateSource`, `fileOutputSink`, `resvgSvgRasterizer`).
-  - `./browser` — the same engine without Node adapters.
+  - `./browser-entry` — canonical browser-intent entry: installs the runtime
+    before the engine evaluates and exposes preparation, export, template-scan,
+    memory-template, and canvas-rasterizer capabilities in one graph.
+  - `./browser` — compatibility engine barrel without Node adapters.
   - `./browser-runtime` — browser bootstrap (installs the byte helpers;
     import before PizZip/docxtemplater run in a browser host), the
     JavaScript-only Shiki engine, and the runtime-preparation API.
@@ -37,19 +40,20 @@ Versioning: [package versioning](https://atlcli.sh/reference/versioning/).
 
 ## Intent-time runtime preparation
 
-Browser entrypoints must import the runtime before any static DOCX dependency:
+Browser hosts should load the ordered entry only after explicit DOCX intent:
 
 ```ts
-import "@atlcli/docx/browser-runtime";
+const {
+  prepareDocxExportRuntime,
+  runExport,
+} = await import("@atlcli/docx/browser-entry");
 ```
 
-After the user has expressed DOCX intent, a host can warm the complete
-first-render runtime:
+The entry installs the byte runtime before PizZip/docxtemplater evaluate, so
+hosts do not maintain their own sequential runtime-to-engine chain. They can
+then warm the complete first-render runtime:
 
 ```ts
-const { prepareDocxExportRuntime } =
-  await import("@atlcli/docx/browser-runtime");
-
 const preparation = await prepareDocxExportRuntime(blocks, {
   codeTheme: "github-light",
   preloadCodeFont: true,
@@ -68,6 +72,9 @@ modal, Word-template selection, or explicit export action keeps ordinary page
 loads untouched. The returned timings cover only intent-to-ready preparation;
 `ExportReport.timings` still describes render work. Browser builds use Shiki's
 JavaScript RegExp engine; Node/Bun imports use Oniguruma.
+
+`./browser` and `./browser-runtime` remain available for compatibility and
+specialized bundles. New intent hosts should use `./browser-entry`.
 
 ## Queued export engine seam
 

--- a/packages/docx/etc/docx.api.md
+++ b/packages/docx/etc/docx.api.md
@@ -983,6 +983,377 @@ export interface TemplateSource {
 }
 ```
 
+### Entry point `./browser-entry`
+
+```ts
+// export: ArchiveBudget
+export interface ArchiveBudget {
+    maxEntryCount: number;
+    maxUncompressedBytes: number;
+    maxSingleEntryUncompressedBytes: number;
+    maxXmlPartUncompressedBytes?: number;
+    maxXmlPartCharacters?: number;
+}
+
+// export: AssetFetcher
+export interface AssetFetcher {
+    fetch(ref: AssetRef, context?: HostCallContext): Promise<Uint8Array>;
+}
+
+// export: AssetRef
+export interface AssetRef {
+    url: string;
+    pageId?: string;
+    filename?: string;
+    trust?: "page" | "export-view";
+}
+
+// export: CanvasRasterizerTiming
+export interface CanvasRasterizerTiming {
+    decodeMs: number;
+    drawMs: number;
+    encodeMs: number;
+}
+
+// export: canvasSvgRasterizer
+export declare function canvasSvgRasterizer(options?: CanvasSvgRasterizerOptions): SvgRasterizer;
+
+// export: CanvasSvgRasterizerOptions
+export interface CanvasSvgRasterizerOptions {
+    document?: Document;
+    decodeTimeoutMs?: number;
+    onTiming?: (timing: CanvasRasterizerTiming) => void;
+}
+
+// export: CurrentUser
+export interface CurrentUser {
+    accountId: string;
+    displayName: string;
+    email?: string;
+}
+
+// export: DocxByteHelpers
+export interface DocxByteHelpers {
+    from(value: ArrayLike<number> | ArrayBuffer | string, encoding?: string): Uint8Array;
+    alloc(size: number): Uint8Array;
+    isBuffer(value: unknown): boolean;
+}
+
+// export: DocxErrorKind
+export type DocxErrorKind = "not-zip" | "not-docx" | "too-large" | "too-many-entries" | "path-traversal" | "invalid-path" | "entry-too-large" | "xml-part-too-large" | "uncompressed-too-large" | "suspicious-compression" | "corrupt-entry" | "active-content";
+
+// export: DocxExportRuntimePreparation
+export interface DocxExportRuntimePreparation {
+    totalMs: number;
+    highlightingMs: number;
+    codeFontMs: number;
+    codeFontBytes: number;
+}
+
+// export: DocxRenderError
+export declare class DocxRenderError extends Error {
+    readonly details: string[];
+    constructor(message: string, details: string[]);
+}
+
+// export: exportDocx
+export declare function exportDocx(input: ExportInput): Promise<ExportResult>;
+
+// export: ExportEnv
+export interface ExportEnv {
+    templates: TemplateSource;
+    assets?: AssetFetcher;
+    rasterizer?: SvgRasterizer;
+    macros?: MacroResolutionOptions;
+    output: OutputSink;
+}
+
+// export: ExportInput
+export interface ExportInput {
+    codeTheme?: CodeThemeId;
+    templateBytes: Uint8Array;
+    details: ConfluencePageDetails;
+    blocks?: ExportBlock[];
+    sourceNotes?: ExportNote[];
+    complete?: boolean;
+    signal?: AbortSignal;
+    onProgress?: ExportProgressCallback;
+    template: TemplateMeta;
+    exportDate?: Date;
+    deps?: ResolveDeps;
+    assets?: AssetFetcher;
+    embedImages?: boolean;
+    rasterizer?: SvgRasterizer;
+    diagramTheme?: DiagramTheme;
+    captionLang?: string;
+    exportControls?: "apply" | "passthrough";
+    macros?: MacroResolutionOptions;
+    tableStyle?: {
+        source: "template" | "confluence";
+        styleId?: string;
+    };
+    updateFields?: "auto" | "always" | "never";
+}
+
+// export: ExportReport
+export interface ExportReport {
+    codeTheme: CodeThemeId;
+    resolvedCount: number;
+    unsupportedNames: string[];
+    skippedImages: number;
+    embeddedImages: number;
+    renderedDiagrams: number;
+    durationMs: number;
+    filename: string;
+    notes: ExportNote[];
+    sourceNotes?: ExportNote[];
+    complete: boolean;
+    scan: ScanResult;
+    timings: ExportTimings;
+}
+
+// export: ExportResult
+export interface ExportResult {
+    bytes: Uint8Array;
+    report: ExportReport;
+}
+
+// export: ExportTimings
+export interface ExportTimings {
+    resolveMs: number;
+    bodyMs: number;
+    highlightEngineInitMs?: number;
+    highlightGrammarLoadMs?: number;
+    highlightTokenizeMs?: number;
+    highlightCodeBlocks?: number;
+    highlightLanguageCount?: number;
+    logoFetchMs: number;
+    includeFetchMs: number;
+    renderMs: number;
+    imageFetchMs: number;
+    imageFetches: number;
+    diagramRenderMs: number;
+    diagramRasterMs: number;
+}
+
+// export: HostCallContext
+export interface HostCallContext {
+    signal?: AbortSignal;
+}
+
+// export: IncludeLookupOutcome
+export type IncludeLookupOutcome = {
+    kind: "resolved";
+    page: IncludePageDetails;
+} | {
+    kind: "ambiguous";
+    count: number;
+    page: IncludePageDetails;
+} | {
+    kind: "not-found-or-forbidden";
+} | {
+    kind: "auth-failed";
+} | {
+    kind: "rate-limited";
+} | {
+    kind: "transient-error";
+    message: string;
+};
+
+// export: IncludePageDetails
+export type IncludePageDetails = ConfluencePageDetails & {
+    exportSource?: ExportPageSource;
+    mediaAttachments?: AdfMediaAttachment[];
+    mediaAttachmentsComplete?: boolean;
+    inlineComments?: InlineComment[];
+    inlineCommentsComplete?: boolean;
+};
+
+// export: IncludePageRef
+export interface IncludePageRef {
+    spaceKey?: string;
+    title?: string;
+    pageId?: string;
+}
+
+// export: installDocxBrowserRuntime
+export declare function installDocxBrowserRuntime(): void;
+
+// export: memoryTemplateSource
+export declare function memoryTemplateSource(bytes: ArrayBuffer | Uint8Array): TemplateSource;
+
+// export: NumberingAllocator
+export declare class NumberingAllocator {
+    private readonly base;
+    private readonly bulletAbstractId;
+    private nextAbstractId;
+    private nextNumId;
+    private bulletNumId;
+    private readonly orderedInstances;
+    private lastNumId;
+    private used;
+    private capReached;
+    constructor(base: NumberingBase);
+    get isUsed(): boolean;
+    get capExceeded(): boolean;
+    acquire(ordered: boolean, start?: number, ilvl?: number): number;
+    private allocNumId;
+    private tryAllocNumId;
+    toXml(): NumberingXml;
+    private bulletAbstractNum;
+    private orderedAbstractNum;
+    private orderedLevel;
+}
+
+// export: NumberingBase
+export interface NumberingBase {
+    abstractNumId: number;
+    numId: number;
+}
+
+// export: NumberingXml
+export interface NumberingXml {
+    abstractNums: string;
+    nums: string;
+}
+
+// export: OutputSink
+export interface OutputSink {
+    emit(name: string, bytes: Uint8Array, context?: HostCallContext): Promise<void>;
+}
+
+// export: PageOwner
+export interface PageOwner {
+    accountId?: string;
+    displayName: string;
+    email?: string;
+}
+
+// export: PlaceholderStatus
+export type PlaceholderStatus = "supported" | "unsupported" | "never";
+
+// export: PreparedDocxExportV1
+export interface PreparedDocxExportV1 {
+    schema: "atlcli.prepared-docx-export/1";
+    renderState: PreparedDocxRenderStateV1 | undefined;
+    archiveDateMs?: number;
+    filename: string;
+    codeTheme: CodeThemeId;
+    complete: boolean;
+    updateFields: NonNullable<ExportInput["updateFields"]>;
+    trustedSeqSequenceNames: string[];
+    resolvedCount: number;
+    unsupportedNames: string[];
+    embeddedImages: number;
+    renderedDiagrams: number;
+    scan: ScanResult;
+    sourceNotes: ExportNote[];
+    baseNotes: ExportNote[];
+    timings: ExportTimings;
+    startedAt: number;
+}
+
+// export: PreparedDocxRenderStateV1
+export interface PreparedDocxRenderStateV1 {
+    archiveBytes: Uint8Array;
+    bodyXml: string;
+    includes: Array<[
+        key: string,
+        xml: string
+    ]>;
+}
+
+// export: prepareDocxCodeHighlighting
+export declare function prepareDocxCodeHighlighting(blocks: readonly ExportBlock[], options?: {
+    codeTheme?: CodeThemeId;
+}): Promise<void>;
+
+// export: prepareDocxExport
+export declare function prepareDocxExport(input: ExportInput): Promise<PreparedDocxExportV1>;
+
+// export: prepareDocxExportRuntime
+export declare function prepareDocxExportRuntime(blocks: readonly ExportBlock[], options?: PrepareDocxExportRuntimeOptions): Promise<DocxExportRuntimePreparation>;
+
+// export: PrepareDocxExportRuntimeOptions
+export interface PrepareDocxExportRuntimeOptions {
+    codeTheme?: CodeThemeId;
+    signal?: AbortSignal;
+}
+
+// export: renderPreparedDocxExport
+export declare function renderPreparedDocxExport(prepared: PreparedDocxExportV1, input?: RenderPreparedDocxExportInput): Promise<ExportResult>;
+
+// export: RenderPreparedDocxExportInput
+export interface RenderPreparedDocxExportInput {
+    signal?: AbortSignal;
+}
+
+// export: ResolveDeps
+export interface ResolveDeps {
+    getSpace?: (spaceKey: string) => Promise<ConfluenceSpace>;
+    getCurrentUser?: () => Promise<CurrentUser>;
+    getPageOwner?: (pageId: string) => Promise<PageOwner | null>;
+    getSpaceHomepageStorage?: (spaceKey: string) => Promise<string | null>;
+    getSpaceLogo?: (spaceKey: string) => Promise<AssetRef | null>;
+    getIncludedPage?: (ref: IncludePageRef) => Promise<IncludeLookupOutcome>;
+}
+
+// export: runExport
+export declare function runExport(input: RunExportInput, env: ExportEnv): Promise<ExportReport>;
+
+// export: RunExportInput
+export interface RunExportInput extends Omit<ExportInput, "templateBytes"> {
+    templateId?: string;
+}
+
+// export: ScanHit
+export interface ScanHit {
+    base: string;
+    status: PlaceholderStatus;
+    count: number;
+    raw: string[];
+    reason?: string;
+}
+
+// export: ScanResult
+export interface ScanResult {
+    supported: ScanHit[];
+    unsupported: ScanHit[];
+    never: ScanHit[];
+    parts: string[];
+    hasContentPlaceholder: boolean;
+    stylerefStyleNames: string[];
+    foreignPlaceholders?: string[];
+    riskyFieldInstructions?: string[];
+    seqSequenceNames?: string[];
+}
+
+// export: scanTemplate
+export declare function scanTemplate(bytes: Uint8Array): ScanResult;
+
+// export: SvgRasterizer
+export interface SvgRasterizer {
+    rasterize(svg: string, target: {
+        widthPx: number;
+        heightPx: number;
+    }, context?: HostCallContext): Promise<Uint8Array>;
+}
+
+// export: TemplateMeta
+export interface TemplateMeta {
+    name: string;
+    modificationDate: Date;
+}
+
+// export: TemplateSource
+export interface TemplateSource {
+    getBytes(id: string, context?: HostCallContext): Promise<Uint8Array>;
+}
+
+// export: unzipDocx
+export declare function unzipDocx(bytes: Uint8Array, budget?: ArchiveBudget): PizZip;
+```
+
 ### Entry point `./browser-runtime`
 
 ```ts

--- a/packages/docx/etc/docx.api.md
+++ b/packages/docx/etc/docx.api.md
@@ -1277,6 +1277,7 @@ export declare function prepareDocxExportRuntime(blocks: readonly ExportBlock[],
 // export: PrepareDocxExportRuntimeOptions
 export interface PrepareDocxExportRuntimeOptions {
     codeTheme?: CodeThemeId;
+    preloadCodeFont?: boolean;
     signal?: AbortSignal;
 }
 

--- a/packages/docx/etc/docx.closure.md
+++ b/packages/docx/etc/docx.closure.md
@@ -38,6 +38,16 @@
 - reaches `@atlcli/export-macros` (frozen): MacroResolutionOptions
 - reachable-but-unexported gaps: none
 
+### Entry point `./browser-entry` — stable
+
+- exported symbols (47): ArchiveBudget, AssetFetcher, AssetRef, CanvasRasterizerTiming, CanvasSvgRasterizerOptions, CurrentUser, DocxByteHelpers, DocxErrorKind, DocxExportRuntimePreparation, DocxRenderError, ExportEnv, ExportInput, ExportReport, ExportResult, ExportTimings, HostCallContext, IncludeLookupOutcome, IncludePageDetails, IncludePageRef, NumberingAllocator, NumberingBase, NumberingXml, OutputSink, PageOwner, PlaceholderStatus, PrepareDocxExportRuntimeOptions, PreparedDocxExportV1, PreparedDocxRenderStateV1, RenderPreparedDocxExportInput, ResolveDeps, RunExportInput, ScanHit, ScanResult, SvgRasterizer, TemplateMeta, TemplateSource, canvasSvgRasterizer, exportDocx, installDocxBrowserRuntime, memoryTemplateSource, prepareDocxCodeHighlighting, prepareDocxExport, prepareDocxExportRuntime, renderPreparedDocxExport, runExport, scanTemplate, unzipDocx
+- same-package closure references: 32
+- reaches `@atlcli/code-highlight` (0.x — frozen-by-closure): CodeThemeId
+- reaches `@atlcli/confluence` (frozen): AdfMediaAttachment, ConfluencePageDetails, ConfluenceSpace, ExportBlock, ExportNote, ExportPageSource, ExportProgressCallback, InlineComment
+- reaches `@atlcli/diagram` (0.x — frozen-by-closure): DiagramTheme
+- reaches `@atlcli/export-macros` (frozen): MacroResolutionOptions
+- reachable-but-unexported gaps: none
+
 ### Entry point `./browser-runtime` — experimental
 
 - exported symbols (10): CanvasRasterizerTiming, CanvasSvgRasterizerOptions, DocxByteHelpers, DocxExportRuntimePreparation, PrepareDocxExportRuntimeOptions, canvasSvgRasterizer, installDocxBrowserRuntime, memoryTemplateSource, prepareDocxCodeHighlighting, prepareDocxExportRuntime

--- a/packages/docx/package.json
+++ b/packages/docx/package.json
@@ -11,8 +11,10 @@
   "sideEffects": [
     "./src/browser-runtime-bootstrap.ts",
     "./src/browser-runtime.ts",
+    "./src/browser-entry.ts",
     "./dist/browser-runtime-bootstrap.js",
-    "./dist/browser-runtime.js"
+    "./dist/browser-runtime.js",
+    "./dist/browser-entry.js"
   ],
   "files": [
     "dist",
@@ -44,6 +46,11 @@
       "development": "./src/browser-runtime.ts",
       "types": "./dist/browser-runtime.d.ts",
       "default": "./dist/browser-runtime.js"
+    },
+    "./browser-entry": {
+      "development": "./src/browser-entry.ts",
+      "types": "./dist/browser-entry.d.ts",
+      "default": "./dist/browser-entry.js"
     },
     "./vite": {
       "development": "./src/vite.ts",

--- a/packages/docx/src/browser-entry.test.ts
+++ b/packages/docx/src/browser-entry.test.ts
@@ -1,0 +1,144 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, dirname, join } from "node:path";
+import { spawnSync } from "node:child_process";
+import {
+  canvasSvgRasterizer,
+  memoryTemplateSource,
+  prepareDocxExportRuntime,
+  runExport,
+  scanTemplate,
+} from "./browser-entry.js";
+import { DOCX_BROWSER_VITE_DEFINES } from "./vite.js";
+
+const fixtureDirs: string[] = [];
+afterAll(() => {
+  for (const dir of fixtureDirs) rmSync(dir, { recursive: true, force: true });
+});
+
+interface BuiltEntry {
+  path: string;
+  source: string;
+}
+
+async function buildFixture(
+  entrypoint: string,
+  options: { guardVendorEvaluation?: boolean } = {},
+): Promise<BuiltEntry> {
+  const outdir = mkdtempSync(join(tmpdir(), "atlcli-docx-browser-entry-"));
+  fixtureDirs.push(outdir);
+  const vendorModules = new Set<string>();
+  const result = await Bun.build({
+    entrypoints: [entrypoint],
+    outdir,
+    target: "browser",
+    format: "esm",
+    conditions: ["development", "browser"],
+    define: DOCX_BROWSER_VITE_DEFINES,
+    plugins: options.guardVendorEvaluation
+      ? [{
+          name: "assert-docx-runtime-before-real-vendors",
+          setup(build) {
+            build.onLoad(
+              { filter: /(?:pizzip|docxtemplater).*[.](?:c|m)?js$/u },
+              async (args) => {
+                const normalized = args.path.replaceAll("\\", "/");
+                const vendor = normalized.includes("/node_modules/pizzip/")
+                  ? "pizzip"
+                  : normalized.includes("/node_modules/docxtemplater/")
+                    ? "docxtemplater"
+                    : undefined;
+                if (!vendor) {
+                  throw new Error(`Unexpected DOCX vendor probe path: ${args.path}`);
+                }
+                vendorModules.add(vendor);
+                return {
+                  contents:
+                    `if (!globalThis.__atlDocxByteHelpers) ` +
+                    `throw new Error(${JSON.stringify(`${vendor} evaluated before the DOCX browser runtime`)});\n` +
+                    await Bun.file(args.path).text(),
+                  loader: "js",
+                };
+              },
+            );
+          },
+        }]
+      : [],
+  });
+  expect(result.success, result.logs.map(String).join("\n")).toBe(true);
+  if (options.guardVendorEvaluation) {
+    expect([...vendorModules].sort()).toEqual(["docxtemplater", "pizzip"]);
+  }
+
+  const artifact = result.outputs.find(({ kind }) => kind === "entry-point")
+    ?? result.outputs[0];
+  if (!artifact) throw new Error(`Bun emitted no entry for ${entrypoint}`);
+  const bytes = new Uint8Array(await artifact.arrayBuffer());
+  const outputPath = artifact.path || join(
+    outdir,
+    `${basename(entrypoint).replace(/[.]ts$/u, "")}.js`,
+  );
+  if (!existsSync(outputPath)) {
+    mkdirSync(dirname(outputPath), { recursive: true });
+    writeFileSync(outputPath, bytes);
+  }
+  return {
+    path: outputPath,
+    source: new TextDecoder().decode(bytes),
+  };
+}
+
+function runBuilt(path: string): ReturnType<typeof spawnSync> {
+  return spawnSync(process.execPath, [path], { encoding: "utf8" });
+}
+
+describe("canonical DOCX browser entry", () => {
+  const combinedFixture =
+    "packages/docx/test-fixtures/browser-entry-minimal.ts";
+  let combinedBuild: BuiltEntry;
+
+  beforeAll(async () => {
+    combinedBuild = await buildFixture(combinedFixture, {
+      guardVendorEvaluation: true,
+    });
+  });
+
+  it("exposes preparation, export, template, scan, and rasterizer capabilities", () => {
+    expect(typeof runExport).toBe("function");
+    expect(typeof prepareDocxExportRuntime).toBe("function");
+    expect(typeof memoryTemplateSource).toBe("function");
+    expect(typeof canvasSvgRasterizer).toBe("function");
+    expect(typeof scanTemplate).toBe("function");
+  });
+
+  it("installs the runtime before the real PizZip/docxtemplater graph evaluates", () => {
+    const run = runBuilt(combinedBuild.path);
+
+    expect(run.status, run.stderr.toString()).toBe(0);
+    expect(run.stdout).toContain("ordered-browser-entry function");
+  });
+
+  it("tree-shakes the optional canvas adapter when a consumer only uses runExport", () => {
+    expect(combinedBuild.source).not.toContain(
+      "canvas SVG rasterization requires a document",
+    );
+    expect(combinedBuild.source).not.toContain(
+      "the diagram SVG did not decode within",
+    );
+  });
+
+  it("declares the runtime dependency before the engine re-export", () => {
+    const source = readFileSync(join(import.meta.dir, "browser-entry.ts"), "utf8");
+    expect(source.indexOf('import "./browser-runtime.js"')).toBeLessThan(
+      source.indexOf('export * from "./index.browser.js"'),
+    );
+  });
+});

--- a/packages/docx/src/browser-entry.ts
+++ b/packages/docx/src/browser-entry.ts
@@ -1,0 +1,30 @@
+/**
+ * Canonical ordered browser entry for DOCX intent hosts.
+ *
+ * The runtime side effect is deliberately the first module request. ESM
+ * evaluates it before the browser engine graph below, so PizZip/docxtemplater
+ * can never run before the namespaced byte helpers are installed. Hosts should
+ * import their engine and browser adapters from this one subpath instead of
+ * recreating that ordering with sequential dynamic imports.
+ */
+import "./browser-runtime.js";
+
+export * from "./index.browser.js";
+
+export {
+  canvasSvgRasterizer,
+  installDocxBrowserRuntime,
+  memoryTemplateSource,
+  prepareDocxCodeHighlighting,
+} from "./browser-runtime.js";
+export type {
+  CanvasRasterizerTiming,
+  CanvasSvgRasterizerOptions,
+  DocxByteHelpers,
+} from "./browser-runtime.js";
+
+// Template inspection is part of the explicit DOCX-intent graph. Keeping the
+// two host-facing helpers here lets browser consumers avoid a second PizZip
+// entry while the wider, non-frozen scan implementation remains on ./scan.
+export { scanTemplate, unzipDocx } from "./scan.js";
+export type { ArchiveBudget, DocxErrorKind } from "./scan.js";

--- a/packages/docx/test-fixtures/browser-entry-minimal.ts
+++ b/packages/docx/test-fixtures/browser-entry-minimal.ts
@@ -1,0 +1,3 @@
+import { runExport } from "../src/browser-entry.js";
+
+console.log("ordered-browser-entry", typeof runExport);

--- a/scripts/check-browser-build.test.ts
+++ b/scripts/check-browser-build.test.ts
@@ -44,6 +44,7 @@ describe("browser-build gate (spec 001 task 6)", () => {
       "packages/docx/src/index.browser.ts",
       "packages/docx/src/internal.ts",
       "packages/docx/src/browser-runtime.ts",
+      "packages/docx/src/browser-entry.ts",
       "packages/diagram/src/index.ts",
       "packages/pdf/src/index.browser.ts",
       "packages/pdf/src/template-authoring-runtime.ts",

--- a/scripts/check-browser-build.ts
+++ b/scripts/check-browser-build.ts
@@ -76,6 +76,7 @@ export const BROWSER_ENTRYPOINTS = [
   "packages/docx/src/index.browser.ts",
   "packages/docx/src/internal.ts",
   "packages/docx/src/browser-runtime.ts",
+  "packages/docx/src/browser-entry.ts",
   "packages/diagram/src/index.ts",
   "packages/pdf/src/index.browser.ts",
   "packages/pdf/src/template-authoring-runtime.ts",

--- a/scripts/consumer-smoke-vite.ts
+++ b/scripts/consumer-smoke-vite.ts
@@ -34,6 +34,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { buildDocx, para } from "../packages/docx/src/fixtures.js";
 import {
   atlcliClosure,
   buildPackages,
@@ -42,13 +43,17 @@ import {
   type SmokeRunResult,
 } from "./consumer-smoke.js";
 
-/** PDF/compiler plus the background-wiring package; the transitive @atlcli
+/** Browser DOCX/PDF roots plus background wiring; the transitive @atlcli
  * closure is derived from the real manifests (never a hardcoded list). */
 const VITE_ROOTS = [
+  "@atlcli/docx",
   "@atlcli/pdf",
   "@atlcli/pdf-compiler-browser",
   "@atlcli/export-wiring",
 ];
+const DOCX_TEMPLATE_BYTES = buildDocx({
+  body: para("$scroll.title") + para("$scroll.content"),
+});
 
 const VITE_VERSION = "8.1.4"; // same major the harness builds with
 
@@ -60,6 +65,7 @@ const INDEX_HTML = `<!doctype html>
 `;
 
 const VITE_CONFIG = `import { defineConfig } from "vite";
+import { DOCX_BROWSER_VITE_DEFINES } from "@atlcli/docx/vite";
 
 export default defineConfig({
   base: "./",
@@ -67,6 +73,9 @@ export default defineConfig({
     // Same preference as apps/browser-export-harness — but NO "development":
     // this build must prove the packed tarballs' dist/ exports.
     conditions: ["browser"],
+  },
+  define: {
+    ...DOCX_BROWSER_VITE_DEFINES,
   },
   build: {
     target: "es2022",
@@ -82,6 +91,13 @@ export default defineConfig({
 
 /** Mirrors apps/browser-export-harness/src/pdf-worker.ts's ?url imports. */
 const ENTRY_TS = `
+// This must be the first DOCX-related edge: export-wiring/jobs also reaches
+// the engine graph, so the canonical entry has to establish its runtime first.
+import {
+  memoryTemplateSource,
+  runExport as runDocxExport,
+  unzipDocx,
+} from "@atlcli/docx/browser-entry";
 import wasmUrl from "@atlcli/pdf-compiler-browser/wasm?url";
 import sansRegularUrl from "@atlcli/pdf/fonts/SourceSans3-Regular.ttf?url";
 import sansItalicUrl from "@atlcli/pdf/fonts/SourceSans3-It.ttf?url";
@@ -129,6 +145,51 @@ type LoadBytes = (url: string) => Promise<Uint8Array>;
   jobsEntrypointLoaded:
     typeof createPdfExportJobExecutor === "function" &&
     typeof createTypescriptDocxExportJobExecutor === "function",
+  async compileDocx() {
+    // Test setup injects a known-good binary fixture. The production consumer
+    // imports only the stable browser entry, not the fixture subpath.
+    const templateBytes = new Uint8Array(${JSON.stringify([...DOCX_TEMPLATE_BYTES])});
+    let emitted: Uint8Array | undefined;
+    const report = await runDocxExport(
+      {
+        details: {
+          id: "browser-entry-smoke",
+          title: "Combined Browser Entry",
+          url: "https://example.invalid/wiki/browser-entry-smoke",
+          version: 1,
+          spaceKey: "SMOKE",
+          storage: "<h1>Vite DOCX Heading</h1><p>One ordered browser entry.</p>",
+          created: "2026-07-01T08:00:00.000Z",
+          modified: "2026-07-02T09:00:00.000Z",
+          createdBy: { displayName: "Smoke Author" },
+          modifiedBy: { displayName: "Smoke Editor" },
+          labels: [],
+        },
+        template: {
+          name: "browser-entry-smoke.docx",
+          modificationDate: new Date("2026-07-10T00:00:00.000Z"),
+        },
+        exportDate: new Date("2026-07-15T10:00:00.000Z"),
+      },
+      {
+        templates: memoryTemplateSource(templateBytes),
+        output: {
+          emit: async (_name, bytes) => {
+            emitted = bytes;
+          },
+        },
+      },
+    );
+    if (!emitted) throw new Error("combined DOCX browser entry emitted nothing");
+    const bytes: Uint8Array = emitted;
+    const documentXml = unzipDocx(bytes).file("word/document.xml")?.asText() ?? "";
+    return {
+      byteLength: bytes.byteLength,
+      filename: report.filename,
+      hasHeading: documentXml.includes("Vite DOCX Heading"),
+      hasBody: documentXml.includes("One ordered browser entry."),
+    };
+  },
   async compile(loadBytes: LoadBytes) {
     const wasm = await loadBytes(wasmUrl);
     const fonts = await Promise.all(
@@ -203,6 +264,20 @@ export interface ViteSmokeResult {
   projectDir: string;
   viteVersion: string;
   smokes: SmokeRunResult;
+}
+
+async function withBrowserBufferScope<T>(action: () => Promise<T>): Promise<T> {
+  // The built chunk is imported under Bun only to keep this smoke headless.
+  // Mask Bun's Node-compatible Buffer global while PizZip detects its host so
+  // the bundle executes the same Uint8Array path as an actual browser.
+  const scope = globalThis as Record<string, unknown>;
+  const originalBuffer = scope.Buffer;
+  scope.Buffer = undefined;
+  try {
+    return await action();
+  } finally {
+    scope.Buffer = originalBuffer;
+  }
 }
 
 export async function runViteSmoke(baseDir?: string): Promise<ViteSmokeResult> {
@@ -290,31 +365,50 @@ export async function runViteSmoke(baseDir?: string): Promise<ViteSmokeResult> {
   }
 
   // --- Execute the PRODUCTION chunk and compile with the EMITTED assets. ---
-  await import(chunkPath);
-  const hook = (globalThis as Record<string, unknown>).__ATLCLI_VITE_SMOKE as {
-    wasmUrl: string;
-    fontUrls: Record<string, string>;
-    expectedFonts: string[];
-    jobsEntrypointLoaded: boolean;
-    compile(load: (url: string) => Promise<Uint8Array>): Promise<{
-      byteLength: number;
-      handleSize: number;
-      mimeType: string;
-      pageCount: number;
-      tagged: boolean;
-      isHandle: boolean;
-      borrowed: boolean;
-      blobSize: number;
-      blobType: string;
-      blobMemoized: boolean;
-      objectUrlScheme: string;
-      urlMemoized: boolean;
-    }>;
-  };
-  if (!hook) throw new Error("built chunk did not install the smoke hook — wrong chunk executed?");
-  if (!hook.jobsEntrypointLoaded) {
+  const { hook, docxResult } = await withBrowserBufferScope(async () => {
+    await import(chunkPath);
+    const hook = (globalThis as Record<string, unknown>).__ATLCLI_VITE_SMOKE as {
+      wasmUrl: string;
+      fontUrls: Record<string, string>;
+      expectedFonts: string[];
+      jobsEntrypointLoaded: boolean;
+      compileDocx(): Promise<{
+        byteLength: number;
+        filename: string;
+        hasHeading: boolean;
+        hasBody: boolean;
+      }>;
+      compile(load: (url: string) => Promise<Uint8Array>): Promise<{
+        byteLength: number;
+        handleSize: number;
+        mimeType: string;
+        pageCount: number;
+        tagged: boolean;
+        isHandle: boolean;
+        borrowed: boolean;
+        blobSize: number;
+        blobType: string;
+        blobMemoized: boolean;
+        objectUrlScheme: string;
+        urlMemoized: boolean;
+      }>;
+    };
+    if (!hook) throw new Error("built chunk did not install the smoke hook — wrong chunk executed?");
+    if (!hook.jobsEntrypointLoaded) {
+      throw new Error(
+        "packed @atlcli/export-wiring/jobs did not expose both PDF and TypeScript DOCX executors",
+      );
+    }
+    return { hook, docxResult: await hook.compileDocx() };
+  });
+  if (
+    docxResult.byteLength < 1_000
+    || !docxResult.hasHeading
+    || !docxResult.hasBody
+    || !docxResult.filename.endsWith(".docx")
+  ) {
     throw new Error(
-      "packed @atlcli/export-wiring/jobs did not expose both PDF and TypeScript DOCX executors",
+      `vite smoke combined DOCX entry produced implausible output: ${JSON.stringify(docxResult)}`,
     );
   }
   const docxCodeFontAssets = ttfAssets.filter((asset) =>
@@ -397,7 +491,8 @@ export async function runViteSmoke(baseDir?: string): Promise<ViteSmokeResult> {
     projectDir,
     viteVersion: VITE_VERSION,
     smokes: {
-      docx: "(not part of the vite smoke)",
+      docx:
+        `DOCX_SMOKE_OK ${docxResult.filename} bytes=${docxResult.byteLength}`,
       pdf: `PDF_SMOKE_OK vite-smoke.pdf pages=${result.pageCount} bytes=${result.byteLength}`,
     },
   };
@@ -406,5 +501,6 @@ export async function runViteSmoke(baseDir?: string): Promise<ViteSmokeResult> {
 if (import.meta.main) {
   const { projectDir, viteVersion, smokes } = await runViteSmoke();
   console.log(`vite tarball smoke OK in ${projectDir} (vite ${viteVersion})`);
+  console.log(smokes.docx);
   console.log(smokes.pdf);
 }

--- a/scripts/consumer-smoke.test.ts
+++ b/scripts/consumer-smoke.test.ts
@@ -52,10 +52,10 @@ describe.skipIf(!enabled)("consumer smoke (spec 009)", () => {
   );
 
   it(
-    "Vite tarball build: ?url wasm/font imports resolve to hashed assets and the production chunk compiles a real PDF",
+    "Vite tarball build: browser assets resolve and the production chunk compiles real DOCX + PDF exports",
     async () => {
       const { viteVersion, smokes } = await runViteSmoke();
-      console.log(`vite ${viteVersion}: ${smokes.pdf}`);
+      console.log(`vite ${viteVersion}: ${smokes.docx} | ${smokes.pdf}`);
     },
     300000,
   );

--- a/scripts/pack-check.test.ts
+++ b/scripts/pack-check.test.ts
@@ -330,18 +330,29 @@ describe("pack-check (spec 009)", () => {
     }
   });
 
-  it("@atlcli/docx ships the embedded code face, its OFL license, and the Node loader", () => {
-    const { entries } = packageOf(
+  it("@atlcli/docx ships the ordered browser entry, maps, font licenses, and Node loader", () => {
+    const { entries, manifest } = packageOf(
       packages.find((p) => p.name === "@atlcli/docx") ?? (undefined as never),
     );
     for (const required of [
       "package/fonts/JetBrainsMono-Regular.ttf",
       "package/fonts/LICENSE-JetBrainsMono.txt",
+      "package/dist/browser-entry.js",
+      "package/dist/browser-entry.js.map",
+      "package/dist/browser-entry.d.ts",
+      "package/dist/browser-entry.d.ts.map",
       "package/dist/font-embedding.js",
       "package/dist/node-code-font.js",
     ]) {
       expect(entries.includes(required), `@atlcli/docx: missing ${required}`).toBe(true);
     }
+    expect(manifest.license).toBe("Apache-2.0");
+    expect(manifest.exports).toMatchObject({
+      "./browser-entry": {
+        types: "./dist/browser-entry.d.ts",
+        default: "./dist/browser-entry.js",
+      },
+    });
   });
 
   it("@atlcli/pdf-compiler-browser ships the vendored PATCHED glue + wasm + LICENSE/NOTICE", () => {

--- a/specs/issue-123-ordered-browser-entry/EVIDENCE.md
+++ b/specs/issue-123-ordered-browser-entry/EVIDENCE.md
@@ -1,0 +1,72 @@
+# Issue #123 implementation evidence
+
+## Result
+
+`@atlcli/docx/browser-entry` is the supported runtime-first browser intent
+entry. It exposes runtime preparation, export, in-memory templates, template
+inspection, and the optional canvas rasterizer without changing Node/CLI
+entrypoints. The extension and neutral browser harness load it only after
+explicit DOCX scan, warm, or export intent.
+
+## Cold and warm topology
+
+Measured in fresh Chromium contexts against the production Vite build. Each
+JavaScript request was delayed by 25 ms so dependent request waves remain
+observable. Heap values come from CDP `Performance.getMetrics` samples taken
+during entry loading; they are measurements, not bundle-size estimates.
+
+| Metric | Legacy runtime then engine | Combined entry |
+| --- | ---: | ---: |
+| Sequential request waves | 2 | 1 |
+| Entry ready | 81.0 ms | 52.6 ms |
+| Warm ready | 5.4 ms | 5.4 ms |
+| Requests | 9 | 9 |
+| Transfer bytes | 775,723 | 775,747 |
+| Decoded bytes | 773,023 | 773,047 |
+| Peak JS heap delta | 2,894,176 bytes | 2,858,244 bytes |
+| Font-file requests at import | 0 | 0 |
+| Warm repeat requests | 0 | 0 |
+
+The combined entry removes one sequential request wave and reduces measured
+cold readiness by 28.4 ms in this controlled trace. It adds 24 transfer and
+decoded bytes, and its sampled peak heap delta is 35,932 bytes lower. The
+benchmark asserts only the topology win, no import-time font fetch, and a
+one-MiB non-regression envelope for measured peak heap.
+
+## Verification
+
+- `bun run test`: 5,814 passed, 14 environment/credential-gated skips, 0
+  failures across 400 files. The first sandboxed run demonstrated that 49
+  local-server tests could not bind ports; the complete out-of-sandbox rerun
+  is the reported result.
+- `bun run typecheck`: passed for the root, extension,
+  `pdf-compiler-browser`, and browser export harness.
+- `bun run build`: 20 build tasks passed, including the extension, harness,
+  DOCX package, CLI, and browser compiler.
+- `bun run check:browser`: all 26 browser entrypoints passed.
+- Harness output and extension output checks passed.
+- Browser harness unit suite: 85 passed.
+- Playwright production harness: 5 passed, including all registered browser
+  DOCX/PDF conformance cases, topology, highlighting, deterministic repeat,
+  font retry, job parity, diagrams, attachments, templates, and Word-quality
+  structure checks.
+- Packed Vite consumer: produced
+  `Combined Browser Entry.docx` (2,058 bytes) and a real tagged PDF (4 pages,
+  41,779 bytes) from installed tarballs.
+- Package/API guards: 16 passed; the tarball contains the combined JavaScript,
+  declarations, source maps, licenses, font asset, and Node loader with no
+  `src/` or `workspace:` leak.
+- `bun run docs:check`: 0 errors, warnings, or hints.
+
+## Dependency and external gates
+
+- The parallel #122 worktree is clean at commit `6e7584d` and changes the
+  existing `prepareDocxExportRuntime` option semantics without adding another
+  public entry. This branch deliberately does not duplicate or cherry-pick
+  that commit; #123 must be rebased onto #122 after it lands.
+- The separate Forge Custom UI repository is outside this worktree. Its
+  combined-entry migration and production cold/warm staging trace remain
+  required before closing #123.
+- The browser harness proves the existing Word-quality and LibreOffice/Word
+  fixture contracts, but no interactive Microsoft Word session was performed
+  in this worktree.

--- a/specs/issue-123-ordered-browser-entry/EVIDENCE.md
+++ b/specs/issue-123-ordered-browser-entry/EVIDENCE.md
@@ -18,24 +18,24 @@ during entry loading; they are measurements, not bundle-size estimates.
 | Metric | Legacy runtime then engine | Combined entry |
 | --- | ---: | ---: |
 | Sequential request waves | 2 | 1 |
-| Entry ready | 81.0 ms | 52.6 ms |
+| Entry ready | 81.0 ms | 52.4 ms |
 | Warm ready | 5.4 ms | 5.4 ms |
 | Requests | 9 | 9 |
-| Transfer bytes | 775,723 | 775,747 |
-| Decoded bytes | 773,023 | 773,047 |
-| Peak JS heap delta | 2,894,176 bytes | 2,858,244 bytes |
+| Transfer bytes | 775,854 | 775,878 |
+| Decoded bytes | 773,154 | 773,178 |
+| Peak JS heap delta | 2,805,968 bytes | 2,895,428 bytes |
 | Font-file requests at import | 0 | 0 |
 | Warm repeat requests | 0 | 0 |
 
 The combined entry removes one sequential request wave and reduces measured
-cold readiness by 28.4 ms in this controlled trace. It adds 24 transfer and
-decoded bytes, and its sampled peak heap delta is 35,932 bytes lower. The
-benchmark asserts only the topology win, no import-time font fetch, and a
-one-MiB non-regression envelope for measured peak heap.
+cold readiness by 28.6 ms in this controlled trace. It adds 24 transfer and
+decoded bytes, and its sampled peak heap delta is 89,460 bytes higher. The
+benchmark asserts only the topology win, no import-time font fetch, and keeps
+that measured peak change inside a one-MiB non-regression envelope.
 
 ## Verification
 
-- `bun run test`: 5,814 passed, 14 environment/credential-gated skips, 0
+- `bun run test`: 5,818 passed, 14 environment/credential-gated skips, 0
   failures across 400 files. The first sandboxed run demonstrated that 49
   local-server tests could not bind ports; the complete out-of-sandbox rerun
   is the reported result.
@@ -46,7 +46,7 @@ one-MiB non-regression envelope for measured peak heap.
 - `bun run check:browser`: all 26 browser entrypoints passed.
 - Harness output and extension output checks passed.
 - Browser harness unit suite: 85 passed.
-- Playwright production harness: 5 passed, including all registered browser
+- Playwright production harness: 6 passed, including all registered browser
   DOCX/PDF conformance cases, topology, highlighting, deterministic repeat,
   font retry, job parity, diagrams, attachments, templates, and Word-quality
   structure checks.
@@ -60,10 +60,9 @@ one-MiB non-regression envelope for measured peak heap.
 
 ## Dependency and external gates
 
-- The parallel #122 worktree is clean at commit `6e7584d` and changes the
-  existing `prepareDocxExportRuntime` option semantics without adding another
-  public entry. This branch deliberately does not duplicate or cherry-pick
-  that commit; #123 must be rebased onto #122 after it lands.
+- #122 landed through PR #124 as `2fa4e70`; this branch is rebased onto that
+  commit. The combined post-rebase browser suite proves the demand-aware font
+  preparation boundary and the ordered entry together.
 - The separate Forge Custom UI repository is outside this worktree. Its
   combined-entry migration and production cold/warm staging trace remain
   required before closing #123.

--- a/specs/issue-123-ordered-browser-entry/PLAN.md
+++ b/specs/issue-123-ordered-browser-entry/PLAN.md
@@ -1,0 +1,47 @@
+# Issue #123: ordered browser DOCX entry
+
+## Goal
+
+Ship one supported browser-intent import that installs the DOCX byte runtime
+before PizZip/docxtemplater evaluate and exposes preparation, export, template,
+and rasterizer capabilities without a host-owned runtime-to-engine waterfall.
+
+## Boundaries
+
+- Keep the Node/CLI entry and the existing `./browser` and `./browser-runtime`
+  compatibility subpaths unchanged.
+- Do not implement or duplicate #122's demand-aware font semantics here. The
+  combined entry forwards the shared preparation contract, and final
+  integration is checked against the parallel #122 worktree.
+- Keep discovery/page entries free of the combined engine. Load it only from a
+  DOCX scan, warm, export, or executor intent boundary.
+- Treat the neutral Vite/Chromium measurements as package and ordinary-browser
+  evidence. Forge staging remains a separate consumer-repository gate.
+
+## Delivery
+
+- [x] Add `@atlcli/docx/browser-entry` with a static runtime-first dependency.
+- [x] Prove real engine evaluation fails without the runtime and succeeds
+      through the combined entry.
+- [x] Cover exports, declarations, maps, browser build, Vite, and packed
+      consumer resolution.
+- [x] Generate a real DOCX in the neutral browser and packed Vite consumers.
+- [x] Move extension and browser-harness consumers to the combined entry at
+      explicit DOCX intent.
+- [x] Record cold request waves, transfer/decoded bytes, entry-to-ready time,
+      warm time, and absence of import-time font fetch.
+- [x] Re-run package, extension, harness, typecheck, and relevant E2E gates.
+
+## External acceptance
+
+- Merge/rebase the completed #122 demand-aware preparation contract before
+  closing #123.
+- Update the separate Forge Custom UI consumer and record its cold/warm staging
+  trace, CSP/lifecycle behavior, cancellation, retry, and cleanup.
+- Word remains a manual compatibility gate; LibreOffice automation is reported
+  only when the tool is present and the browser-produced artifact is checked.
+
+## Unresolved questions
+
+None for the atlcli implementation. The Forge staging result and #122 merge
+commit are external inputs to issue closure.

--- a/src/content/docs/reference/docx-engine.md
+++ b/src/content/docs/reference/docx-engine.md
@@ -44,8 +44,9 @@ Entry points (package `exports` conditions, mirroring `@atlcli/core`):
 | Import | Resolves to | Use |
 |--------|-------------|-----|
 | `@atlcli/docx` | Node barrel | engine + Node filesystem adapters |
-| `@atlcli/docx/browser` | browser barrel | engine only (no `node:` imports, CI-gated) |
-| `@atlcli/docx/browser-runtime` | browser support | byte compatibility bootstrap plus memory/canvas adapters |
+| `@atlcli/docx/browser-entry` | ordered browser entry | canonical intent graph: runtime bootstrap, engine, preparation, template helpers, and memory/canvas adapters |
+| `@atlcli/docx/browser` | compatibility browser barrel | engine only (no `node:` imports, CI-gated) |
+| `@atlcli/docx/browser-runtime` | compatibility browser support | byte compatibility bootstrap plus memory/canvas adapters |
 | `@atlcli/docx/vite` | Vite defines | build-time replacements required by PizZip/docxtemplater |
 | `@atlcli/docx/scan` | scan module | lightweight template scan without pulling the full engine |
 
@@ -63,7 +64,7 @@ report note.
 
 The RegExp implementation is selected by the host entrypoint, not by runtime
 capability detection. Node/Bun imports install Oniguruma. Browser-conditioned
-imports and `@atlcli/docx/browser-runtime` install only Shiki's JavaScript
+imports and `@atlcli/docx/browser-entry` install only Shiki's JavaScript
 RegExp engine; no browser module imports `shiki/wasm` or the Oniguruma adapter.
 The concrete engine modules remain separate so Vite cannot discover and emit
 an unused WASM chunk. Once the first highlighter initializes, the engine is
@@ -73,8 +74,8 @@ different implementation.
 After explicit DOCX intent, every host can start awaitable runtime preparation:
 
 ```ts
-import "@atlcli/docx/browser-runtime";
-import { prepareDocxExportRuntime } from "@atlcli/docx/browser-runtime";
+const { prepareDocxExportRuntime } =
+  await import("@atlcli/docx/browser-entry");
 
 const preparation = await prepareDocxExportRuntime(blocks, {
   codeTheme: "github-light",
@@ -160,7 +161,7 @@ despite the similar name — see
 `SvgRasterizer` drives mermaid diagram embedding (spec 005a) — it supplies the mandatory PNG
 fallback Word needs next to the vector SVG. Also optional: a host that omits it exports mermaid
 blocks as readable source code blocks with a `diagram-skipped` report note. Two implementations
-ship: the neutral browser canvas rasterizer (`@atlcli/docx/browser-runtime`) and a Node
+ship: the neutral browser canvas rasterizer (`@atlcli/docx/browser-entry`) and a Node
 rasterizer over the WebAssembly build of resvg (`resvgSvgRasterizer` in
 `packages/docx/src/node-adapters.ts`) that the CLI uses.
 
@@ -568,19 +569,28 @@ printing — not only the one this flag requests.
 
 ## Browser hosts
 
-Browser consumers install the DOCX-specific compatibility layer before importing the engine:
+Browser consumers load one ordered graph after explicit DOCX intent:
 
 ```ts
-import "@atlcli/docx/browser-runtime";
-
-const { runExport } = await import("@atlcli/docx/browser");
+const {
+  canvasSvgRasterizer,
+  memoryTemplateSource,
+  prepareDocxExportRuntime,
+  runExport,
+  scanTemplate,
+} = await import("@atlcli/docx/browser-entry");
 ```
 
-`installDocxBrowserRuntime()` installs namespaced `Uint8Array` helpers; it does not create a
-fake global `Buffer`. `memoryTemplateSource()` and `canvasSvgRasterizer()` provide neutral DOM
-adapters. Storage, authenticated asset fetching, download/save behavior, and UI remain owned by
-the consuming host. Vite hosts also spread `docxViteDefines` from `@atlcli/docx/vite` into their
-`define` configuration.
+The entry evaluates `installDocxBrowserRuntime()` before the
+PizZip/docxtemplater engine graph. It installs namespaced `Uint8Array` helpers
+and does not create a fake global `Buffer`. `memoryTemplateSource()` and
+`canvasSvgRasterizer()` provide neutral DOM adapters. Storage, authenticated
+asset fetching, download/save behavior, and UI remain owned by the consuming
+host. Vite hosts also spread `DOCX_BROWSER_VITE_DEFINES` from
+`@atlcli/docx/vite` into their `define` configuration.
+
+The compatibility `./browser` and `./browser-runtime` subpaths remain
+available, but new hosts must not recreate the old sequential import chain.
 
 `apps/browser-export-harness` is the permanent package-conformance consumer. Its production
 build runs the real engine and canvas path in Chromium without extension APIs or native Node

--- a/src/content/docs/reference/export-api.md
+++ b/src/content/docs/reference/export-api.md
@@ -31,7 +31,7 @@ entrypoint's full symbol list and transitive type closure is committed and CI-gu
 
 | Class | Meaning |
 |---|---|
-| **stable** | Frozen v1. Breaking changes = major version, with one `@deprecated` minor first. |
+| **stable** | Frozen v1. Breaking changes = major version, with one `@deprecated` minor first. Includes the canonical `@atlcli/docx/browser-entry`. |
 | **experimental** | Exported and usable, but may change in minor releases (0.x packages, `./browser-runtime`, `./vite`). |
 | **internal** | Non-frozen implementation subpaths (`./internal`, `./scan`, `./fixtures`, `./template`). May change without notice. |
 
@@ -251,6 +251,8 @@ Explicitly **not** part of the freeze:
   (raw Typst template), `./browser-runtime` and `./vite` (host bootstrap, experimental).
   The browser runtime also re-exports stable `prepareDocxExportRuntime`; its narrower
   `prepareDocxCodeHighlighting(blocks, options?)` compatibility helper remains experimental.
+  The stable `@atlcli/docx/browser-entry` is the supported ordered browser
+  composition of the frozen engine API and those browser capabilities.
 - The 0.x packages: `@atlcli/core`, `@atlcli/diagram`, `@atlcli/jira`, `@atlcli/plugin-api`,
   `@atlcli/template-pack`, `@atlcli/export-node` — see the freeze table in
   [Package Versioning](/reference/versioning/) for the per-package reasoning. Types owned by

--- a/src/content/docs/reference/package-consumption.md
+++ b/src/content/docs/reference/package-consumption.md
@@ -56,7 +56,7 @@ Declared per package via `engines` and verified by the consumer-smoke suites
 | `@atlcli/jira` | **Bun only** (≥ 1.3) | The barrel's webhook server is `Bun.serve`-native |
 | `@atlcli/confluence` | Node ≥ 20, Bun, browsers | The default barrel is isomorphic; the non-frozen `./internal` subpath (sync-db, webhook-server, …) is **Bun-only** |
 | `@atlcli/code-highlight` | Node ≥ 20, Bun, browsers | Node/Bun installs Oniguruma; browser conditions install the JavaScript RegExp engine; languages/themes use generated direct loaders |
-| `@atlcli/docx` | Node ≥ 20, Bun, browsers | Browser hosts import `./browser-runtime` first |
+| `@atlcli/docx` | Node ≥ 20, Bun, browsers | Browser intent hosts import the ordered `./browser-entry`; legacy split subpaths remain compatible |
 | `@atlcli/pdf` | Node ≥ 20, Bun, browsers | Fully isomorphic |
 | `@atlcli/pdf-compiler-browser` | Node ≥ 20, Bun, browsers | Needs `WebAssembly`; wasm/fonts supplied by the host |
 | `@atlcli/export-jobs` | Node ≥ 20, Bun, browsers | Durable job records, validation, and host-injected persistence ports |


### PR DESCRIPTION
## Summary

- add the supported `@atlcli/docx/browser-entry` surface for ordered runtime preparation, export, templates, scanning, and rasterization
- migrate the extension and neutral browser harness to explicit DOCX-intent loading
- add package, API, build, closure, packed-consumer, and production browser topology guards

## Why

Browser hosts previously had to await runtime bootstrap before importing the DOCX engine. That preserved a cold runtime-to-engine request waterfall even when the host already knew it intended to export DOCX.

## Result

- sequential request waves: 2 → 1
- entry-ready: 81.0 ms → 52.4 ms under the controlled 25 ms/request trace
- warm-ready: 5.4 ms → 5.4 ms
- transfer size: +24 bytes; decoded size: +24 bytes
- sampled peak JS heap delta: +89,460 bytes, within the asserted 1 MiB non-regression envelope
- no import-time font request and no warm repeat requests

## Verification

- `bun run test`: 5,818 passed, 14 environment/credential-gated skips, 0 failed across 400 files
- `bun run typecheck`
- production Playwright browser harness: 6 passed
- package/API/closure/pack/browser-build/docs gates
- packed Vite consumer produced a real DOCX and tagged four-page PDF
- detailed evidence: `specs/issue-123-ordered-browser-entry/EVIDENCE.md`

## Dependency and remaining acceptance

- rebased on the merged #122 / PR #124 change (`2fa4e70`)
- Forge Custom UI migration plus its staging cold/warm topology trace remain outside this repository and are still required before closing #123

Refs #123