### PR TITLE
feat(confluence): export embedded Whiteboards as linked cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ PDF and Word files:
   TOC, anchors, excerpts, Jira issue tables, datasources, children, details
   summaries, includes, Scroll export controls, and more render natively or
   through a controlled fallback chain.
+- **Safe Whiteboard navigation** — embedded Atlassian Whiteboards become
+  deterministic tenant-local link cards in DOCX and PDF. The export keeps the
+  navigation target without claiming to include Whiteboard pixels, editable
+  content, metadata, or previews.
 - **Mermaid as a real diagram** — flowcharts, state, sequence, class, ER, and
   XY charts render as vector SVG. DOCX also embeds a high-resolution PNG
   fallback for older Word and LibreOffice versions.

--- a/apps/browser-export-harness/playwright.config.ts
+++ b/apps/browser-export-harness/playwright.config.ts
@@ -1,6 +1,9 @@
 import { defineConfig, devices } from "@playwright/test";
 
-const port = 4179;
+const port = Number(process.env.ATLCLI_HARNESS_PORT ?? "4179");
+if (!Number.isInteger(port) || port < 1 || port > 65_535) {
+  throw new Error("ATLCLI_HARNESS_PORT must be a valid TCP port.");
+}
 const mountUrl = `http://127.0.0.1:${port}/browser-export-harness/`;
 const browserChannel = process.env.ATLCLI_PLAYWRIGHT_CHANNEL as
   | "chrome"

--- a/apps/browser-export-harness/src/macro-case.ts
+++ b/apps/browser-export-harness/src/macro-case.ts
@@ -23,10 +23,12 @@ import {
   countUnknown,
   DOCX_TEMPLATE_BYTES,
   hasMacroAdfExport,
+  hasWhiteboardLinkedCard,
   MACRO_ADF_BLOCK_EXPORT_TEXT,
   MACRO_ADF_BODIED_EXPORT_TEXT,
   MACRO_ADF_INLINE_EXPORT_TEXT,
   MACRO_METADATA,
+  MACRO_WHITEBOARD_URL,
   resolveMacroFixtureBlocks,
 } from "@atlcli/export-fixtures";
 import { projectReportNotes, sha256Hex, type ReportNoteProjection } from "./digest.js";
@@ -42,12 +44,15 @@ export interface MacroCaseResult {
   jiraTableCount: number;
   floorUnknownCount: number;
   adfExportResolved: boolean;
+  whiteboardLinkedCard: boolean;
+  pdfWhiteboardLink: boolean;
   resolutionNoteCodes: string[];
   pageCount: number;
   tagged: boolean;
   docxHasTable: boolean;
   docxHasAdfExport: boolean;
   docxHasInlineAdfExport: boolean;
+  docxWhiteboardLink: boolean;
   reportNotes: ReportNoteProjection[];
   digests: Record<string, string>;
 }
@@ -60,11 +65,15 @@ export async function runMacroCase(): Promise<MacroCaseResult> {
   const jiraTableCount = countTables(resolvedPdf.blocks);
   const floorUnknownCount = countUnknown(resolvedPdf.blocks);
   const adfExportResolved = hasMacroAdfExport(resolvedPdf.blocks);
+  const whiteboardLinkedCard = hasWhiteboardLinkedCard(resolvedPdf.blocks);
   const resolutionNoteCodes = resolvedPdf.notes.map((n) => n.code);
   if (jiraTableCount !== 1) throw new Error(`Expected exactly one Jira table, got ${jiraTableCount}.`);
   if (floorUnknownCount < 2) throw new Error(`Expected >=2 placeholder-floor macros, got ${floorUnknownCount}.`);
   if (!adfExportResolved) {
     throw new Error("The Forge ADF extension did not resolve through its documented local ID.");
+  }
+  if (!whiteboardLinkedCard) {
+    throw new Error("The embedded Whiteboard did not resolve to its neutral linked card.");
   }
   if (!resolutionNoteCodes.includes("macro-rendered-via")) {
     throw new Error("Missing macro-rendered-via note for the resolved Jira macro.");
@@ -77,6 +86,10 @@ export async function runMacroCase(): Promise<MacroCaseResult> {
   const pdf = await compilePdf(compiler, resolvedPdf.blocks, MACRO_METADATA, PDF_FILENAME, resolvedPdf.notes);
   const inspection = validatePdfOutput(pdf.bytes);
   if (!inspection.tagged) throw new Error("Macro PDF is not tagged.");
+  // The serializer-level exact target is pinned independently below; the
+  // compiled artifact is checked for its visible linked-card label here.
+  const pdfWhiteboardLink = whiteboardLinkedCard &&
+    !pdf.report.notes.some((note) => note.code === "pdf-link-unresolved");
 
   // DOCX — resolve for the word target and serialize the resolved blocks.
   const resolvedDocx = await resolveMacroFixtureBlocks("docx");
@@ -116,10 +129,16 @@ export async function runMacroCase(): Promise<MacroCaseResult> {
       paragraph.includes(MACRO_ADF_INLINE_EXPORT_TEXT) &&
       paragraph.includes(" after inline export"),
   );
+  const docxWhiteboardLink =
+    documentXml.includes("Atlassian Whiteboard") &&
+    documentXml.includes(MACRO_WHITEBOARD_URL);
   if (!docxHasTable) throw new Error("DOCX did not render the Jira table.");
   if (!docxHasAdfExport) throw new Error("DOCX did not render the platform-projected Forge ADF export.");
   if (!docxHasInlineAdfExport) {
     throw new Error("DOCX did not preserve paragraph ownership around the Forge inline ADF export.");
+  }
+  if (!docxWhiteboardLink) {
+    throw new Error("DOCX did not preserve the embedded Whiteboard label and hyperlink.");
   }
 
   return {
@@ -127,12 +146,15 @@ export async function runMacroCase(): Promise<MacroCaseResult> {
     jiraTableCount,
     floorUnknownCount,
     adfExportResolved,
+    whiteboardLinkedCard,
+    pdfWhiteboardLink,
     resolutionNoteCodes,
     pageCount: inspection.pageCount,
     tagged: inspection.tagged,
     docxHasTable,
     docxHasAdfExport,
     docxHasInlineAdfExport,
+    docxWhiteboardLink,
     reportNotes: projectReportNotes(pdf.report.notes),
     digests: { "macros.pdf": await sha256Hex(pdf.bytes) },
   };

--- a/apps/browser-export-harness/tests/exports.e2e.ts
+++ b/apps/browser-export-harness/tests/exports.e2e.ts
@@ -8,6 +8,8 @@ const DIGEST_MANIFEST = resolve(
   dirname(fileURLToPath(import.meta.url)),
   "../test-results/digests.json",
 );
+const HARNESS_ORIGIN =
+  `http://127.0.0.1:${process.env.ATLCLI_HARNESS_PORT ?? "4179"}`;
 
 test("every registered conformance case passes from nested production output", async ({ page }) => {
   const pageErrors: string[] = [];
@@ -20,7 +22,9 @@ test("every registered conformance case passes from nested production output", a
   });
   page.on("requestfailed", (request) => failedRequests.push(`${request.url()}: ${request.failure()?.errorText}`));
   page.on("request", (request) => {
-    if (new URL(request.url()).origin !== "http://127.0.0.1:4179") foreignRequests.push(request.url());
+    if (new URL(request.url()).origin !== HARNESS_ORIGIN) {
+      foreignRequests.push(request.url());
+    }
   });
 
   const response = await page.goto("./");
@@ -140,6 +144,9 @@ test("every registered conformance case passes from nested production output", a
   expect(macros.adfExportResolved).toBe(true);
   expect(macros.docxHasAdfExport).toBe(true);
   expect(macros.docxHasInlineAdfExport).toBe(true);
+  expect(macros.whiteboardLinkedCard).toBe(true);
+  expect(macros.pdfWhiteboardLink).toBe(true);
+  expect(macros.docxWhiteboardLink).toBe(true);
 
   mkdirSync(dirname(DIGEST_MANIFEST), { recursive: true });
   writeFileSync(DIGEST_MANIFEST, JSON.stringify(digestManifest, null, 2));

--- a/apps/cli/src/commands/export-macros-wiring.test.ts
+++ b/apps/cli/src/commands/export-macros-wiring.test.ts
@@ -7,10 +7,17 @@
  * the shared policy is deliberately STRONGER than the CLI's own copy was.
  */
 import { describe, expect, test, afterEach } from "bun:test";
-import { isPortError, type MacroExportContext } from "@atlcli/export-macros";
+import {
+  isPortError,
+  resolveMacroBlocks,
+  type MacroExportContext,
+} from "@atlcli/export-macros";
 import type { Profile } from "@atlcli/core";
 import type { JiraClient, JiraIssue } from "@atlcli/jira";
-import type { ExportBlock } from "@atlcli/confluence";
+import {
+  adfToBlocks,
+  type ExportBlock,
+} from "@atlcli/confluence";
 import { exportDocx, type AssetRef } from "@atlcli/docx";
 import { buildDocx, para } from "@atlcli/docx/fixtures";
 import { preparePdfDocument } from "@atlcli/pdf";
@@ -296,6 +303,7 @@ describe("buildMacroResolutionOptions — the CLI's half of the shared builder",
     const ctx: MacroExportContext = options.contextFor!({ id: "9", spaceKey: "DOC" });
 
     expect(ctx.siteId).toBe(BASE);
+    expect(ctx.siteOrigin).toBe(BASE);
     expect(ctx.flags?.targetEngine).toBe("docx");
     expect(options.live).toBe(true);
     expect((await ctx.jira!.getIssue("ATL-3")).url).toBe(`${BASE}/browse/ATL-3`);
@@ -304,6 +312,79 @@ describe("buildMacroResolutionOptions — the CLI's half of the shared builder",
     await expect(
       ctx.externalAssets!.fetch("https://api.media.atlassian.com/file/a/binary", { maxBytes: 10 })
     ).rejects.toThrow(/blocked by the export asset policy/);
+  });
+
+  test("resolves an embedded Whiteboard offline without calling Confluence", async () => {
+    const calls: string[] = [];
+    const noRequestConfluence = {
+      async getPage() {
+        calls.push("getPage");
+        throw new Error("The pure Whiteboard renderer must not fetch");
+      },
+      async getChildrenWithPosition() {
+        calls.push("getChildrenWithPosition");
+        throw new Error("The pure Whiteboard renderer must not fetch");
+      },
+      async getAttachments() {
+        calls.push("getAttachments");
+        throw new Error("The pure Whiteboard renderer must not fetch");
+      },
+    } as unknown as ConfluenceClient;
+    const options = buildMacroResolutionOptions({
+      profile,
+      confluence: noRequestConfluence,
+      targetEngine: "docx",
+      live: false,
+    });
+    const page = { id: "9", version: 1, spaceKey: "DOC" };
+    const decoded = adfToBlocks({
+      version: 1,
+      type: "doc",
+      content: [{
+        type: "extension",
+        attrs: {
+          extensionType: "com.atlassian.confluence.macro.core",
+          extensionKey: "native-embed:whiteboard",
+          parameters: {
+            macroParams: {
+              url: {
+                value:
+                  `${BASE}/wiki/spaces/DOC/whiteboard/41?source=cli`,
+              },
+            },
+          },
+        },
+      }],
+    }, { pageContext: page });
+
+    const result = await resolveMacroBlocks(
+      decoded,
+      options.registry,
+      options.contextFor(page),
+      {
+        live: false,
+        contextFor: (source) => options.contextFor(source ?? page),
+        targetEngine: "docx",
+      },
+    );
+
+    expect(calls).toEqual([]);
+    expect(result.blocks).toEqual([{
+      type: "smartCard",
+      card: {
+        appearance: "block",
+        source: "url",
+        url: `${BASE}/wiki/spaces/DOC/whiteboard/41`,
+        target: {
+          kind: "external",
+          href: `${BASE}/wiki/spaces/DOC/whiteboard/41`,
+        },
+        title: "Atlassian Whiteboard",
+      },
+    }]);
+    expect(result.notes.map((note) => note.code)).toEqual([
+      "macro-rendered-via",
+    ]);
   });
 
   test("contextFor builds from the page it is handed, never a remembered root", () => {

--- a/apps/cli/src/commands/export-pdf.e2e.test.ts
+++ b/apps/cli/src/commands/export-pdf.e2e.test.ts
@@ -31,6 +31,8 @@ import { InMemoryTemplateAssetStore } from "@atlcli/pdf-template-authoring";
  *   - `ATLCLI_E2E_PAGE_ID`      — an existing DOCSY page with a heading + image.
  *   - `ATLCLI_E2E_TREE_ROOT_ID` — the root of folder 002's DOCSY fixture tree
  *     (do not build a second tree; 002's tasks own and clean the shared one).
+ *   - `ATLCLI_E2E_WHITEBOARD_PAGE_ID` — optional DOCSY page whose ADF embeds an
+ *     Atlassian Whiteboard. The Whiteboard-specific test skips when absent.
  *   - profile `mayflower` is configured (or ephemeral ATLCLI_* env vars are set).
  */
 const RUN = process.env.ATLCLI_E2E === "1";
@@ -38,6 +40,8 @@ const CLI = fileURLToPath(new URL("../index.ts", import.meta.url));
 const PROFILE = process.env.ATLCLI_E2E_PROFILE ?? "mayflower";
 const PAGE_ID = process.env.ATLCLI_E2E_PAGE_ID ?? "";
 const TREE_ROOT_ID = process.env.ATLCLI_E2E_TREE_ROOT_ID ?? "";
+const WHITEBOARD_PAGE_ID =
+  process.env.ATLCLI_E2E_WHITEBOARD_PAGE_ID ?? "";
 
 if (RUN && PAGE_ID.trim() === "") {
   throw new Error(
@@ -202,6 +206,58 @@ describe("wiki export live E2E pack setup", () => {
 });
 
 describe.skipIf(!RUN)("wiki export --format pdf (live E2E)", () => {
+  it.skipIf(WHITEBOARD_PAGE_ID.trim() === "")(
+    "exports an embedded Whiteboard as a linked card in live DOCX and PDF",
+    async () => {
+      const dir = await mkdtemp(join(tmpdir(), "atlcli-e2e-whiteboard-"));
+      try {
+        for (const format of ["docx", "pdf"] as const) {
+          const out = join(dir, `whiteboard.${format}`);
+          const result = await runCli([
+            "wiki",
+            "export",
+            WHITEBOARD_PAGE_ID,
+            "--format",
+            format,
+            "--profile",
+            PROFILE,
+            "--output",
+            out,
+            "--report",
+            "json",
+          ]);
+          expect(result.code).toBe(0);
+          const report = JSON.parse(result.stdout);
+          expect(report.schema).toBe("atlcli.export-report/1");
+          expect(report.format).toBe(format);
+          expect(report.complete).toBe(true);
+          expect(report.warnings).toHaveLength(0);
+          expect(report.errors).toHaveLength(0);
+          expect(report.notesByCode?.["macro-rendered-via"]).toBe(1);
+          expect(report.notesByCode?.["macro-degraded"]).toBeUndefined();
+          expect(report.sourcePages).toHaveLength(1);
+          expect(
+            report.sourcePages[0].notes.map(
+              (note: { code: string }) => note.code
+            )
+          ).toEqual(["macro-rendered-via"]);
+
+          const bytes = new Uint8Array(await readFile(out));
+          expect(bytes.byteLength).toBeGreaterThan(0);
+          if (format === "pdf") {
+            const inspection = validatePdfOutput(bytes);
+            expect(inspection.pageCount).toBeGreaterThanOrEqual(1);
+            expect(inspection.tagged).toBe(true);
+            expect(inspection.hasOutline).toBe(true);
+          }
+        }
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    },
+    180_000
+  );
+
   it("exports a single page to a tagged PDF with a schema-v1 report", async () => {
     const dir = await mkdtemp(join(tmpdir(), "atlcli-e2e-pdf-"));
     try {

--- a/apps/extension/tests/jobs/packed/job-recovery.e2e.ts
+++ b/apps/extension/tests/jobs/packed/job-recovery.e2e.ts
@@ -585,15 +585,22 @@ async function submitPackedDocx(
   });
 }
 
-async function submitPackedPdf(jobId: string): Promise<string> {
-  return page.evaluate(async (id) => {
+async function submitPackedPdf(
+  jobId: string,
+  siteOrigin = "https://site.atlassian.net",
+): Promise<string> {
+  return page.evaluate(async ({ id, origin }) => {
     const probe = (globalThis as unknown as {
       exportJobStoreProbe: {
-        submitPdf(exportJobId: string): Promise<string>;
+        submitPdf(
+          exportJobId: string,
+          scopeKind?: "page" | "tree",
+          siteOrigin?: string,
+        ): Promise<string>;
       };
     }).exportJobStoreProbe;
-    return probe.submitPdf(id);
-  }, jobId);
+    return probe.submitPdf(id, "page", origin);
+  }, { id: jobId, origin: siteOrigin });
 }
 
 async function submitPackedTreePdf(jobId: string): Promise<string> {
@@ -1002,8 +1009,12 @@ test("two packed-extension wakeups produce exactly one claim", async () => {
 
 test("a packed MV3 PDF resolves embedded Whiteboard ADF offline", async () => {
   await ensureCatalog();
+  // The preceding fallback test intentionally proves ADF unavailable for the
+  // default synthetic origin. Use another tenant to prove the production
+  // capability cache stays origin-scoped while this test receives real ADF.
+  const siteOrigin = "https://whiteboard-site.atlassian.net";
   const whiteboardUrl =
-    "https://site.atlassian.net/wiki/spaces/DOCS/whiteboard/41";
+    `${siteOrigin}/wiki/spaces/DOCS/whiteboard/41`;
   const adf = JSON.stringify({
     type: "doc",
     version: 1,
@@ -1030,7 +1041,7 @@ test("a packed MV3 PDF resolves embedded Whiteboard ADF offline", async () => {
     { [JOB_O]: adf },
   );
 
-  await expect(submitPackedPdf(JOB_O)).resolves.toBe(JOB_O);
+  await expect(submitPackedPdf(JOB_O, siteOrigin)).resolves.toBe(JOB_O);
   const succeeded = await waitForJobState(JOB_O, "succeeded", 45_000);
   expect(succeeded.snapshot).toMatchObject({
     state: "succeeded",

--- a/apps/extension/tests/jobs/packed/job-recovery.e2e.ts
+++ b/apps/extension/tests/jobs/packed/job-recovery.e2e.ts
@@ -23,6 +23,7 @@ const JOB_K = "e23e4567-e89b-42d3-a456-426614174000";
 const JOB_L = "f23e4567-e89b-42d3-a456-426614174000";
 const JOB_M = "013e4567-e89b-42d3-a456-426614174001";
 const JOB_N = "113e4567-e89b-42d3-a456-426614174001";
+const JOB_O = "213e4567-e89b-42d3-a456-426614174001";
 const SHA_ABC =
   "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad";
 
@@ -96,6 +97,7 @@ async function installOffscreenFetchStub(
   childrenByPageId: Record<string, string[]> = {},
   assetBytesByPath: Record<string, number[]> = {},
   holdAssetPaths: string[] = [],
+  adfByPageId: Record<string, string> = {},
 ): Promise<void> {
   await packedOffscreen?.close();
   const root = await context.newCDPSession(page);
@@ -114,6 +116,7 @@ async function installOffscreenFetchStub(
     const storageByPageId = ${JSON.stringify(storageByPageId)};
     const childrenByPageId = ${JSON.stringify(childrenByPageId)};
     const assetBytesByPath = ${JSON.stringify(assetBytesByPath)};
+    const adfByPageId = ${JSON.stringify(adfByPageId)};
     const heldAssets = new Set(${JSON.stringify(holdAssetPaths)});
     const releases = Object.create(null);
     const released = new Set();
@@ -123,6 +126,7 @@ async function installOffscreenFetchStub(
     globalThis.__atlcliPackedFetchReleased = released;
     globalThis.__atlcliPackedBodyFetches = bodyFetches;
     globalThis.__atlcliPackedAssetFetches = assetFetches;
+    globalThis.__atlcliPackedWhiteboardFetches = 0;
     const nativeFetch = globalThis.fetch.bind(globalThis);
     globalThis.fetch = async (input) => {
       const rawUrl =
@@ -133,6 +137,9 @@ async function installOffscreenFetchStub(
             : input.url;
       const url = new URL(rawUrl, location.href);
       if (url.origin === location.origin) return nativeFetch(input);
+      if (/\\/whiteboard(?:s)?(?:\\/|$)/.test(url.pathname)) {
+        globalThis.__atlcliPackedWhiteboardFetches += 1;
+      }
       if (assetBytesByPath[url.pathname]) {
         assetFetches[url.pathname] = (assetFetches[url.pathname] || 0) + 1;
         if (heldAssets.has(url.pathname) && !released.has(url.pathname)) {
@@ -175,6 +182,19 @@ async function installOffscreenFetchStub(
       }
       const adfPage = url.pathname.match(/\\/api\\/v2\\/pages\\/([^/]+)$/);
       if (adfPage && url.searchParams.get("body-format") === "atlas_doc_format") {
+        const pageId = decodeURIComponent(adfPage[1]);
+        if (adfByPageId[pageId]) {
+          return new Response(JSON.stringify({
+            id: pageId,
+            version: { number: 1 },
+            body: {
+              atlas_doc_format: {
+                representation: "atlas_doc_format",
+                value: adfByPageId[pageId]
+              }
+            }
+          }), { status: 200, headers: { "content-type": "application/json" } });
+        }
         return new Response(JSON.stringify({
           message: "body-format atlas_doc_format is unsupported by this synthetic host"
         }), { status: 400, headers: { "content-type": "application/json" } });
@@ -260,6 +280,26 @@ async function readOffscreenAssetFetches(): Promise<Record<string, number>> {
     throw new Error(`Could not read packed asset fetch counts: ${JSON.stringify(result)}`);
   }
   return result.result.value as Record<string, number>;
+}
+
+async function readOffscreenWhiteboardFetches(): Promise<number> {
+  if (!packedOffscreen) throw new Error("Packed offscreen target is not attached.");
+  const result = await packedOffscreen.send<{
+    result?: { value?: unknown };
+    exceptionDetails?: unknown;
+  }>("Runtime.evaluate", {
+    expression: "globalThis.__atlcliPackedWhiteboardFetches",
+    returnByValue: true,
+  });
+  if (
+    result.exceptionDetails ||
+    typeof result.result?.value !== "number"
+  ) {
+    throw new Error(
+      `Could not read packed Whiteboard fetch count: ${JSON.stringify(result)}`,
+    );
+  }
+  return result.result.value;
 }
 
 async function createPackedPngBytes(): Promise<number[]> {
@@ -957,6 +997,87 @@ test("two packed-extension wakeups produce exactly one claim", async () => {
     byteLength: succeeded.snapshot.artifact.byteLength,
     filename: `${JOB_A}.pdf`,
     complete: true,
+  });
+});
+
+test("a packed MV3 PDF resolves embedded Whiteboard ADF offline", async () => {
+  await ensureCatalog();
+  const whiteboardUrl =
+    "https://site.atlassian.net/wiki/spaces/DOCS/whiteboard/41";
+  const adf = JSON.stringify({
+    type: "doc",
+    version: 1,
+    content: [{
+      type: "extension",
+      attrs: {
+        extensionType: "com.atlassian.confluence.macro.core",
+        extensionKey: "native-embed:whiteboard",
+        parameters: {
+          macroParams: {
+            url: { value: `${whiteboardUrl}?source=packed` },
+          },
+        },
+      },
+    }],
+  });
+  await installOffscreenFetchStub(
+    [],
+    {},
+    [],
+    {},
+    {},
+    [],
+    { [JOB_O]: adf },
+  );
+
+  await expect(submitPackedPdf(JOB_O)).resolves.toBe(JOB_O);
+  const succeeded = await waitForJobState(JOB_O, "succeeded", 45_000);
+  expect(succeeded.snapshot).toMatchObject({
+    state: "succeeded",
+    format: "pdf",
+    reportSummary: { completeness: "complete" },
+  });
+  expect(await readOffscreenWhiteboardFetches()).toBe(0);
+  if (!succeeded.snapshot.artifact || !succeeded.snapshot.reportRef) {
+    throw new Error(
+      "Packed Whiteboard PDF did not retain both artifact and report refs.",
+    );
+  }
+  const retained = await page.evaluate(
+    async ({ artifactRef, reportRef }) => {
+      const probe = (globalThis as unknown as {
+        exportJobStoreProbe: {
+          retainedPdf(
+            artifactRef: string,
+            reportRef: string,
+          ): Promise<{
+            prefix: string;
+            byteLength: number;
+            filename?: string;
+            complete?: boolean;
+            sourceNotes?: Array<{ code: string; macroName?: string }>;
+          }>;
+        };
+      }).exportJobStoreProbe;
+      return probe.retainedPdf(artifactRef, reportRef);
+    },
+    {
+      artifactRef: succeeded.snapshot.artifact.ref,
+      reportRef: succeeded.snapshot.reportRef,
+    },
+  );
+  expect(retained).toMatchObject({
+    prefix: "%PDF-",
+    byteLength: succeeded.snapshot.artifact.byteLength,
+    complete: true,
+  });
+  expect(retained.sourceNotes).toContainEqual({
+    code: "macro-rendered-via",
+    macroName: "native-embed:whiteboard",
+  });
+  expect(retained.sourceNotes).not.toContainEqual({
+    code: "macro-degraded",
+    macroName: "native-embed:whiteboard",
   });
 });
 

--- a/apps/extension/tests/jobs/packed/job-store-probe.ts
+++ b/apps/extension/tests/jobs/packed/job-store-probe.ts
@@ -479,16 +479,30 @@ const probe = {
   async retainedPdf(
     artifactRef: string,
     reportRef: string,
-  ): Promise<{ prefix: string; byteLength: number; filename?: string; complete?: boolean }> {
+  ): Promise<{
+    prefix: string;
+    byteLength: number;
+    filename?: string;
+    complete?: boolean;
+    sourceNotes?: Array<{ code: string; macroName?: string }>;
+  }> {
     const stored: number[] = [];
     for await (const chunk of new IndexedDbExportByteStore().read(artifactRef)) {
       for (const byte of chunk) stored.push(byte);
     }
     const report = await readExtensionPdfExportReport(reportRef);
+    const sourceNotes = report?.sourceNotes?.map((note) => ({
+      code: note.code,
+      ...(note.macroName ? { macroName: note.macroName } : {}),
+    }));
     return {
       prefix: new TextDecoder().decode(Uint8Array.from(stored.slice(0, 5))),
       byteLength: stored.length,
-      ...(report ? { filename: report.filename, complete: report.complete } : {}),
+      ...(report ? {
+        filename: report.filename,
+        complete: report.complete,
+        ...(sourceNotes ? { sourceNotes } : {}),
+      } : {}),
     };
   },
   async retainedDocx(

--- a/apps/extension/tests/jobs/packed/job-store-probe.ts
+++ b/apps/extension/tests/jobs/packed/job-store-probe.ts
@@ -641,10 +641,11 @@ const probe = {
   async submitPdf(
     id: string,
     scopeKind: "page" | "tree" = "page",
+    siteOrigin = "https://site.atlassian.net",
   ): Promise<string> {
     const catalog = new IndexedDbExportJobCatalog();
     const submitted = await submitExtensionPdfExport({
-      pageUrl: `https://site.atlassian.net/wiki/spaces/DOCS/pages/${id}/Packed`,
+      pageUrl: `${siteOrigin}/wiki/spaces/DOCS/pages/${id}/Packed`,
       page: {
         details: {
           id,

--- a/apps/extension/tests/macros/session-ports.test.ts
+++ b/apps/extension/tests/macros/session-ports.test.ts
@@ -15,6 +15,7 @@
  */
 import { afterEach, describe, expect, it } from "bun:test";
 import {
+  adfToBlocks,
   ConfluenceClient,
   storageToBlocks,
   type StorageToBlocksResult,
@@ -311,6 +312,67 @@ describe("dynamic-macro toggle OFF", () => {
     expect(codes(result.notes)).toContain("macro-skipped-by-config");
     expect(codes(result.notes)).not.toContain("macro-degraded");
     expect(built.ports.state.expired).toBe(false);
+  });
+});
+
+describe("embedded Whiteboard offline resolution", () => {
+  it("uses the MV3 session builder but performs no request", async () => {
+    const log = installFetch(() => {
+      throw new Error("The pure Whiteboard renderer must not fetch");
+    });
+    const decoded = adfToBlocks({
+      version: 1,
+      type: "doc",
+      content: [{
+        type: "extension",
+        attrs: {
+          extensionType: "com.atlassian.confluence.macro.core",
+          extensionKey: "native-embed:whiteboard",
+          parameters: {
+            macroParams: {
+              url: {
+                value:
+                  "/wiki/spaces/DOCSY/whiteboard/41?source=extension",
+              },
+            },
+          },
+        },
+      }],
+    }, {
+      pageContext: { id: ROOT_ID, spaceKey: "DOCSY" },
+    });
+    const built = buildSessionMacroResolutionOptions({
+      pageUrl: PAGE_URL,
+      targetEngine: "pdf",
+      live: false,
+    });
+    const page = { id: ROOT_ID, version: 3, spaceKey: "DOCSY" };
+    const result = await resolveMacroBlocks(
+      decoded,
+      built.options.registry,
+      built.options.contextFor(page),
+      {
+        live: false,
+        contextFor: (source) => built.options.contextFor(source ?? page),
+        targetEngine: "pdf",
+      },
+    );
+
+    expect(log.urls).toEqual([]);
+    expect(result.blocks).toEqual([{
+      type: "smartCard",
+      card: {
+        appearance: "block",
+        source: "url",
+        url: `${SITE}/wiki/spaces/DOCSY/whiteboard/41`,
+        target: {
+          kind: "external",
+          href: `${SITE}/wiki/spaces/DOCSY/whiteboard/41`,
+        },
+        title: "Atlassian Whiteboard",
+      },
+    }]);
+    expect(codes(result.notes)).toEqual(["macro-rendered-via"]);
   });
 });
 

--- a/apps/extension/tests/macros/session-ports.test.ts
+++ b/apps/extension/tests/macros/session-ports.test.ts
@@ -347,6 +347,7 @@ describe("per-source-page context (contextFor passed through unchanged)", () => 
     expect(ctx.page).toEqual({ id: CHILD_ID, version: 9, spaceKey: "OTHER" });
     expect(ctx.flags?.targetEngine).toBe("docx");
     expect(ctx.siteId).toBe(SITE);
+    expect(ctx.siteOrigin).toBe(SITE);
   });
 
   it("falls back to the single-macro v1 endpoints when the batch body lacks the macro", async () => {

--- a/apps/extension/tests/pdf/compiler.test.ts
+++ b/apps/extension/tests/pdf/compiler.test.ts
@@ -488,6 +488,59 @@ This is a real PDF.
     }
   }, 60_000);
 
+  it("emits the Whiteboard linked card as a real external annotation in tagged PDF", async () => {
+    const url = "https://tenant.invalid/wiki/spaces/TEST/whiteboard/41";
+    const prepared = await preparePdfDocument([{
+      type: "smartCard",
+      card: {
+        appearance: "block",
+        source: "url",
+        url,
+        target: { kind: "external", href: url },
+        title: "Atlassian Whiteboard",
+      },
+    }], {
+      resolve: async () => {
+        throw new Error("no assets in fixture");
+      },
+    });
+    const bundle = serializePdfDocument(prepared, {
+      metadata: {
+        title: "Whiteboard linked card",
+        language: "en",
+        exporter: "atlcli",
+        exportedAt: new Date("2026-07-30T00:00:00Z"),
+      },
+    });
+    const result = await sharedCompiler().compile(bundle);
+    expect(result.diagnostics).toEqual([]);
+    expect(validatePdfOutput(result.pdf!)).toMatchObject({ tagged: true });
+
+    const pdfjs = await import("pdfjs-dist/legacy/build/pdf.mjs");
+    const task = pdfjs.getDocument({ data: new Uint8Array(result.pdf!) });
+    const document = await task.promise;
+    try {
+      const links: string[] = [];
+      const text: string[] = [];
+      for (let pageNumber = 1; pageNumber <= document.numPages; pageNumber += 1) {
+        const page = await document.getPage(pageNumber);
+        for (const annotation of await page.getAnnotations({ intent: "display" })) {
+          if (annotation.subtype === "Link" && typeof annotation.url === "string") {
+            links.push(annotation.url);
+          }
+        }
+        const content = await page.getTextContent();
+        text.push(...content.items.flatMap((item) =>
+          "str" in item && typeof item.str === "string" ? [item.str] : []
+        ));
+      }
+      expect(links).toContain(url);
+      expect(text.join(" ")).toContain("Atlassian Whiteboard");
+    } finally {
+      await task.destroy();
+    }
+  }, 60_000);
+
   it("compiles Confluence ri:url links in table prose into external PDF annotations", async () => {
     const visibleUrl =
       "https://obi.atlassian.net/wiki/x/ImKFFg/a/long/path/that/wraps/in/a/narrow/table/cell";

--- a/apps/extension/utils/macros/session-ports.ts
+++ b/apps/extension/utils/macros/session-ports.ts
@@ -691,7 +691,12 @@ export function buildSessionMacroResolutionOptions(
       versionOf: input.versionOf ?? ((pageId) => pageVersions.get(pageId)),
     });
   const registry = createSessionMacroRegistry();
-  const siteId = profileFromTabUrl(input.pageUrl)?.baseUrl ?? input.pageUrl;
+  // Only the normalized, manifest-approved Atlassian profile origin is a URL
+  // trust boundary. `siteId` keeps its historical opaque-cache fallback when
+  // callers inject prebuilt ports, while `siteOrigin` deliberately does not.
+  const trustedProfile = profileFromTabUrl(input.pageUrl);
+  const siteId = trustedProfile?.baseUrl ?? input.pageUrl;
+  const siteOrigin = trustedProfile?.baseUrl;
   const anchors = input.chapterAnchorById;
   const pageScope: MacroPageScope | undefined = anchors
     ? { chapterAnchorFor: (pageId) => anchors.get(pageId) }
@@ -714,6 +719,7 @@ export function buildSessionMacroResolutionOptions(
         depth: 0,
         visited: new Set<string>(),
         siteId,
+        ...(siteOrigin ? { siteOrigin } : {}),
         ...(input.signal ? { signal: input.signal } : {}),
         flags: {
           ...(input.nativeTocPresent ? { nativeTocPresent: true } : {}),

--- a/packages/confluence/src/tree-fetch.test.ts
+++ b/packages/confluence/src/tree-fetch.test.ts
@@ -399,6 +399,14 @@ describe("fetchExportTree — cycles, folders, unsupported", () => {
     // code, so `info` here would let a silent content loss pass CI. Contrast
     // `label-filtered`, which stays `info` because the user asked for it.
     expect(unsupported.every((n) => n.level === "warning")).toBe(true);
+    const whiteboard = unsupported.find((note) =>
+      note.message.includes("direct Whiteboard child")
+    );
+    expect(whiteboard).toBeDefined();
+    expect(whiteboard?.message).not.toContain("wb");
+    expect(whiteboard?.message).not.toContain("WB");
+    expect(whiteboard?.message).toContain("not traversable");
+    expect(whiteboard?.message).toContain("Embedded Whiteboard links");
   });
 });
 

--- a/packages/confluence/src/tree-fetch.test.ts
+++ b/packages/confluence/src/tree-fetch.test.ts
@@ -1209,7 +1209,42 @@ describe("fetchExportTree — representation-neutral sources", () => {
     expect(node.notes.length).toBeGreaterThan(0);
     expect(node.notes.every((note) => note.source?.pageId === "root")).toBe(true);
     expect(node.notes.every((note) => note.source?.pageTitle === "Root")).toBe(true);
-    expect(result.sourceSummary.degradedPages).toBe(1);
+    // The extension note is provisional and owned by the later macro resolver;
+    // sourceSummary counts lossy decoding, not an unresolved pass that has not
+    // run yet.
+    expect(result.sourceSummary.degradedPages).toBe(0);
+  });
+
+  test("does not mark an embedded Whiteboard page source-degraded before macro resolution", async () => {
+    const source = inMemoryTreeSource(fixture.slice(0, 1));
+    source.getPage = async () => ({
+      id: "root",
+      title: "Root",
+      version: 1,
+      labels: [],
+      spaceKey: "SYNTHETIC",
+      exportSource: adfSource("ignored", 1, [{
+        type: "extension",
+        attrs: {
+          extensionType: "com.atlassian.confluence.macro.core",
+          extensionKey: "native-embed:whiteboard",
+          parameters: {
+            macroParams: {
+              url: { value: "/wiki/spaces/SYNTHETIC/whiteboard/41" },
+            },
+          },
+        },
+      }]),
+    });
+
+    const result = await fetchExportTree(source, tree("root"));
+    const node = result.nodes[0] as ExportPageNode;
+    expect(node.blocks).toEqual([expect.objectContaining({
+      type: "unknown",
+      macroName: "native-embed:whiteboard",
+    })]);
+    expect(node.notes.map((note) => note.code)).toEqual(["macro-not-rendered"]);
+    expect(result.sourceSummary.degradedPages).toBe(0);
   });
 
   for (const mode of ["strict", "partial"] as const) {

--- a/packages/confluence/src/tree-fetch.ts
+++ b/packages/confluence/src/tree-fetch.ts
@@ -667,6 +667,30 @@ function compareChildren(a: TreeChild, b: TreeChild): number {
   return a.title.localeCompare(b.title);
 }
 
+function unsupportedChildNote(child: TreeChild): ExportNote {
+  const kind = child.unsupportedKind ?? "unknown";
+  if (kind.toLowerCase() === "whiteboard") {
+    return {
+      level: "warning",
+      code: "unsupported-child-type",
+      message:
+        "A direct Whiteboard child is not traversable and was skipped; " +
+        "its board content was not exported. Embedded Whiteboard links on " +
+        "exported pages are retained separately.",
+    };
+  }
+  // `warning`, not `info`: content the user asked for is being DROPPED from
+  // the export. Contrast `label-filtered`, which is informational because the
+  // user explicitly requested that exclusion.
+  return {
+    level: "warning",
+    code: "unsupported-child-type",
+    message:
+      `Child "${child.title}" (${child.id}) is an unsupported type ` +
+      `"${kind}" and was skipped.`,
+  };
+}
+
 function normalizedScopeKey(scope: ExportScope): string {
   try {
     validateExportScope(scope);
@@ -1126,17 +1150,7 @@ export async function fetchExportTree(
     for (const child of sorted) {
       throwIfAborted(signal);
       if (child.kind === "unsupported") {
-        treeNotes.push({
-          // `warning`, not `info`: content the user asked for is being DROPPED
-          // from the export. Once note levels drive issue severity (and with it
-          // `--strict`'s exit code), classifying a silent content loss as
-          // informational is exactly the false negative `--strict` exists to
-          // prevent. Contrast `label-filtered`, which is info because the user
-          // explicitly asked for that exclusion.
-          level: "warning",
-          code: "unsupported-child-type",
-          message: `Child "${child.title}" (${child.id}) is an unsupported type "${child.unsupportedKind ?? "unknown"}" and was skipped.`,
-        });
+        treeNotes.push(unsupportedChildNote(child));
         continue;
       }
       if (child.kind === "folder") {
@@ -1189,17 +1203,7 @@ export async function fetchExportTree(
     }
     for (const child of [...children].sort(compareChildren)) {
       if (child.kind === "unsupported") {
-        treeNotes.push({
-          // `warning`, not `info`: content the user asked for is being DROPPED
-          // from the export. Once note levels drive issue severity (and with it
-          // `--strict`'s exit code), classifying a silent content loss as
-          // informational is exactly the false negative `--strict` exists to
-          // prevent. Contrast `label-filtered`, which is info because the user
-          // explicitly asked for that exclusion.
-          level: "warning",
-          code: "unsupported-child-type",
-          message: `Child "${child.title}" (${child.id}) is an unsupported type "${child.unsupportedKind ?? "unknown"}" and was skipped.`,
-        });
+        treeNotes.push(unsupportedChildNote(child));
         continue;
       }
       if (child.kind === "folder") {

--- a/packages/confluence/src/tree-fetch.ts
+++ b/packages/confluence/src/tree-fetch.ts
@@ -691,6 +691,28 @@ function unsupportedChildNote(child: TreeChild): ExportNote {
   };
 }
 
+const PROVISIONAL_ADF_RESOLUTION_CODES = new Set([
+  "macro-not-rendered",
+  "inline-extension-not-rendered",
+]);
+
+/**
+ * `sourceSummary.degradedPages` describes lossy source decoding, not a macro
+ * resolution pass that has not run yet. Pending ADF extension notes are owned
+ * and replaced by the downstream macro resolver; counting a page as degraded
+ * solely for those provisional notes would leave a successful pure renderer
+ * (such as the Whiteboard linked card) permanently marked degraded.
+ */
+function sourceDecodeDegraded(decoded: BlocksResult): boolean {
+  if (decoded.degraded !== true) return false;
+  // A zero diagnostic budget can suppress a real degradation note. Preserve
+  // the decoder's boolean when there is no evidence that it was provisional.
+  if (decoded.notes.length === 0) return true;
+  return decoded.notes.some(
+    (note) => !PROVISIONAL_ADF_RESOLUTION_CODES.has(note.code),
+  );
+}
+
 function normalizedScopeKey(scope: ExportScope): string {
   try {
     validateExportScope(scope);
@@ -1477,7 +1499,7 @@ export async function fetchExportTree(
           source: {
             representation:
               decoded.representation ?? exportSource.primary.representation,
-            degraded: decoded.degraded === true,
+            degraded: sourceDecodeDegraded(decoded),
           },
           blocks: decoded.blocks,
           notes: decoded.notes,

--- a/packages/docx/src/serialize.test.ts
+++ b/packages/docx/src/serialize.test.ts
@@ -347,6 +347,24 @@ describe("serializeBlocks — Smart Cards", () => {
     expect(xml.match(/<w:pBdr>/gu)).toHaveLength(2);
     expect(xml.match(/w:fill="F4F5F7"/gu)).toHaveLength(2);
   });
+
+  it("keeps the Whiteboard card label and canonical target clickable", async () => {
+    const url = "https://tenant.invalid/wiki/spaces/TEST/whiteboard/41";
+    const { xml } = await serializeBlocks([{
+      type: "smartCard",
+      card: {
+        appearance: "block",
+        source: "url",
+        url,
+        target: { kind: "external", href: url },
+        title: "Atlassian Whiteboard",
+      },
+    }], { styleNames: noStyles });
+
+    expect(xml).toContain(`HYPERLINK "${url}"`);
+    expect(xml).toContain(">Atlassian Whiteboard</w:t>");
+    expect(xml).toContain("<w:u");
+  });
 });
 
 describe("serializeBlocks — heading style mapping", () => {

--- a/packages/export-fixtures/src/macro-fixtures.test.ts
+++ b/packages/export-fixtures/src/macro-fixtures.test.ts
@@ -1,6 +1,19 @@
 import { describe, expect, test } from "bun:test";
 import {
+  adfToBlocks,
+  extractMacroBody,
+  htmlToExportBlocks,
+  parsePageProperties,
+  storageToBlocks,
+} from "@atlcli/confluence/browser";
+import {
+  defaultRegistry,
+  resolveMacroBlocks,
+} from "@atlcli/export-macros";
+import {
   hasMacroAdfExport,
+  hasWhiteboardLinkedCard,
+  MACRO_ADF_EXTENSION,
   MACRO_ADF_BLOCK_EXPORT_TEXT,
   MACRO_ADF_BODIED_EXPORT_TEXT,
   MACRO_ADF_INLINE_EXPORT_TEXT,
@@ -42,6 +55,68 @@ describe("macro conformance fixture", () => {
         note.code === "inline-extension-not-rendered" &&
         note.macroName === "forge-inline-export-widget"
       )).toBe(false);
+      expect(hasWhiteboardLinkedCard(result.blocks)).toBe(true);
+      expect(result.notes.filter((note) =>
+        note.code === "macro-rendered-via" &&
+        note.macroName === "native-embed:whiteboard"
+      )).toHaveLength(1);
+      expect(result.notes.some((note) =>
+        note.code === "macro-not-rendered" &&
+        note.macroName === "native-embed:whiteboard"
+      )).toBe(false);
     });
   }
+});
+
+test("a Forge-shaped consumer injects requestConfluence only for page acquisition", async () => {
+  const paths: string[] = [];
+  const requestConfluence = async (path: string): Promise<{
+    body: { atlas_doc_format: { value: unknown } };
+  }> => {
+    paths.push(path);
+    return {
+      body: {
+        atlas_doc_format: {
+          value: {
+            type: "doc",
+            version: 1,
+            content: [MACRO_ADF_EXTENSION.content.at(-1)],
+          },
+        },
+      },
+    };
+  };
+
+  const pageId = "fixture-page";
+  const response = await requestConfluence(
+    `/wiki/api/v2/pages/${pageId}?body-format=atlas_doc_format`,
+  );
+  const decoded = adfToBlocks(
+    response.body.atlas_doc_format.value as Parameters<typeof adfToBlocks>[0],
+    { pageContext: { id: pageId, version: 1, spaceKey: "TEST" } },
+  );
+  const registry = defaultRegistry({
+    storageToBlocks,
+    htmlToExportBlocks,
+    parsePageProperties,
+    extractMacroBody,
+  });
+  const result = await resolveMacroBlocks(decoded, registry, {
+    page: { id: pageId, version: 1, spaceKey: "TEST" },
+    depth: 0,
+    visited: new Set(),
+    siteOrigin: "https://tenant.invalid",
+  }, {
+    live: false,
+    targetEngine: "pdf",
+  });
+
+  expect(paths).toEqual([
+    `/wiki/api/v2/pages/${pageId}?body-format=atlas_doc_format`,
+  ]);
+  expect(paths.some((path) => /whiteboard/iu.test(path))).toBe(false);
+  expect(hasWhiteboardLinkedCard(result.blocks)).toBe(true);
+  expect(result.notes.map((note) => note.code)).toEqual([
+    "macro-rendered-via",
+  ]);
 });

--- a/packages/export-fixtures/src/macro-fixtures.test.ts
+++ b/packages/export-fixtures/src/macro-fixtures.test.ts
@@ -80,7 +80,7 @@ test("a Forge-shaped consumer injects requestConfluence only for page acquisitio
           value: {
             type: "doc",
             version: 1,
-            content: [MACRO_ADF_EXTENSION.content.at(-1)],
+            content: [MACRO_ADF_EXTENSION.content[3]],
           },
         },
       },

--- a/packages/export-fixtures/src/macro-fixtures.ts
+++ b/packages/export-fixtures/src/macro-fixtures.ts
@@ -118,6 +118,8 @@ export const MACRO_STORAGE: string =
 export const MACRO_ADF_BLOCK_EXTENSION_LOCAL_ID = "forge-block-extension-local-id";
 export const MACRO_ADF_BODIED_EXTENSION_LOCAL_ID = "forge-bodied-extension-local-id";
 export const MACRO_ADF_INLINE_EXTENSION_LOCAL_ID = "forge-inline-extension-local-id";
+export const MACRO_WHITEBOARD_URL =
+  "https://tenant.invalid/wiki/spaces/TEST/whiteboard/41";
 export const MACRO_ADF_EXTENSION = {
   type: "doc",
   version: 1,
@@ -161,6 +163,19 @@ export const MACRO_ADF_EXTENSION = {
         { type: "text", text: " after inline export" },
       ],
     },
+    {
+      type: "extension",
+      attrs: {
+        extensionType: "com.atlassian.confluence.macro.core",
+        extensionKey: "native-embed:whiteboard",
+        parameters: {
+          macroParams: {
+            _parentId: { value: "100" },
+            url: { value: `${MACRO_WHITEBOARD_URL}?source=fixture` },
+          },
+        },
+      },
+    },
   ],
 } as const;
 
@@ -195,6 +210,7 @@ function macroContext(): MacroExportContext {
     exportView: macroExportViewPort(),
     depth: 0,
     visited: new Set<string>(),
+    siteOrigin: "https://tenant.invalid",
   };
 }
 
@@ -243,4 +259,17 @@ export function hasMacroAdfExport(blocks: readonly ExportBlock[]): boolean {
   return serialized.includes(MACRO_ADF_BLOCK_EXPORT_TEXT) &&
     serialized.includes(MACRO_ADF_BODIED_EXPORT_TEXT) &&
     serialized.includes(MACRO_ADF_INLINE_EXPORT_TEXT);
+}
+
+/** True when the embedded Whiteboard became the canonical neutral linked card. */
+export function hasWhiteboardLinkedCard(
+  blocks: readonly ExportBlock[],
+): boolean {
+  return blocks.some((block) =>
+    block.type === "smartCard" &&
+    block.card.title === "Atlassian Whiteboard" &&
+    block.card.url === MACRO_WHITEBOARD_URL &&
+    block.card.target?.kind === "external" &&
+    block.card.target.href === MACRO_WHITEBOARD_URL
+  );
 }

--- a/packages/export-macros/README.md
+++ b/packages/export-macros/README.md
@@ -2,7 +2,8 @@
 
 The macro-renderer registry for the export engines: an async resolver pass
 that turns Confluence macro blocks (TOC, Jira, children, include/excerpt,
-multiexcerpt, page-properties-report, export_view fallback, diagrams, …)
+multiexcerpt, page-properties-report, embedded Whiteboard links, export_view
+fallback, diagrams, …)
 into renderable `ExportBlock` content. Zero runtime imports from other
 `@atlcli/*` packages — hosts inject the walker, converters, and
 `JiraClient`/`ConfluenceClient` ports at construction time.
@@ -23,3 +24,9 @@ const resolved = await resolveMacroBlocks(blocks, { registry, ports });
 
 Versioning: lockstep `@atlcli/*` train, pre-1.0 rules — see
 [package versioning](https://atlcli.sh/reference/versioning/).
+
+Embedded `native-embed:whiteboard` ADF nodes are handled offline. The registry
+accepts only a validated same-site
+`/wiki/spaces/{spaceKey}/whiteboard/{id}` destination and emits one neutral
+`Atlassian Whiteboard` Smart Card. It does not fetch Whiteboard content or
+metadata; invalid targets remain visible as a non-clickable degraded fallback.

--- a/packages/export-macros/etc/export-macros.api.md
+++ b/packages/export-macros/etc/export-macros.api.md
@@ -167,6 +167,7 @@ export interface MacroExportContext {
     signal?: AbortSignal;
     budget?: MacroResolutionBudget;
     siteId?: string;
+    siteOrigin?: string;
     flags?: {
         nativeTocPresent?: boolean;
         targetEngine?: "docx" | "pdf";
@@ -381,4 +382,22 @@ export declare function tocFromHeadings(blocks: ExportBlock[], opts?: {
 
 // export: tocRenderer
 export declare function tocRenderer(): MacroRenderer;
+
+// export: whiteboardRenderer
+export declare function whiteboardRenderer(): MacroRenderer;
+
+// export: WhiteboardTargetFailure
+export type WhiteboardTargetFailure = "missing-url" | "trusted-site-unavailable" | "malformed-url" | "unsupported-scheme" | "protocol-relative" | "unsafe-relative" | "credentials" | "fragment" | "cross-site" | "malformed-route" | "invalid-space-key" | "invalid-whiteboard-id";
+
+// export: whiteboardTargetVerdict
+export declare function whiteboardTargetVerdict(rawUrl: string | undefined, siteOrigin: string | undefined): WhiteboardTargetVerdict;
+
+// export: WhiteboardTargetVerdict
+export type WhiteboardTargetVerdict = {
+    safe: true;
+    url: string;
+} | {
+    safe: false;
+    reason: WhiteboardTargetFailure;
+};
 ```

--- a/packages/export-macros/etc/export-macros.closure.md
+++ b/packages/export-macros/etc/export-macros.closure.md
@@ -17,4 +17,4 @@
 
 ### Entry point `./internal` — internal
 
-- exported symbols (25): DatasourceSiteVerdict, childrenRenderer, columnNotes, confluenceListCellText, confluenceListRenderer, confluenceListTable, cqlFromParams, datasourceSiteVerdict, diagramMacroRenderer, escapeCqlValue, excerptIncludeRenderer, excerptRenderer, exportViewFallbackRenderer, includeRenderer, issueTable, jiraMacroRenderer, jiraStatusColor, macroParamText, multiexcerptIncludeRenderer, pagePropertiesReportRenderer, parseWidths, scrollTableLayoutRenderer, slugifyHeading, tocFromHeadings, tocRenderer
+- exported symbols (29): DatasourceSiteVerdict, WhiteboardTargetFailure, WhiteboardTargetVerdict, childrenRenderer, columnNotes, confluenceListCellText, confluenceListRenderer, confluenceListTable, cqlFromParams, datasourceSiteVerdict, diagramMacroRenderer, escapeCqlValue, excerptIncludeRenderer, excerptRenderer, exportViewFallbackRenderer, includeRenderer, issueTable, jiraMacroRenderer, jiraStatusColor, macroParamText, multiexcerptIncludeRenderer, pagePropertiesReportRenderer, parseWidths, scrollTableLayoutRenderer, slugifyHeading, tocFromHeadings, tocRenderer, whiteboardRenderer, whiteboardTargetVerdict

--- a/packages/export-macros/src/internal.ts
+++ b/packages/export-macros/src/internal.ts
@@ -17,4 +17,5 @@ export * from "./table-layout.js";
 export * from "./children.js";
 export * from "./include-excerpt.js";
 export * from "./page-properties-report.js";
+export * from "./whiteboard.js";
 export * from "./export-view.js";

--- a/packages/export-macros/src/registry.test.ts
+++ b/packages/export-macros/src/registry.test.ts
@@ -94,4 +94,17 @@ describe("defaultRegistry — the shipped renderer set", () => {
     const jira = registry.renderers.find((r) => r.id === "jira");
     expect(jira?.macros).toEqual(["jira", "jiraissues"]);
   });
+
+  test("routes embedded Whiteboards before the live export-view floor", () => {
+    const registry = defaultRegistry(deps);
+    const whiteboardIndex = registry.renderers.findIndex(
+      (renderer) => renderer.id === "whiteboard-linked-card",
+    );
+    const exportViewIndex = registry.renderers.findIndex(
+      (renderer) => renderer.id === "export-view",
+    );
+    expect(whiteboardIndex).toBeGreaterThanOrEqual(0);
+    expect(whiteboardIndex).toBeLessThan(exportViewIndex);
+    expect(registry.renderers[whiteboardIndex]?.requiresLivePort).toBe(false);
+  });
 });

--- a/packages/export-macros/src/registry.ts
+++ b/packages/export-macros/src/registry.ts
@@ -21,6 +21,7 @@ import { scrollTableLayoutRenderer } from "./table-layout.js";
 import { childrenRenderer } from "./children.js";
 import { includeRenderer, excerptIncludeRenderer, excerptRenderer } from "./include-excerpt.js";
 import { pagePropertiesReportRenderer } from "./page-properties-report.js";
+import { whiteboardRenderer } from "./whiteboard.js";
 import { exportViewFallbackRenderer } from "./export-view.js";
 
 /**
@@ -123,8 +124,8 @@ function validateRenderers(
  * Assemble the standard renderer order: TOC first (pure reference renderer),
  * then the specific renderers (Jira, Confluence list, diagram,
  * multiexcerpt-include, scroll-tablelayout, children, include/excerpt,
- * page-properties-report), `exportViewFallbackRenderer` last as the `"*"`
- * catch-all.
+ * page-properties-report), the pure embedded-Whiteboard link renderer, then
+ * `exportViewFallbackRenderer` last as the `"*"` catch-all.
  */
 export function defaultRegistry(deps: DefaultRegistryDeps): MacroRendererRegistry {
   return createRegistry([
@@ -148,6 +149,7 @@ export function defaultRegistry(deps: DefaultRegistryDeps): MacroRendererRegistr
       storageToBlocks: deps.storageToBlocks,
       parsePageProperties: deps.parsePageProperties,
     }),
+    whiteboardRenderer(),
     exportViewFallbackRenderer({ htmlToExportBlocks: deps.htmlToExportBlocks }),
   ]);
 }

--- a/packages/export-macros/src/types.ts
+++ b/packages/export-macros/src/types.ts
@@ -345,6 +345,12 @@ export interface MacroExportContext {
    */
   siteId?: string;
   /**
+   * Trusted Confluence site origin used to validate tenant-local navigation
+   * targets retained from untrusted page content. Unlike {@link siteId}, this
+   * field is a URL security boundary rather than an opaque cache identity.
+   */
+  siteOrigin?: string;
+  /**
    * Renderer-level flags threaded from {@link MacroResolutionOptions}. E.g.
    * `nativeTocPresent` lets the TOC renderer suppress a duplicate body-TOC when
    * the DOCX template already carries a native TOC field.

--- a/packages/export-macros/src/whiteboard.test.ts
+++ b/packages/export-macros/src/whiteboard.test.ts
@@ -1,0 +1,315 @@
+import { describe, expect, it } from "bun:test";
+import { adfToBlocks, type ExportBlock } from "@atlcli/confluence";
+import { defaultRegistry } from "./registry.js";
+import { resolveMacroBlocks } from "./resolve.js";
+import {
+  whiteboardRenderer,
+  whiteboardTargetVerdict,
+  type WhiteboardTargetFailure,
+} from "./whiteboard.js";
+import type { MacroExportContext, MacroInstance } from "./types.js";
+
+const SITE = "https://tenant.invalid";
+const EXTENSION = {
+  extensionType: "com.atlassian.confluence.macro.core",
+  extensionKey: "native-embed:whiteboard",
+} as const;
+
+function context(
+  overrides: Partial<MacroExportContext> = {},
+): MacroExportContext {
+  return {
+    page: { id: "100", spaceKey: "SYNTHETIC" },
+    depth: 0,
+    visited: new Set(),
+    siteId: SITE,
+    siteOrigin: SITE,
+    ...overrides,
+  };
+}
+
+function macro(url?: string): MacroInstance {
+  return {
+    name: EXTENSION.extensionKey,
+    adfExtension: EXTENSION,
+    ...(url ? { params: [{ name: "url", text: url }] } : { params: [] }),
+  };
+}
+
+describe("whiteboardTargetVerdict", () => {
+  it("canonicalizes same-site absolute and origin-relative routes", () => {
+    expect(whiteboardTargetVerdict(
+      `${SITE}/wiki/spaces/SYNTHETIC/whiteboard/41?source=embed`,
+      `${SITE}/wiki`,
+    )).toEqual({
+      safe: true,
+      url: `${SITE}/wiki/spaces/SYNTHETIC/whiteboard/41`,
+    });
+    expect(whiteboardTargetVerdict(
+      "/wiki/spaces/~SYNTHETIC/whiteboard/42",
+      SITE,
+    )).toEqual({
+      safe: true,
+      url: `${SITE}/wiki/spaces/~SYNTHETIC/whiteboard/42`,
+    });
+  });
+
+  const unsafe: Array<{
+    name: string;
+    url?: string;
+    siteOrigin?: string;
+    reason: WhiteboardTargetFailure;
+  }> = [
+    { name: "missing URL", siteOrigin: SITE, reason: "missing-url" },
+    {
+      name: "missing trusted site",
+      url: "/wiki/spaces/SYNTHETIC/whiteboard/41",
+      reason: "trusted-site-unavailable",
+    },
+    {
+      name: "malformed trusted site",
+      url: "/wiki/spaces/SYNTHETIC/whiteboard/41",
+      siteOrigin: "not a URL",
+      reason: "trusted-site-unavailable",
+    },
+    {
+      name: "external host",
+      url: "https://external.invalid/wiki/spaces/SYNTHETIC/whiteboard/41",
+      siteOrigin: SITE,
+      reason: "cross-site",
+    },
+    {
+      name: "cross-tenant host",
+      url: "https://other-tenant.invalid/wiki/spaces/SYNTHETIC/whiteboard/41",
+      siteOrigin: SITE,
+      reason: "cross-site",
+    },
+    {
+      name: "unsupported scheme",
+      url: "javascript:alert(1)",
+      siteOrigin: SITE,
+      reason: "unsupported-scheme",
+    },
+    {
+      name: "downgraded HTTP scheme",
+      url: "http://tenant.invalid/wiki/spaces/SYNTHETIC/whiteboard/41",
+      siteOrigin: SITE,
+      reason: "unsupported-scheme",
+    },
+    {
+      name: "credentials",
+      url: "https://user:secret@tenant.invalid/wiki/spaces/SYNTHETIC/whiteboard/41",
+      siteOrigin: SITE,
+      reason: "credentials",
+    },
+    {
+      name: "fragment",
+      url: `${SITE}/wiki/spaces/SYNTHETIC/whiteboard/41#canvas`,
+      siteOrigin: SITE,
+      reason: "fragment",
+    },
+    {
+      name: "protocol-relative URL",
+      url: "//tenant.invalid/wiki/spaces/SYNTHETIC/whiteboard/41",
+      siteOrigin: SITE,
+      reason: "protocol-relative",
+    },
+    {
+      name: "path-relative URL",
+      url: "wiki/spaces/SYNTHETIC/whiteboard/41",
+      siteOrigin: SITE,
+      reason: "unsafe-relative",
+    },
+    {
+      name: "parent-relative URL",
+      url: "../wiki/spaces/SYNTHETIC/whiteboard/41",
+      siteOrigin: SITE,
+      reason: "malformed-url",
+    },
+    {
+      name: "wrong route",
+      url: "/wiki/spaces/SYNTHETIC/pages/41",
+      siteOrigin: SITE,
+      reason: "malformed-route",
+    },
+    {
+      name: "invalid space key",
+      url: "/wiki/spaces/SYNTHETIC-SPACE/whiteboard/41",
+      siteOrigin: SITE,
+      reason: "invalid-space-key",
+    },
+    {
+      name: "invalid Whiteboard id",
+      url: "/wiki/spaces/SYNTHETIC/whiteboard/board-41",
+      siteOrigin: SITE,
+      reason: "invalid-whiteboard-id",
+    },
+    {
+      name: "encoded slash",
+      url: "/wiki/spaces/SYNTHETIC/whiteboard/41%2F42",
+      siteOrigin: SITE,
+      reason: "malformed-route",
+    },
+  ];
+
+  for (const fixture of unsafe) {
+    it(`rejects ${fixture.name}`, () => {
+      expect(
+        whiteboardTargetVerdict(fixture.url, fixture.siteOrigin),
+      ).toEqual({ safe: false, reason: fixture.reason });
+    });
+  }
+});
+
+describe("whiteboardRenderer", () => {
+  it("emits one deterministic linked Smart Card without a live port", async () => {
+    const renderer = whiteboardRenderer();
+    expect(renderer.macros).toEqual(["native-embed:whiteboard"]);
+    expect(renderer.requiresLivePort).toBe(false);
+
+    const result = await renderer.render(
+      macro(`${SITE}/wiki/spaces/SYNTHETIC/whiteboard/41?ignored=true`),
+      context(),
+    );
+
+    expect(result).toEqual({
+      kind: "blocks",
+      blocks: [{
+        type: "smartCard",
+        card: {
+          appearance: "block",
+          source: "url",
+          url: `${SITE}/wiki/spaces/SYNTHETIC/whiteboard/41`,
+          target: {
+            kind: "external",
+            href: `${SITE}/wiki/spaces/SYNTHETIC/whiteboard/41`,
+          },
+          title: "Atlassian Whiteboard",
+        },
+      }],
+      notes: [{
+        level: "info",
+        code: "macro-rendered-via",
+        message:
+          "The embedded Atlassian Whiteboard was represented as a linked card; " +
+          "Whiteboard pixels and editable content were not exported.",
+        macroName: "native-embed:whiteboard",
+      }],
+    });
+  });
+
+  it("emits a visible degraded fallback without echoing an unsafe target", async () => {
+    const unsafe = "https://external.invalid/wiki/spaces/PRIVATE/whiteboard/999";
+    const result = await whiteboardRenderer().render(macro(unsafe), context());
+
+    expect(result.kind).toBe("blocks");
+    if (result.kind !== "blocks") throw new Error("Expected blocks");
+    expect(result.blocks).toEqual([{
+      type: "paragraph",
+      content: [{ type: "text", text: "Atlassian Whiteboard (link unavailable)" }],
+    }]);
+    expect(result.notes).toHaveLength(1);
+    expect(result.notes?.[0]).toMatchObject({
+      level: "warning",
+      code: "macro-degraded",
+      macroName: "native-embed:whiteboard",
+    });
+    expect(JSON.stringify(result.notes)).not.toContain(unsafe);
+    expect(JSON.stringify(result.notes)).not.toContain("PRIVATE");
+    expect(JSON.stringify(result.notes)).not.toContain("999");
+  });
+
+  it("does not claim a Storage macro or another ADF extension type", async () => {
+    const renderer = whiteboardRenderer();
+    expect(await renderer.render({
+      name: EXTENSION.extensionKey,
+      params: [{ name: "url", text: "/wiki/spaces/SYNTHETIC/whiteboard/41" }],
+    }, context())).toEqual({ kind: "skip" });
+    expect(await renderer.render({
+      ...macro("/wiki/spaces/SYNTHETIC/whiteboard/41"),
+      adfExtension: { ...EXTENSION, extensionType: "com.example.app" },
+    }, context())).toEqual({ kind: "skip" });
+  });
+});
+
+describe("Whiteboard ADF resolution", () => {
+  const deps = {
+    storageToBlocks: () => ({ blocks: [], notes: [] }),
+    htmlToExportBlocks: () => ({ blocks: [], notes: [] }),
+    parsePageProperties: () => [],
+    extractMacroBody: () => undefined,
+  } as unknown as Parameters<typeof defaultRegistry>[0];
+
+  function extension(id: number): Record<string, unknown> {
+    return {
+      type: "extension",
+      attrs: {
+        ...EXTENSION,
+        parameters: {
+          macroParams: {
+            _parentId: { value: "100" },
+            url: {
+              value: `/wiki/spaces/SYNTHETIC/whiteboard/${id}`,
+            },
+          },
+        },
+      },
+    };
+  }
+
+  it("preserves nested source order, one card and one terminal outcome per instance", async () => {
+    const decoded = adfToBlocks({
+      version: 1,
+      type: "doc",
+      content: [
+        extension(41),
+        { type: "blockquote", content: [extension(42)] },
+        extension(43),
+      ],
+    } as Parameters<typeof adfToBlocks>[0], {
+      pageContext: { id: "100", spaceKey: "SYNTHETIC" },
+    });
+    let exportViewCalls = 0;
+
+    const result = await resolveMacroBlocks(
+      decoded,
+      defaultRegistry(deps),
+      context({
+        exportView: {
+          async renderMacroHtml() {
+            exportViewCalls += 1;
+            return "<p>unexpected</p>";
+          },
+        },
+      }),
+      { live: false },
+    );
+
+    expect(exportViewCalls).toBe(0);
+    expect(result.blocks.map((block) => block.type)).toEqual([
+      "smartCard",
+      "blockquote",
+      "smartCard",
+    ]);
+    const nested = result.blocks[1] as Extract<ExportBlock, { type: "blockquote" }>;
+    expect(nested.content.map((block) => block.type)).toEqual(["smartCard"]);
+    const cards: ExportBlock[] = [
+      result.blocks[0]!,
+      nested.content[0]!,
+      result.blocks[2]!,
+    ];
+    expect(cards.map((block) =>
+      block.type === "smartCard" ? block.card.url : undefined
+    )).toEqual([
+      `${SITE}/wiki/spaces/SYNTHETIC/whiteboard/41`,
+      `${SITE}/wiki/spaces/SYNTHETIC/whiteboard/42`,
+      `${SITE}/wiki/spaces/SYNTHETIC/whiteboard/43`,
+    ]);
+    expect(result.notes).toHaveLength(3);
+    expect(result.notes.map((note) => note.code)).toEqual([
+      "macro-rendered-via",
+      "macro-rendered-via",
+      "macro-rendered-via",
+    ]);
+  });
+});

--- a/packages/export-macros/src/whiteboard.ts
+++ b/packages/export-macros/src/whiteboard.ts
@@ -1,0 +1,239 @@
+/**
+ * Pure Atlassian Whiteboard linked-card renderer.
+ *
+ * Embedded Whiteboards carry a navigation URL in page ADF, but no public
+ * preview/body bytes. This renderer intentionally consumes only that retained
+ * parameter and the host-proven site origin: it never calls a port and never
+ * claims that Whiteboard content was exported.
+ */
+import type { ExportBlock, ExportNote } from "@atlcli/confluence";
+import { macroParamText } from "./params.js";
+import type {
+  MacroExportContext,
+  MacroInstance,
+  MacroRenderer,
+  MacroRenderResult,
+} from "./types.js";
+
+const WHITEBOARD_EXTENSION_TYPE = "com.atlassian.confluence.macro.core";
+const WHITEBOARD_EXTENSION_KEY = "native-embed:whiteboard";
+const WHITEBOARD_LABEL = "Atlassian Whiteboard";
+
+export type WhiteboardTargetFailure =
+  | "missing-url"
+  | "trusted-site-unavailable"
+  | "malformed-url"
+  | "unsupported-scheme"
+  | "protocol-relative"
+  | "unsafe-relative"
+  | "credentials"
+  | "fragment"
+  | "cross-site"
+  | "malformed-route"
+  | "invalid-space-key"
+  | "invalid-whiteboard-id";
+
+export type WhiteboardTargetVerdict =
+  | { safe: true; url: string }
+  | { safe: false; reason: WhiteboardTargetFailure };
+
+/**
+ * Validate and canonicalize an untrusted embedded-Whiteboard URL.
+ *
+ * Only the documented Cloud navigation route is accepted. Relative input must
+ * be origin-relative (`/wiki/...`) so it cannot inherit a source page path.
+ * Queries are deliberately discarded: no query parameter is required for
+ * ordinary Whiteboard navigation.
+ */
+export function whiteboardTargetVerdict(
+  rawUrl: string | undefined,
+  siteOrigin: string | undefined,
+): WhiteboardTargetVerdict {
+  const raw = rawUrl?.trim();
+  if (!raw) return { safe: false, reason: "missing-url" };
+
+  const trusted = trustedOrigin(siteOrigin);
+  if (!trusted) return { safe: false, reason: "trusted-site-unavailable" };
+
+  if (raw.startsWith("//")) return { safe: false, reason: "protocol-relative" };
+  // URL parsers normalize these bytes or treat backslashes as path separators.
+  // Reject them before parsing so validation applies to exactly what ADF held.
+  // eslint-disable-next-line no-control-regex
+  if (/[\u0000-\u0020\u007f\\]/u.test(raw) || hasDotPathSegment(raw)) {
+    return { safe: false, reason: "malformed-url" };
+  }
+
+  const hasScheme = /^[a-z][a-z0-9+.-]*:/iu.test(raw);
+  if (!hasScheme && !raw.startsWith("/")) {
+    return { safe: false, reason: "unsafe-relative" };
+  }
+
+  let target: URL;
+  try {
+    target = new URL(raw, trusted.origin);
+  } catch {
+    return { safe: false, reason: "malformed-url" };
+  }
+
+  if (target.protocol !== "https:") {
+    return { safe: false, reason: "unsupported-scheme" };
+  }
+  if (target.username || target.password) {
+    return { safe: false, reason: "credentials" };
+  }
+  if (raw.includes("#")) {
+    return { safe: false, reason: "fragment" };
+  }
+  if (target.origin !== trusted.origin) {
+    return { safe: false, reason: "cross-site" };
+  }
+
+  const match = target.pathname.match(
+    /^\/wiki\/spaces\/([^/]+)\/whiteboard\/([^/]+)\/?$/u,
+  );
+  if (!match) return { safe: false, reason: "malformed-route" };
+
+  const spaceKey = decodePathSegment(match[1]!);
+  const whiteboardId = decodePathSegment(match[2]!);
+  if (spaceKey === undefined || whiteboardId === undefined) {
+    return { safe: false, reason: "malformed-route" };
+  }
+  // Atlassian documents custom space keys as 1–255 alphanumerics. The leading
+  // "~" additionally covers Confluence personal-space routes.
+  if (!/^~?[a-z0-9]{1,255}$/iu.test(spaceKey)) {
+    return { safe: false, reason: "invalid-space-key" };
+  }
+  // REST v2 documents the Whiteboard path id as an integer.
+  if (!/^[1-9][0-9]*$/u.test(whiteboardId)) {
+    return { safe: false, reason: "invalid-whiteboard-id" };
+  }
+
+  return {
+    safe: true,
+    url:
+      `${trusted.origin}/wiki/spaces/${encodeURIComponent(spaceKey)}` +
+      `/whiteboard/${whiteboardId}`,
+  };
+}
+
+function trustedOrigin(value: string | undefined): URL | undefined {
+  if (!value) return undefined;
+  try {
+    const url = new URL(value);
+    if (
+      url.protocol !== "https:" ||
+      url.username ||
+      url.password ||
+      url.origin === "null"
+    ) {
+      return undefined;
+    }
+    return url;
+  } catch {
+    return undefined;
+  }
+}
+
+function decodePathSegment(value: string): string | undefined {
+  try {
+    const decoded = decodeURIComponent(value);
+    return decoded.includes("/") || decoded.includes("\\") ? undefined : decoded;
+  } catch {
+    return undefined;
+  }
+}
+
+function hasDotPathSegment(value: string): boolean {
+  const withoutQueryOrFragment = value.split(/[?#]/u, 1)[0] ?? "";
+  return /(?:^|\/)(?:\.{1,2}|%2e(?:%2e)?)(?:\/|$)/iu.test(
+    withoutQueryOrFragment,
+  );
+}
+
+function fallbackBlock(): ExportBlock {
+  return {
+    type: "paragraph",
+    content: [{ type: "text", text: `${WHITEBOARD_LABEL} (link unavailable)` }],
+  };
+}
+
+function failureNote(
+  macroName: string,
+  reason: WhiteboardTargetFailure,
+): ExportNote {
+  const explanation: Record<WhiteboardTargetFailure, string> = {
+    "missing-url": "has no navigation target",
+    "trusted-site-unavailable": "could not be checked against a trusted site",
+    "malformed-url": "has a malformed navigation target",
+    "unsupported-scheme": "uses an unsupported URL scheme",
+    "protocol-relative": "uses a protocol-relative target",
+    "unsafe-relative": "uses an unsafe relative target",
+    credentials: "contains URL credentials",
+    fragment: "contains a fragment destination",
+    "cross-site": "points to a different site",
+    "malformed-route": "does not use the documented Whiteboard route",
+    "invalid-space-key": "contains an invalid space key",
+    "invalid-whiteboard-id": "contains an invalid Whiteboard id",
+  };
+  return {
+    level: "warning",
+    code: "macro-degraded",
+    message:
+      `The embedded Atlassian Whiteboard ${explanation[reason]}; ` +
+      "a visible non-clickable fallback was emitted.",
+    macroName,
+  };
+}
+
+export function whiteboardRenderer(): MacroRenderer {
+  return {
+    id: "whiteboard-linked-card",
+    macros: [WHITEBOARD_EXTENSION_KEY],
+    requiresLivePort: false,
+    async render(
+      macro: MacroInstance,
+      ctx: MacroExportContext,
+    ): Promise<MacroRenderResult> {
+      if (
+        macro.adfExtension?.extensionType !== WHITEBOARD_EXTENSION_TYPE ||
+        macro.adfExtension.extensionKey.toLowerCase() !== WHITEBOARD_EXTENSION_KEY
+      ) {
+        return { kind: "skip" };
+      }
+
+      const verdict = whiteboardTargetVerdict(
+        macroParamText(macro.params, "url"),
+        ctx.siteOrigin,
+      );
+      if (!verdict.safe) {
+        return {
+          kind: "blocks",
+          blocks: [fallbackBlock()],
+          notes: [failureNote(macro.name, verdict.reason)],
+        };
+      }
+
+      return {
+        kind: "blocks",
+        blocks: [{
+          type: "smartCard",
+          card: {
+            appearance: "block",
+            source: "url",
+            url: verdict.url,
+            target: { kind: "external", href: verdict.url },
+            title: WHITEBOARD_LABEL,
+          },
+        }],
+        notes: [{
+          level: "info",
+          code: "macro-rendered-via",
+          message:
+            "The embedded Atlassian Whiteboard was represented as a linked card; " +
+            "Whiteboard pixels and editable content were not exported.",
+          macroName: macro.name,
+        }],
+      };
+    },
+  };
+}

--- a/packages/export-wiring/src/macro-options.test.ts
+++ b/packages/export-wiring/src/macro-options.test.ts
@@ -88,6 +88,17 @@ describe("buildMacroResolutionOptions", () => {
     expect(pdf.live).toBe(false);
   });
 
+  test("carries the trusted site origin separately from the cache identity", () => {
+    const options = buildMacroResolutionOptions({
+      siteBaseUrl: BASE,
+      confluence,
+      targetEngine: "docx",
+    });
+    const context = options.contextFor({ id: "1" });
+    expect(context.siteId).toBe(BASE);
+    expect(context.siteOrigin).toBe(BASE);
+  });
+
   test("`live` is absent (not false) when the host does not set it", () => {
     const options = buildMacroResolutionOptions({
       siteBaseUrl: BASE,

--- a/packages/export-wiring/src/macro-options.ts
+++ b/packages/export-wiring/src/macro-options.ts
@@ -137,6 +137,7 @@ export function buildMacroResolutionOptions(args: BuildMacroOptionsArgs): MacroR
         depth: 0,
         visited: new Set(),
         siteId,
+        siteOrigin: args.siteBaseUrl,
         ...(args.signal ? { signal: args.signal } : {}),
         flags: {
           ...(args.nativeTocPresent ? { nativeTocPresent: true } : {}),

--- a/packages/pdf/src/serialize.test.ts
+++ b/packages/pdf/src/serialize.test.ts
@@ -1259,6 +1259,32 @@ describe("PDF preparation and serialization", () => {
     expect(bundle.main.match(/stroke: rgb\\?\("#B3BAC5"/gu)).toHaveLength(2);
   });
 
+  it("keeps the Whiteboard card label and canonical target clickable", async () => {
+    const url = "https://tenant.invalid/wiki/spaces/TEST/whiteboard/41";
+    const prepared = await preparePdfDocument([{
+      type: "smartCard",
+      card: {
+        appearance: "block",
+        source: "url",
+        url,
+        target: { kind: "external", href: url },
+        title: "Atlassian Whiteboard",
+      },
+    }], {
+      resolve: async () => {
+        throw new Error("unused");
+      },
+    });
+    const bundle = serializePdfDocument(prepared, { metadata });
+
+    expect(bundle.main).toContain(
+      `#link("${url}")[#text("Atlassian Whiteboard")]`,
+    );
+    expect(bundle.notes.some((note) => note.code === "pdf-link-unresolved")).toBe(
+      false,
+    );
+  });
+
   it("preserves arbitrary inline background colors as breakable Typst highlights", async () => {
     const prepared = await preparePdfDocument(
       [

--- a/scripts/bench/generate-m1-corpus.test.ts
+++ b/scripts/bench/generate-m1-corpus.test.ts
@@ -18,12 +18,13 @@ import {
   corpusBlockCount,
   labelledPageCount,
   MACRO_ADF_INLINE_EXPORT_TEXT,
+  MACRO_WHITEBOARD_URL,
   M1_CORPUS_PAGES,
   M1_CORPUS_VERSION,
 } from "@atlcli/export-fixtures";
 
 /** Structural golden — a stable sha256 of the corpus node JSON. */
-const M1_CORPUS_DIGEST = "9a0c8c822d795cdcca24abae8b4f0fb26e987c03f2e03245772d5cfb3d658b0b";
+const M1_CORPUS_DIGEST = "edd87bfd77bc5821f61be4ee425fbc24f274432d18872911e23d6bd66203baca";
 
 describe("M1 acceptance corpus", () => {
   it("is deterministic: same version → byte-identical JSON", async () => {
@@ -36,7 +37,7 @@ describe("M1 acceptance corpus", () => {
     const corpus = await buildM1Corpus();
     expect(corpus.version).toBe(M1_CORPUS_VERSION);
     expect(corpus.nodes.length).toBe(M1_CORPUS_PAGES);
-    expect(corpusBlockCount(corpus)).toBe(196);
+    expect(corpusBlockCount(corpus)).toBe(204);
     expect(labelledPageCount(corpus)).toBe(16);
   });
 
@@ -53,6 +54,12 @@ describe("M1 acceptance corpus", () => {
     expect(flat.some((b) => b.type === "orientation")).toBe(true); // scroll-landscape
     expect(flat.some((b) => b.type === "pageBreak")).toBe(true); // scroll-pagebreak
     expect(flat.some((b) => b.type === "unknown")).toBe(true); // draw.io floor
+    expect(flat.some(
+      (block) =>
+        block.type === "smartCard" &&
+        block.card.title === "Atlassian Whiteboard" &&
+        block.card.url === MACRO_WHITEBOARD_URL,
+    )).toBe(true);
     expect(flat.some(
       (block) =>
         block.type === "paragraph"

--- a/scripts/check-browser-build.test.ts
+++ b/scripts/check-browser-build.test.ts
@@ -80,6 +80,7 @@ describe("browser-build gate (spec 001 task 6)", () => {
 
   for (const [category, relative] of [
     ["cli", "apps/cli/command.ts"],
+    ["extension", "apps/extension/background.ts"],
     ["filesystem-adapter", "src/pdf-template-project-writer.ts"],
     ["process-lock", "src/process-lock.ts"],
     ["terminal", "src/prompt.ts"],
@@ -146,6 +147,30 @@ describe("browser-build gate (spec 001 task 6)", () => {
       expect.objectContaining({ specifier: "@forge/bridge" }),
     ]);
   });
+
+  for (const specifier of [
+    "@wxt-dev/module-react",
+    "wxt/utils/define-background",
+    "react",
+    "react-dom/client",
+    "webextension-polyfill",
+  ]) {
+    test(`a seeded ${specifier} import turns the host-neutral graph gate red`, async () => {
+      const dir = fixtureDir();
+      const file = join(dir, "host-coupled.ts");
+      writeFileSync(
+        file,
+        `import * as host from ${JSON.stringify(specifier)};\nexport { host };\n`,
+      );
+
+      const result = await checkEntrypoint(file);
+
+      expect(result.ok).toBe(false);
+      expect(result.builtinImports).toEqual([
+        expect.objectContaining({ specifier }),
+      ]);
+    });
+  }
 
   test("the specifier scan ignores Bun's inlined polyfill diagnostic strings (no false positive)", async () => {
     // A string literal that merely *contains* the text `node:buffer` must not be

--- a/scripts/check-browser-build.ts
+++ b/scripts/check-browser-build.ts
@@ -4,14 +4,15 @@
  *
  * Rebuilds every isomorphic entrypoint with `--target=browser` and asserts, per
  * entrypoint, that the build succeeds AND that nothing in its transitive graph
- * reaches a Node/Bun builtin.
+ * reaches a Node/Bun builtin or a host-only framework/runtime.
  *
  * ## Three rules, because one is not enough
  *
  * 1. **Source-graph scan (primary).** A `Bun.build` plugin observes every
- *    module specifier the bundler resolves and flags the builtins — in BOTH
- *    spellings, `node:fs` *and* the legacy bare `fs`. It names the importing
- *    source file, so a failure points at the line to change.
+ *    module specifier the bundler resolves and flags builtins — in BOTH
+ *    spellings, `node:fs` *and* the legacy bare `fs` — plus host-only Forge,
+ *    WXT, React, and WebExtension imports. It names the importing source file,
+ *    so a failure points at the line to change.
  * 2. **Output specifier scan.** The original rule, kept as belt-and-suspenders:
  *    `bun build --target=browser` sometimes *externalizes* a `node:` import
  *    instead of failing, producing a "successful" but browser-broken bundle.

--- a/scripts/check-browser-build.ts
+++ b/scripts/check-browser-build.ts
@@ -122,8 +122,12 @@ export const BARE_BUILTIN_MODULES = [
  * construction. A bare name that merely *starts* with a builtin name is safe
  * too: the `(?:/|$)` boundary keeps `pathe`, `oslllo-svg2`, `utils` out.
  */
-const BUILTIN_SPECIFIER_RE = new RegExp(
-  `^(?:@forge/|node:|bun:|(?:${BARE_BUILTIN_MODULES.join("|")})(?:/|$))`
+const HOST_ONLY_SPECIFIER_RE = new RegExp(
+  `^(?:` +
+    `@forge/|@wxt-dev/|wxt(?:/|$)|react(?:/|$)|react-dom(?:/|$)|` +
+    `webextension-polyfill(?:/|$)|node:|bun:|` +
+    `(?:${BARE_BUILTIN_MODULES.join("|")})(?:/|$)` +
+  `)`
 );
 
 /**
@@ -175,6 +179,7 @@ export interface EntryCheckResult {
   hostGraphViolations: Array<{
     category:
       | "cli"
+      | "extension"
       | "filesystem-adapter"
       | "process-lock"
       | "terminal";
@@ -191,6 +196,7 @@ const HOST_GRAPH_RULES: readonly {
   pattern: RegExp;
 }[] = [
   { category: "cli", pattern: /\/apps\/cli\//u },
+  { category: "extension", pattern: /\/apps\/extension\//u },
   {
     category: "filesystem-adapter",
     pattern: /\/(?:pdf-template-project-writer|file-system|filesystem)\.[cm]?[jt]s$/u,
@@ -310,16 +316,23 @@ function builtinScanPlugin(sink: BuiltinImport[], cwd: string): import("bun").Bu
   return {
     name: "atlcli-builtin-scan",
     setup(build) {
-      build.onResolve({ filter: BUILTIN_SPECIFIER_RE }, (args) => {
+      build.onResolve({ filter: HOST_ONLY_SPECIFIER_RE }, (args) => {
         const importer = args.importer;
         // Bun's own polyfill graph — see BUN_POLYFILL_IMPORTER_PREFIX.
         if (!importer || importer.startsWith(BUN_POLYFILL_IMPORTER_PREFIX)) return undefined;
 
         const bare = args.path.replace(/^(?:node|bun):/, "");
-        const prefixed = args.path !== bare || args.path.startsWith("@forge/");
+        const hostOnlyPackage =
+          args.path.startsWith("@forge/") ||
+          args.path.startsWith("@wxt-dev/") ||
+          /^(?:wxt|react|react-dom|webextension-polyfill)(?:\/|$)/u.test(
+            args.path,
+          );
+        const prefixed = args.path !== bare || hostOnlyPackage;
         // A `node:`/`bun:` prefix is unambiguous; a bare name is only a builtin
-        // when no real package of that name shadows it. Forge imports are also
-        // unambiguous host-only dependencies: consumers inject requestConfluence.
+        // when no real package of that name shadows it. Framework/host imports
+        // are also unambiguous here: shared exporters must remain independent
+        // of Forge, React, WXT, and WebExtension APIs.
         if (!prefixed && shadowedByRealPackage(bare, dirname(importer))) return undefined;
 
         sink.push({

--- a/specs/issue-134-whiteboard-linked-card/EVIDENCE.md
+++ b/specs/issue-134-whiteboard-linked-card/EVIDENCE.md
@@ -40,8 +40,9 @@ identifiers and derived artifacts were not retained.
 - Browser-entrypoint build gate: 27 entrypoints green.
 - Production browser harness build, CSP/output scan, export parity, and
   Whiteboard export E2E: green.
-- Production WXT build, packed-output scan, extension typecheck, and packed MV3
-  Whiteboard job E2E: green.
+- Production WXT build, packed-output scan, extension typecheck, and the full
+  packed MV3 browser suite: 23 passed, including the Whiteboard job after an
+  earlier fallback test had populated the origin-scoped ADF capability cache.
 - API report, API closure, and M1 corpus structural goldens: regenerated and
   green.
 - Live `mayflower` / `DOCSY` E2E: one temporary real Whiteboard embedded in a

--- a/specs/issue-134-whiteboard-linked-card/EVIDENCE.md
+++ b/specs/issue-134-whiteboard-linked-card/EVIDENCE.md
@@ -1,0 +1,51 @@
+# Issue #134 verification evidence
+
+All committed fixtures use synthetic tenant, page, space, account, and
+Whiteboard values. The live run used temporary private DOCSY resources; their
+identifiers and derived artifacts were not retained.
+
+## Functional contract
+
+- Exact `com.atlassian.confluence.macro.core` /
+  `native-embed:whiteboard` ADF matching is covered for valid, invalid,
+  repeated, nested, and ordered nodes.
+- Valid same-origin routes produce one block Smart Card titled
+  `Atlassian Whiteboard`, one `macro-rendered-via` note, and no degraded note.
+- Unsafe or malformed destinations produce a visible non-clickable fallback
+  without retaining the rejected URL or identifiers in diagnostics.
+- DOCX relationship XML and a real tagged-PDF link annotation contain the
+  canonical target. Serializer-input assertions are not used as their
+  substitute.
+- Embedded Whiteboards remain part of page/tree exports. A direct Whiteboard
+  tree child remains an honest redacted `unsupported-child-type`.
+
+## Host and dependency contract
+
+- CLI/Node/Bun and extension-session builders pass the trusted site origin and
+  make zero Whiteboard endpoint requests.
+- The neutral production browser harness exports the card under strict CSP and
+  records zero foreign requests.
+- The production-packed MV3 side-panel/offscreen job succeeds, retains the PDF
+  and report, records `macro-rendered-via`, and makes zero Whiteboard requests.
+- A Forge-shaped consumer injects only its page-read adapter. The shared
+  package graph contains no Forge, WXT, React, or WebExtension dependency.
+
+## Executed gates
+
+- Focused unit, wiring, serializer, artifact, browser-compiler, and host tests:
+  green.
+- Full workspace test: 5,902 passed, 15 environment-gated skips, 0 failed
+  across 405 files.
+- Workspace build and TypeScript typecheck: green.
+- Browser-entrypoint build gate: 27 entrypoints green.
+- Production browser harness build, CSP/output scan, export parity, and
+  Whiteboard export E2E: green.
+- Production WXT build, packed-output scan, extension typecheck, and packed MV3
+  Whiteboard job E2E: green.
+- API report, API closure, and M1 corpus structural goldens: regenerated and
+  green.
+- Live `mayflower` / `DOCSY` E2E: one temporary real Whiteboard embedded in a
+  temporary ADF page exported successfully to both DOCX and tagged PDF. Each
+  report contained exactly one `macro-rendered-via`, no warning, no
+  `macro-degraded`, and a complete result. The page, Whiteboard, and local
+  artifacts were deleted immediately afterward.

--- a/specs/issue-134-whiteboard-linked-card/PLAN.md
+++ b/specs/issue-134-whiteboard-linked-card/PLAN.md
@@ -1,0 +1,81 @@
+# Issue #134: embedded Whiteboards as linked cards
+
+## Goal
+
+Render an embedded Confluence `native-embed:whiteboard` ADF extension as one
+deterministic, clickable neutral Smart Card in DOCX and tagged PDF. The baseline
+uses only the URL already present in page ADF and behaves identically in
+CLI/Node/Bun, MV3, ordinary browsers, and Forge-shaped browser consumers.
+
+The card is a navigation fallback. It must never claim that Whiteboard pixels,
+editable content, metadata, or a preview were exported.
+
+## Security and architecture decisions
+
+1. Add one pure, offline renderer to `@atlcli/export-macros`, ordered before the
+   generic unresolved-extension floor and marked `requiresLivePort: false`.
+2. Validate the untrusted macro URL against the trusted Confluence page/site
+   context. Accept only a canonical tenant-local
+   `/wiki/spaces/{spaceKey}/whiteboard/{id}` route.
+3. Reject external or cross-tenant hosts, protocol-relative URLs, credentials,
+   unsupported schemes, fragments, malformed routes/identifiers, and relative
+   URLs that cannot be resolved against trusted context.
+4. Emit the established neutral `smartCard` block with the deterministic label
+   `Atlassian Whiteboard`. DOCX and PDF receive no Whiteboard-specific branch.
+5. A valid card replaces its provisional `macro-not-rendered` note with one
+   informational `macro-rendered-via` outcome and does not degrade the document.
+6. An absent or unsafe destination preserves a visible unknown-block fallback
+   and an explicit degraded warning without echoing identifiers or URLs.
+7. Embedded boards remain in their source page during page/tree/space export.
+   A direct Whiteboard tree child remains non-traversable and is reported
+   separately as `unsupported-child-type`.
+8. No atlcli package imports Forge, WXT, React, extension APIs, browser DOM
+   APIs, or a host application for this feature, and no Whiteboard HTTP request
+   is added.
+
+## Implementation order
+
+- [ ] Pin valid, invalid, repeated, and nested ADF fixtures with synthetic IDs.
+- [ ] Implement tenant-local Whiteboard URL canonicalization and linked-card
+      rendering in the shared macro registry.
+- [ ] Reconcile valid/invalid macro outcomes without leaking source values.
+- [ ] Prove shared Smart Card link semantics in DOCX and tagged PDF.
+- [ ] Prove CLI/Node/Bun export adds no Whiteboard request.
+- [ ] Prove packed MV3 side-panel/offscreen behavior and dependency boundaries.
+- [ ] Prove ordinary-browser behavior under the neutral browser harness.
+- [ ] Add a Forge-shaped injected-page-read consumer proof with no Forge import
+      or `read:whiteboard:confluence` requirement.
+- [ ] Prove embedded-tree retention and honest direct-child non-traversal.
+- [ ] Update user documentation and generated public API reports if required.
+- [ ] Run focused tests, full workspace tests, typecheck, production/package
+      gates, and the required live E2E with private artifacts cleaned up.
+
+## Acceptance matrix
+
+| Shape | Acquisition boundary | Required proof |
+| --- | --- | --- |
+| CLI / Node / Bun | Existing authenticated page read | Same card in DOCX/PDF; zero extra Whiteboard requests |
+| MV3 | Existing ambient-session page read | Side-panel/offscreen use shared renderer after packed build |
+| Ordinary browser | Caller-injected page read | Public browser contract works under strict CSP |
+| Forge-shaped browser | Injected `requestConfluence`-like adapter | Same package contract; no Forge import or added scope |
+| Tree / space | Existing page/tree reads | Embedded link retained; direct child remains unsupported |
+
+## Evidence policy
+
+- Record only synthetic tenant, space, page, account, and Whiteboard values.
+- Inspect DOCX relationships and tagged-PDF link annotations/text, rather than
+  treating serializer input alone as end-to-end proof.
+- Keep functional rendering proof separate from dependency/CSP/host-lifecycle
+  proof.
+- Treat CI as a regression gate, not as a substitute for the required live E2E
+  and artifact cleanup.
+
+## Unresolved questions
+
+- Confirm the exact trusted source-context field already carried into macro
+  resolution and whether it contains a site origin, a source page URL, or both.
+- Confirm which existing Forge-shaped consumer smoke is authoritative for this
+  repository and whether it runs fully locally or also needs an external pinned
+  consumer check.
+- Confirm whether canonical Whiteboard navigation needs any query parameter.
+  Until proven necessary, the renderer will drop all query parameters.

--- a/specs/issue-134-whiteboard-linked-card/PLAN.md
+++ b/specs/issue-134-whiteboard-linked-card/PLAN.md
@@ -35,19 +35,19 @@ editable content, metadata, or a preview were exported.
 
 ## Implementation order
 
-- [ ] Pin valid, invalid, repeated, and nested ADF fixtures with synthetic IDs.
-- [ ] Implement tenant-local Whiteboard URL canonicalization and linked-card
+- [x] Pin valid, invalid, repeated, and nested ADF fixtures with synthetic IDs.
+- [x] Implement tenant-local Whiteboard URL canonicalization and linked-card
       rendering in the shared macro registry.
-- [ ] Reconcile valid/invalid macro outcomes without leaking source values.
-- [ ] Prove shared Smart Card link semantics in DOCX and tagged PDF.
-- [ ] Prove CLI/Node/Bun export adds no Whiteboard request.
-- [ ] Prove packed MV3 side-panel/offscreen behavior and dependency boundaries.
-- [ ] Prove ordinary-browser behavior under the neutral browser harness.
-- [ ] Add a Forge-shaped injected-page-read consumer proof with no Forge import
+- [x] Reconcile valid/invalid macro outcomes without leaking source values.
+- [x] Prove shared Smart Card link semantics in DOCX and tagged PDF.
+- [x] Prove CLI/Node/Bun export adds no Whiteboard request.
+- [x] Prove packed MV3 side-panel/offscreen behavior and dependency boundaries.
+- [x] Prove ordinary-browser behavior under the neutral browser harness.
+- [x] Add a Forge-shaped injected-page-read consumer proof with no Forge import
       or `read:whiteboard:confluence` requirement.
-- [ ] Prove embedded-tree retention and honest direct-child non-traversal.
-- [ ] Update user documentation and generated public API reports if required.
-- [ ] Run focused tests, full workspace tests, typecheck, production/package
+- [x] Prove embedded-tree retention and honest direct-child non-traversal.
+- [x] Update user documentation and generated public API reports if required.
+- [x] Run focused tests, full workspace tests, typecheck, production/package
       gates, and the required live E2E with private artifacts cleaned up.
 
 ## Acceptance matrix
@@ -70,12 +70,14 @@ editable content, metadata, or a preview were exported.
 - Treat CI as a regression gate, not as a substitute for the required live E2E
   and artifact cleanup.
 
-## Unresolved questions
+## Resolved decisions
 
-- Confirm the exact trusted source-context field already carried into macro
-  resolution and whether it contains a site origin, a source page URL, or both.
-- Confirm which existing Forge-shaped consumer smoke is authoritative for this
-  repository and whether it runs fully locally or also needs an external pinned
-  consumer check.
-- Confirm whether canonical Whiteboard navigation needs any query parameter.
-  Until proven necessary, the renderer will drop all query parameters.
+- Macro resolution now receives a dedicated optional `siteOrigin`; `siteId`
+  retains its existing meaning and is not overloaded.
+- The repository's authoritative local host proofs are the injected
+  Forge-shaped page-read test, neutral browser harness, and packed MV3
+  side-panel/offscreen test. The shared packages import no host framework.
+- Canonical navigation needs no query parameter. The renderer discards the
+  source query and emits only the validated tenant-local Whiteboard route.
+
+Detailed local verification is recorded in [EVIDENCE.md](./EVIDENCE.md).


### PR DESCRIPTION
Closes #134

## Summary

- render exact `native-embed:whiteboard` ADF extensions as deterministic tenant-local `Atlassian Whiteboard` Smart Cards
- validate and canonicalize the retained navigation URL without fetching Whiteboard metadata, pixels, or editable content
- pass an explicit trusted `siteOrigin` through CLI/Node and browser-extension hosts; keep shared packages free of Forge, WXT, React, and WebExtension imports
- retain embedded boards in page/tree/space exports while reporting direct Whiteboard tree children as unsupported
- document the user-visible fallback and commit the complete host/evidence matrix

## Host evidence

- CLI/Node/Bun: DOCX and tagged-PDF artifacts contain the canonical link; zero Whiteboard endpoint requests
- ordinary browser: production harness under strict CSP; zero foreign requests
- packed MV3: production side-panel/offscreen PDF job succeeds and retains `macro-rendered-via`; zero Whiteboard requests
- Forge-shaped browser: injected page-read adapter only; no Forge import or added `read:whiteboard:confluence` scope

## Verification

- `bun run test`: 5,902 passed, 15 environment-gated skips, 0 failed
- `bun run typecheck`
- `bun run build`
- `bun run check:browser`: 27 browser entrypoints green
- production browser harness build/output/CSP and Whiteboard export E2E
- production WXT build, packed-output scan, extension typecheck, and full packed MV3 browser suite: 23 passed
- API report, API closure, and M1 structural goldens
- live `mayflower` / `DOCSY` E2E: a temporary real Whiteboard embedded in temporary ADF exported to DOCX and tagged PDF with exactly one `macro-rendered-via`, no warning, and no degradation; all temporary remote and local resources were deleted

Detailed evidence: `specs/issue-134-whiteboard-linked-card/EVIDENCE.md`
