### PR TITLE
perf(ci): add evidence-gated throughput foundations

### DIFF
--- a/.github/workflows/ci-topology-canary.yml
+++ b/.github/workflows/ci-topology-canary.yml
@@ -1,0 +1,210 @@
+name: CI topology comparison
+
+on:
+  workflow_dispatch:
+    inputs:
+      topology:
+        description: Duration-aware candidate to compare with the legacy four shards
+        required: true
+        default: general-2x1
+        type: choice
+        options:
+          - general-2x1
+          - general-3x1
+          - general-2x2-workers
+  schedule:
+    # Non-required rotation; it never runs on pull requests.
+    - cron: "17 4 * * 3"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-topology-comparison-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  plan:
+    name: Freeze candidate topology
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      topology: ${{ steps.topology.outputs.topology }}
+      matrix: ${{ steps.matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Select manual or rotating scheduled candidate
+        id: topology
+        env:
+          REQUESTED_TOPOLOGY: ${{ inputs.topology }}
+        run: |
+          topology="$REQUESTED_TOPOLOGY"
+          if [[ -z "$topology" ]]; then
+            case $((GITHUB_RUN_NUMBER % 3)) in
+              0) topology="general-2x1" ;;
+              1) topology="general-3x1" ;;
+              2) topology="general-2x2-workers" ;;
+            esac
+          fi
+          echo "topology=$topology" >> "$GITHUB_OUTPUT"
+
+      - name: Validate inventory and freeze matrix
+        id: matrix
+        env:
+          TOPOLOGY: ${{ steps.topology.outputs.topology }}
+        run: |
+          bun scripts/ci/test-lanes.ts --check --topology "$TOPOLOGY"
+          echo "matrix=$(bun scripts/ci/test-lanes.ts --topology "$TOPOLOGY" --matrix)" >> "$GITHUB_OUTPUT"
+
+  legacy:
+    name: Legacy shard ${{ matrix.shard }}/4
+    needs: plan
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Restore Bun package cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Install legacy PDF proof tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes poppler-utils
+
+      - name: Provision legacy pinned PDF fonts
+        run: bun run fonts:ensure
+
+      - name: Run legacy shard
+        env:
+          SHARD: ${{ matrix.shard }}
+        run: |
+          mkdir -p test-results
+          bun run test --shard="${SHARD}/4" \
+            --reporter=junit \
+            --reporter-outfile="test-results/legacy-${SHARD}.xml" \
+            2>&1 | tee "test-results/legacy-${SHARD}.log"
+
+      - name: Upload legacy JUnit
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: topology-legacy-${{ matrix.shard }}-${{ github.run_attempt }}-${{ github.sha }}
+          path: test-results/legacy-${{ matrix.shard }}.xml
+          if-no-files-found: error
+
+      - name: Upload failed legacy log
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: topology-legacy-${{ matrix.shard }}-failure-${{ github.run_attempt }}-${{ github.sha }}
+          path: test-results/legacy-${{ matrix.shard }}.log
+          if-no-files-found: error
+
+  candidate:
+    name: Candidate ${{ matrix.group }}
+    needs: plan
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.plan.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Restore Bun package cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Install owning PDF proof tools
+        if: matrix.poppler
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes poppler-utils
+
+      - name: Provision owning pinned PDF fonts
+        if: matrix.fonts
+        run: bun run fonts:ensure
+
+      - name: Run duration-aware execution group
+        env:
+          TOPOLOGY: ${{ matrix.topology }}
+          GROUP: ${{ matrix.group }}
+        run: |
+          mkdir -p test-results
+          bun scripts/ci/run-test-lane.ts \
+            --topology "$TOPOLOGY" \
+            --group "$GROUP" \
+            --junit "test-results/candidate-${GROUP}.xml" \
+            2>&1 | tee "test-results/candidate-${GROUP}.log"
+
+      - name: Upload candidate JUnit
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: topology-candidate-${{ matrix.group }}-${{ github.run_attempt }}-${{ github.sha }}
+          path: test-results/candidate-${{ matrix.group }}.xml
+          if-no-files-found: error
+
+      - name: Upload failed candidate log
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: topology-candidate-${{ matrix.group }}-failure-${{ github.run_attempt }}-${{ github.sha }}
+          path: test-results/candidate-${{ matrix.group }}.log
+          if-no-files-found: error
+
+  comparison-complete:
+    name: Non-required topology comparison complete
+    if: always()
+    needs: [plan, legacy, candidate]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Require both same-SHA branches
+        env:
+          PLAN: ${{ needs.plan.result }}
+          LEGACY: ${{ needs.legacy.result }}
+          CANDIDATE: ${{ needs.candidate.result }}
+          TOPOLOGY: ${{ needs.plan.outputs.topology }}
+        run: |
+          {
+            echo "## CI topology comparison"
+            echo
+            echo "- Candidate: \`$TOPOLOGY\`"
+            echo "- Legacy result: \`$LEGACY\`"
+            echo "- Candidate result: \`$CANDIDATE\`"
+            echo "- SHA: \`${GITHUB_SHA}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+          [[ "$PLAN" == "success" && "$LEGACY" == "success" && "$CANDIDATE" == "success" ]]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,11 @@ on:
     # `pull_request`-triggered workflow in this repo carries this same list;
     # scripts/ci/workflow-policy.test.ts enforces it.
     types: [opened, synchronize, reopened, ready_for_review]
+  # Inactive until a repository merge queue is enabled. Keeping the trigger on
+  # the default branch first prevents a future queue from waiting forever for
+  # a required context that no workflow can create.
+  merge_group:
+    types: [checks_requested]
   schedule:
     # Full unfiltered drift guard. Path routing must never become the only proof.
     - cron: "33 5 * * 6"
@@ -19,6 +24,7 @@ on:
 
 permissions:
   contents: read
+  actions: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -49,8 +55,17 @@ jobs:
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-          FULL_RUN: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+          MERGE_GROUP_BASE_SHA: ${{ github.event.merge_group.base_sha }}
+          MERGE_GROUP_HEAD_SHA: ${{ github.event.merge_group.head_sha }}
+          FULL_RUN: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'merge_group' }}
         run: |
+          if [[ "${{ github.event_name }}" == "merge_group" ]] && \
+             { [[ -z "$MERGE_GROUP_BASE_SHA" ]] || [[ -z "$MERGE_GROUP_HEAD_SHA" ]]; }; then
+            echo "::warning::Merge-group comparison SHA is incomplete; running every gate"
+            bun scripts/ci/classify-changes.ts --full >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           if [[ "$FULL_RUN" == "true" ]]; then
             bun scripts/ci/classify-changes.ts --full >> "$GITHUB_OUTPUT"
             exit 0
@@ -248,6 +263,63 @@ jobs:
       - name: Shape-parity gate
         run: bun run check:parity
 
+  # Compatibility signal only. GitHub runner Chrome is intentionally not a
+  # substitute for Playwright-matched Chromium in the required MV3 proof.
+  browser-system-chrome-canary:
+    name: Non-required system Chrome compatibility
+    needs: changes
+    if: needs.changes.outputs.code == 'true' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Restore Bun package cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Provision pinned PDF fonts
+        run: bun run fonts:ensure
+
+      - name: Record browser compatibility surface
+        run: |
+          {
+            echo "## System Chrome compatibility canary"
+            echo
+            echo "- Runner image: \`${ImageOS:-unknown} ${ImageVersion:-unknown}\`"
+            echo "- System browser: \`$(google-chrome --version)\`"
+            echo "- Playwright: \`$(bunx playwright --version)\`"
+            echo "- Channel: \`chrome\` (non-required)"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Type check browser export harness
+        run: bun run typecheck:browser-export-harness
+
+      - name: Build browser export harness
+        run: bun run build:browser-export-harness
+
+      - name: Check browser export harness artifact
+        run: bun run check:browser-export-harness
+
+      - name: Assert conformance-case registry
+        run: bun run assert:conformance-cases
+
+      - name: Run neutral harness on system Chrome
+        env:
+          ATLCLI_PLAYWRIGHT_CHANNEL: chrome
+        run: bun run test:browser-export-harness
+
   required:
     name: required
     if: always()
@@ -312,3 +384,73 @@ jobs:
           require_result "macOS PDF" "$CODE_REQUIRED" "$MACOS"
           require_result "Windows PDF sink" "$CODE_REQUIRED" "$WINDOWS"
           require_result "Browser export harness" "$CODE_REQUIRED" "$BROWSER"
+
+  # Measurement is deliberately downstream from, and non-blocking for, the
+  # stable required check. A telemetry failure stays visible without delaying
+  # or satisfying merge proof.
+  telemetry:
+    name: Non-required CI timing telemetry
+    if: always() && needs.changes.result == 'success'
+    needs: [changes, required]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Prepare telemetry input
+        run: mkdir -p test-results
+
+      - name: Download same-run JUnit artifacts
+        if: needs.changes.outputs.code == 'true'
+        uses: actions/download-artifact@v5
+        with:
+          pattern: bun-test-shard-*-${{ github.sha }}
+          path: test-results
+
+      - name: Read same-attempt Actions jobs
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const jobs = await github.paginate(
+              "GET /repos/{owner}/{repo}/actions/runs/{run_id}/attempts/{attempt_number}/jobs",
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: context.runId,
+                attempt_number: Number(process.env.GITHUB_RUN_ATTEMPT),
+                per_page: 100,
+              },
+            );
+            require("node:fs").writeFileSync(
+              "actions-jobs.json",
+              JSON.stringify({ jobs }, null, 2),
+            );
+
+      - name: Summarize timing evidence
+        env:
+          CI_TEST_TOPOLOGY: legacy-4-shard
+          CI_ROUTE_CODE: ${{ needs.changes.outputs.code }}
+          CI_ROUTE_CONSUMER: ${{ needs.changes.outputs.consumer }}
+          CI_ROUTE_DOCS: ${{ needs.changes.outputs.docs }}
+          CI_ROUTE_README_MEDIA: ${{ needs.changes.outputs.readmeMedia }}
+        run: |
+          bun scripts/ci/telemetry-summary.ts \
+            --junit test-results \
+            --jobs actions-jobs.json \
+            --out ci-timing.json
+
+      - name: Upload timing evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ci-timing-${{ github.run_attempt }}-${{ github.sha }}
+          path: ci-timing.json
+          if-no-files-found: warn

--- a/.github/workflows/reusable-quality.yml
+++ b/.github/workflows/reusable-quality.yml
@@ -134,14 +134,20 @@ jobs:
 
           exit "$TEST_EXIT"
 
-      - name: Upload test shard reports
+      - name: Upload test shard JUnit
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: bun-test-shard-${{ matrix.shard }}-${{ github.sha }}
-          path: |
-            test-results/bun-test-shard-${{ matrix.shard }}.xml
-            test-results/bun-test-shard-${{ matrix.shard }}.log
+          path: test-results/bun-test-shard-${{ matrix.shard }}.xml
+          if-no-files-found: error
+
+      - name: Upload failed test shard log
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bun-test-shard-${{ matrix.shard }}-failure-log-${{ github.sha }}
+          path: test-results/bun-test-shard-${{ matrix.shard }}.log
           if-no-files-found: error
 
   security-attestation:

--- a/.github/workflows/security-attestation.yml
+++ b/.github/workflows/security-attestation.yml
@@ -40,9 +40,6 @@ jobs:
         with:
           bun-version: '1.3.14'
 
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-
       - name: Emit security attestation
         run: bun scripts/security/attest.ts --out security-attestation.json
 

--- a/scripts/ci/actions-timings.test.ts
+++ b/scripts/ci/actions-timings.test.ts
@@ -57,6 +57,50 @@ describe("Actions timing summary", () => {
     expect(summary.jobs[1]?.runnerSeconds).toBeNull();
   });
 
+  test("ignores GitHub timestamp anomalies for skipped jobs", () => {
+    const summary = summarizeActionsJobs([
+      {
+        id: 1,
+        name: "required",
+        status: "completed",
+        conclusion: "success",
+        created_at: "2026-07-30T10:00:00Z",
+        started_at: "2026-07-30T10:00:01Z",
+        completed_at: "2026-07-30T10:00:05Z",
+      },
+      {
+        id: 2,
+        name: "skipped-attestation",
+        status: "completed",
+        conclusion: "skipped",
+        created_at: "2026-07-30T10:00:00Z",
+        started_at: "2026-07-30T10:00:10Z",
+        completed_at: "2026-07-30T10:00:09Z",
+        steps: [
+          {
+            name: "skipped-step",
+            conclusion: "skipped",
+            started_at: "2026-07-30T10:00:10Z",
+            completed_at: "2026-07-30T10:00:09Z",
+          },
+        ],
+      },
+    ]);
+
+    expect(summary).toMatchObject({
+      sampleClass: "green",
+      eligibleForGreenPercentiles: true,
+      workflowWallSeconds: 5,
+      criticalPathSeconds: 5,
+      criticalPathJobs: ["required"],
+    });
+    expect(summary.jobs[1]).toMatchObject({
+      queueSeconds: null,
+      runnerSeconds: null,
+      phases: [{ name: "skipped-step", durationSeconds: null }],
+    });
+  });
+
   test("labels failures separately from green percentile samples", () => {
     const summary = summarizeActionsJobs([
       {

--- a/scripts/ci/actions-timings.test.ts
+++ b/scripts/ci/actions-timings.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  summarizeActionsJobs,
+  type ActionsJob,
+} from "./actions-timings.js";
+
+describe("Actions timing summary", () => {
+  test("computes queue, runner, phase, wall, critical-path, and runner-minute data", () => {
+    const fixture = JSON.parse(
+      readFileSync(join(import.meta.dir, "fixtures/actions-jobs.json"), "utf8"),
+    ) as { jobs: ActionsJob[]; dependencies: Record<string, string[]> };
+    const summary = summarizeActionsJobs(fixture.jobs, fixture.dependencies);
+
+    expect(summary).toMatchObject({
+      schema: 1,
+      sampleClass: "green",
+      eligibleForGreenPercentiles: true,
+      workflowWallSeconds: 90,
+      criticalPathSeconds: 90,
+      criticalPathJobs: ["changes", "quality", "required"],
+      totalRunnerMinutes: 1.25,
+    });
+    expect(summary.jobs[0]).toMatchObject({
+      queueSeconds: 5,
+      runnerSeconds: 10,
+      phases: [{ name: "Classify", durationSeconds: 5 }],
+    });
+  });
+
+  test("counts a started cancelled job in runner minutes but excludes it from green samples", () => {
+    const jobs: ActionsJob[] = [
+      {
+        id: 1,
+        name: "cancelled-test",
+        status: "completed",
+        conclusion: "cancelled",
+        created_at: "2026-07-30T10:00:00Z",
+        started_at: "2026-07-30T10:00:10Z",
+        completed_at: "2026-07-30T10:01:10Z",
+      },
+      {
+        id: 2,
+        name: "never-started",
+        status: "completed",
+        conclusion: "skipped",
+        created_at: "2026-07-30T10:00:00Z",
+        started_at: null,
+        completed_at: null,
+      },
+    ];
+    const summary = summarizeActionsJobs(jobs);
+    expect(summary.sampleClass).toBe("cancelled");
+    expect(summary.eligibleForGreenPercentiles).toBe(false);
+    expect(summary.totalRunnerMinutes).toBe(1);
+    expect(summary.jobs[1]?.runnerSeconds).toBeNull();
+  });
+
+  test("labels failures separately from green percentile samples", () => {
+    const summary = summarizeActionsJobs([
+      {
+        id: 1,
+        name: "test",
+        status: "completed",
+        conclusion: "failure",
+        created_at: "2026-07-30T10:00:00Z",
+        started_at: "2026-07-30T10:00:01Z",
+        completed_at: "2026-07-30T10:00:02Z",
+      },
+    ]);
+    expect(summary.sampleClass).toBe("failed");
+    expect(summary.eligibleForGreenPercentiles).toBe(false);
+  });
+
+  test("rejects malformed and backwards timestamps", () => {
+    const base: ActionsJob = {
+      id: 1,
+      name: "test",
+      status: "completed",
+      conclusion: "success",
+      created_at: "2026-07-30T10:00:00Z",
+      started_at: "2026-07-30T10:00:01Z",
+      completed_at: "2026-07-30T10:00:02Z",
+    };
+    expect(() =>
+      summarizeActionsJobs([{ ...base, started_at: "not-a-date" }]),
+    ).toThrow("invalid");
+    expect(() =>
+      summarizeActionsJobs([
+        {
+          ...base,
+          started_at: "2026-07-30T10:00:03Z",
+          completed_at: "2026-07-30T10:00:02Z",
+        },
+      ]),
+    ).toThrow("precedes start");
+  });
+});

--- a/scripts/ci/actions-timings.ts
+++ b/scripts/ci/actions-timings.ts
@@ -1,0 +1,195 @@
+#!/usr/bin/env bun
+import { readFileSync } from "node:fs";
+
+export interface ActionsStep {
+  name: string;
+  status?: string;
+  conclusion?: string | null;
+  started_at?: string | null;
+  completed_at?: string | null;
+}
+
+export interface ActionsJob {
+  id: number;
+  name: string;
+  status: string;
+  conclusion: string | null;
+  created_at?: string | null;
+  started_at?: string | null;
+  completed_at?: string | null;
+  steps?: ActionsStep[];
+}
+
+export interface JobTiming {
+  id: number;
+  name: string;
+  conclusion: string | null;
+  queueSeconds: number | null;
+  runnerSeconds: number | null;
+  phases: Array<{
+    name: string;
+    conclusion: string | null | undefined;
+    durationSeconds: number | null;
+  }>;
+}
+
+export interface ActionsTimingSummary {
+  schema: 1;
+  sampleClass: "green" | "failed" | "cancelled";
+  eligibleForGreenPercentiles: boolean;
+  workflowWallSeconds: number | null;
+  criticalPathSeconds: number | null;
+  criticalPathJobs: string[];
+  totalRunnerMinutes: number;
+  jobs: JobTiming[];
+}
+
+function timestamp(value: string | null | undefined, field: string): number | null {
+  if (!value) return null;
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) throw new Error(`invalid ${field} timestamp: ${value}`);
+  return parsed;
+}
+
+function elapsedSeconds(
+  start: string | null | undefined,
+  end: string | null | undefined,
+  label: string,
+): number | null {
+  const started = timestamp(start, `${label} start`);
+  const completed = timestamp(end, `${label} completion`);
+  if (started === null || completed === null) return null;
+  if (completed < started) throw new Error(`${label} completion precedes start`);
+  return (completed - started) / 1_000;
+}
+
+function sampleClass(jobs: readonly ActionsJob[]): ActionsTimingSummary["sampleClass"] {
+  if (jobs.some((job) => job.conclusion === "cancelled")) return "cancelled";
+  if (
+    jobs.some(
+      (job) =>
+        job.conclusion !== null &&
+        job.conclusion !== "success" &&
+        job.conclusion !== "skipped",
+    )
+  ) {
+    return "failed";
+  }
+  return "green";
+}
+
+function criticalPath(
+  jobs: readonly ActionsJob[],
+  dependencies: Readonly<Record<string, readonly string[]>>,
+  workflowStart: number | null,
+): { seconds: number | null; jobs: string[] } {
+  if (workflowStart === null) return { seconds: null, jobs: [] };
+  const byName = new Map(jobs.map((job) => [job.name, job]));
+  const completed = jobs
+    .map((job) => ({ job, completed: timestamp(job.completed_at, `${job.name} completion`) }))
+    .filter(
+      (entry): entry is { job: ActionsJob; completed: number } =>
+        entry.completed !== null,
+    )
+    .sort((left, right) => right.completed - left.completed);
+  const terminal = completed[0];
+  if (!terminal) return { seconds: null, jobs: [] };
+
+  const path = [terminal.job.name];
+  const seen = new Set(path);
+  let current = terminal.job.name;
+  while (true) {
+    const parents = (dependencies[current] ?? [])
+      .map((name) => byName.get(name))
+      .filter((job): job is ActionsJob => Boolean(job))
+      .map((job) => ({
+        job,
+        completed: timestamp(job.completed_at, `${job.name} completion`),
+      }))
+      .filter(
+        (entry): entry is { job: ActionsJob; completed: number } =>
+          entry.completed !== null,
+      )
+      .sort((left, right) => right.completed - left.completed);
+    const parent = parents[0]?.job;
+    if (!parent || seen.has(parent.name)) break;
+    path.unshift(parent.name);
+    seen.add(parent.name);
+    current = parent.name;
+  }
+
+  return {
+    seconds: (terminal.completed - workflowStart) / 1_000,
+    jobs: path,
+  };
+}
+
+export function summarizeActionsJobs(
+  jobs: readonly ActionsJob[],
+  dependencies: Readonly<Record<string, readonly string[]>> = {},
+): ActionsTimingSummary {
+  const createdTimes = jobs
+    .map((job) => timestamp(job.created_at, `${job.name} creation`))
+    .filter((value): value is number => value !== null);
+  const completedTimes = jobs
+    .map((job) => timestamp(job.completed_at, `${job.name} completion`))
+    .filter((value): value is number => value !== null);
+  const workflowStart = createdTimes.length > 0 ? Math.min(...createdTimes) : null;
+  const workflowEnd = completedTimes.length > 0 ? Math.max(...completedTimes) : null;
+  if (workflowStart !== null && workflowEnd !== null && workflowEnd < workflowStart) {
+    throw new Error("workflow completion precedes creation");
+  }
+
+  const timings = jobs.map((job): JobTiming => {
+    const runnerSeconds = elapsedSeconds(job.started_at, job.completed_at, job.name);
+    const queueSeconds = elapsedSeconds(job.created_at, job.started_at, `${job.name} queue`);
+    return {
+      id: job.id,
+      name: job.name,
+      conclusion: job.conclusion,
+      queueSeconds,
+      runnerSeconds,
+      phases: (job.steps ?? []).map((step) => ({
+        name: step.name,
+        conclusion: step.conclusion,
+        durationSeconds: elapsedSeconds(
+          step.started_at,
+          step.completed_at,
+          `${job.name} / ${step.name}`,
+        ),
+      })),
+    };
+  });
+  const classification = sampleClass(jobs);
+  const critical = criticalPath(jobs, dependencies, workflowStart);
+
+  return {
+    schema: 1,
+    sampleClass: classification,
+    eligibleForGreenPercentiles: classification === "green",
+    workflowWallSeconds:
+      workflowStart === null || workflowEnd === null
+        ? null
+        : (workflowEnd - workflowStart) / 1_000,
+    criticalPathSeconds: critical.seconds,
+    criticalPathJobs: critical.jobs,
+    totalRunnerMinutes:
+      timings.reduce((total, job) => total + (job.runnerSeconds ?? 0), 0) / 60,
+    jobs: timings,
+  };
+}
+
+async function main(): Promise<void> {
+  const [path] = process.argv.slice(2);
+  if (!path) throw new Error("usage: bun scripts/ci/actions-timings.ts <jobs-api.json>");
+  const payload = JSON.parse(readFileSync(path, "utf8")) as {
+    jobs?: ActionsJob[];
+    dependencies?: Record<string, string[]>;
+  };
+  if (!Array.isArray(payload.jobs)) throw new Error("jobs API payload is missing jobs");
+  process.stdout.write(
+    `${JSON.stringify(summarizeActionsJobs(payload.jobs, payload.dependencies), null, 2)}\n`,
+  );
+}
+
+if (import.meta.main) await main();

--- a/scripts/ci/actions-timings.ts
+++ b/scripts/ci/actions-timings.ts
@@ -86,6 +86,7 @@ function criticalPath(
   if (workflowStart === null) return { seconds: null, jobs: [] };
   const byName = new Map(jobs.map((job) => [job.name, job]));
   const completed = jobs
+    .filter((job) => job.conclusion !== "skipped")
     .map((job) => ({ job, completed: timestamp(job.completed_at, `${job.name} completion`) }))
     .filter(
       (entry): entry is { job: ActionsJob; completed: number } =>
@@ -101,7 +102,10 @@ function criticalPath(
   while (true) {
     const parents = (dependencies[current] ?? [])
       .map((name) => byName.get(name))
-      .filter((job): job is ActionsJob => Boolean(job))
+      .filter(
+        (job): job is ActionsJob =>
+          Boolean(job) && job?.conclusion !== "skipped",
+      )
       .map((job) => ({
         job,
         completed: timestamp(job.completed_at, `${job.name} completion`),
@@ -132,6 +136,7 @@ export function summarizeActionsJobs(
     .map((job) => timestamp(job.created_at, `${job.name} creation`))
     .filter((value): value is number => value !== null);
   const completedTimes = jobs
+    .filter((job) => job.conclusion !== "skipped")
     .map((job) => timestamp(job.completed_at, `${job.name} completion`))
     .filter((value): value is number => value !== null);
   const workflowStart = createdTimes.length > 0 ? Math.min(...createdTimes) : null;
@@ -141,8 +146,13 @@ export function summarizeActionsJobs(
   }
 
   const timings = jobs.map((job): JobTiming => {
-    const runnerSeconds = elapsedSeconds(job.started_at, job.completed_at, job.name);
-    const queueSeconds = elapsedSeconds(job.created_at, job.started_at, `${job.name} queue`);
+    const skipped = job.conclusion === "skipped";
+    const runnerSeconds = skipped
+      ? null
+      : elapsedSeconds(job.started_at, job.completed_at, job.name);
+    const queueSeconds = skipped
+      ? null
+      : elapsedSeconds(job.created_at, job.started_at, `${job.name} queue`);
     return {
       id: job.id,
       name: job.name,
@@ -152,11 +162,13 @@ export function summarizeActionsJobs(
       phases: (job.steps ?? []).map((step) => ({
         name: step.name,
         conclusion: step.conclusion,
-        durationSeconds: elapsedSeconds(
-          step.started_at,
-          step.completed_at,
-          `${job.name} / ${step.name}`,
-        ),
+        durationSeconds: skipped
+          ? null
+          : elapsedSeconds(
+              step.started_at,
+              step.completed_at,
+              `${job.name} / ${step.name}`,
+            ),
       })),
     };
   });

--- a/scripts/ci/fixtures/actions-jobs.json
+++ b/scripts/ci/fixtures/actions-jobs.json
@@ -1,0 +1,45 @@
+{
+  "total_count": 3,
+  "jobs": [
+    {
+      "id": 1,
+      "name": "changes",
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-07-30T10:00:00Z",
+      "started_at": "2026-07-30T10:00:05Z",
+      "completed_at": "2026-07-30T10:00:15Z",
+      "steps": [
+        {
+          "name": "Classify",
+          "status": "completed",
+          "conclusion": "success",
+          "started_at": "2026-07-30T10:00:07Z",
+          "completed_at": "2026-07-30T10:00:12Z"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "name": "quality",
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-07-30T10:00:00Z",
+      "started_at": "2026-07-30T10:00:20Z",
+      "completed_at": "2026-07-30T10:01:20Z"
+    },
+    {
+      "id": 3,
+      "name": "required",
+      "status": "completed",
+      "conclusion": "success",
+      "created_at": "2026-07-30T10:00:00Z",
+      "started_at": "2026-07-30T10:01:25Z",
+      "completed_at": "2026-07-30T10:01:30Z"
+    }
+  ],
+  "dependencies": {
+    "quality": ["changes"],
+    "required": ["quality"]
+  }
+}

--- a/scripts/ci/fixtures/bun-1.3.14-junit.xml
+++ b/scripts/ci/fixtures/bun-1.3.14-junit.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="bun test" tests="2" assertions="2" failures="0" skipped="1" time="0.03">
+  <testsuite name="packages/example/src/example.test.ts" file="packages/example/src/example.test.ts" tests="2" assertions="2" failures="0" skipped="1" time="0">
+    <testsuite name="example" file="packages/example/src/example.test.ts" line="4" tests="2" assertions="2" failures="0" skipped="1" time="0.03">
+      <testcase name="passes" classname="example" time="0.02" file="packages/example/src/example.test.ts" line="5" assertions="1" />
+      <testcase name="is optional" classname="example" time="0.01" file="packages/example/src/example.test.ts" line="6" assertions="1"><skipped /></testcase>
+    </testsuite>
+  </testsuite>
+</testsuites>

--- a/scripts/ci/run-test-lane.ts
+++ b/scripts/ci/run-test-lane.ts
@@ -1,0 +1,75 @@
+#!/usr/bin/env bun
+import { resolve } from "node:path";
+import { discoverTestFiles, normalizeRepositoryTestPath } from "./test-inventory.js";
+import {
+  loadTestLaneMetadata,
+  planTestLanes,
+  type TestExecutionGroup,
+  type TestTopology,
+} from "./test-lanes.js";
+
+export function buildTestLaneCommand(
+  group: TestExecutionGroup,
+  junitFile: string,
+): string[] {
+  if (group.workers !== 1 && group.workers !== 2) {
+    throw new Error(`worker count must be exactly 1 or 2: ${group.workers}`);
+  }
+  if (!junitFile.trim()) throw new Error("JUnit output path is required");
+  if (group.files.length === 0) throw new Error("test execution group is empty");
+
+  const files = group.files.map(normalizeRepositoryTestPath);
+  if (new Set(files).size !== files.length) {
+    throw new Error("test execution group contains duplicate paths");
+  }
+  if (
+    group.workers === 2 &&
+    (group.lane !== "general" ||
+      group.mode !== "parallel" ||
+      group.atomicGroups.length > 0 ||
+      group.requirements.includes("stateful") ||
+      group.requirements.includes("typst-runtime"))
+  ) {
+    throw new Error(`test execution group is not worker-safe: ${group.id}`);
+  }
+
+  const args = ["bun", "run", "test", "--"];
+  if (group.workers === 2) args.push("--parallel=2");
+  args.push(
+    ...files.map((file) => `./${file}`),
+    "--reporter=junit",
+    `--reporter-outfile=${junitFile}`,
+  );
+  if (args.some((arg) => arg === "--concurrent")) {
+    throw new Error("global --concurrent is forbidden");
+  }
+  return args;
+}
+
+function option(args: readonly string[], name: string): string {
+  const index = args.indexOf(name);
+  const value = index >= 0 ? args[index + 1] : undefined;
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const topology = option(args, "--topology") as TestTopology;
+  const groupId = option(args, "--group");
+  const junitFile = option(args, "--junit");
+  const plan = planTestLanes(discoverTestFiles(), loadTestLaneMetadata(), topology);
+  const group = plan.groups.find((candidate) => candidate.id === groupId);
+  if (!group) throw new Error(`unknown execution group for ${topology}: ${groupId}`);
+
+  const child = Bun.spawn(buildTestLaneCommand(group, junitFile), {
+    cwd: resolve(import.meta.dir, "../.."),
+    stdin: "inherit",
+    stdout: "inherit",
+    stderr: "inherit",
+  });
+  const exitCode = await child.exited;
+  if (exitCode !== 0) process.exit(exitCode);
+}
+
+if (import.meta.main) await main();

--- a/scripts/ci/telemetry-summary.test.ts
+++ b/scripts/ci/telemetry-summary.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildCiTelemetrySummary,
+  telemetryMarkdown,
+} from "./telemetry-summary.js";
+
+function junit(file: string, seconds: number): string {
+  return (
+    "<testsuites><testsuite>" +
+    `<testcase name="works" classname="suite" time="${seconds}" file="${file}" />` +
+    "</testsuite></testsuites>"
+  );
+}
+
+describe("CI telemetry summary", () => {
+  test("combines disjoint lane JUnit with Actions timing data", () => {
+    const summary = buildCiTelemetrySummary({
+      commitSha: "a".repeat(40),
+      sourceRun: "run-1",
+      topology: "legacy-4-shard",
+      routes: { code: true },
+      junit: [
+        { lane: "shard-1", xml: junit("pkg/slow.test.ts", 2) },
+        { lane: "shard-2", xml: junit("pkg/fast.test.ts", 1) },
+      ],
+      jobs: [
+        {
+          id: 1,
+          name: "tests",
+          status: "completed",
+          conclusion: "success",
+          created_at: "2026-07-30T10:00:00Z",
+          started_at: "2026-07-30T10:00:01Z",
+          completed_at: "2026-07-30T10:00:04Z",
+        },
+      ],
+    });
+    expect(summary).toMatchObject({
+      schema: 1,
+      files: 2,
+      testcases: 2,
+    });
+    expect(summary.slowestFiles[0]).toMatchObject({
+      file: "pkg/slow.test.ts",
+      durationSeconds: 2,
+    });
+    expect(telemetryMarkdown(summary)).toContain("legacy-4-shard");
+  });
+
+  test("fails closed when two lane artifacts own the same file", () => {
+    expect(() =>
+      buildCiTelemetrySummary({
+        commitSha: "a".repeat(40),
+        sourceRun: "run-1",
+        topology: "candidate",
+        routes: {},
+        junit: [
+          { lane: "one", xml: junit("pkg/a.test.ts", 1) },
+          { lane: "two", xml: junit("pkg/a.test.ts", 1) },
+        ],
+        jobs: [],
+      }),
+    ).toThrow("duplicate file ownership");
+  });
+});

--- a/scripts/ci/telemetry-summary.ts
+++ b/scripts/ci/telemetry-summary.ts
@@ -1,0 +1,176 @@
+#!/usr/bin/env bun
+import {
+  appendFileSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  writeFileSync,
+} from "node:fs";
+import { basename, dirname, extname, join, resolve } from "node:path";
+import {
+  summarizeActionsJobs,
+  type ActionsJob,
+  type ActionsTimingSummary,
+} from "./actions-timings.js";
+import {
+  assertDisjointLaneOwnership,
+  parseBunJUnit,
+  type FileTiming,
+} from "./test-timings.js";
+
+export interface CiTelemetrySummary {
+  schema: 1;
+  commitSha: string;
+  sourceRun: string;
+  topology: string;
+  routes: Record<string, boolean>;
+  files: number;
+  testcases: number;
+  lanes: Array<{
+    lane: string;
+    files: number;
+    testcases: number;
+    durationSeconds: number;
+  }>;
+  slowestFiles: FileTiming[];
+  actions: ActionsTimingSummary;
+}
+
+export function buildCiTelemetrySummary(options: {
+  commitSha: string;
+  sourceRun: string;
+  topology: string;
+  routes: Record<string, boolean>;
+  junit: Array<{ lane: string; xml: string }>;
+  jobs: ActionsJob[];
+  dependencies?: Record<string, string[]>;
+}): CiTelemetrySummary {
+  if (!/^[0-9a-f]{40}$/i.test(options.commitSha)) {
+    throw new Error("telemetry commit SHA must contain 40 hexadecimal characters");
+  }
+  const artifacts = options.junit.map(({ lane, xml }) =>
+    parseBunJUnit(xml, { namespace: options.topology, lane }),
+  );
+  assertDisjointLaneOwnership(artifacts);
+  const files = artifacts.flatMap((artifact) => artifact.files);
+  return {
+    schema: 1,
+    commitSha: options.commitSha.toLowerCase(),
+    sourceRun: options.sourceRun,
+    topology: options.topology,
+    routes: options.routes,
+    files: files.length,
+    testcases: artifacts.reduce(
+      (total, artifact) => total + artifact.testcases.length,
+      0,
+    ),
+    lanes: artifacts.map((artifact) => ({
+      lane: artifact.lane,
+      files: artifact.files.length,
+      testcases: artifact.testcases.length,
+      durationSeconds: artifact.files.reduce(
+        (total, file) => total + file.durationSeconds,
+        0,
+      ),
+    })),
+    slowestFiles: [...files]
+      .sort(
+        (left, right) =>
+          right.durationSeconds - left.durationSeconds ||
+          left.file.localeCompare(right.file),
+      )
+      .slice(0, 20),
+    actions: summarizeActionsJobs(options.jobs, options.dependencies),
+  };
+}
+
+export function telemetryMarkdown(summary: CiTelemetrySummary): string {
+  const lines = [
+    "## CI timing telemetry",
+    "",
+    `- Topology: \`${summary.topology}\``,
+    `- Test files / cases: ${summary.files} / ${summary.testcases}`,
+    `- Workflow wall time: ${summary.actions.workflowWallSeconds ?? "unavailable"}s`,
+    `- Runner time: ${summary.actions.totalRunnerMinutes.toFixed(2)} min`,
+    `- Sample class: \`${summary.actions.sampleClass}\``,
+    "",
+    "| Lane | Files | Cases | Testcase time |",
+    "| --- | ---: | ---: | ---: |",
+    ...summary.lanes.map(
+      (lane) =>
+        `| ${lane.lane} | ${lane.files} | ${lane.testcases} | ${lane.durationSeconds.toFixed(3)}s |`,
+    ),
+    "",
+    "### Slowest files",
+    "",
+    ...summary.slowestFiles.map(
+      (file) => `- \`${file.file}\`: ${file.durationSeconds.toFixed(3)}s`,
+    ),
+    "",
+  ];
+  return lines.join("\n");
+}
+
+function filesRecursively(directory: string): string[] {
+  const result: string[] = [];
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) result.push(...filesRecursively(path));
+    else if (entry.isFile()) result.push(path);
+  }
+  return result.sort((left, right) => left.localeCompare(right));
+}
+
+function option(args: readonly string[], name: string): string {
+  const index = args.indexOf(name);
+  const value = index >= 0 ? args[index + 1] : undefined;
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const junitDirectory = option(args, "--junit");
+  const jobsPath = option(args, "--jobs");
+  const outPath = option(args, "--out");
+  const jobsPayload = JSON.parse(readFileSync(jobsPath, "utf8")) as {
+    jobs?: ActionsJob[];
+    dependencies?: Record<string, string[]>;
+  };
+  if (!Array.isArray(jobsPayload.jobs)) throw new Error("jobs payload is missing jobs");
+
+  const junit = filesRecursively(junitDirectory)
+    .filter((path) => extname(path) === ".xml")
+    .map((path) => ({
+      lane: basename(path, ".xml"),
+      xml: readFileSync(path, "utf8"),
+    }));
+  const summary = buildCiTelemetrySummary({
+    commitSha: process.env.GITHUB_SHA ?? "",
+    sourceRun:
+      process.env.GITHUB_SERVER_URL &&
+      process.env.GITHUB_REPOSITORY &&
+      process.env.GITHUB_RUN_ID
+        ? `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`
+        : "local",
+    topology: process.env.CI_TEST_TOPOLOGY ?? "legacy-4-shard",
+    routes: {
+      code: process.env.CI_ROUTE_CODE === "true",
+      consumer: process.env.CI_ROUTE_CONSUMER === "true",
+      docs: process.env.CI_ROUTE_DOCS === "true",
+      readmeMedia: process.env.CI_ROUTE_README_MEDIA === "true",
+    },
+    junit,
+    jobs: jobsPayload.jobs,
+    dependencies: jobsPayload.dependencies,
+  });
+  mkdirSync(dirname(resolve(outPath)), { recursive: true });
+  writeFileSync(outPath, `${JSON.stringify(summary, null, 2)}\n`);
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    appendFileSync(process.env.GITHUB_STEP_SUMMARY, telemetryMarkdown(summary));
+  } else {
+    process.stdout.write(telemetryMarkdown(summary));
+  }
+}
+
+if (import.meta.main) await main();

--- a/scripts/ci/test-inventory.test.ts
+++ b/scripts/ci/test-inventory.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  buildTestInventory,
+  discoverTestFiles,
+  normalizeRepositoryTestPath,
+  repositoryRelativePath,
+} from "./test-inventory.js";
+
+describe("test inventory", () => {
+  test("includes every Bun naming family with stable full-path ordering", () => {
+    expect(
+      buildTestInventory([
+        "z/same.test.ts",
+        "a/same.test.ts",
+        "pkg/alpha_test.jsx",
+        "pkg/bravo.spec.js",
+        "pkg/charlie_spec.tsx",
+        "pkg/not-a-test.ts",
+        "./pkg/bravo.spec.js",
+      ]),
+    ).toEqual([
+      "a/same.test.ts",
+      "pkg/alpha_test.jsx",
+      "pkg/bravo.spec.js",
+      "pkg/charlie_spec.tsx",
+      "z/same.test.ts",
+    ]);
+  });
+
+  test("excludes hidden, dependency, generated, output, and Playwright artifact directories", () => {
+    expect(
+      buildTestInventory([
+        ".hidden/secret.test.ts",
+        ".turbo/cache.test.ts",
+        "node_modules/pkg/index.test.ts",
+        "packages/x/dist/index.test.js",
+        "packages/x/build/index.spec.js",
+        "packages/x/generated/schema_test.ts",
+        "coverage/report.test.ts",
+        "playwright-report/output.test.ts",
+        "test-results/retry.spec.ts",
+        "packages/x/src/index.test.ts",
+      ]),
+    ).toEqual(["packages/x/src/index.test.ts"]);
+  });
+
+  test("normalizes separators and rejects absolute or escaping paths", () => {
+    expect(buildTestInventory(["packages\\x\\src\\index.test.ts"])).toEqual([
+      "packages/x/src/index.test.ts",
+    ]);
+    expect(() => normalizeRepositoryTestPath("../outside.test.ts")).toThrow("escapes");
+    expect(() => normalizeRepositoryTestPath("/tmp/outside.test.ts")).toThrow(
+      "repository-relative",
+    );
+  });
+
+  test("discovers a synthetic tree without following symlinks outside it", () => {
+    const root = mkdtempSync(join(tmpdir(), "atlcli-test-inventory-"));
+    const outside = mkdtempSync(join(tmpdir(), "atlcli-test-inventory-outside-"));
+    try {
+      mkdirSync(join(root, "pkg", "nested"), { recursive: true });
+      mkdirSync(join(root, "node_modules", "ignored"), { recursive: true });
+      writeFileSync(join(root, "pkg", "nested", "b.test.ts"), "");
+      writeFileSync(join(root, "pkg", "a_spec.js"), "");
+      writeFileSync(join(root, "node_modules", "ignored", "bad.test.ts"), "");
+      writeFileSync(join(outside, "outside.test.ts"), "");
+      symlinkSync(outside, join(root, "outside-link"));
+
+      expect(discoverTestFiles(root)).toEqual([
+        "pkg/a_spec.js",
+        "pkg/nested/b.test.ts",
+      ]);
+      expect(repositoryRelativePath(root, join(root, "pkg", "a_spec.js"))).toBe(
+        "pkg/a_spec.js",
+      );
+      expect(() => repositoryRelativePath(root, join(outside, "outside.test.ts"))).toThrow(
+        "outside repository",
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+      rmSync(outside, { recursive: true, force: true });
+    }
+  });
+});

--- a/scripts/ci/test-inventory.ts
+++ b/scripts/ci/test-inventory.ts
@@ -1,0 +1,105 @@
+#!/usr/bin/env bun
+import { readdirSync, realpathSync } from "node:fs";
+import { isAbsolute, relative, resolve, sep } from "node:path";
+
+const TEST_FILE_PATTERN =
+  /(?:\.|_)(?:test|spec)\.(?:js|jsx|ts|tsx)$/;
+
+const EXCLUDED_DIRECTORY_NAMES = new Set([
+  "build",
+  "coverage",
+  "dist",
+  "generated",
+  "node_modules",
+  "test-results",
+]);
+
+const EXCLUDED_DIRECTORY_PREFIXES = [
+  ".turbo/",
+  "artifacts/",
+  "playwright-report/",
+];
+
+function posix(path: string): string {
+  return path.replaceAll("\\", "/").replace(/^\.\//, "");
+}
+
+export function normalizeRepositoryTestPath(path: string): string {
+  const normalized = posix(path.trim());
+  if (!normalized || isAbsolute(normalized)) {
+    throw new Error(`test path must be repository-relative: ${path}`);
+  }
+
+  const segments = normalized.split("/");
+  if (segments.some((segment) => !segment || segment === "." || segment === "..")) {
+    throw new Error(`test path escapes or is not normalized: ${path}`);
+  }
+  return normalized;
+}
+
+function isExcludedPath(path: string): boolean {
+  const segments = path.split("/");
+  return (
+    segments.some(
+      (segment) =>
+        segment.startsWith(".") ||
+        EXCLUDED_DIRECTORY_NAMES.has(segment),
+    ) ||
+    EXCLUDED_DIRECTORY_PREFIXES.some(
+      (prefix) => path === prefix.slice(0, -1) || path.startsWith(prefix),
+    )
+  );
+}
+
+export function buildTestInventory(paths: readonly string[]): string[] {
+  const inventory = new Set<string>();
+  for (const path of paths) {
+    const normalized = normalizeRepositoryTestPath(path);
+    if (isExcludedPath(normalized) || !TEST_FILE_PATTERN.test(normalized)) continue;
+    inventory.add(normalized);
+  }
+  return [...inventory].sort((left, right) => left.localeCompare(right));
+}
+
+export function repositoryRelativePath(root: string, candidate: string): string {
+  const resolvedRoot = realpathSync(root);
+  const resolvedCandidate = realpathSync(candidate);
+  const path = relative(resolvedRoot, resolvedCandidate);
+  if (!path || path === ".." || path.startsWith(`..${sep}`) || isAbsolute(path)) {
+    throw new Error(`path is outside repository root: ${candidate}`);
+  }
+  return normalizeRepositoryTestPath(path);
+}
+
+function walkFiles(root: string, directory: string, output: string[]): void {
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    if (entry.isSymbolicLink()) continue;
+
+    const absolute = resolve(directory, entry.name);
+    const path = posix(relative(root, absolute));
+    if (entry.isDirectory()) {
+      if (!isExcludedPath(path)) walkFiles(root, absolute, output);
+      continue;
+    }
+    if (entry.isFile()) output.push(path);
+  }
+}
+
+export function discoverTestFiles(root = resolve(import.meta.dir, "../..")): string[] {
+  const resolvedRoot = realpathSync(root);
+  const files: string[] = [];
+  walkFiles(resolvedRoot, resolvedRoot, files);
+  return buildTestInventory(files);
+}
+
+async function main(): Promise<void> {
+  const args = new Set(process.argv.slice(2));
+  const inventory = discoverTestFiles();
+  if (args.has("--json")) {
+    process.stdout.write(`${JSON.stringify({ schema: 1, files: inventory }, null, 2)}\n`);
+    return;
+  }
+  for (const file of inventory) process.stdout.write(`${file}\n`);
+}
+
+if (import.meta.main) await main();

--- a/scripts/ci/test-lanes.json
+++ b/scripts/ci/test-lanes.json
@@ -1,0 +1,85 @@
+{
+  "schema": 1,
+  "baselineSha": "9ffbe22e604413226a863064da31dc6981f76ce0",
+  "conservativeDefaultSeconds": 5,
+  "files": [
+    {
+      "path": "scripts/api-report.test.ts",
+      "lane": "package-contract"
+    },
+    {
+      "path": "scripts/dist-hygiene.test.ts",
+      "lane": "package-contract"
+    },
+    {
+      "path": "apps/cli/src/commands/auth-test-isolation.test.ts",
+      "atomicGroup": "auth-isolation",
+      "requirements": ["stateful"]
+    },
+    {
+      "path": "apps/cli/src/e2e/registry-isolation.test.ts",
+      "atomicGroup": "registry-isolation",
+      "requirements": ["stateful"]
+    },
+    {
+      "path": "packages/pdf-compiler-browser/src/callout-accessibility.test.ts",
+      "lane": "pdf-typst",
+      "requirements": ["fonts", "typst-runtime"]
+    },
+    {
+      "path": "packages/pdf-compiler-browser/src/chapter-running-head.test.ts",
+      "lane": "pdf-typst",
+      "requirements": ["fonts", "typst-runtime"]
+    },
+    {
+      "path": "packages/pdf-compiler-browser/src/compiler.test.ts",
+      "lane": "pdf-typst",
+      "requirements": ["fonts", "typst-runtime"]
+    },
+    {
+      "path": "packages/pdf-compiler-browser/src/docx-template-assets.test.ts",
+      "lane": "pdf-typst",
+      "requirements": ["fonts", "poppler", "typst-runtime"]
+    },
+    {
+      "path": "packages/pdf-compiler-browser/src/docx-template-intake-chain.test.ts",
+      "lane": "pdf-typst",
+      "requirements": ["fonts", "poppler", "typst-runtime"]
+    },
+    {
+      "path": "packages/pdf-compiler-browser/src/emoji-font-coverage.test.ts",
+      "lane": "pdf-typst",
+      "requirements": ["fonts", "typst-runtime"]
+    },
+    {
+      "path": "packages/pdf-compiler-browser/src/fonts-compile.test.ts",
+      "lane": "pdf-typst",
+      "requirements": ["fonts", "typst-runtime"]
+    },
+    {
+      "path": "packages/pdf-compiler-browser/src/label-injection.test.ts",
+      "lane": "pdf-typst",
+      "requirements": ["fonts", "typst-runtime"]
+    },
+    {
+      "path": "packages/pdf-compiler-browser/src/pdf-accessibility-claims.test.ts",
+      "lane": "pdf-typst",
+      "requirements": ["fonts", "typst-runtime"]
+    },
+    {
+      "path": "packages/pdf-compiler-browser/src/pdf-lang-catalog.test.ts",
+      "lane": "pdf-typst",
+      "requirements": ["fonts", "typst-runtime"]
+    },
+    {
+      "path": "packages/pdf-compiler-browser/src/second-template.test.ts",
+      "lane": "pdf-typst",
+      "requirements": ["fonts", "typst-runtime"]
+    },
+    {
+      "path": "packages/pdf-compiler-browser/src/template-migration-parity.test.ts",
+      "lane": "pdf-typst",
+      "requirements": ["fonts", "typst-runtime"]
+    }
+  ]
+}

--- a/scripts/ci/test-lanes.test.ts
+++ b/scripts/ci/test-lanes.test.ts
@@ -1,0 +1,266 @@
+import { describe, expect, test } from "bun:test";
+import { buildTestLaneCommand } from "./run-test-lane.js";
+import {
+  planTestLanes,
+  type TestExecutionGroup,
+  type TestLaneMetadata,
+  type TestLaneMetadataEntry,
+  type TestTopology,
+} from "./test-lanes.js";
+
+const SHA = "a".repeat(40);
+
+function metadata(
+  files: TestLaneMetadataEntry[] = [],
+  conservativeDefaultSeconds = 5,
+): TestLaneMetadata {
+  return {
+    schema: 1,
+    baselineSha: SHA,
+    conservativeDefaultSeconds,
+    files,
+  };
+}
+
+function plan(
+  inventory: string[],
+  files: TestLaneMetadataEntry[],
+  topology: TestTopology = "general-2x1",
+) {
+  return planTestLanes(inventory, metadata(files), topology);
+}
+
+function assignment(planResult: ReturnType<typeof plan>): Map<string, string> {
+  return new Map(
+    planResult.groups.flatMap((group) =>
+      group.files.map((file): [string, string] => [file, group.job]),
+    ),
+  );
+}
+
+function group(
+  overrides: Partial<TestExecutionGroup> = {},
+): TestExecutionGroup {
+  return {
+    id: "general-1",
+    job: "general-1",
+    lane: "general",
+    mode: "serial",
+    workers: 1,
+    files: ["pkg/a.test.ts"],
+    requirements: [],
+    atomicGroups: [],
+    estimatedSeconds: 1,
+    ...overrides,
+  };
+}
+
+describe("duration-aware test lanes", () => {
+  test("uses deterministic LPT balancing independent of inventory order", () => {
+    const inventory = ["pkg/a.test.ts", "pkg/b.test.ts", "pkg/c.test.ts", "pkg/d.test.ts"];
+    const files = [
+      { path: "pkg/a.test.ts", durationSeconds: 8 },
+      { path: "pkg/b.test.ts", durationSeconds: 7 },
+      { path: "pkg/c.test.ts", durationSeconds: 3 },
+      { path: "pkg/d.test.ts", durationSeconds: 2 },
+    ];
+    const forward = plan(inventory, files);
+    const reverse = plan([...inventory].reverse(), [...files].reverse());
+
+    expect(forward).toEqual(reverse);
+    const jobs = assignment(forward);
+    expect(jobs.get("pkg/a.test.ts")).not.toBe(jobs.get("pkg/b.test.ts"));
+    expect(
+      forward.groups
+        .filter(({ lane }) => lane === "general")
+        .map(({ estimatedSeconds }) => estimatedSeconds),
+    ).toEqual([10, 10]);
+  });
+
+  test("defaults new files to general with the larger historical p95 fallback", () => {
+    const result = plan(
+      ["pkg/fast.test.ts", "pkg/slow.test.ts", "pkg/new.test.ts"],
+      [
+        { path: "pkg/fast.test.ts", durationSeconds: 1 },
+        { path: "pkg/slow.test.ts", durationSeconds: 9 },
+      ],
+    );
+    expect(result.fallbackSeconds).toBe(9);
+    expect(
+      result.groups.find((candidate) => candidate.files.includes("pkg/new.test.ts"))?.lane,
+    ).toBe("general");
+  });
+
+  test("rejects duplicate inventory, duplicate metadata, stale paths, and lane conflicts", () => {
+    expect(() =>
+      planTestLanes(["pkg/a.test.ts", "pkg/a.test.ts"], metadata(), "general-2x1"),
+    ).toThrow("duplicate paths");
+    expect(() =>
+      plan(
+        ["pkg/a.test.ts"],
+        [{ path: "pkg/a.test.ts" }, { path: "pkg/a.test.ts" }],
+      ),
+    ).toThrow("duplicate test-lane metadata");
+    expect(() =>
+      plan(["pkg/a.test.ts"], [{ path: "pkg/stale.test.ts" }]),
+    ).toThrow("stale test-lane metadata");
+    expect(() =>
+      plan(
+        ["pkg/a.test.ts"],
+        [
+          {
+            path: "pkg/a.test.ts",
+            lane: "package-contract",
+            requirements: ["typst-runtime"],
+          },
+        ],
+      ),
+    ).toThrow("conflicting");
+  });
+
+  test("preserves combined setup requirements on an explicit PDF/Typst lane", () => {
+    const result = plan(
+      ["pkg/compiler.test.ts"],
+      [
+        {
+          path: "pkg/compiler.test.ts",
+          lane: "pdf-typst",
+          requirements: ["poppler", "fonts", "typst-runtime"],
+        },
+      ],
+    );
+    expect(result.groups).toEqual([
+      expect.objectContaining({
+        id: "pdf-typst",
+        workers: 1,
+        requirements: ["fonts", "poppler", "typst-runtime"],
+      }),
+    ]);
+  });
+
+  test("keeps atomic groups indivisible in a separate serial execution group", () => {
+    const result = plan(
+      ["pkg/a.test.ts", "pkg/b.test.ts", "pkg/safe.test.ts"],
+      [
+        {
+          path: "pkg/a.test.ts",
+          durationSeconds: 6,
+          atomicGroup: "shared-state",
+          requirements: ["stateful"],
+        },
+        {
+          path: "pkg/b.test.ts",
+          durationSeconds: 4,
+          atomicGroup: "shared-state",
+          requirements: ["stateful"],
+        },
+      ],
+      "general-2x2-workers",
+    );
+    const serial = result.groups.find((candidate) =>
+      candidate.atomicGroups.includes("shared-state"),
+    );
+    expect(serial).toMatchObject({
+      mode: "serial",
+      workers: 1,
+      files: ["pkg/a.test.ts", "pkg/b.test.ts"],
+    });
+    expect(
+      result.groups.find((candidate) => candidate.files.includes("pkg/safe.test.ts")),
+    ).toMatchObject({ mode: "parallel", workers: 2 });
+  });
+
+  test("omits zero-file lanes and retains an exact pairwise-disjoint union", () => {
+    const inventory = ["a/same.test.ts", "b/same.test.ts", "pkg/space name.test.ts"];
+    const result = plan(inventory, [], "general-3x1");
+    const assigned = result.groups.flatMap(({ files }) => files);
+    expect(result.groups.every(({ files }) => files.length > 0)).toBe(true);
+    expect([...assigned].sort()).toEqual([...inventory].sort());
+    expect(new Set(assigned).size).toBe(inventory.length);
+    expect(result.groups.some(({ lane }) => lane === "package-contract")).toBe(false);
+  });
+
+  test("emits argv-safe commands with an exact bounded worker flag", () => {
+    const command = buildTestLaneCommand(
+      group({
+        id: "general-1-parallel",
+        mode: "parallel",
+        workers: 2,
+        files: ["pkg/space name.test.ts", "a/same.test.ts", "b/same.test.ts"],
+      }),
+      "junit/general-1.xml",
+    );
+    expect(command).toEqual([
+      "bun",
+      "run",
+      "test",
+      "--",
+      "--parallel=2",
+      "./pkg/space name.test.ts",
+      "./a/same.test.ts",
+      "./b/same.test.ts",
+      "--reporter=junit",
+      "--reporter-outfile=junit/general-1.xml",
+    ]);
+    expect(command).not.toContain("--concurrent");
+
+    expect(
+      buildTestLaneCommand(group(), "junit/general-1.xml"),
+    ).not.toContain("--parallel=2");
+  });
+
+  test("rejects empty, duplicate, escaping, implicit, and unsafe parallel groups", () => {
+    expect(() => buildTestLaneCommand(group({ files: [] }), "out.xml")).toThrow("empty");
+    expect(() =>
+      buildTestLaneCommand(group({ files: ["pkg/a.test.ts", "pkg/a.test.ts"] }), "out.xml"),
+    ).toThrow("duplicate");
+    expect(() =>
+      buildTestLaneCommand(group({ files: ["../outside.test.ts"] }), "out.xml"),
+    ).toThrow();
+    expect(() =>
+      buildTestLaneCommand(group({ workers: 0 as 1 }), "out.xml"),
+    ).toThrow("exactly 1 or 2");
+    for (const unsafe of [
+      group({ lane: "package-contract", mode: "parallel", workers: 2 }),
+      group({ lane: "pdf-typst", mode: "parallel", workers: 2 }),
+      group({
+        mode: "parallel",
+        workers: 2,
+        requirements: ["stateful"],
+      }),
+      group({
+        mode: "parallel",
+        workers: 2,
+        atomicGroups: ["shared"],
+      }),
+    ]) {
+      expect(() => buildTestLaneCommand(unsafe, "out.xml")).toThrow("not worker-safe");
+    }
+  });
+
+  test("accepts only the three named candidate topologies", () => {
+    expect(() =>
+      planTestLanes(["pkg/a.test.ts"], metadata(), "legacy-4-shard" as TestTopology),
+    ).toThrow("unknown test topology");
+  });
+
+  test("exposes stable group identifiers for a workflow matrix", () => {
+    const result = plan(
+      ["pkg/a.test.ts", "pkg/contract.test.ts", "pkg/pdf.test.ts"],
+      [
+        { path: "pkg/contract.test.ts", lane: "package-contract" },
+        {
+          path: "pkg/pdf.test.ts",
+          lane: "pdf-typst",
+          requirements: ["fonts", "poppler", "typst-runtime"],
+        },
+      ],
+      "general-2x2-workers",
+    );
+    expect(result.groups.map(({ id }) => id)).toEqual([
+      "general-1-parallel",
+      "package-contract",
+      "pdf-typst",
+    ]);
+  });
+});

--- a/scripts/ci/test-lanes.ts
+++ b/scripts/ci/test-lanes.ts
@@ -1,0 +1,405 @@
+#!/usr/bin/env bun
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import {
+  discoverTestFiles,
+  normalizeRepositoryTestPath,
+} from "./test-inventory.js";
+
+export type TestLane = "general" | "package-contract" | "pdf-typst";
+export type TestTopology =
+  | "general-2x1"
+  | "general-3x1"
+  | "general-2x2-workers";
+export type SetupRequirement = "fonts" | "poppler" | "stateful" | "typst-runtime";
+
+export interface TestLaneMetadataEntry {
+  path: string;
+  durationSeconds?: number;
+  lane?: TestLane;
+  requirements?: SetupRequirement[];
+  atomicGroup?: string;
+}
+
+export interface TestLaneMetadata {
+  schema: 1;
+  baselineSha: string;
+  conservativeDefaultSeconds: number;
+  files: TestLaneMetadataEntry[];
+}
+
+export interface TestExecutionGroup {
+  id: string;
+  job: string;
+  lane: TestLane;
+  mode: "parallel" | "serial";
+  workers: 1 | 2;
+  files: string[];
+  requirements: SetupRequirement[];
+  atomicGroups: string[];
+  estimatedSeconds: number;
+}
+
+export interface TestLanePlan {
+  schema: 1;
+  topology: TestTopology;
+  baselineSha: string;
+  fallbackSeconds: number;
+  inventoryCount: number;
+  groups: TestExecutionGroup[];
+}
+
+const TOPOLOGIES = new Set<TestTopology>([
+  "general-2x1",
+  "general-3x1",
+  "general-2x2-workers",
+]);
+const LANES = new Set<TestLane>(["general", "package-contract", "pdf-typst"]);
+const REQUIREMENTS = new Set<SetupRequirement>([
+  "fonts",
+  "poppler",
+  "stateful",
+  "typst-runtime",
+]);
+
+interface ValidatedEntry extends TestLaneMetadataEntry {
+  path: string;
+  lane: TestLane;
+  requirements: SetupRequirement[];
+}
+
+interface AssignmentUnit {
+  key: string;
+  files: string[];
+  weight: number;
+  requirements: SetupRequirement[];
+  atomicGroup?: string;
+}
+
+function percentile95(values: readonly number[]): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((left, right) => left - right);
+  return sorted[Math.ceil(sorted.length * 0.95) - 1]!;
+}
+
+function uniqueSorted<T extends string>(values: readonly T[]): T[] {
+  return [...new Set(values)].sort((left, right) => left.localeCompare(right));
+}
+
+function validateMetadata(
+  inventory: readonly string[],
+  metadata: TestLaneMetadata,
+): Map<string, ValidatedEntry> {
+  if (metadata.schema !== 1) throw new Error(`unsupported test-lane schema: ${metadata.schema}`);
+  if (!/^[0-9a-f]{40}$/i.test(metadata.baselineSha)) {
+    throw new Error("test-lane baseline SHA must contain 40 hexadecimal characters");
+  }
+  if (
+    !Number.isFinite(metadata.conservativeDefaultSeconds) ||
+    metadata.conservativeDefaultSeconds <= 0
+  ) {
+    throw new Error("conservativeDefaultSeconds must be positive");
+  }
+
+  const inventorySet = new Set(inventory);
+  const entries = new Map<string, ValidatedEntry>();
+  for (const rawEntry of metadata.files) {
+    const path = normalizeRepositoryTestPath(rawEntry.path);
+    if (entries.has(path)) throw new Error(`duplicate test-lane metadata: ${path}`);
+    if (!inventorySet.has(path)) throw new Error(`stale test-lane metadata: ${path}`);
+    const lane = rawEntry.lane ?? "general";
+    if (!LANES.has(lane)) throw new Error(`invalid lane for ${path}: ${lane}`);
+    if (
+      rawEntry.durationSeconds !== undefined &&
+      (!Number.isFinite(rawEntry.durationSeconds) || rawEntry.durationSeconds <= 0)
+    ) {
+      throw new Error(`invalid historical duration for ${path}`);
+    }
+    const requirements = uniqueSorted(rawEntry.requirements ?? []);
+    for (const requirement of requirements) {
+      if (!REQUIREMENTS.has(requirement)) {
+        throw new Error(`invalid setup requirement for ${path}: ${requirement}`);
+      }
+    }
+    if (rawEntry.atomicGroup !== undefined) {
+      if (!/^[a-z0-9][a-z0-9._-]*$/.test(rawEntry.atomicGroup)) {
+        throw new Error(`invalid atomic group for ${path}`);
+      }
+      if (lane !== "general") {
+        throw new Error(`atomic groups are supported only in the general lane: ${path}`);
+      }
+      if (!requirements.includes("stateful")) {
+        throw new Error(`atomic group must declare the stateful requirement: ${path}`);
+      }
+    }
+    if (lane === "package-contract" && requirements.includes("typst-runtime")) {
+      throw new Error(`conflicting package-contract and typst requirements: ${path}`);
+    }
+    entries.set(path, { ...rawEntry, path, lane, requirements });
+  }
+  return entries;
+}
+
+function groupGeneralUnits(
+  files: readonly string[],
+  metadata: ReadonlyMap<string, ValidatedEntry>,
+  fallbackSeconds: number,
+): AssignmentUnit[] {
+  const atomic = new Map<string, AssignmentUnit>();
+  const units: AssignmentUnit[] = [];
+  for (const file of files) {
+    const entry = metadata.get(file);
+    const weight = entry?.durationSeconds ?? fallbackSeconds;
+    if (!entry?.atomicGroup) {
+      units.push({
+        key: file,
+        files: [file],
+        weight,
+        requirements: entry?.requirements ?? [],
+      });
+      continue;
+    }
+    const previous = atomic.get(entry.atomicGroup) ?? {
+      key: `atomic:${entry.atomicGroup}`,
+      files: [],
+      weight: 0,
+      requirements: [],
+      atomicGroup: entry.atomicGroup,
+    };
+    previous.files.push(file);
+    previous.weight += weight;
+    previous.requirements = uniqueSorted([
+      ...previous.requirements,
+      ...(entry.requirements ?? []),
+    ]);
+    atomic.set(entry.atomicGroup, previous);
+  }
+  units.push(...atomic.values());
+  return units.sort(
+    (left, right) => right.weight - left.weight || left.key.localeCompare(right.key),
+  );
+}
+
+interface GeneralBin {
+  index: number;
+  safe: AssignmentUnit[];
+  serial: AssignmentUnit[];
+  safeWeight: number;
+  serialWeight: number;
+}
+
+function assignGeneralBins(
+  units: readonly AssignmentUnit[],
+  jobCount: number,
+  workers: 1 | 2,
+): GeneralBin[] {
+  const bins: GeneralBin[] = Array.from({ length: jobCount }, (_, index) => ({
+    index,
+    safe: [],
+    serial: [],
+    safeWeight: 0,
+    serialWeight: 0,
+  }));
+  for (const unit of units) {
+    const serial = Boolean(unit.atomicGroup) || unit.requirements.includes("stateful");
+    const bin = [...bins].sort((left, right) => {
+      const leftLoad = left.serialWeight + left.safeWeight / workers;
+      const rightLoad = right.serialWeight + right.safeWeight / workers;
+      return leftLoad - rightLoad || left.index - right.index;
+    })[0]!;
+    if (serial) {
+      bin.serial.push(unit);
+      bin.serialWeight += unit.weight;
+    } else {
+      bin.safe.push(unit);
+      bin.safeWeight += unit.weight;
+    }
+  }
+  return bins;
+}
+
+function executionGroup(
+  id: string,
+  job: string,
+  lane: TestLane,
+  mode: "parallel" | "serial",
+  workers: 1 | 2,
+  units: readonly AssignmentUnit[],
+): TestExecutionGroup | null {
+  const files = units.flatMap((unit) => unit.files).sort((left, right) => left.localeCompare(right));
+  if (files.length === 0) return null;
+  return {
+    id,
+    job,
+    lane,
+    mode,
+    workers,
+    files,
+    requirements: uniqueSorted(units.flatMap((unit) => unit.requirements)),
+    atomicGroups: uniqueSorted(
+      units.flatMap((unit) => (unit.atomicGroup ? [unit.atomicGroup] : [])),
+    ),
+    estimatedSeconds:
+      units.reduce((total, unit) => total + unit.weight, 0) / workers,
+  };
+}
+
+function assertPlanCoverage(plan: TestLanePlan, inventory: readonly string[]): void {
+  const assigned = plan.groups.flatMap((group) => group.files);
+  const duplicates = assigned.filter((file, index) => assigned.indexOf(file) !== index);
+  if (duplicates.length > 0) {
+    throw new Error(`test files assigned more than once: ${uniqueSorted(duplicates).join(", ")}`);
+  }
+  const expected = [...inventory].sort((left, right) => left.localeCompare(right));
+  const actual = [...assigned].sort((left, right) => left.localeCompare(right));
+  if (JSON.stringify(expected) !== JSON.stringify(actual)) {
+    const assignedSet = new Set(actual);
+    const missing = expected.filter((file) => !assignedSet.has(file));
+    throw new Error(`test lane plan does not cover inventory: ${missing.join(", ")}`);
+  }
+  if (plan.groups.some((group) => group.files.length === 0)) {
+    throw new Error("test lane plan contains an empty execution group");
+  }
+}
+
+export function planTestLanes(
+  rawInventory: readonly string[],
+  metadata: TestLaneMetadata,
+  topology: TestTopology,
+): TestLanePlan {
+  if (!TOPOLOGIES.has(topology)) throw new Error(`unknown test topology: ${topology}`);
+  const inventory = uniqueSorted(rawInventory.map(normalizeRepositoryTestPath));
+  if (inventory.length !== rawInventory.length) {
+    throw new Error("test inventory contains duplicate paths");
+  }
+  const entries = validateMetadata(inventory, metadata);
+  const measured = [...entries.values()].flatMap((entry) =>
+    entry.durationSeconds === undefined ? [] : [entry.durationSeconds],
+  );
+  const fallbackSeconds = Math.max(
+    metadata.conservativeDefaultSeconds,
+    percentile95(measured),
+  );
+
+  const filesByLane: Record<TestLane, string[]> = {
+    general: [],
+    "package-contract": [],
+    "pdf-typst": [],
+  };
+  for (const file of inventory) {
+    filesByLane[entries.get(file)?.lane ?? "general"].push(file);
+  }
+
+  const jobCount = topology === "general-3x1" ? 3 : 2;
+  const workers: 1 | 2 = topology === "general-2x2-workers" ? 2 : 1;
+  const units = groupGeneralUnits(filesByLane.general, entries, fallbackSeconds);
+  const bins = assignGeneralBins(units, jobCount, workers);
+  const groups: TestExecutionGroup[] = [];
+  for (const bin of bins) {
+    const job = `general-${bin.index + 1}`;
+    const safe = executionGroup(
+      workers === 2 ? `${job}-parallel` : job,
+      job,
+      "general",
+      workers === 2 ? "parallel" : "serial",
+      workers,
+      bin.safe,
+    );
+    if (safe) groups.push(safe);
+    const serial = executionGroup(
+      `${job}-serial`,
+      job,
+      "general",
+      "serial",
+      1,
+      bin.serial,
+    );
+    if (serial) groups.push(serial);
+  }
+
+  for (const lane of ["package-contract", "pdf-typst"] as const) {
+    const laneUnits = filesByLane[lane].map((file): AssignmentUnit => {
+      const entry = entries.get(file);
+      return {
+        key: file,
+        files: [file],
+        weight: entry?.durationSeconds ?? fallbackSeconds,
+        requirements: entry?.requirements ?? [],
+      };
+    });
+    const group = executionGroup(lane, lane, lane, "serial", 1, laneUnits);
+    if (group) groups.push(group);
+  }
+
+  const plan: TestLanePlan = {
+    schema: 1,
+    topology,
+    baselineSha: metadata.baselineSha,
+    fallbackSeconds,
+    inventoryCount: inventory.length,
+    groups,
+  };
+  assertPlanCoverage(plan, inventory);
+  return plan;
+}
+
+export function explainTestLanePlan(plan: TestLanePlan): string {
+  const lines = [
+    `topology=${plan.topology} inventory=${plan.inventoryCount} fallback=${plan.fallbackSeconds.toFixed(3)}s`,
+  ];
+  for (const group of plan.groups) {
+    lines.push(
+      `${group.id}: ${group.files.length} files, workers=${group.workers}, estimated=${group.estimatedSeconds.toFixed(3)}s` +
+        (group.requirements.length > 0
+          ? `, setup=${group.requirements.join("+")}`
+          : ""),
+    );
+  }
+  return lines.join("\n");
+}
+
+export function loadTestLaneMetadata(
+  path = resolve(import.meta.dir, "test-lanes.json"),
+): TestLaneMetadata {
+  return JSON.parse(readFileSync(path, "utf8")) as TestLaneMetadata;
+}
+
+function topologyFromArgs(args: readonly string[]): TestTopology {
+  const index = args.indexOf("--topology");
+  const value = index >= 0 ? args[index + 1] : undefined;
+  if (!value || !TOPOLOGIES.has(value as TestTopology)) {
+    throw new Error(
+      `--topology must be one of ${[...TOPOLOGIES].join(", ")}`,
+    );
+  }
+  return value as TestTopology;
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2);
+  const plan = planTestLanes(
+    discoverTestFiles(),
+    loadTestLaneMetadata(),
+    topologyFromArgs(args),
+  );
+  if (args.includes("--matrix")) {
+    process.stdout.write(
+      `${JSON.stringify({
+        include: plan.groups.map((group) => ({
+          topology: plan.topology,
+          group: group.id,
+          lane: group.lane,
+          workers: group.workers,
+          fonts: group.requirements.includes("fonts"),
+          poppler: group.requirements.includes("poppler"),
+        })),
+      })}\n`,
+    );
+  } else if (args.includes("--json")) {
+    process.stdout.write(`${JSON.stringify(plan, null, 2)}\n`);
+  } else {
+    process.stdout.write(`${explainTestLanePlan(plan)}\n`);
+  }
+}
+
+if (import.meta.main) await main();

--- a/scripts/ci/test-timings.test.ts
+++ b/scripts/ci/test-timings.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  assertDisjointLaneOwnership,
+  createTimingSnapshot,
+  parseBunJUnit,
+} from "./test-timings.js";
+
+function junit(testcases: string): string {
+  return `<?xml version="1.0"?><testsuites><testsuite name="outer">${testcases}</testsuite></testsuites>`;
+}
+
+describe("Bun JUnit timings", () => {
+  test("parses the sanitized Bun 1.3.14 nesting and leaf outcomes", () => {
+    const xml = readFileSync(join(import.meta.dir, "fixtures/bun-1.3.14-junit.xml"), "utf8");
+    const artifact = parseBunJUnit(xml, { namespace: "legacy", lane: "test-1" });
+
+    expect(artifact.files).toEqual([
+      {
+        file: "packages/example/src/example.test.ts",
+        durationSeconds: 0.03,
+        tests: 2,
+        passed: 1,
+        failed: 0,
+        skipped: 1,
+      },
+    ]);
+    expect(artifact.testcases.map(({ outcome }) => outcome)).toEqual(["passed", "skipped"]);
+  });
+
+  test("retains failure counts and decodes XML attributes", () => {
+    const artifact = parseBunJUnit(
+      junit(
+        '<testcase name="a &amp; b" classname="suite" time="1.25" file="pkg/a.test.ts"><failure /></testcase>',
+      ),
+      { namespace: "candidate", lane: "general-1" },
+    );
+    expect(artifact.testcases[0]?.name).toBe("a & b");
+    expect(artifact.files[0]?.failed).toBe(1);
+  });
+
+  test("rejects duplicate leaf identities but ignores repeated suite file attributes", () => {
+    const testcase =
+      '<testcase name="same" classname="suite" time="0.1" file="pkg/a.test.ts" />';
+    expect(() =>
+      parseBunJUnit(junit(`${testcase}${testcase}`), {
+        namespace: "legacy",
+        lane: "test-1",
+      }),
+    ).toThrow("duplicate testcase identity");
+
+    expect(() =>
+      parseBunJUnit(
+        '<testsuites><testsuite file="pkg/a.test.ts"><testsuite file="pkg/a.test.ts">' +
+          testcase +
+          "</testsuite></testsuite></testsuites>",
+        { namespace: "legacy", lane: "test-1" },
+      ),
+    ).not.toThrow();
+  });
+
+  test("rejects malformed, invalid, negative, absolute, and escaping inputs", () => {
+    expect(() =>
+      parseBunJUnit("<testsuites><testcase", { namespace: "n", lane: "l" }),
+    ).toThrow("testsuites envelope");
+    for (const time of ["NaN", "Infinity", "-0.1"]) {
+      expect(() =>
+        parseBunJUnit(
+          junit(`<testcase name="bad" time="${time}" file="pkg/a.test.ts" />`),
+          { namespace: "n", lane: "l" },
+        ),
+      ).toThrow("invalid testcase duration");
+    }
+    for (const file of ["/tmp/a.test.ts", "../a.test.ts"]) {
+      expect(() =>
+        parseBunJUnit(junit(`<testcase name="bad" time="1" file="${file}" />`), {
+          namespace: "n",
+          lane: "l",
+        }),
+      ).toThrow();
+    }
+  });
+
+  test("rejects duplicate file ownership within one topology namespace", () => {
+    const xml = junit('<testcase name="a" time="1" file="pkg/a.test.ts" />');
+    const legacyA = parseBunJUnit(xml, { namespace: "legacy", lane: "test-1" });
+    const legacyB = parseBunJUnit(xml, { namespace: "legacy", lane: "test-2" });
+    const candidate = parseBunJUnit(xml, { namespace: "candidate", lane: "test-1" });
+
+    expect(() => assertDisjointLaneOwnership([legacyA, legacyB])).toThrow(
+      "duplicate file ownership",
+    );
+    expect(() => assertDisjointLaneOwnership([legacyA, candidate])).not.toThrow();
+  });
+
+  test("creates a versioned snapshot only from disjoint artifacts", () => {
+    const artifact = parseBunJUnit(
+      junit('<testcase name="a" time="1" file="pkg/a.test.ts" />'),
+      { namespace: "legacy", lane: "test-1" },
+    );
+    expect(
+      createTimingSnapshot({
+        baselineSha: "a".repeat(40),
+        sourceRun: "https://github.com/example/repo/actions/runs/1",
+        artifacts: [artifact],
+      }),
+    ).toMatchObject({ schema: 1, baselineSha: "a".repeat(40), samples: 1 });
+    expect(() =>
+      createTimingSnapshot({
+        baselineSha: "not-a-sha",
+        sourceRun: "run",
+        artifacts: [artifact],
+      }),
+    ).toThrow("baseline SHA");
+  });
+});

--- a/scripts/ci/test-timings.ts
+++ b/scripts/ci/test-timings.ts
@@ -1,0 +1,217 @@
+#!/usr/bin/env bun
+import { readFileSync } from "node:fs";
+import { normalizeRepositoryTestPath } from "./test-inventory.js";
+
+export type TestOutcome = "passed" | "failed" | "skipped";
+
+export interface TestcaseTiming {
+  identity: string;
+  name: string;
+  classname: string;
+  file: string;
+  durationSeconds: number;
+  outcome: TestOutcome;
+}
+
+export interface FileTiming {
+  file: string;
+  durationSeconds: number;
+  tests: number;
+  passed: number;
+  failed: number;
+  skipped: number;
+}
+
+export interface LaneTimingArtifact {
+  schema: 1;
+  namespace: string;
+  lane: string;
+  files: FileTiming[];
+  testcases: TestcaseTiming[];
+}
+
+export interface TimingSnapshot {
+  schema: 1;
+  baselineSha: string;
+  sourceRun: string;
+  samples: number;
+  files: FileTiming[];
+}
+
+const ATTRIBUTE_PATTERN =
+  /([A-Za-z_:][A-Za-z0-9_.:-]*)\s*=\s*(?:"([^"]*)"|'([^']*)')/g;
+const TESTCASE_PATTERN =
+  /<testcase\b([^>]*?)(?:\/\s*>|>([\s\S]*?)<\/testcase\s*>)/g;
+
+function decodeXml(value: string): string {
+  return value.replace(
+    /&(?:amp|lt|gt|quot|apos|#\d+|#x[0-9a-fA-F]+);/g,
+    (entity) => {
+      if (entity === "&amp;") return "&";
+      if (entity === "&lt;") return "<";
+      if (entity === "&gt;") return ">";
+      if (entity === "&quot;") return '"';
+      if (entity === "&apos;") return "'";
+      const hexadecimal = entity.startsWith("&#x");
+      const digits = entity.slice(hexadecimal ? 3 : 2, -1);
+      const codePoint = Number.parseInt(digits, hexadecimal ? 16 : 10);
+      if (!Number.isSafeInteger(codePoint)) throw new Error(`invalid XML entity: ${entity}`);
+      return String.fromCodePoint(codePoint);
+    },
+  );
+}
+
+function parseAttributes(source: string): Map<string, string> {
+  const attributes = new Map<string, string>();
+  ATTRIBUTE_PATTERN.lastIndex = 0;
+  for (const match of source.matchAll(ATTRIBUTE_PATTERN)) {
+    const name = match[1]!;
+    if (attributes.has(name)) throw new Error(`duplicate XML attribute: ${name}`);
+    attributes.set(name, decodeXml(match[2] ?? match[3] ?? ""));
+  }
+  return attributes;
+}
+
+function requiredAttribute(attributes: ReadonlyMap<string, string>, name: string): string {
+  const value = attributes.get(name);
+  if (value === undefined || value === "") {
+    throw new Error(`testcase is missing ${name}`);
+  }
+  return value;
+}
+
+function duration(attributes: ReadonlyMap<string, string>): number {
+  const raw = requiredAttribute(attributes, "time");
+  const value = Number(raw);
+  if (!Number.isFinite(value) || value < 0) {
+    throw new Error(`invalid testcase duration: ${raw}`);
+  }
+  return value;
+}
+
+function outcome(body: string): TestOutcome {
+  const skipped = /<skipped\b/.test(body);
+  const failed = /<(?:failure|error)\b/.test(body);
+  if (skipped && failed) throw new Error("testcase cannot be both skipped and failed");
+  if (skipped) return "skipped";
+  if (failed) return "failed";
+  return "passed";
+}
+
+function validateXmlEnvelope(xml: string, matchedTestcases: number): void {
+  if (!/<testsuites\b/.test(xml) || !/<\/testsuites\s*>/.test(xml)) {
+    throw new Error("malformed JUnit XML: missing testsuites envelope");
+  }
+  const testcaseOpeners = xml.match(/<testcase\b/g)?.length ?? 0;
+  if (testcaseOpeners !== matchedTestcases) {
+    throw new Error("malformed JUnit XML: unclosed testcase");
+  }
+}
+
+export function parseBunJUnit(
+  xml: string,
+  options: { namespace: string; lane: string },
+): LaneTimingArtifact {
+  if (!options.namespace.trim() || !options.lane.trim()) {
+    throw new Error("namespace and lane are required");
+  }
+
+  const testcases: TestcaseTiming[] = [];
+  const identities = new Set<string>();
+  TESTCASE_PATTERN.lastIndex = 0;
+  for (const match of xml.matchAll(TESTCASE_PATTERN)) {
+    const attributes = parseAttributes(match[1] ?? "");
+    const file = normalizeRepositoryTestPath(requiredAttribute(attributes, "file"));
+    const name = requiredAttribute(attributes, "name");
+    const classname = attributes.get("classname") ?? "";
+    const identity = `${file}\u0000${classname}\u0000${name}`;
+    if (identities.has(identity)) {
+      throw new Error(`duplicate testcase identity: ${file} :: ${classname} :: ${name}`);
+    }
+    identities.add(identity);
+    testcases.push({
+      identity,
+      name,
+      classname,
+      file,
+      durationSeconds: duration(attributes),
+      outcome: outcome(match[2] ?? ""),
+    });
+  }
+  validateXmlEnvelope(xml, testcases.length);
+
+  const byFile = new Map<string, FileTiming>();
+  for (const testcase of testcases) {
+    const aggregate = byFile.get(testcase.file) ?? {
+      file: testcase.file,
+      durationSeconds: 0,
+      tests: 0,
+      passed: 0,
+      failed: 0,
+      skipped: 0,
+    };
+    aggregate.durationSeconds += testcase.durationSeconds;
+    aggregate.tests += 1;
+    aggregate[testcase.outcome] += 1;
+    byFile.set(testcase.file, aggregate);
+  }
+
+  return {
+    schema: 1,
+    namespace: options.namespace,
+    lane: options.lane,
+    files: [...byFile.values()].sort((left, right) => left.file.localeCompare(right.file)),
+    testcases,
+  };
+}
+
+export function assertDisjointLaneOwnership(
+  artifacts: readonly LaneTimingArtifact[],
+): void {
+  const owners = new Map<string, string>();
+  for (const artifact of artifacts) {
+    for (const file of artifact.files) {
+      const key = `${artifact.namespace}\u0000${file.file}`;
+      const previous = owners.get(key);
+      if (previous) {
+        throw new Error(
+          `duplicate file ownership in ${artifact.namespace}: ${file.file} (${previous}, ${artifact.lane})`,
+        );
+      }
+      owners.set(key, artifact.lane);
+    }
+  }
+}
+
+export function createTimingSnapshot(options: {
+  baselineSha: string;
+  sourceRun: string;
+  artifacts: readonly LaneTimingArtifact[];
+}): TimingSnapshot {
+  if (!/^[0-9a-f]{40}$/i.test(options.baselineSha)) {
+    throw new Error("baseline SHA must contain 40 hexadecimal characters");
+  }
+  if (!options.sourceRun.trim()) throw new Error("source run is required");
+  assertDisjointLaneOwnership(options.artifacts);
+
+  const files = options.artifacts
+    .flatMap((artifact) => artifact.files)
+    .sort((left, right) => left.file.localeCompare(right.file));
+  return {
+    schema: 1,
+    baselineSha: options.baselineSha.toLowerCase(),
+    sourceRun: options.sourceRun,
+    samples: options.artifacts.length,
+    files,
+  };
+}
+
+async function main(): Promise<void> {
+  const [path, namespace = "legacy", lane = "lane"] = process.argv.slice(2);
+  if (!path) throw new Error("usage: bun scripts/ci/test-timings.ts <junit.xml> [namespace] [lane]");
+  process.stdout.write(
+    `${JSON.stringify(parseBunJUnit(readFileSync(path, "utf8"), { namespace, lane }), null, 2)}\n`,
+  );
+}
+
+if (import.meta.main) await main();

--- a/scripts/ci/workflow-policy.test.ts
+++ b/scripts/ci/workflow-policy.test.ts
@@ -152,6 +152,18 @@ describe("CI workflow policy", () => {
     expect(trigger).toContain("types: [opened, synchronize, reopened, ready_for_review]");
   });
 
+  it("is ready to run full proof for merge-queue candidates", async () => {
+    const ci = await workflow("ci.yml");
+    expect(ci).toContain("merge_group:");
+    expect(ci).toContain("types: [checks_requested]");
+    expect(ci).toContain("github.event.merge_group.base_sha");
+    expect(ci).toContain("github.event.merge_group.head_sha");
+    expect(ci).toContain("github.event_name == 'merge_group'");
+    const required = block(ci, /^ {2}required:\s*$/, 2);
+    expect(required).not.toBeNull();
+    expect(required).toContain("name: required");
+  });
+
   it("spells out the same trigger types on every pull_request workflow", async () => {
     for (const name of await workflowNames()) {
       const trigger = pullRequestTrigger(await workflow(name));
@@ -196,6 +208,20 @@ describe("CI workflow policy", () => {
     );
   });
 
+  it("keeps system Chrome as a scheduled non-required neutral canary", async () => {
+    const ci = await workflow("ci.yml");
+    const canary = block(ci, /^ {2}browser-system-chrome-canary:\s*$/, 2);
+    const required = block(ci, /^ {2}required:\s*$/, 2);
+    expect(canary).not.toBeNull();
+    expect(canary).toContain("continue-on-error: true");
+    expect(canary).toContain("github.event_name == 'schedule'");
+    expect(canary).toContain("ATLCLI_PLAYWRIGHT_CHANNEL: chrome");
+    expect(canary).toContain("google-chrome --version");
+    expect(canary).not.toContain("playwright@1.55.0 install");
+    expect(required).not.toBeNull();
+    expect(required).not.toContain("browser-system-chrome-canary");
+  });
+
   it("keeps four complete blocking Bun shards with unique reports and a fail-closed aggregate", async () => {
     const reusable = await workflow("reusable-quality.yml");
     const staticQuality = block(reusable, /^ {2}static-quality:\s*$/, 2);
@@ -220,6 +246,8 @@ describe("CI workflow policy", () => {
     expect(tests).toContain("0 fail");
     expect(tests).toContain("if: always()");
     expect(tests).toContain("bun-test-shard-${{ matrix.shard }}.xml");
+    expect(tests).toContain("Upload failed test shard log");
+    expect(tests).toContain("if: failure()");
     expect(tests).toContain("bun-test-shard-${{ matrix.shard }}.log");
     expect(tests).not.toContain("continue-on-error:");
 
@@ -238,6 +266,62 @@ describe("CI workflow policy", () => {
     expect(complete).toContain(
       '[[ "$ATTESTATION_REQUIRED" == "true" && "$ATTESTATION" != "success" ]]',
     );
+  });
+
+  it("keeps timing telemetry outside every required status dependency graph", async () => {
+    const ci = await workflow("ci.yml");
+    const telemetry = block(ci, /^ {2}telemetry:\s*$/, 2);
+    const required = block(ci, /^ {2}required:\s*$/, 2);
+    expect(telemetry).not.toBeNull();
+    expect(telemetry).toContain("name: Non-required CI timing telemetry");
+    expect(telemetry).toContain("needs: [changes, required]");
+    expect(telemetry).toContain("if: always()");
+    expect(telemetry).toContain("actions/download-artifact@v5");
+    expect(telemetry).toContain("bun scripts/ci/telemetry-summary.ts");
+    expect(required).not.toBeNull();
+    expect(required).not.toContain("telemetry");
+
+    for (const statusName of ["required", "draft-fast", "superseded"]) {
+      const status = block(ci, new RegExp(`^ {2}${statusName}:\\s*$`), 2);
+      if (status !== null) expect(status).not.toMatch(/needs:[^\n]*telemetry/);
+    }
+  });
+
+  it("keeps duration-aware topology comparisons off pull requests", async () => {
+    const comparison = await workflow("ci-topology-canary.yml");
+    expect(comparison).not.toContain("pull_request:");
+    for (const topology of [
+      "general-2x1",
+      "general-3x1",
+      "general-2x2-workers",
+    ]) {
+      expect(comparison).toContain(topology);
+    }
+    expect(comparison).toContain("bun scripts/ci/test-lanes.ts --check");
+    expect(comparison).toContain("bun scripts/ci/run-test-lane.ts");
+    expect(comparison).toContain("shard: [1, 2, 3, 4]");
+    expect(comparison).toContain("if: matrix.poppler");
+    expect(comparison).toContain("if: matrix.fonts");
+  });
+
+  it("keeps the standalone security attestation dependency-free", async () => {
+    const attestation = await workflow("security-attestation.yml");
+    const source = await readFile(
+      join(REPO_ROOT, "scripts", "security", "attest.ts"),
+      "utf8",
+    );
+    const imports = [
+      ...source.matchAll(
+        /^\s*import\s+[^;\n]+?\s+from\s+["']([^"']+)["'];?\s*$/gm,
+      ),
+      ...source.matchAll(
+        /^\s*import\(\s*["']([^"']+)["']\s*\)/gm,
+      ),
+    ].map((match) => match[1]!);
+    expect(imports.length).toBeGreaterThan(0);
+    expect(imports.every((specifier) => specifier.startsWith("node:"))).toBe(true);
+    expect(attestation).not.toContain("bun install --frozen-lockfile");
+    expect(attestation).toContain("bun scripts/security/attest.ts");
   });
 
   it("keeps the pinned consumer gate in CI and moves latest to a canary", async () => {

--- a/scripts/consumer-smoke-filelink.ts
+++ b/scripts/consumer-smoke-filelink.ts
@@ -41,6 +41,22 @@ export interface FilelinkSmokeResult {
   smokes: SmokeRunResult;
 }
 
+export interface InstallResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+export interface FilelinkInstallCoordinator {
+  bunVersion: string;
+  allowedPackages: ReadonlySet<string>;
+  install: () => InstallResult;
+  recreate: () => void;
+  warn?: (message: string) => void;
+}
+
+export const KNOWN_FILELINK_EEXIST_BUN_VERSION = "1.3.14";
+
 export const FILELINK_SMOKE_ENV: Record<string, string> = {
   NODE_ENV: "production",
   // Bun 1.3.14 gives a direct `file:` dependency and a transitive
@@ -49,6 +65,70 @@ export const FILELINK_SMOKE_ENV: Record<string, string> = {
   // imported from the direct copy cannot observe the runtime used by DOCX.
   ATLCLI_ASSERT_SHARED_CODE_HIGHLIGHT_STATE: "0",
 };
+
+const ANSI_ESCAPE = /\u001b\[[0-?]*[ -/]*[@-~]/g;
+const KNOWN_FILELINK_EEXIST =
+  /^error: File exists: failed to link package (@atlcli\/[a-z0-9][a-z0-9._-]*)$/;
+const SECOND_FATAL_MARKER =
+  /\b(?:error|failed|panic|fatal|ENOENT|integrity|checksum|signal)\b/i;
+
+function normalizedInstallLines(result: InstallResult): string[] {
+  return `${result.stdout}\n${result.stderr}`
+    .replaceAll("\r\n", "\n")
+    .replace(ANSI_ESCAPE, "")
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+export function knownFilelinkEexistPackage(
+  result: InstallResult,
+  bunVersion: string,
+  allowedPackages: ReadonlySet<string>,
+): string | null {
+  if (bunVersion !== KNOWN_FILELINK_EEXIST_BUN_VERSION || result.exitCode === 0) return null;
+
+  const lines = normalizedInstallLines(result);
+  const matches = lines.flatMap((line) => {
+    const match = KNOWN_FILELINK_EEXIST.exec(line);
+    return match?.[1] ? [match[1]] : [];
+  });
+  if (matches.length !== 1) return null;
+
+  const packageName = matches[0]!;
+  if (!allowedPackages.has(packageName)) return null;
+
+  const remaining = lines.filter((line) => !KNOWN_FILELINK_EEXIST.test(line));
+  if (remaining.some((line) => SECOND_FATAL_MARKER.test(line))) return null;
+  return packageName;
+}
+
+function installFailure(result: InstallResult): Error {
+  return new Error(
+    `bun install (filelink consumer) failed:\n${result.stdout}\n${result.stderr}`,
+  );
+}
+
+export function installFilelinkWithKnownRetry(coordinator: FilelinkInstallCoordinator): void {
+  const first = coordinator.install();
+  if (first.exitCode === 0) return;
+
+  const packageName = knownFilelinkEexistPackage(
+    first,
+    coordinator.bunVersion,
+    coordinator.allowedPackages,
+  );
+  if (!packageName) throw installFailure(first);
+
+  coordinator.warn?.(
+    `Bun ${coordinator.bunVersion} hit the known file-link EEXIST for ${packageName}; ` +
+      "recreating the throwaway consumer and retrying once",
+  );
+  coordinator.recreate();
+
+  const second = coordinator.install();
+  if (second.exitCode !== 0) throw installFailure(second);
+}
 
 export async function runFilelinkSmoke(baseDir?: string): Promise<FilelinkSmokeResult> {
   const workDir = baseDir ?? join(tmpdir(), `atlcli-filelink-smoke-${process.pid}`);
@@ -72,16 +152,22 @@ export async function runFilelinkSmoke(baseDir?: string): Promise<FilelinkSmokeR
   };
 
   const projectDir = join(workDir, "consumer");
-  scaffoldConsumer(projectDir, {
-    dependencies,
-    overrides,
-    devDependencies: CONSUMER_DEV_DEPS,
+  const recreate = (): void => {
+    rmSync(projectDir, { recursive: true, force: true });
+    scaffoldConsumer(projectDir, {
+      dependencies,
+      overrides,
+      devDependencies: CONSUMER_DEV_DEPS,
+    });
+  };
+  recreate();
+  installFilelinkWithKnownRetry({
+    bunVersion: Bun.version,
+    allowedPackages: new Set(publishablePackages().map((pkg) => pkg.name)),
+    install: () => run(["bun", "install"], projectDir),
+    recreate,
+    warn: (message) => console.warn(`::warning::${message}`),
   });
-
-  const install = run(["bun", "install"], projectDir);
-  if (install.exitCode !== 0) {
-    throw new Error(`bun install (filelink consumer) failed:\n${install.stdout}\n${install.stderr}`);
-  }
   // NOTE: no workspace-leak assertion here — `file:` DIRECTORY installs link
   // the real workspace manifests verbatim (still carrying `workspace:*`
   // ranges); the consumer's `overrides` pin every `@atlcli/*` resolution to

--- a/scripts/consumer-smoke.test.ts
+++ b/scripts/consumer-smoke.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it } from "bun:test";
 import { runTarballSmoke } from "./consumer-smoke.js";
 import {
   FILELINK_SMOKE_ENV,
+  KNOWN_FILELINK_EEXIST_BUN_VERSION,
+  installFilelinkWithKnownRetry,
+  knownFilelinkEexistPackage,
   runFilelinkSmoke,
+  type InstallResult,
 } from "./consumer-smoke-filelink.js";
 import { runNodeSmoke } from "./consumer-smoke-node.js";
 import { runViteSmoke } from "./consumer-smoke-vite.js";
@@ -18,6 +22,15 @@ import { runViteSmoke } from "./consumer-smoke-vite.js";
  */
 
 const enabled = process.env.ATLCLI_CONSUMER_SMOKE === "1";
+const allowedPackages = new Set(["@atlcli/confluence", "@atlcli/pdf"]);
+const success: InstallResult = { exitCode: 0, stdout: "", stderr: "" };
+const knownFailure = (
+  line = "error: File exists: failed to link package @atlcli/confluence",
+): InstallResult => ({
+  exitCode: 1,
+  stdout: "bun install v1.3.14\nResolving dependencies\n",
+  stderr: `${line}\n`,
+});
 
 describe("filesystem-link package identity", () => {
   it("does not compare state across Bun's distinct direct and transitive file: copies", () => {
@@ -25,6 +38,94 @@ describe("filesystem-link package identity", () => {
       NODE_ENV: "production",
       ATLCLI_ASSERT_SHARED_CODE_HIGHLIGHT_STATE: "0",
     });
+  });
+});
+
+describe("known Bun file-link EEXIST retry", () => {
+  it("recognizes only the reviewed Bun/package/error tuple", () => {
+    expect(
+      knownFilelinkEexistPackage(
+        knownFailure(),
+        KNOWN_FILELINK_EEXIST_BUN_VERSION,
+        allowedPackages,
+      ),
+    ).toBe("@atlcli/confluence");
+    expect(knownFilelinkEexistPackage(knownFailure(), "1.3.15", allowedPackages)).toBeNull();
+    expect(
+      knownFilelinkEexistPackage(
+        knownFailure("error: File exists: failed to link package @atlcli/unknown"),
+        KNOWN_FILELINK_EEXIST_BUN_VERSION,
+        allowedPackages,
+      ),
+    ).toBeNull();
+  });
+
+  it("recreates once and performs exactly one retry for the known signature", () => {
+    const attempts = [knownFailure(), success];
+    let installs = 0;
+    let recreates = 0;
+    const warnings: string[] = [];
+    installFilelinkWithKnownRetry({
+      bunVersion: KNOWN_FILELINK_EEXIST_BUN_VERSION,
+      allowedPackages,
+      install: () => attempts[installs++]!,
+      recreate: () => recreates++,
+      warn: (message) => warnings.push(message),
+    });
+    expect(installs).toBe(2);
+    expect(recreates).toBe(1);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("@atlcli/confluence");
+    expect(warnings[0]).not.toContain("/tmp/");
+  });
+
+  it("keeps a second exact failure fatal and never attempts a third install", () => {
+    let installs = 0;
+    expect(() =>
+      installFilelinkWithKnownRetry({
+        bunVersion: KNOWN_FILELINK_EEXIST_BUN_VERSION,
+        allowedPackages,
+        install: () => {
+          installs++;
+          return knownFailure();
+        },
+        recreate: () => {},
+      }),
+    ).toThrow("bun install (filelink consumer) failed");
+    expect(installs).toBe(2);
+  });
+
+  it("does not retry adjacent, mixed, or mutated failures", () => {
+    const failures: InstallResult[] = [
+      knownFailure("error: File exists: package cache already exists"),
+      knownFailure("npm error EEXIST"),
+      {
+        ...knownFailure(),
+        stderr:
+          "error: File exists: failed to link package @atlcli/confluence\n" +
+          "fatal: checksum verification failed\n",
+      },
+      knownFailure("error: Directory exists: failed to link package @atlcli/confluence"),
+      knownFailure("error: File exists: failed linking package @atlcli/confluence"),
+    ];
+
+    for (const failure of failures) {
+      let installs = 0;
+      expect(() =>
+        installFilelinkWithKnownRetry({
+          bunVersion: KNOWN_FILELINK_EEXIST_BUN_VERSION,
+          allowedPackages,
+          install: () => {
+            installs++;
+            return failure;
+          },
+          recreate: () => {
+            throw new Error("must not recreate");
+          },
+        }),
+      ).toThrow();
+      expect(installs).toBe(1);
+    }
   });
 });
 

--- a/specs/github-ci-throughput/EVIDENCE.md
+++ b/specs/github-ci-throughput/EVIDENCE.md
@@ -1,0 +1,94 @@
+# GitHub CI throughput rollout evidence
+
+This file records public or synthetic evidence only. Promotion decisions remain
+open until the live sample gates in `PLAN.md` are satisfied.
+
+## Implementation snapshot
+
+- Planning baseline SHA: `9ffbe22e604413226a863064da31dc6981f76ce0`
+- Baseline Bun inventory: 405 test files
+- Current implementation inventory: 410 test files
+- Required topology: `legacy-4-shard` (unchanged)
+- Candidate topologies: `general-2x1`, `general-3x1`,
+  `general-2x2-workers`
+- Browser required topology: `browser-combined-serial` (unchanged)
+- System Chrome: scheduled/manual non-required compatibility canary
+- Merge queue: workflow trigger ready; repository transfer and queue activation
+  remain external and deferred
+
+## Local synthetic proof
+
+| Contract | Result |
+| --- | --- |
+| Bun 1.3.14 exact file-link retry classifier | Passed focused tests |
+| Test discovery and path safety | Passed focused tests |
+| JUnit parsing, duplicate ownership, and timing aggregation | Passed focused tests |
+| Actions queue/runner/wall timing aggregation | Passed focused tests |
+| Deterministic LPT lanes and argv-safe runner | Passed focused tests |
+| Workflow dependency and non-required telemetry policy | Passed focused tests |
+| Security attestation dependency-free policy | Passed focused tests |
+| Complete root suite | 5,938 passed, 15 skipped, 0 failed across 410 files |
+| TypeScript typecheck (root, extension, compiler, harness) | Passed |
+| Complete build | Passed, 20 Turbo tasks |
+| Full Bun/npm/pnpm consumer proof | 12 passed, 0 failed |
+| Documentation check/build | Passed, 78 pages built |
+| Neutral bundled-Chromium harness | 6 passed, 0 failed |
+| Packed MV3 PDF.js worker proof | 2 passed, 0 failed |
+| Packed MV3 durable-jobs proof | 23 passed, 0 failed |
+| Browser/Node shape parity | Passed |
+| Required local Atlassian E2E | Not run: `ATLCLI_E2E_PAGE_ID` is unavailable |
+
+The checked timing metadata intentionally contains no invented historical file
+durations. Until a live JUnit snapshot is reviewed, new and unmeasured files
+use the conservative five-second fallback.
+
+## Candidate balance before live timings
+
+The fallback-only planner assigns every current test file once. These estimates
+are planning weights, not measured runtimes:
+
+| Topology | General allocation |
+| --- | --- |
+| `general-2x1` | two nearly equal sequential jobs |
+| `general-3x1` | three nearly equal sequential jobs |
+| `general-2x2-workers` | two bounded `--parallel=2` groups plus separate serial stateful groups |
+
+Package-contract and PDF/Typst tests are excluded from the general groups.
+Poppler is requested only by the owning PDF/Typst group in the comparison
+workflow.
+
+## Live evidence still required
+
+No candidate has been promoted. The following evidence must be populated from
+public GitHub Actions runs:
+
+- three green same-SHA legacy comparisons for each test topology;
+- file and testcase identity equality for every comparison;
+- queue time, critical path, and total runner-minutes;
+- ten seeded stability probes before considering `--parallel=2`;
+- package self-build, artifact fan-out, and co-located comparisons;
+- at least 20 representative pull requests or 14 days of zero-miss classifier
+  shadow evidence before selective routing;
+- browser serial/parallel/split comparisons and distinct runner image evidence;
+- draft-to-ready live-state race proof before enabling `draft-fast`;
+- ten merge-group equivalence runs after any separately approved queue
+  activation.
+
+The repository-required live/read-only Atlassian E2E remains a commit blocker
+until the operator supplies the retained private fixture through the local
+environment. No customer identifier or credential was copied into this file.
+
+## Promotion status
+
+| Optimization | Status | Reason |
+| --- | --- | --- |
+| Exact Bun file-link retry | Implemented | Closed signature, one retry maximum |
+| Dependency-free security attestation | Implemented | Script imports only `node:` built-ins |
+| Successful raw test-log retention reduction | Implemented | JUnit always; raw log only on failure |
+| Duration-aware test topology | Measuring | Required lane remains legacy |
+| System Chrome neutral harness | Canary only | Cannot replace matched Chromium/MV3 proof |
+| Package build reuse | Held | Same-SHA artifact/co-located evidence absent |
+| Selective product routing | Held | Shadow graph and observation gate incomplete |
+| Draft-fast | Held | Depends on selective routing and live PR-state proof |
+| Browser branch parallelism | Held | Isolation and ten-run comparison incomplete |
+| Merge queue activation | Deferred | External repository ownership decision required |

--- a/specs/github-ci-throughput/PLAN.md
+++ b/specs/github-ci-throughput/PLAN.md
@@ -20,14 +20,22 @@ The implementation must:
 1. keep every currently required correctness, packaging, platform, browser,
    and consumer contract;
 2. balance tests by measured duration instead of file count;
-3. avoid rebuilding the same publishable packages in isolated jobs;
-4. give draft pull requests fast feedback and reserve full proof for
+3. compare GitHub job fan-out with Bun worker-process parallelism and promote
+   the fastest topology that preserves isolation and coverage;
+4. avoid rebuilding the same publishable packages in isolated jobs when
+   artifact transfer or a producer dependency does not lengthen the critical
+   path;
+5. give draft pull requests fast feedback and reserve full proof for
    merge-ready commits;
-5. run only impact-relevant gates after the selector has proved that it fails
+6. run only impact-relevant gates after the selector has proved that it fails
    open safely;
-6. keep a full scheduled drift guard and a manual full-run escape hatch;
-7. retain Playwright and a Playwright-matched Chromium for packed MV3 tests;
-8. keep the stable `required` status name used by branch protection.
+7. keep classifier latency below a defined budget before selective routing is
+   promoted;
+8. allow no more than one required runner allocation after the final selected
+   product proof;
+9. keep a full scheduled drift guard and a manual full-run escape hatch;
+10. retain Playwright and a Playwright-matched Chromium for packed MV3 tests;
+11. keep the stable `required` status name used by branch protection.
 
 This plan changes CI and test orchestration only. It does not change product
 behavior.
@@ -37,19 +45,60 @@ behavior.
 Implement the work in evidence-gated stages:
 
 1. add timing and selection observability without skipping any existing gate;
-2. eliminate the known Bun file-link flake and duplicate package builds;
-3. replace the four file-count shards with deterministic duration-aware lanes;
-4. shadow a package/dependency-aware change selector before allowing it to
+2. eliminate the known Bun file-link flake;
+3. replace the four file-count shards with deterministic duration-aware lanes
+   and compare two sequential lanes, three sequential lanes, and two
+   two-worker lanes on the same timing snapshot;
+4. compare a narrow publishable-package artifact fan-out with a co-located
+   package-proof topology before choosing the build-reuse design;
+5. flatten the required tail and parallelize only independent setup/proof
+   steps;
+6. shadow a package/dependency-aware change selector before allowing it to
    skip work;
-5. split draft feedback from merge-ready proof;
-6. optimize browser provisioning after the Linux test critical path has moved;
-7. prepare, but do not activate, GitHub merge-queue support until the
+7. split draft feedback from merge-ready proof;
+8. optimize browser provisioning after the Linux test critical path has moved;
+9. prepare, but do not activate, GitHub merge-queue support until the
    repository ownership requirement is resolved.
 
-Do **not** begin with more shards, larger runners, remote Turbo cache, removing
-Playwright, disabling strict branch protection, or broad test retries. Those
-changes either fail to address the measured bottleneck, add unproven external
-state, or weaken the evidence contract.
+Do **not** add shards or workers blindly, purchase larger runners, introduce a
+remote Turbo cache, remove Playwright, disable strict branch protection, or add
+broad test retries. A third lane and Bun `--parallel=2` are explicit bounded
+A/B candidates in this plan; neither is promoted without measured critical
+path, queue, runner-minute, isolation, and coverage evidence.
+
+## OSS patterns adopted and bounded
+
+This plan uses current primary-source patterns, but keeps their external
+services and repository-scale assumptions optional:
+
+- [Next.js CI](https://github.com/vercel/next.js/blob/canary/.github/workflows/build_and_test.yml)
+  freezes a timing artifact for duration-weighted groups and uses one stable
+  aggregate. Atlcli adopts the frozen snapshot and timing-based assignment,
+  without requiring Next.js's external timing service.
+- [pnpm CI](https://github.com/pnpm/pnpm/blob/main/.github/workflows/ci.yml)
+  compiles once for artifact consumers, separates producer dependency fronts,
+  and keeps one aggregate; its
+  [test workflow](https://github.com/pnpm/pnpm/blob/main/.github/workflows/test.yml)
+  uses reverse-dependent affected packages and bounded workers. Atlcli adopts
+  those candidates only behind fail-open routing and artifact/self-build A/B
+  evidence.
+- [Playwright primary CI](https://github.com/microsoft/playwright/blob/main/.github/workflows/tests_primary.yml)
+  uses measured unequal shard weights and atomic stateful groups. Atlcli mirrors
+  weighted ownership and retains serial boundaries for persistent browser and
+  real Typst state.
+- [Turborepo CI](https://github.com/vercel/turborepo/blob/main/.github/workflows/turborepo-test.yml)
+  uses GitHub's native parallel steps for independent setup. Atlcli adopts
+  step-level A/B probes but not Turborepo's larger OSS runners or remote cache
+  in the initial rollout.
+- [Vite CI](https://github.com/vitejs/vite/blob/main/.github/workflows/ci.yml)
+  co-locates build-dependent proof where transfer overhead would dominate.
+  That is the reason T3 compares co-located package proof with artifact fan-out
+  instead of mandating one architecture.
+
+Next.js's mid-stack PR optimizer is a later throughput option only if atlcli
+adopts stacked pull requests operationally. It is not part of required proof in
+this plan: every PR must still receive a current full merge-ready result before
+merge.
 
 ## Measured baseline
 
@@ -65,7 +114,10 @@ They are the baseline against which the implementation is accepted.
 | Last green pre-sync full workflow | 5 min 37 s |
 | Final merge-SHA first attempt, red only from consumer flake | 5 min 28 s |
 | Final validation including one flaky retry | 7 min 55 s |
+| Change-classifier job | about 6 s |
 | Browser job | 1 min 55 s |
+| Neutral browser E2E payload inside that job | about 24 s |
+| Packed MV3 build plus two proof payloads inside that job | about 37 s |
 | Consumer smoke | 1 min 51 s before the retry |
 | Same-SHA draft-to-ready work discarded in PR #135 | about 10 runner-minutes |
 
@@ -105,8 +157,8 @@ PR #135 also demonstrated the merge-throughput problem:
 | Path | Current responsibility | Relevant constraint |
 | --- | --- | --- |
 | `.github/workflows/ci.yml` | Event routing, platform/browser jobs, stable `required` aggregate | Every product change selects almost every gate |
-| `.github/workflows/reusable-quality.yml` | Static quality, four Bun shards, security attestation | Four shards repeat install, Poppler, and font setup |
-| `.github/workflows/reusable-consumer-smoke.yml` | Pinned and latest external-consumer matrix | Rebuilds packages and has no bounded known-flake recovery |
+| `.github/workflows/reusable-quality.yml` | Static quality, root build, four Bun shards, security attestation | Four shards repeat install, Poppler, and font setup; inner aggregate adds a tail runner |
+| `.github/workflows/reusable-consumer-smoke.yml` | Pinned and latest external-consumer matrix | Rebuilds packages, serializes independent consumer contracts, and has no bounded known-flake recovery |
 | `.github/workflows/security-attestation.yml` | Exact-SHA attestation on every main push | Installs the full workspace although `attest.ts` imports only Bun/Node built-ins |
 | `scripts/ci/classify-changes.ts` | Conservative path classifier | One broad `code` bit covers all `apps/`, `packages/`, and product scripts |
 | `scripts/ci/classify-changes.test.ts` | Classifier regression tests | Unknown and workflow paths deliberately fail open |
@@ -116,8 +168,8 @@ PR #135 also demonstrated the merge-throughput problem:
 | `scripts/api-report.test.ts` | Builds packages and validates public API reports/closures | Build runs inside a general Bun shard |
 | `scripts/dist-hygiene.test.ts` | Builds packages and validates emitted artifacts | Performs a second isolated package build |
 | `scripts/consumer-smoke-filelink.ts` | Creates a throwaway `file:` consumer | One un-retried `bun install` can fail with the known Bun `EEXIST` signature |
-| `apps/browser-export-harness/playwright.config.ts` | Neutral ordinary-browser contract | Supports `chrome` or `chromium`, currently one worker |
-| `apps/extension/tests/jobs/packed/job-recovery.e2e.ts` | Packed MV3 durable-job behavior | Requires persistent extension context and `channel: "chromium"` |
+| `apps/browser-export-harness/playwright.config.ts` | Neutral ordinary-browser contract | Supports `chrome` or `chromium`, currently one worker; CI runs it serially before MV3 proof |
+| `apps/extension/tests/jobs/packed/job-recovery.e2e.ts` | Packed MV3 durable-job behavior | Requires persistent extension context and `channel: "chromium"`; its branch is currently serialized after neutral E2E |
 
 The authoritative root test command remains:
 
@@ -135,6 +187,13 @@ resolution.
 
 - Every test file discovered by the repository's Bun test conventions is
   assigned to exactly one required full-proof lane.
+- The topology selected for required CI uses a fixed, reviewed worker count.
+  It never uses Bun's CPU-count default, and it never enables global
+  `--concurrent`.
+- Bun process-parallel candidates may run only files proved independent under
+  `--parallel=2`, which implies per-file isolation. Stateful/order-sensitive
+  groups, package-contract work, and real Typst/PDF proof remain explicit
+  serial lanes unless separately isolated.
 - A newly added test file is never silently omitted because it lacks historical
   timing data.
 - Duplicate and missing assignments fail before any test lane is allowed to
@@ -166,6 +225,12 @@ resolution.
 - A merge-ready `required` job verifies the current PR head SHA and non-draft
   state through a read-only GitHub API check immediately before reporting
   success. Event payload state alone is not sufficient for this final guard.
+- There is at most one required runner job after the slowest selected product
+  proof. No `quality-complete -> final-pr-state -> required` runner chain is
+  permitted.
+- Timing/selection telemetry is a non-required sibling. `required`, draft
+  status, and final PR-state proof must never depend on telemetry completion or
+  success.
 - Strict up-to-date protection remains enabled unless a separately approved
   merge-queue migration replaces the manual update workflow.
 
@@ -173,13 +238,18 @@ resolution.
 
 - Local consumer tests remain self-contained: without a verified CI build
   manifest they build packages exactly as today.
-- CI may reuse a package artifact only when its manifest matches the exact
+- CI may reuse a package artifact or verified co-located build only when its
+  manifest matches the exact
   workflow SHA, lockfile digest, package list, and expected `dist` files.
 - A missing, stale, incomplete, or mismatched build manifest must trigger a
   rebuild or fail; it must never make publication tests vacuous.
 - The Bun `EEXIST` retry is limited to the exact known file-link signature,
   recreates the throwaway consumer, and runs at most once.
 - No other package-manager, build, resolution, or smoke failure is retried.
+- Build reuse is not a correctness goal at the expense of wall time. If the
+  complete producer/transfer/consumer chain is slower than the current
+  self-contained baseline, retain the faster self-build path and record the
+  artifact topology as rejected.
 
 ### Browser shapes
 
@@ -218,7 +288,11 @@ resolution.
 - automatically transferring the repository to a GitHub organization;
 - automatically enabling a merge queue or changing repository settings;
 - running live Atlassian credentials in GitHub Actions;
-- suppressing the full weekly drift guard.
+- suppressing the full weekly drift guard;
+- forcing artifact fan-out when same-job reuse or the existing self-contained
+  path is faster;
+- making timing telemetry part of the required dependency graph;
+- using Bun's unbounded/default CPU worker count or global `--concurrent`.
 
 ## Target modes and gate topology
 
@@ -240,31 +314,45 @@ resolution.
 The intended full topology is:
 
 1. `changes` computes proof mode, affected packages/capabilities, current
-   PR-state validity, and fail-open overrides.
-2. A caller-level `package-build` job, or a single-purpose reusable workflow
-   called directly by `ci.yml`, builds publishable outputs once and emits an
-   exact-SHA artifact manifest.
+   PR-state validity, and fail-open overrides within a p95 budget of ten
+   seconds.
+2. One selected package-proof topology owns the package/consumer path. The
+   preferred candidates build publishable outputs once through either a narrow
+   caller-level artifact producer followed by parallel consumers or a
+   co-located job with parallel proof branches. If both are slower, the
+   measured self-build baseline remains temporarily authoritative. No topology
+   places a full root/private-app build in front of package consumers.
 3. `static-quality` performs offline contract checks and typecheck in parallel
-   with the build.
-4. `package-contract` and `consumer-smoke` depend directly on the caller-level
-   build job and consume its same-run artifact in parallel. Neither waits for
-   the complete reusable-quality workflow.
-5. `unit-tests` runs two deterministic, duration-balanced lanes without
-   Poppler.
+   with package proof.
+4. Package-contract and consumer contracts start at the earliest verified
+   publishable-package boundary. They never wait for the complete reusable
+   quality workflow, private app builds, or extension-output checks.
+5. `unit-tests` uses the A/B winner among two sequential lanes, three
+   sequential lanes, or two lanes with exactly two Bun worker processes. It
+   never installs Poppler.
 6. `pdf-typst-proof` runs real Typst/PDF tests with only their required fonts
    and Poppler tools.
 7. macOS PDF, Windows sink, neutral browser, and packed MV3 gates are selected
    by affected capabilities or by full-run policy.
-8. The aggregate job uses a mode-dependent name: `draft-fast` for draft
+8. The combined browser topology overlaps neutral and packed-MV3 branches only
+   after their profile roots, ports, outputs, and browser state are proved
+   independent; otherwise it keeps them serial or uses the measured split-job
+   winner.
+9. Exactly one aggregate job follows the final selected proof. It performs the
+   last live PR-state check itself and uses a mode-dependent name:
+   `draft-fast` for draft
    feedback, `superseded` for stale events, and the stable `required` name only
    for merge-ready/full evidence.
+10. Telemetry runs as a non-required sibling fan-in and cannot delay or satisfy
+    the aggregate.
 
-Two general-purpose unit lanes are the starting point, not an immutable count.
-The measured payload remaining after package-contract and real-Typst work is
-removed is expected to be about 269 seconds, or about 135 seconds per balanced
-lane. This preserves current job-count pressure while moving the outliers into
-explicit lanes. Increase the lane count only if post-change measurements prove
-that runner availability, rather than job fan-out, is not the limiting factor.
+The measured general payload after package-contract and real-Typst work is
+removed is about 269 seconds. Two sequential lanes have a theoretical payload
+ceiling of about 135 seconds; three sequential lanes reduce it to about 90
+seconds. Two `--parallel=2` lanes may achieve similar or better wall time
+without a third GitHub runner, but change file isolation and therefore require
+the strongest stability proof. The executor must collect all three candidates
+before choosing; the plan does not preselect a winner.
 
 ## Performance and safety acceptance gates
 
@@ -276,9 +364,14 @@ runs. Keep correctness gates independent from performance gates.
 | Gate | Required evidence |
 | --- | --- |
 | Weighted-lane completeness | Three consecutive scheduled/manual comparisons with identical discovered file sets, zero duplicates, and zero missing test cases |
-| Weighted-lane balance | Slowest general unit lane no more than 1.5 times the fastest general unit lane |
+| Lane execution topology | Same-SHA comparisons of two sequential lanes, three sequential lanes, and two `--parallel=2` lanes; winner has zero coverage/isolation differences, lower p50 critical path, and no unacceptable queue/runner-minute regression |
+| Weighted-lane balance | For the selected job topology, slowest general unit job no more than 1.5 times the fastest |
+| Package-proof topology | At least three same-SHA comparisons of current self-build, narrow artifact fan-out, and co-located proof; promote only a topology that preserves every contract and shortens the complete package/consumer critical path |
+| Required tail | Workflow-policy proof and three live runs show at most one required runner allocation after the slowest selected product proof; telemetry is not an ancestor |
+| Classifier budget | Over at least 20 representative runs, classifier p95 at most 10 s and every error/unknown input fails open |
 | Selective routing | At least 20 representative product PRs or 14 calendar days in shadow mode, zero under-selection findings |
 | Consumer retry | Synthetic signature tests pass; exact known failure retries once; every adjacent/nonmatching failure does not retry |
+| Step-level parallelism | At least ten comparisons show isolated paths/outputs, identical results, lower critical path, and no more than 10% runner-minute regression |
 | System Chrome canary | Nonblocking only in this plan; record ten distinct runner Image Version values, and require a separate Playwright-upgrade/compatibility plan before any promotion |
 | Merge queue | Repository is organization-owned, queue is enabled, `merge_group` full proof is green for at least ten merges |
 
@@ -288,7 +381,12 @@ runs. Keep correctness gates independent from performance gates.
 | --- | ---: |
 | Merge-ready p50 wall time over at least 10 product PRs | at most 3 min 30 s |
 | Merge-ready p95 wall time over at least 20 product PRs | at most 5 min |
+| Merge-ready stretch p50 after all safe A/B promotions | at most 2 min 30 s |
+| Merge-ready stretch p95 after all safe A/B promotions | at most 4 min |
 | Slowest required Linux test lane p95 | at most 2 min 45 s |
+| Change classifier p95 | at most 10 s |
+| Tail from final selected proof completion to aggregate completion p95 | at most 15 s |
+| Required runner jobs after the final selected proof | at most 1 |
 | Draft-fast p50 wall time | at most 2 min |
 | Runner-minute reduction for comparable product PRs | at least 25% |
 | Classified infrastructure false failures over 30 merge-ready runs | zero |
@@ -296,9 +394,18 @@ runs. Keep correctness gates independent from performance gates.
 | Test files omitted or duplicated in a full run | zero |
 | Typical targeted product jobs after routing promotion | at most 6 |
 
+Planning hypothesis, not a promotion guarantee: for a PR-135-shaped full run
+without abnormal external runner queueing, the combined safe winners should
+move merge-ready p50 into roughly 2 minutes 15 seconds to 2 minutes 45 seconds.
+T0 evidence replaces this range; the executor must not tune measurements or
+weaken gates merely to make the estimate true.
+
 If the correctness promotion gates pass but the performance target does not,
 stop and measure job setup, runner queue time, and artifact transfer separately.
-Do not add shards or caches based only on intuition.
+The hard p50/p95 targets remain completion gates; the stretch targets guide
+topology selection but do not justify a correctness or runner-minute
+regression. Do not add shards, workers, caches, or containers based only on
+intuition.
 
 ## Commands required by the executor
 
@@ -334,13 +441,15 @@ The implementation may modify or create files in these areas only:
 - `.github/workflows/reusable-consumer-smoke.yml`
 - a new `.github/workflows/reusable-package-build.yml`
 - a new `.github/workflows/reusable-package-contract.yml`
+- a new `.github/workflows/reusable-package-proof.yml` only if the measured
+  co-located topology wins
 - `.github/workflows/security-attestation.yml`
 - `.github/workflows/consumer-smoke.yml`
 - `.github/workflows/release-core.yml`
 - `.github/workflows/release-cli.yml`
 - `.github/workflows/release.yml`, limited to wiring the existing preflight to
   the shared package-build producer
-- a new reusable browser or package-build workflow only if the final topology
+- a new reusable browser or package-proof workflow only if the final topology
   is clearer than extending the files above
 - `scripts/ci/**`
 - `scripts/ci/classify-changes.ts`
@@ -352,6 +461,8 @@ The implementation may modify or create files in these areas only:
 - `scripts/consumer-smoke-filelink.ts`
 - `scripts/consumer-smoke.test.ts`
 - `scripts/install-matrix.test.ts`
+- new `scripts/ci/run-consumer-leg.ts` and focused consumer-leg test entrypoints
+  only if required by the selected bounded parallel topology
 - `package.json`
 - `turbo.json`
 - test/package manifests needed to expose explicit CI commands
@@ -400,12 +511,12 @@ default.
 | --- | --- | --- |
 | T0 | Establish exact timing and selection telemetry | none |
 | T1 | Make the Bun file-link smoke deterministically retry only the known flake | T0 |
-| T2 | Build a fail-closed test inventory and duration-aware lane planner | T0 |
-| T3 | Reuse one package build and promote weighted full-test lanes | T1, T2 |
+| T2 | Build a fail-closed test inventory and benchmark lane/worker topologies | T0 |
+| T3 | Select the fastest verified package-proof and weighted-test topology | T1, T2 |
 | T4 | Shadow package/capability-aware change routing | T0 |
 | T5 | Promote safe selective routing | T3, T4 |
 | T6 | Separate draft-fast feedback from merge-ready proof | T5 |
-| T7 | Optimize neutral-browser and packed-MV3 provisioning | T3, T5 |
+| T7 | Parallelize and optimize neutral-browser and packed-MV3 provisioning | T3, T5 |
 | T8 | Prepare merge-queue support without changing repository ownership | T6 |
 | T9 | Document, validate, and record rollout evidence | T1–T8 as selected |
 
@@ -459,7 +570,7 @@ coverage, lane balance, critical path, or selected-versus-skipped gates.
    Keep skipped/unstarted jobs out of runner-minute totals, and label
    cancelled/failed attempts separately so they cannot enter green-run
    p50/p95 samples.
-4. Add a workflow summary job or step that downloads same-run JUnit artifacts,
+4. Add a non-required workflow summary job that downloads same-run JUnit artifacts,
    writes:
    - selected proof mode and routes;
    - per-lane setup and test duration;
@@ -470,14 +581,39 @@ coverage, lane balance, critical path, or selected-versus-skipped gates.
    to `$GITHUB_STEP_SUMMARY` and a JSON artifact.
    Do not derive checkout, setup, queue, artifact-transfer, critical-path, or
    runner-minute values from JUnit.
-5. Upload JUnit XML on every run. Upload full raw test logs only on failure;
+5. Record named phase timings in addition to job totals:
+   - checkout, runtime setup, each cache restore, dependency installation,
+     fonts, Poppler, browser provisioning, artifact upload/download/verify;
+   - filtered publishable-package build, pack hooks, and package-contract;
+   - each consumer contract (`file-link`, tarball/Vite, Node/npm, npm/pnpm);
+   - neutral browser E2E, packed MV3 build, packed worker proof, packed durable
+     jobs proof, and shape parity;
+   - final-product-proof completion and aggregate completion.
+   Phase names are a versioned schema and must be stable across A/B candidates.
+6. Make the timing summary a non-required sibling fan-in with `if: always()`.
+   `scripts/ci/workflow-policy.test.ts` must fail if `required`,
+   `draft-fast`, `superseded`, or any live PR-state guard declares telemetry as
+   a `needs` dependency. Telemetry failure remains visible but can neither
+   delay nor satisfy merge proof.
+7. Upload JUnit XML on every run. Upload full raw test logs only on failure;
    timing evidence must not depend on retaining successful console logs.
-6. Do not automatically commit timings from a PR. A scheduled/manual main run
+8. Do not automatically commit timings from a PR. A scheduled/manual main run
    may emit a candidate timing artifact for explicit review.
-7. Bootstrap the first checked timing snapshot from the final PR #135 artifacts
+9. Bootstrap the first checked timing snapshot from the final PR #135 artifacts
    if still available. If they have expired, run one complete baseline and use
    that result. Do not fabricate missing durations.
-8. Remove the `bun install --frozen-lockfile` step from
+10. At the beginning of each scheduled/manual topology comparison, upload one
+    validated timing snapshot as a run-local artifact containing its schema,
+    source SHA/run, and content digest. Every candidate lane and rerun in that
+    comparison consumes that immutable snapshot. Candidate jobs must not
+    independently refresh or redistribute timings during a run. Newly
+    discovered files receive T2's conservative fallback weight.
+11. Tag every comparison with a topology identifier:
+    `legacy-4-shard`, `general-2x1`, `general-3x1`,
+    `general-2x2-workers`, `package-self-build`, `package-artifact-fanout`,
+    `package-colocated`, `browser-combined-serial`,
+    `browser-combined-parallel`, or `browser-split`.
+12. Remove the `bun install --frozen-lockfile` step from
    `.github/workflows/security-attestation.yml` after adding a workflow-policy
    assertion that `scripts/security/attest.ts` remains dependency-free. Its
    current imports are all `node:` built-ins and the script reads repository
@@ -498,8 +634,10 @@ Trigger one manual full workflow. Expected:
 
 - all legacy gates still run;
 - `required` remains green only when all selected gates pass;
+- the telemetry job is not an ancestor of any required/status job;
 - the summary lists 405 test files at the planning baseline, subject only to
   legitimate test additions after that baseline;
+- phase timings and the frozen timing-snapshot digest are present;
 - no source, environment secret, absolute home path, or private identifier
   appears in the timing artifact.
 
@@ -586,12 +724,14 @@ retries exactly once.
 
 `fix(ci): bound the known Bun filelink retry`
 
-## T2 — Build a fail-closed test inventory and duration-aware lane planner
+## T2 — Build a fail-closed test inventory and benchmark lane/worker topologies
 
 ### Purpose
 
 Replace Bun's file-count shard selection with deterministic longest-processing-
-time assignment based on measured test-file duration.
+time assignment based on measured test-file duration, then measure GitHub-job
+fan-out against bounded Bun worker-process parallelism before choosing the
+required topology.
 
 ### Changes
 
@@ -615,13 +755,20 @@ time assignment based on measured test-file duration.
      `general`, `package-contract`, or `pdf-typst`;
    - zero or more orthogonal setup requirements such as `fonts`, `poppler`,
      or `typst-runtime`;
+   - an optional atomic-group identifier for files that must share one serial
+     process because they intentionally exercise order/global-state behavior;
    - no test outcome or private data.
 4. Add `scripts/ci/test-lanes.ts`:
    - assign every inventory file to exactly one lane, defaulting a new
      unannotated file to `general`;
    - assign `package-contract` and `pdf-typst` files to their explicit lanes;
-   - assign remaining files to two general lanes with deterministic
+   - accept only the candidate shapes `general-2x1`, `general-3x1`, and
+     `general-2x2-workers`;
+   - assign remaining files to two or three general jobs with deterministic
      longest-processing-time bin packing;
+   - keep atomic groups indivisible and emit them as explicit serial execution
+     groups inside the least-loaded candidate job; account for that serial tail
+     in job-duration balancing;
    - give a newly discovered file without timing the larger of the historical
      p95 duration and a conservative fixed default;
    - reject duplicate, stale, conflicting, or invalid metadata;
@@ -630,9 +777,16 @@ time assignment based on measured test-file duration.
      shell-evaluate a path.
 5. Add `scripts/ci/run-test-lane.ts`. It must:
    - load one already validated lane by identifier;
-   - spawn `bun run test -- ./repo-relative-file...` with an argv array, never a
-     constructed shell string or command substitution;
+   - spawn `bun run test -- [--parallel=2] ./repo-relative-file...` with an argv
+     array, never a constructed shell string or command substitution;
    - preserve the root `development` condition and JUnit reporter arguments;
+   - accept only worker counts `1` or `2`; never omit the value and inherit the
+     runner CPU count;
+   - never add global `--concurrent`;
+   - reject worker count `2` when the selected execution group contains an
+     atomic group, package-contract work, real Typst/PDF proof, or any explicit
+     stateful override; a `general-2x2-workers` job may run a separate serial
+     execution group before/after its worker-safe group;
    - reject an empty, unknown, duplicate, absolute, or escaping path before
      spawning Bun.
 6. Add `scripts/ci/test-lanes.test.ts` covering:
@@ -645,13 +799,39 @@ time assignment based on measured test-file duration.
    - combined requirements such as `fonts` plus `poppler`;
    - zero-file lanes;
    - spaces/special characters and colliding filename filters;
+   - accepted/rejected worker counts and exact `--parallel=2` argv placement;
+   - atomic groups remaining serial and indivisible;
+   - rejection of `--concurrent`, implicit/default worker counts, and parallel
+     package/Typst/stateful lanes;
    - exact union and pairwise-disjoint lane sets.
 7. Add a coverage assertion that compares inventory with the union of planned
    lanes before tests start. The assertion must fail before a zero-test lane can
    be accepted.
-8. On scheduled/manual runs only, run the legacy four shards and candidate lanes
-   side by side until the promotion gate is satisfied. Compare file identities
-   and JUnit test cases, not only totals.
+8. On scheduled/manual runs only, compare the legacy four shards with one
+   candidate topology at a time. Every comparison must use the same SHA and the
+   frozen T0 timing snapshot. Rotate through:
+   - `general-2x1`;
+   - `general-3x1`;
+   - `general-2x2-workers`.
+   Do not execute every candidate in every PR run. Compare file identities and
+   JUnit test cases, not only totals.
+9. For `general-2x2-workers`, add a stability probe that repeats the complete
+   candidate with at least ten fixed, recorded random seeds across the three
+   comparison runs and fails on any file/testcase difference, leaked handle,
+   port collision, temp/output collision, or order-dependent result. Use Bun's
+   `--randomize` only in this non-required probe; required lanes remain
+   deterministically ordered.
+10. Select the required topology only after at least three green comparisons
+    per candidate. Rank candidates by:
+    - identical coverage and zero isolation findings first;
+    - p50/p95 full-workflow critical path;
+    - p50/p95 job queue delay;
+    - summed runner-minutes;
+    - rerun granularity and debuggability.
+    A third GitHub lane may be promoted only if its wall-time improvement
+    survives queueing and runner-minute growth. Prefer bounded in-job workers
+    when they are equally fast and equally stable because they consume fewer
+    runner allocations.
 
 ### Initial capability ownership
 
@@ -666,6 +846,11 @@ At minimum, assign:
 - tests that resolve pinned PDF fonts as requiring `fonts`;
 - all other Bun tests as `general`.
 
+At minimum, inspect the existing registry/auth isolation probes and every test
+that spawns a nested Bun test process. Mark only the outer orchestration file
+atomic when required; do not broadly serialize an entire package without
+evidence.
+
 Search actual imports and subprocess calls before finalizing the list. Do not
 infer setup needs from filenames alone. A file may have one lane and multiple
 requirements, for example lane `pdf-typst` with both `fonts` and `poppler`.
@@ -674,139 +859,192 @@ requirements, for example lane `pdf-typst` with both `fonts` and `poppler`.
 
 ```bash
 bun run test scripts/ci/test-inventory.test.ts scripts/ci/test-lanes.test.ts scripts/ci/test-timings.test.ts
-bun scripts/ci/test-lanes.ts --check
+bun scripts/ci/test-lanes.ts --check --topology general-2x1
+bun scripts/ci/test-lanes.ts --check --topology general-3x1
+bun scripts/ci/test-lanes.ts --check --topology general-2x2-workers
 ```
 
 Expected:
 
 - every discovered test file is assigned exactly once;
 - no stale metadata remains;
-- two general lanes have an estimated duration ratio at or below 1.5;
+- every candidate has exact union/pairwise-disjoint coverage;
+- every candidate's slowest general job has an estimated duration ratio at or
+  below 1.5 compared with its fastest general job;
+- every worker-safe group in `general-2x2-workers` emits exactly
+  `--parallel=2`, never `--concurrent`; every stateful/atomic file appears once
+  in a separately reported serial group, and no Typst/package-contract file is
+  present;
 - explicit package and Typst lanes contain their known heavy tests.
 
-Run three scheduled/manual legacy-versus-candidate comparisons. Record workflow
-URLs and exact coverage comparison in
+Run three scheduled/manual legacy-versus-candidate comparisons for each
+candidate topology. Record workflow URLs, exact coverage comparison, phase
+timings, queue delay, runner-minutes, and the promotion decision in
 `specs/github-ci-throughput/EVIDENCE.md`.
 
 ### Commit
 
-`perf(ci): plan tests by measured duration`
+`perf(ci): benchmark duration-aware test topologies`
 
-## T3 — Reuse one package build and promote weighted full-test lanes
+## T3 — Select the fastest verified package-proof and weighted-test topology
 
 ### Purpose
 
-Remove repeated package builds and repeated PDF tool setup from general unit
-workers, then make the duration-aware lanes the required full proof.
+Remove the measured duplicate publishable-package builds and repeated PDF setup
+without replacing them with a longer producer/upload/download chain. Promote
+the T2 lane/worker winner and a package-proof topology only after end-to-end
+same-SHA comparisons.
 
 ### Changes
 
-1. Add `.github/workflows/reusable-package-build.yml` as the single-purpose
-   build producer. `ci.yml` calls it as a top-level `package-build` job directly
-   after `changes`. Build-independent reusable quality starts after `changes`
-   in parallel; only package-contract and consumer jobs declare
-   `needs: [changes, package-build]`. The producer:
-   - installs pinned dependencies;
-   - restores the existing Bun and Turbo caches;
-   - owns the workflow's single full `bun run build` invocation;
-   - runs build-dependent output checks such as
-     `bun run check:extension-output`;
+1. Before changing required CI, use T0 phase telemetry to establish:
+   - the current `package-self-build` path from job start through every
+     package-contract and consumer assertion;
+   - filtered publishable-package build and pack-hook time;
+   - each consumer contract time (`file-link`, tarball/Vite, Node/npm,
+     npm/pnpm);
+   - checkout/install/cache/setup, artifact transfer, verification, queue, and
+     aggregate-tail time.
+   Keep the current 1 minute 51 second consumer job as the historical reference,
+   but compare complete topology critical paths rather than subtracting phases
+   arithmetically.
+2. Implement two non-required same-SHA candidates behind a
+   `workflow_dispatch` topology input:
+   - `package-artifact-fanout`: a narrow producer builds/packs publishable
+     packages, then package-contract and consumer legs download and verify the
+     same artifact in parallel;
+   - `package-colocated`: one job builds publishable packages once, verifies a
+     local manifest, then runs independent package-contract and consumer legs
+     in bounded step/process parallelism within that workspace.
+   Compare each candidate with `package-self-build` at least three times. If
+   neither candidate shortens the complete merge-ready critical path without a
+   correctness or unacceptable runner-minute regression, retain self-build and
+   record both candidates as rejected. Do not force artifact reuse merely to
+   make a "build once" metric green.
+3. For `package-artifact-fanout`, add
+   `.github/workflows/reusable-package-build.yml` as a single-purpose,
+   caller-level producer directly after `changes`. The producer:
+   - installs pinned dependencies and restores existing Bun/Turbo caches;
+   - runs the existing narrow publishable-package command
+     `bunx turbo run build --filter=./packages/* --output-logs=errors-only`,
+     not the full root `bun run build`;
+   - does not build private CLI, extension, or browser-harness apps and does not
+     run `check:extension-output`;
    - stages the complete generated consumer closure, not only `dist/**`:
      publishable JS/declarations/maps, package `files` assets, PDF fonts and
-     licenses, DOCX fonts, compiler vendor/WASM files, and the tarballs produced
-     by real prepack/pack hooks;
-   - derives that closure from the publishable package manifests and actual
-     pack output, with explicit regression fixtures for
-     `packages/pdf`, `packages/docx`, and
+     licenses, DOCX fonts, compiler vendor/WASM files, and tarballs produced by
+     real prepack/pack hooks;
+   - derives the closure from publishable manifests and actual pack output,
+     with regression fixtures for `packages/pdf`, `packages/docx`, and
      `packages/pdf-compiler-browser`;
    - writes a manifest containing exact workflow SHA, Bun version, `bun.lock`
      digest, package names, artifact role (`workspace-overlay` or `tarball`),
-     and a SHA-256 for every regular artifact file;
-   - uploads the closed closure plus the manifest under an exact-SHA artifact
-     name;
-   - exposes the immutable v4 upload's `artifact-id` and `artifact-digest` as
-     caller outputs.
-2. Add `scripts/ci/package-build-artifact.ts` and
-   `scripts/ci/package-build-artifact.test.ts`.
-   - Reject a different SHA or lock digest.
+     and SHA-256 for every regular artifact file;
+   - uploads the closure and manifest under a unique exact-SHA/run-attempt name
+     with `retention-days: 1`;
+   - A/B-measures the default compression against `compression-level: 0` for
+     already compressed tarball/WASM/font payloads and keeps zero compression
+     only when upload plus download wall time improves in at least three
+     same-SHA comparisons;
+   - exposes the immutable upload's `artifact-id` and `artifact-digest`.
+4. Add `scripts/ci/package-build-artifact.ts` and
+   `scripts/ci/package-build-artifact.test.ts` for both artifact and
+   co-located manifests.
+   - Reject a different SHA, Bun version, lock digest, package list, or role.
    - Verify every listed regular file's SHA-256.
-   - Reject missing/unexpected package directories, files not listed in the
-     closed manifest, and missing JS/declaration output.
+   - Reject missing/unexpected package directories, unlisted files, and missing
+     JS/declaration output.
    - Reject path traversal, symlinks, sockets, devices, and other special files.
-   - Verify before any artifact file is imported, packed, linked, or passed to
-     `bun install`.
-   - Accept artifacts only by the `needs: package-build` same-run ID/digest;
-     prohibit cross-run and `workflow_run` downloads.
-3. Refactor `scripts/api-report.test.ts` and
-   `scripts/dist-hygiene.test.ts` so:
-   - local/default execution still builds packages first;
-   - the `package-contract` CI job may skip only the build step after the
-     verified artifact is present;
-   - all API report, closure, dist-path, Node-import, and publication
-     assertions remain unchanged.
-4. Apply the same verified-prebuilt contract to consumer helpers. Do not
-   recognize a bare boolean such as `CI=1` as proof; require the manifest.
-   `ci.yml` must make reusable package-contract and reusable consumer calls
-   depend directly on `package-build` and pass the artifact ID/digest. The
-   build-independent quality caller must not depend on package-build. Do not
-   express this as `consumer-smoke needs: test`, which would serialize the
-   consumer behind the complete reusable quality workflow.
-   - File-link tests overlay the verified generated package files onto their
-     checkout before linking the real package directories.
-   - Tarball/Node tests consume the verified tarballs produced by the real pack
-     hooks.
-   - Consumer assertions still prove installed `/dist/` resolution and package
-     contents; reuse must not turn packaging into a mocked shape.
-5. Add `.github/workflows/reusable-package-contract.yml` to consume and verify
-   the build artifact before running API reports, closure, dist hygiene, and
-   package assertions. Replace the four `--shard=N/4` jobs in
-   `.github/workflows/reusable-quality.yml` with:
-   - two general unit lanes;
-   - one `pdf-typst-proof` lane.
-   Package-contract is a separate caller-level reusable job so it can wait for
-   the build without delaying static, unit, or PDF lanes.
-6. General lanes:
-   - do not install Poppler;
-   - do not provision fonts unless their exact file list requires them;
-   - invoke the root test contract with explicit file arguments;
-   - upload JUnit XML always and raw logs on failure.
-7. The PDF/Typst lane installs only its proved OS tools and fonts.
-8. The package-contract reusable workflow downloads/verifies the build artifact
-   before running its explicit files.
-9. Consumer smoke downloads/verifies the same exact-run artifact instead of
-   rebuilding it.
-10. Remove the full build from `static-quality`; otherwise the new build owner
-    would still duplicate publishable builds on another runner. Keep its
-    non-build static/type checks parallel with package build, unit, and PDF
-    lanes whenever there is no artifact dependency.
-11. Update `scripts/ci/workflow-policy.test.ts` to prove:
-    - there are no legacy `--shard=N/4` required jobs after promotion;
-    - the selected full topology contains exactly one `bun run build` owner;
-    - each planned lane has a unique report;
+   - Verify before any generated file is imported, packed, linked, or passed to
+     a package manager.
+   - Artifact consumers accept only the `needs: package-build` same-run
+     ID/digest; prohibit cross-run and `workflow_run` downloads.
+5. For `package-colocated`, add a single-purpose reusable package-proof
+   workflow or equivalent caller-level job. After the narrow filtered build and
+   local manifest verification, it:
+   - runs package-contract and consumer legs with GitHub `parallel`/`background`
+     or a small checked subprocess coordinator;
+   - gives every leg a unique temporary root, cache/profile/output paths, JUnit
+     file, and raw failure log;
+   - aggregates every exit code fail closed and never lets an early success
+     hide a later failure;
+   - keeps the known T1 retry inside the `file-link` leg only;
+   - accepts worse rerun granularity only if the end-to-end wall-time win is
+     measured.
+6. Refactor `scripts/api-report.test.ts` and
+   `scripts/dist-hygiene.test.ts` so local/default execution remains
+   self-contained and builds first. CI may skip only their build phase after
+   the exact verified manifest is present. Preserve every API report, closure,
+   dist-path, Node-import, and publication assertion.
+7. Refactor consumer orchestration into independently timed legs:
+   - Bun file-link;
+   - Bun tarball plus Vite/browser-shaped consumer;
+   - Node/npm plus npm/pnpm install matrix.
+   File-link overlays verified generated files before linking real package
+   directories. Tarball/Node legs consume real pack-hook tarballs. Every leg
+   must still prove installed `/dist/` resolution and package contents; build
+   reuse must not become a mocked package shape.
+8. In artifact mode, add
+   `.github/workflows/reusable-package-contract.yml` and make package-contract
+   plus consumer legs depend directly on `package-build`. They must not depend
+   on complete reusable quality. In co-located mode, do not create empty
+   artifact download jobs merely to mimic this DAG.
+9. Replace the legacy four `--shard=N/4` jobs with the T2 winner plus one
+   explicit serial `pdf-typst-proof` lane:
+   - general jobs install neither Poppler nor unrelated fonts;
+   - PDF/Typst installs only proved tools/fonts;
+   - every job invokes the root test contract with explicit argv-safe files;
+   - JUnit uploads always and raw logs only on failure.
+10. Use GitHub's native step `parallel` only for independent setup work after
+    checkout, for example Bun setup beside disjoint cache restores. Do not
+    parallelize two cache actions that mutate the same path or run dependency
+    installation before setup/cache completion. Capture a serial and parallel
+    comparison over at least ten runs; retain parallel setup only when it is
+    faster and stable.
+11. Remove the full root build from `static-quality`; it must not sit in front
+    of package consumers. Preserve complete build coverage explicitly:
+    - the selected package path builds all publishable packages;
+    - static/app proof builds the CLI without rebuilding all packages;
+    - T7 owns browser-harness and extension builds plus their output checks;
+    - T9 still runs the complete local `bun run build`.
+    If a direct app build cannot consume current package output without
+    rebuilding dependencies, measure that targeted duplication separately; do
+    not put an unrelated private-app build into the package producer.
+12. Flatten aggregation while changing the topology:
+    - remove the inner `quality-complete` runner allocation;
+    - expose caller-level single-purpose results to one fail-closed aggregate;
+    - permit no more than one required runner job after the slowest selected
+      product proof;
+    - keep telemetry outside that dependency graph.
+    T6 must extend this same aggregate with final live PR-state validation, not
+    add another tail job.
+13. Update `scripts/ci/workflow-policy.test.ts` to prove:
+    - no legacy `--shard=N/4` job remains after promotion;
+    - the selected T2 topology and exact worker count are fixed;
+    - every planned lane/consumer leg has a unique report;
     - Poppler appears only in the PDF proof lane;
-    - package/consumer jobs depend directly on the caller-level build and
-      require same-run manifest verification;
-    - aggregates remain fail closed.
-12. Keep a manual `workflow_dispatch` legacy-full topology that is independent
-    of the new planner and artifact path. Retain it through T5/T6 promotion and
-    at least 30 subsequent green merge-ready full runs. Remove it only in a
-    separate PR after its rollback value is explicitly reviewed.
-13. Update every in-repository caller atomically:
-    - `ci.yml` starts build-independent reusable quality beside the pinned
-      package build, then passes build outputs only to reusable
-      package-contract and pinned consumer smoke;
-    - `release-core.yml`, `release-cli.yml`, and `release.yml` start
-      build-independent quality beside the pinned producer and make their
-      package-contract/preflight aggregate depend on both;
-    - `consumer-smoke.yml` adds a producer using the selected `latest` Bun leg
-      so the floating canary remains a latest-runtime build and install test.
-    Add workflow-policy tests that enumerate every `uses:
-    ./.github/workflows/reusable-quality.yml` and
-    `uses: ./.github/workflows/reusable-package-contract.yml` or
-    `uses: ./.github/workflows/reusable-consumer-smoke.yml` caller. Fail if a
-    package-contract/consumer caller lacks its build inputs/`needs` edge, or if
-    build-independent quality incorrectly waits for package-build.
-14. Do not change release publishing jobs or execute a release. Run only the
+    - a package artifact consumer has a direct producer edge and exact
+      same-run manifest verification;
+    - no full root/private-app build blocks package consumers;
+    - all publishable packages and all three apps retain an owning build gate;
+    - one aggregate is the only required tail job;
+    - telemetry is not an ancestor of any status job;
+    - selected/unselected results remain fail closed.
+14. Keep a manual `workflow_dispatch` legacy-full topology independent of the
+    new planner and package path. Retain it through T5/T6 promotion and at least
+    30 subsequent green merge-ready full runs. Remove it only in a separate PR
+    after explicit review.
+15. Update every in-repository caller according to the selected topology:
+    - `ci.yml` starts build-independent static/unit/PDF proof immediately after
+      classification and starts package proof at the earliest safe boundary;
+    - release preflights remain self-contained unless the selected verified
+      reusable package topology clearly applies; do not serialize release
+      quality behind unrelated app builds;
+    - `consumer-smoke.yml` keeps the selected `latest` Bun leg as a
+      latest-runtime build-and-install canary.
+    Workflow-policy tests must enumerate every reusable quality/package/consumer
+    caller and reject missing inputs/edges or unnecessary build dependencies.
+16. Do not change release publishing jobs or execute a release. Run only the
     documented release dry-run if release-preflight wiring needs end-to-end
     validation.
 
@@ -835,6 +1073,8 @@ No consumer or contract test may skip its build on any rejected manifest.
 
 ```bash
 bun run test scripts/ci/test-inventory.test.ts scripts/ci/test-lanes.test.ts scripts/ci/package-build-artifact.test.ts scripts/ci/workflow-policy.test.ts scripts/api-report.test.ts scripts/dist-hygiene.test.ts
+bun run test scripts/consumer-smoke.test.ts scripts/install-matrix.test.ts
+ATLCLI_CONSUMER_SMOKE=1 bun run test scripts/consumer-smoke.test.ts scripts/install-matrix.test.ts
 bun run test
 bun run typecheck
 bun run build
@@ -843,15 +1083,22 @@ bun run build
 Expected: all commands pass. In the first promoted full workflow:
 
 - the lane coverage guard reports every current test file exactly once;
-- the slowest general lane is no more than 1.5 times the fastest;
+- the selected T2 topology is named and its slowest general job is no more than
+  1.5 times the fastest;
 - Poppler installation occurs only in its owning lane;
-- package build executes once;
-- the consumer and package-contract jobs verify and reuse that artifact;
+- the chosen package topology beats or matches the retained self-build
+  baseline under its promotion constraints;
+- package/consumer legs verify the exact manifest and none waits for private
+  app builds or complete reusable quality;
+- every publishable package and CLI/browser/extension app still has an owning
+  build gate;
+- exactly one required aggregate follows the final selected product proof;
+- telemetry completes independently;
 - `required` is green.
 
 ### Commit
 
-`perf(ci): reuse package builds across balanced lanes`
+`perf(ci): select the fastest verified quality topology`
 
 ## T4 — Shadow package/capability-aware change routing
 
@@ -921,27 +1168,40 @@ full.
    and both sides of renames without shell word splitting. For a deleted or
    renamed workspace manifest, load the base graph as well as the head graph;
    fail open if either side cannot be reconstructed.
-3. Preserve a compact CLI that writes GitHub outputs.
-4. Add table-driven tests for every workspace/capability family, mixed changes,
+3. Preserve a compact CLI that writes GitHub outputs and keep the classifier
+   off dependency installation. Replace `fetch-depth: 0` with the minimum
+   event-specific checkout/fetch:
+   - pull request: exact base and head commits/trees;
+   - `merge_group`: exact group base and head;
+   - `push`: before/head when valid, otherwise fail open;
+   - schedule/manual full mode: HEAD only because no diff is needed.
+   Do not fetch complete history merely to reconstruct two workspace graphs.
+4. Measure checkout, runtime setup, graph/import scan, GitHub API lookup, and
+   output emission separately. Keep the existing pinned Bun setup while total
+   classifier p95 remains at or below ten seconds. Only if it breaches that
+   budget, A/B a workspace-install-free runner such as a checked,
+   reproducibly generated Node-compatible JS entrypoint. Do not add generated
+   classifier code and its maintenance cost for an unmeasured one-second win.
+5. Add table-driven tests for every workspace/capability family, mixed changes,
    renamed/deleted files, Windows separators, empty input, workflow changes,
    unknown roots, dependency cycles, static cross-package test imports, dynamic
    override edges, and deleted manifests.
-5. In shadow mode, workflows continue running the existing full selected
+6. In shadow mode, workflows continue running the existing full selected
    product proof but display:
    - candidate gates;
    - gates that would have been skipped;
    - affected packages;
    - fail-open reason.
-6. For each shadow PR, compare the candidate lane file set against the full
+7. For each shadow PR, compare the candidate lane file set against the full
    inventory and package graph. Record any test failure that would have occurred
    outside the candidate set as an under-selection finding.
-7. Add counterfactual route tests before collecting passive shadow evidence:
+8. Add counterfactual route tests before collecting passive shadow evidence:
    - for every route family, mutate a synthetic workspace/capability fixture
      so one owning gate is the only failing gate;
    - assert that the candidate route necessarily selects that gate;
    - assert that removing the relevant dependency/capability edge makes the
      regression test fail.
-8. Replay the changed-path sets from known historical red commits/runs:
+9. Replay the changed-path sets from known historical red commits/runs:
    - PR #135 API report/closure failure
      [run 30515886454](https://github.com/BjoernSchotte/atlcli/actions/runs/30515886454)
      must select package-contract proof;
@@ -954,8 +1214,12 @@ full.
      Confluence/export-path diff.
    Fetch exact paths/SHAs from the public run/PR evidence; do not encode
    abbreviated or guessed commit IDs.
-9. Keep scheduled, manual, and `main` runs full regardless of candidate output.
-10. Add a manual `workflow_dispatch` full run as the operator's recovery path.
+10. Keep scheduled, manual, and `main` runs full regardless of candidate output.
+11. Add a manual `workflow_dispatch` full run as the operator's recovery path.
+12. Add workflow-policy checks that every product job still waits only for the
+    classifier outputs it needs. Always-required static/package work may start
+    immediately only when doing so cannot create a second status path or violate
+    draft routing; optional gates remain classifier-controlled.
 
 ### Promotion gate
 
@@ -965,6 +1229,10 @@ broader surface coverage. The observation window is drift evidence, not proof
 by itself that skipped gates would catch a future regression. Evidence must
 include CLI, Jira, Confluence/export, publishable-package, extension, browser
 harness, PDF, workflow/global, and mixed changes.
+
+The same observation set must show classifier p95 at or below ten seconds.
+Selective routing is not promoted if graph/import precision saves jobs but adds
+more than the budgeted serial startup latency.
 
 If any under-selection is found:
 
@@ -980,7 +1248,9 @@ bun scripts/ci/classify-changes.ts --full
 ```
 
 Expected: full output selects every gate; fixtures produce the documented
-candidate routes; unknown inputs fail open.
+candidate routes; unknown inputs fail open; full schedule/manual mode needs
+only HEAD; representative base/head fixtures avoid a full-history checkout;
+classifier p95 evidence is at most ten seconds before promotion.
 
 ### Commit
 
@@ -1061,15 +1331,16 @@ ensuring Ready always produces a fresh, complete required result.
    live PR. Fail closed to merge-ready/full if current state cannot be read.
 3. Include `converted_to_draft` in the PR event policy so superseded full work
    can be cancelled on a best-effort basis and replaced with the fast lane.
-4. Add a `final-pr-state` job after selected proof gates and immediately before
-   the aggregate. It re-reads current head/draft state and exposes the final
-   display mode. Use one always-running aggregate with a name derived from this
-   final-state output:
+4. Do not add a separate `final-pr-state` runner job. Extend the one
+   fail-closed aggregate retained by T3. Its display name is derived from the
+   initial live-state-aware `changes` output:
    - `draft-fast` for draft evidence;
    - `superseded` for stale events;
    - `required` only for non-draft merge-ready/full proof.
    A skipped job named `required` is not acceptable because GitHub can treat a
-   skipped required check as successful.
+   skipped required check as successful. If a run initially qualifies as
+   merge-ready and becomes stale later, its already named `required` must fail;
+   a later current run replaces it.
 5. `draft-fast` runs:
    - change classification;
    - impacted general unit tests;
@@ -1090,9 +1361,9 @@ ensuring Ready always produces a fresh, complete required result.
    - the run's proof mode is merge-ready;
    - every selected gate succeeded.
    If state changed or cannot be read, fail the already named check. A run that
-   became stale in the narrow interval after `final-pr-state` may therefore
-   produce a red `required`, but never a green one. The live race probe must
-   prove that a later valid run can replace that red result.
+   became stale after initial classification may therefore produce a red
+   `required`, but never a green one. The live race probe must prove that a
+   later valid run can replace that red result.
 9. Treat GitHub concurrency cancellation as a cost optimization only; GitHub
    does not guarantee run ordering inside one concurrency group. Correctness
    comes from the live-state/head guards and mode-dependent check names. Add
@@ -1104,8 +1375,13 @@ ensuring Ready always produces a fresh, complete required result.
    - avoid toggling Ready merely to restart CI;
    - use "rerun failed jobs" only for a classified infrastructure failure.
 11. Add workflow-policy fixtures for opened draft, draft synchronization,
-   converted-to-draft, ready-for-review, ready synchronization, reopened ready,
-   delayed/superseded events, main push, schedule, and dispatch.
+    converted-to-draft, ready-for-review, ready synchronization, reopened ready,
+    delayed/superseded events, main push, schedule, and dispatch. Assert that:
+    - there is no `final-pr-state` job;
+    - `quality-complete` has not reappeared;
+    - the mode-named aggregate is the only required runner allocation after
+      selected proof;
+    - telemetry is not in its `needs` graph.
 
 ### Acceptance
 
@@ -1117,6 +1393,8 @@ ensuring Ready always produces a fresh, complete required result.
   the fresh current-head `required` run succeeds.
 - Draft p50 is at most two minutes over ten representative runs.
 - The required context name remains `required`.
+- The tail from the slowest selected proof completion through aggregate
+  completion has p95 at most 15 seconds and contains one runner job.
 
 ### Verification
 
@@ -1136,7 +1414,9 @@ Open a disposable Draft PR changing a synthetic test fixture:
    merge-ready proof;
 7. deliver a delayed old-event fixture/probe and confirm it reports
    `superseded` when detected by final state, and never reports a successful
-   stale `required`.
+   stale `required`;
+8. confirm the workflow graph contains no intermediate aggregate/final-state
+   runner and record the proof-to-aggregate tail duration.
 
 Do not use customer data or create remote Atlassian resources for this workflow
 probe.
@@ -1145,14 +1425,14 @@ probe.
 
 `perf(ci): reserve full proof for merge-ready changes`
 
-## T7 — Optimize neutral-browser and packed-MV3 provisioning
+## T7 — Parallelize and optimize neutral-browser and packed-MV3 provisioning
 
 ### Purpose
 
-Reduce browser setup and allow neutral and extension-specific contracts to run
-independently without confusing system Chrome with hermetic extension proof.
-This task follows the Linux critical-path work because the current 1 minute
-55 second browser job is not the bottleneck.
+Reduce browser setup and overlap independent neutral/MV3 proof branches without
+confusing system Chrome with hermetic extension proof. This task follows the
+Linux critical-path work because the current 1 minute 55 second browser job is
+not the initial bottleneck, but it can become the slowest gate after T2/T3.
 
 ### Decisions
 
@@ -1164,46 +1444,80 @@ extensions because stable Chrome/Edge removed the relevant command-line flags.
 References:
 
 - [GitHub-hosted runner images](https://docs.github.com/en/actions/concepts/runners/github-hosted-runners#runner-images)
+- [GitHub Actions parallel/background steps](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idstepsparallel)
 - [Playwright Chrome extension testing](https://playwright.dev/docs/chrome-extensions)
 - [Playwright Chromium headless modes](https://playwright.dev/docs/browsers#chromium-new-headless-mode)
 
 ### Changes
 
-1. First implement a non-required same-SHA A/B experiment:
-   - A keeps the current combined browser job;
-   - B separates neutral and MV3 setup.
-   Measure workflow wall time, each setup/test phase, and summed runner-minutes
-   for full/global, harness-only, and extension-only route fixtures.
-2. Promote the split only if all hold over at least ten comparisons:
-   - full/global browser critical path does not regress;
-   - full/global browser runner-minutes increase by no more than 10%;
+1. Implement three non-required same-SHA topology candidates:
+   - `browser-combined-serial`: today's shared setup and serial proof order;
+   - `browser-combined-parallel`: one shared job that overlaps independent
+     neutral and packed-MV3 branches with GitHub `background`/`wait`;
+   - `browser-split`: separate neutral and MV3 jobs.
+   Measure full workflow/browser wall time, every phase, queue delay, and summed
+   runner-minutes for full/global, harness-only, and extension-only fixtures.
+2. In `browser-combined-parallel`, complete shared checkout, runtime/cache
+   setup, dependency install, fonts/vendor setup, and required browser
+   provisioning first. Then execute two bounded branches:
+   - neutral: harness build/output/conformance, neutral E2E, then shape parity;
+   - MV3: one packed extension build, worker proof, then durable-job proof.
+   Shape parity remains in the neutral branch because it consumes
+   `test-results/digests.json`; it must not wait for or consume MV3 output.
+3. Before overlapping those branches, prove they use different:
+   - Playwright output/report directories;
+   - persistent profile/user-data roots;
+   - temporary directories and generated output roots;
+   - ports/service processes;
+   - JUnit/raw-log artifact names.
+   Run at least ten non-required contention probes. Any shared IndexedDB,
+   service worker, cache, profile, output cleanup, or fixed-port dependency
+   keeps the affected branch serial until isolated.
+4. Also A/B native step `parallel` for independent setup actions after checkout,
+   such as Bun setup and disjoint cache restores. Do not parallelize actions
+   that write the same cache/tool path, dependency installation before runtime
+   setup, or browser installation with a cache restore to the same directory.
+5. Promote `browser-combined-parallel` only when at least ten comparisons show:
+   - identical conformance cases, digests, browser assertions, and artifacts;
+   - full/global browser critical path improves by at least 15 seconds;
+   - no new flake, leak, collision, or resource-exhaustion signature;
+   - runner-minutes increase by no more than 10%.
+   Based on PR #135, the neutral E2E payload was about 24 seconds and the MV3
+   build/proof branch about 37 seconds, so useful overlap is plausible but not
+   assumed.
+6. Promote `browser-split` instead only if:
+   - it beats both combined candidates for full/global wall time, or does not
+     regress full/global wall time;
+   - its runner-minute increase is at most 10%;
    - representative narrow harness/extension routes save at least 25% browser
      runner-minutes.
-   Otherwise keep one job and use step-level route selection; do not duplicate
-   checkout, Bun install, fonts, browser provisioning, and caches for no
-   measured gain.
-3. If the split passes, use:
+   Otherwise keep the faster combined topology; do not duplicate checkout, Bun
+   install, fonts, browser provisioning, and caches for no measured gain.
+7. If split wins, use:
    - `browser-neutral`: harness build/output/conformance/E2E followed by shape
-     parity, because `check:parity` consumes the harness-produced
-     `test-results/digests.json`;
+     parity;
    - `browser-extension-mv3`: one packed extension build, worker proof, and
      durable-job proof.
-   Do not place shape parity in the MV3 job or run it without the neutral digest
-   artifact.
-4. Keep both jobs selected for full/global changes. T5 may select them
-   independently for narrow changes.
-5. Keep the required MV3 job on `channel: "chromium"` with Playwright's matched
-   full Chromium and persistent contexts.
-6. Use Playwright's supported `install --no-shell chromium` form when the job
-   needs the full browser for extension loading and does not need the separate
-   headless shell.
-7. Benchmark, rather than assume, Playwright browser cache value:
+   Keep both selected for full/global changes; T5 may select them independently
+   for narrow changes.
+8. Measure three distinct provisioning contracts rather than treating
+   "Playwright" as one browser download:
+   - system Google Chrome for a fast, permanently non-required neutral canary;
+   - Playwright's matched headless shell for hermetic neutral harness work when
+     the pinned Playwright version supports that exact project;
+   - Playwright's matched full Chromium for required MV3 extension loading.
+   Record browser executable/version/channel per branch.
+9. Keep the required MV3 path on `channel: "chromium"` with Playwright's matched
+   full Chromium and persistent contexts. Use the supported
+   `install --no-shell chromium` form when that path needs full Chromium but not
+   the separate headless shell.
+10. Benchmark, rather than assume, Playwright browser cache value:
    - cache restore plus dependency install;
    - fresh browser install;
    - `--with-deps` versus runner-provided libraries in a nonblocking canary.
    Do not remove `--with-deps` from the required lane until ten **distinct**
    recorded GitHub runner Image Version values pass.
-8. Add a permanently nonblocking neutral-harness compatibility project using
+11. Add a permanently nonblocking neutral-harness compatibility project using
    `ATLCLI_PLAYWRIGHT_CHANNEL=chrome` and the runner's system Google Chrome.
    At the planning baseline Playwright 1.55 is matched to Chromium 140/tested
    stable Chrome 139 while the observed runner image carried Chrome 150.
@@ -1211,15 +1525,21 @@ References:
    system Chrome requires a separate Playwright-upgrade PR/plan, full hermetic
    browser proof, and ten distinct runner-image versions. Keep MV3 on bundled
    Chromium regardless.
-9. Preserve a visible Playwright, bundled Chromium, system Chrome, and runner
-   Image Version summary.
-10. Do not increase Playwright workers while packed tests share persistent
+12. Preserve a visible Playwright, bundled Chromium/headless-shell, system
+    Chrome, and runner Image Version summary.
+13. Do not increase Playwright workers while packed tests share persistent
    profile, cache, service worker, or IndexedDB state.
-11. If parallelism is pursued later, first create independent profile roots and
-   fixtures per test, prove no test depends on state established by an earlier
-   test, then increase workers in a separate PR.
-12. Upload traces only on failure; keep the existing production-build and
+14. Branch-level overlap is not permission to increase Playwright's per-project
+    worker count. If worker parallelism is pursued later, first create
+    independent profile roots and fixtures per test, prove no test depends on
+    state established by an earlier test, then increase workers in a separate
+    PR.
+15. Upload traces only on failure; keep the existing production-build and
     artifact scans.
+16. Add workflow-policy checks for the selected topology identifier, unique
+    outputs/profile roots, required full Chromium on MV3, non-required system
+    Chrome, and the absence of an unnecessary serial dependency between proven
+    independent branches.
 
 ### Verification
 
@@ -1231,15 +1551,18 @@ bun run test:browser-export-harness
 bun run --cwd apps/extension test:worker-extension-browser
 bun run --cwd apps/extension test:jobs-extension-browser
 bun run check:parity
+bun run test scripts/ci/workflow-policy.test.ts
 ```
 
 Expected: all hermetic gates pass on bundled Chromium. The system-Chrome canary
 is reported separately and cannot satisfy or replace any required result in
-this plan. If the split does not meet its A/B gate, the combined job remains.
+this plan. Record all three topology comparisons. Promote the fastest candidate
+that meets its correctness and runner-minute gates; otherwise retain the
+combined serial job.
 
 ### Commit
 
-`perf(ci): separate neutral and MV3 browser proof`
+`perf(ci): parallelize isolated browser proof`
 
 ## T8 — Prepare merge-queue support without changing repository ownership
 
@@ -1280,8 +1603,23 @@ the repository has no queue.
 8. Retain full `main` push proof until at least ten queue merges demonstrate
    that the tested merge-group SHA and landed main SHA provide equivalent
    evidence.
-9. Only then evaluate whether redundant post-merge product jobs can be reduced.
-   Security attestation and release evidence remain exact-SHA requirements.
+9. For those ten merges, record the merge-group tree SHA, landed-main tree SHA,
+   workflow revision, required result, post-merge result, queue wait, and
+   runner-minutes. Any tree/workflow mismatch resets the equivalence window and
+   keeps full `main`.
+10. Only then run a separate non-required A/B evaluation of:
+    - current full post-merge product CI;
+    - minimal post-merge exact-SHA evidence containing security attestation,
+      docs/deployment ownership, and a lightweight product smoke while weekly,
+      manual, release, and every merge group remain full.
+    Reduction of `main` product CI is a runner-capacity optimization for the
+    next PR, not proof for the PR that already merged.
+11. Promote minimal post-merge evidence only when the queue cannot land a tree
+    other than the full-proven merge-group tree, branch/ruleset enforcement
+    prevents bypass, and at least ten further shadow comparisons show no
+    evidence difference. Otherwise keep full `main`.
+12. Security attestation, release evidence, and any deployment-specific proof
+    remain exact-landed-SHA requirements regardless of product-CI reduction.
 
 ### Personal-repository fallback
 
@@ -1306,7 +1644,9 @@ After activation, record ten queue workflow URLs and prove:
 - each group ran full required evidence;
 - superseded groups were cancelled safely;
 - the merged SHA corresponds to the proven candidate;
-- no PR author had to merge/rebase `main` manually.
+- no PR author had to merge/rebase `main` manually;
+- the tree/workflow equivalence and post-merge shadow tables are complete
+  before any reduction is proposed.
 
 ### Commit
 
@@ -1324,10 +1664,13 @@ Update `src/content/docs/contributing.md` with a concise CI section covering:
 - draft-fast versus merge-ready proof;
 - the stable `required` check;
 - how affected routes fail open;
+- the selected lane/worker, package-proof, and browser topology identifiers;
+- why Bun worker count is fixed and why `--concurrent` is not used;
 - how to run the full suite locally;
 - when to synchronize `main`;
 - how to start a manual full run;
 - what qualifies for a targeted infrastructure retry;
+- how to trigger the legacy/manual full fallback;
 - how to inspect timing/selection summaries.
 
 Create `specs/github-ci-throughput/EVIDENCE.md` during implementation. It may
@@ -1385,10 +1728,18 @@ For each promoted phase record:
 
 - baseline and candidate workflow URLs;
 - exact SHA and event/proof mode;
+- frozen timing-snapshot source SHA/run and content digest;
+- lane, package, and browser topology identifiers;
 - selected gates and fail-open reason;
 - discovered/assigned test files;
 - per-lane setup/test/wall duration;
+- per-consumer-contract and per-browser-branch duration;
+- classifier checkout/runtime/graph/import/API/output phases and p50/p95;
+- artifact build/pack/compression/upload/download/verify phases;
 - workflow critical path and runner-minutes;
+- queue delay for every critical-path job;
+- completion time of the last selected product proof, aggregate completion, and
+  number of tail runner allocations;
 - retries and their exact classification;
 - p50/p95 window calculation;
 - correctness promotion-gate result;
@@ -1401,10 +1752,15 @@ For each promoted phase record:
 | Missing or duplicate test file | Restore full legacy topology and fail the planner check | Patch the count or ignore the file |
 | Selective route misses a relevant failure | Force that capability to full, add regression fixture, restart shadow window | Leave selective routing active while investigating |
 | Package artifact verification fails | Rebuild locally in the owning job or fail | Set a generic skip-build flag |
+| Package artifact/producer chain is slower than self-build | Retain self-build or co-located winner and record rejection | Force fan-out to satisfy "build once" |
 | Consumer exact retry fails twice | Keep the gate red and diagnose Bun/package identity | Add more retries |
 | General lanes remain imbalanced | Refresh real timings and recompute | Add random shards |
+| `--parallel=2` changes coverage/state or flakes | Keep sequential lane winner and add isolation evidence | Add retries or global `--concurrent` |
+| Native parallel steps race on cache/output/profile state | Restore serial step/branch order | Hide the race with `continue-on-error` |
 | System Chrome canary flakes | Keep it nonblocking or remove it | Replace MV3 bundled Chromium |
 | Runner queue time rises from job fan-out | Reduce general lane count and keep explicit heavy lanes | Buy larger runners without measurement |
+| Classifier p95 exceeds 10 seconds | Hold selective-routing promotion and optimize measured phase | Accept fixed serial latency to save speculative jobs |
+| More than one runner follows final product proof | Flatten final guard into the aggregate | Add another summary/status job |
 | Ready PR displays only draft proof | Disable merge until event/aggregate policy is fixed | Merge based on stale green status |
 | Merge-group SHA cannot be mapped | Keep strict manual synchronization | Turn strict protection off |
 
@@ -1420,18 +1776,37 @@ complete:
       critical path, and runner-minutes.
 - [ ] The known Bun file-link `EEXIST` retries exactly once and every other
       error remains fail closed.
-- [ ] Package build output is produced once and consumed only after exact-SHA
-      manifest verification.
+- [ ] Every package topology uses exact-SHA manifest verification; if a
+      build-reuse candidate wins, it produces publishable output once for its
+      consumer branches.
 - [ ] Every full-run Bun test file is assigned exactly once.
-- [ ] Three legacy-versus-weighted comparisons show no coverage difference.
+- [ ] Each of `general-2x1`, `general-3x1`, and
+      `general-2x2-workers` has three legacy comparisons with no coverage
+      difference.
+- [ ] The selected lane/worker topology is recorded with fixed worker count,
+      queue/runner-minute evidence, and zero isolation findings.
 - [ ] General unit lane duration ratio is at most 1.5.
 - [ ] Poppler and font setup occur only in owning lanes.
+- [ ] Current package self-build, narrow artifact fan-out, and co-located proof
+      have same-SHA comparisons; the fastest topology satisfying every
+      correctness/runner-minute gate is selected.
+- [ ] Consumer contracts are independently timed and use isolated roots when
+      executed concurrently.
+- [ ] The full root/private-app build does not block package consumers.
+- [ ] Classifier p95 is at most 10 seconds before selective routing is promoted.
 - [ ] Selective routing has at least 20 PRs or 14 days of zero-miss shadow
       evidence.
-- [ ] Global, unknown, scheduled, manual, and main events run full.
+- [ ] Global/unknown changes plus scheduled/manual events run full; `main`
+      remains full unless T8's separately proven merge-queue equivalence and
+      post-merge shadow gate explicitly select the minimal mode.
 - [ ] Draft-fast and merge-ready modes are structurally and live proven.
 - [ ] The required branch-protection status remains exactly `required`.
+- [ ] Exactly one required runner job follows the final selected product proof,
+      its tail p95 is at most 15 seconds, and telemetry is not an ancestor.
 - [ ] Packed MV3 proof uses Playwright-matched Chromium.
+- [ ] Serial combined, parallel combined, and split browser topologies are
+      measured; any promoted overlap has unique profiles/ports/outputs and ten
+      stable comparisons.
 - [ ] System Chrome, if used, remains a separate compatibility signal until its
       separately planned Playwright-upgrade/compatibility promotion is approved.
 - [ ] Merge-queue support is either proven after an approved organization move
@@ -1439,6 +1814,8 @@ complete:
 - [ ] Merge-ready p50 is at most 3 minutes 30 seconds and p95 at most 5 minutes
       over the required sample windows, or the initiative remains open with
       measured blockers.
+- [ ] The 2 minute 30 second p50 / 4 minute p95 stretch result is reported
+      honestly as met or missed; missing it does not permit weaker proof.
 - [ ] Comparable product PR runner-minutes fall by at least 25%.
 - [ ] Full test, typecheck, build, docs, browser, consumer, and required local
       E2E gates pass.
@@ -1452,18 +1829,29 @@ Stop and report instead of improvising if:
 - the live workflow/test topology no longer matches the current-state map;
 - Bun's discovered test set cannot be reconciled exactly with the inventory;
 - a required test depends on execution order or state from a different lane;
+- Bun `--parallel=2` changes file/testcase coverage, exposes unexplained
+  order/global-state dependence, or requires global `--concurrent`;
 - GitHub treats an older same-SHA `required` success as mergeable after a
   Draft-to-Ready transition before the fresh run is pending; do not promote
   draft-fast in that state—retain full draft CI or require a new head SHA;
 - weighted selection changes product assertions or test semantics;
 - package output cannot be safely reused without weakening local self-contained
   tests;
+- all package reuse candidates lengthen the complete critical path; retain the
+  measured self-build winner and stop package-topology expansion rather than
+  improvising a broader artifact;
 - the consumer failure signature is broader or mixed with another real error;
 - a route cannot be derived confidently from package/capability ownership;
+- classifier p95 exceeds ten seconds during the promotion window;
 - shadow mode finds any under-selection;
 - the stable `required` context would need to be renamed;
 - system Chrome would be required for packed MV3 extension loading;
 - Playwright or GitHub runner image drift makes the canary unreliable;
+- browser branch overlap shares a profile, port, cache, IndexedDB,
+  service-worker, output-cleanup, or temporary-directory boundary that cannot
+  be isolated within scope;
+- more than one required runner allocation would remain after final product
+  proof, or telemetry would become a required ancestor;
 - completion requires a remote cache token, larger-runner purchase, repository
   transfer, branch-protection change, or other new external authority;
 - live E2E requires committing or logging private identifiers;
@@ -1474,6 +1862,10 @@ Stop and report instead of improvising if:
 - Timing metadata will drift as tests are added or become heavier. Refresh it
   from successful main/scheduled evidence, review the diff, and keep unknown
   files conservatively weighted.
+- Freeze one timing snapshot per comparison run. Never let reruns or candidate
+  jobs rebalance from different timing data.
+- Keep Bun worker count explicit. A runner image with more CPUs must not
+  silently increase CI concurrency.
 - A package dependency change can expand reverse-dependent tests and gates.
   Classifier tests must be updated in the same PR as new workspaces or
   capabilities.
@@ -1483,6 +1875,9 @@ Stop and report instead of improvising if:
   drift guard is the backstop that detects selector assumptions becoming stale.
 - GitHub runner images and system Chrome update independently of this
   repository. Keep the version visible and the MV3 gate hermetic.
+- GitHub native `parallel`/`background` steps still share one runner filesystem
+  and CPU/memory budget. Revalidate path/profile/cache ownership whenever a
+  participating command changes.
 - Revisit remote Turbo cache only after local build reuse and routing are
   measured. If the remaining wall time is predominantly repeated uncached
   builds, write a separate threat/cost/availability plan before adding a
@@ -1498,9 +1893,10 @@ Stop and report instead of improvising if:
    Playwright upgrade plus ten distinct runner Image Version values; it is not
    completed by this plan.
 3. **Remote Turbo cache** — recommended default: out of scope. Reassess only
-   after single-build reuse and weighted lanes have produced at least 20
+   after the selected package topology and weighted lanes have produced at least 20
    merge-ready samples.
-4. **Performance threshold adjustment** — recommended default: keep the
-   proposed 3 minute 30 second p50 and 5 minute p95. Change them only from
-   measured runner availability, not to declare an underperforming rollout
-   complete.
+4. **Performance threshold adjustment** — recommended default: keep
+   3 minutes 30 seconds p50 and 5 minutes p95 as hard completion gates, and add
+   2 minutes 30 seconds p50 / 4 minutes p95 as stretch targets for the complete
+   safe A/B rollout. Change hard gates only from measured runner availability,
+   not to declare an underperforming rollout complete.

--- a/specs/github-ci-throughput/PLAN.md
+++ b/specs/github-ci-throughput/PLAN.md
@@ -1,0 +1,1506 @@
+# GitHub CI throughput and merge-ready latency
+
+- Status: proposed
+- Planning baseline: `27d2e95bd90ea0695f5f7442efec807ec1dca155`
+  (`main`, 2026-07-30)
+- Investigation reference:
+  [PR #135](https://github.com/BjoernSchotte/atlcli/pull/135), which
+  implemented issue #134
+- Primary workflow:
+  [final PR #135 revalidation](https://github.com/BjoernSchotte/atlcli/actions/runs/30518558159)
+
+## Goal
+
+Reduce merge-ready CI latency and runner consumption enough to support a
+higher number of independent pull requests per day without weakening the
+single required branch-protection contract.
+
+The implementation must:
+
+1. keep every currently required correctness, packaging, platform, browser,
+   and consumer contract;
+2. balance tests by measured duration instead of file count;
+3. avoid rebuilding the same publishable packages in isolated jobs;
+4. give draft pull requests fast feedback and reserve full proof for
+   merge-ready commits;
+5. run only impact-relevant gates after the selector has proved that it fails
+   open safely;
+6. keep a full scheduled drift guard and a manual full-run escape hatch;
+7. retain Playwright and a Playwright-matched Chromium for packed MV3 tests;
+8. keep the stable `required` status name used by branch protection.
+
+This plan changes CI and test orchestration only. It does not change product
+behavior.
+
+## Executive decision
+
+Implement the work in evidence-gated stages:
+
+1. add timing and selection observability without skipping any existing gate;
+2. eliminate the known Bun file-link flake and duplicate package builds;
+3. replace the four file-count shards with deterministic duration-aware lanes;
+4. shadow a package/dependency-aware change selector before allowing it to
+   skip work;
+5. split draft feedback from merge-ready proof;
+6. optimize browser provisioning after the Linux test critical path has moved;
+7. prepare, but do not activate, GitHub merge-queue support until the
+   repository ownership requirement is resolved.
+
+Do **not** begin with more shards, larger runners, remote Turbo cache, removing
+Playwright, disabling strict branch protection, or broad test retries. Those
+changes either fail to address the measured bottleneck, add unproven external
+state, or weaken the evidence contract.
+
+## Measured baseline
+
+The values below are from the final PR #135 workflow unless stated otherwise.
+They are the baseline against which the implementation is accepted.
+
+| Metric | Baseline |
+| --- | ---: |
+| Repository test files | 405 |
+| Bun test cases | about 5,900 |
+| Linux test payloads | 45 s / 135 s / 254 s / 55 s |
+| Linux shard job durations | 80 s / 160 s / 299 s / 88 s |
+| Last green pre-sync full workflow | 5 min 37 s |
+| Final merge-SHA first attempt, red only from consumer flake | 5 min 28 s |
+| Final validation including one flaky retry | 7 min 55 s |
+| Browser job | 1 min 55 s |
+| Consumer smoke | 1 min 51 s before the retry |
+| Same-SHA draft-to-ready work discarded in PR #135 | about 10 runner-minutes |
+
+The files were evenly divided, but their runtimes were not:
+
+- shard 1: 102 files, 1,526 tests, about 45 seconds of test payload;
+- shard 2: 101 files, 1,541 tests, about 135 seconds;
+- shard 3: 101 files, 1,250 tests, about 254 seconds;
+- shard 4: 101 files, 1,602 tests, about 55 seconds.
+
+The primary heavy work in shard 3 was:
+
+- the real Typst derivative pipeline in
+  `packages/pdf-compiler-browser/src/compiler.test.ts`, about 101 seconds;
+- the build plus API report and closure checks in
+  `scripts/api-report.test.ts`, about 76 seconds.
+
+Shard 2 separately rebuilt publishable packages in
+`scripts/dist-hygiene.test.ts`, about 44 seconds. The static job and consumer
+smoke also build overlapping package outputs in separate filesystems.
+
+The final false failure was a Bun `EEXIST` file-link failure while installing
+`@atlcli/confluence` in the throwaway consumer. Retrying the identical failed
+job succeeded. Earlier PR #135 failures were not CI noise: API, corpus, and
+packed MV3 gates caught incomplete product changes and must remain represented.
+
+PR #135 also demonstrated the merge-throughput problem:
+
+1. a complete run passed in 5 minutes 37 seconds;
+2. `main` had advanced by one commit;
+3. strict up-to-date branch protection required a new merge SHA;
+4. every full gate ran again;
+5. the consumer flake then forced a targeted rerun.
+
+## Current-state map
+
+| Path | Current responsibility | Relevant constraint |
+| --- | --- | --- |
+| `.github/workflows/ci.yml` | Event routing, platform/browser jobs, stable `required` aggregate | Every product change selects almost every gate |
+| `.github/workflows/reusable-quality.yml` | Static quality, four Bun shards, security attestation | Four shards repeat install, Poppler, and font setup |
+| `.github/workflows/reusable-consumer-smoke.yml` | Pinned and latest external-consumer matrix | Rebuilds packages and has no bounded known-flake recovery |
+| `.github/workflows/security-attestation.yml` | Exact-SHA attestation on every main push | Installs the full workspace although `attest.ts` imports only Bun/Node built-ins |
+| `scripts/ci/classify-changes.ts` | Conservative path classifier | One broad `code` bit covers all `apps/`, `packages/`, and product scripts |
+| `scripts/ci/classify-changes.test.ts` | Classifier regression tests | Unknown and workflow paths deliberately fail open |
+| `scripts/ci/workflow-policy.test.ts` | Structural CI contract | Protects the stable aggregate and fail-closed skip behavior |
+| `package.json` | Root test/typecheck/build commands | Root `test` is not a Turbo task and discovers the whole repository |
+| `turbo.json` | Build/typecheck caching and dependencies | No test task exists |
+| `scripts/api-report.test.ts` | Builds packages and validates public API reports/closures | Build runs inside a general Bun shard |
+| `scripts/dist-hygiene.test.ts` | Builds packages and validates emitted artifacts | Performs a second isolated package build |
+| `scripts/consumer-smoke-filelink.ts` | Creates a throwaway `file:` consumer | One un-retried `bun install` can fail with the known Bun `EEXIST` signature |
+| `apps/browser-export-harness/playwright.config.ts` | Neutral ordinary-browser contract | Supports `chrome` or `chromium`, currently one worker |
+| `apps/extension/tests/jobs/packed/job-recovery.e2e.ts` | Packed MV3 durable-job behavior | Requires persistent extension context and `channel: "chromium"` |
+
+The authoritative root test command remains:
+
+```bash
+bun run test
+```
+
+Never substitute bare `bun test` for the complete repository command. The root
+script supplies the `development` export condition required by workspace source
+resolution.
+
+## Required invariants
+
+### Correctness and coverage
+
+- Every test file discovered by the repository's Bun test conventions is
+  assigned to exactly one required full-proof lane.
+- A newly added test file is never silently omitted because it lacks historical
+  timing data.
+- Duplicate and missing assignments fail before any test lane is allowed to
+  pass.
+- Skipped tests remain visible; pass-count equality is not used as a substitute
+  for file/test-case coverage.
+- Full scheduled and manual runs remain unfiltered.
+- Changes to workflows, dependency/lock files, root TypeScript/Turbo config,
+  patches, vendored runtime inputs, CI selection code, or unknown paths fail
+  open to the full matrix.
+- Product tests keep their existing assertions, timeouts, fixtures, and
+  host-specific boundaries. CI optimization must not weaken tests to make them
+  faster.
+
+### Required status
+
+- Branch protection continues to require exactly one stable status named
+  `required`.
+- `required` uses `if: always()` and rejects every selected job that is not
+  `success`.
+- It accepts `skipped` only when the classifier explicitly marks the
+  corresponding gate unselected.
+- A ready pull request can never inherit a draft-fast success without a new
+  full-proof run.
+- Runs classified as Draft or superseded by the final pre-aggregate state check
+  use `draft-fast` or `superseded`, never `required`. A run that becomes stale
+  after that check may end with a failing `required`, but can never report a
+  successful `required`.
+- A merge-ready `required` job verifies the current PR head SHA and non-draft
+  state through a read-only GitHub API check immediately before reporting
+  success. Event payload state alone is not sufficient for this final guard.
+- Strict up-to-date protection remains enabled unless a separately approved
+  merge-queue migration replaces the manual update workflow.
+
+### Consumer and publication
+
+- Local consumer tests remain self-contained: without a verified CI build
+  manifest they build packages exactly as today.
+- CI may reuse a package artifact only when its manifest matches the exact
+  workflow SHA, lockfile digest, package list, and expected `dist` files.
+- A missing, stale, incomplete, or mismatched build manifest must trigger a
+  rebuild or fail; it must never make publication tests vacuous.
+- The Bun `EEXIST` retry is limited to the exact known file-link signature,
+  recreates the throwaway consumer, and runs at most once.
+- No other package-manager, build, resolution, or smoke failure is retried.
+
+### Browser shapes
+
+- `@playwright/test` remains the browser runner and assertion API.
+- Packed MV3 tests continue to use Playwright's matched full Chromium with a
+  persistent context. They must not use the GitHub runner's arbitrary system
+  Chrome/Chromium executable.
+- The neutral browser harness may exercise system Google Chrome only as a
+  separately visible compatibility lane until promotion evidence is met.
+- Runner Chrome is not treated as a replacement for packed-extension proof.
+- Worker count remains one for stateful packed suites until their profile,
+  IndexedDB, service-worker, and cache dependencies are explicitly isolated.
+
+### Privacy and security
+
+- Do not copy tokens, customer documents, tenant URLs, page IDs, space IDs,
+  account IDs, or derived private artifacts into workflow logs, fixtures,
+  timing data, this spec, commits, or PR text.
+- Test timing data contains repository-relative test paths and durations only.
+- Live Atlassian E2E remains outside GitHub-hosted CI.
+- Workflow permissions remain least-privilege. T6 may add
+  `pull-requests: read` for current-state validation, and T0 may add
+  `actions: read` to the summary job for same-run job timestamps; no write
+  token or third-party cache credential is required.
+
+## Non-goals
+
+- changing CLI, DOCX, PDF, extension, Forge-shaped, or browser export behavior;
+- reducing test assertions or deleting slow regression coverage;
+- replacing Playwright with Selenium, Puppeteer, raw CDP, or shell scripts;
+- using system Chrome for packed MV3 extension tests;
+- enabling arbitrary retries for unit, browser, package, or platform failures;
+- disabling strict branch protection to save builds;
+- purchasing larger runners before the software topology is corrected;
+- introducing a remote Turbo-cache service or its credentials in this plan;
+- automatically transferring the repository to a GitHub organization;
+- automatically enabling a merge queue or changing repository settings;
+- running live Atlassian credentials in GitHub Actions;
+- suppressing the full weekly drift guard.
+
+## Target modes and gate topology
+
+### Event modes
+
+| Event | Proof mode | Required behavior |
+| --- | --- | --- |
+| Draft PR opened/synchronized | `draft-fast` | Impact-relevant unit/type checks and docs/media gates |
+| PR marked ready | `merge-ready` | Complete selected product proof for the exact merge candidate |
+| Non-draft PR synchronized/reopened | `merge-ready` | Complete selected product proof |
+| PR converted to draft | `draft-fast` | Cancel superseded full work and return to fast feedback |
+| `push` to `main` | `full` | Full unfiltered post-merge evidence until merge-queue equivalence is proven |
+| Weekly schedule | `full` | Full unfiltered drift guard and timing refresh |
+| `workflow_dispatch` | `full` | Manual escape hatch |
+| `merge_group` | `full` | Land inactive support before organization/merge-queue activation |
+
+### Full-proof jobs
+
+The intended full topology is:
+
+1. `changes` computes proof mode, affected packages/capabilities, current
+   PR-state validity, and fail-open overrides.
+2. A caller-level `package-build` job, or a single-purpose reusable workflow
+   called directly by `ci.yml`, builds publishable outputs once and emits an
+   exact-SHA artifact manifest.
+3. `static-quality` performs offline contract checks and typecheck in parallel
+   with the build.
+4. `package-contract` and `consumer-smoke` depend directly on the caller-level
+   build job and consume its same-run artifact in parallel. Neither waits for
+   the complete reusable-quality workflow.
+5. `unit-tests` runs two deterministic, duration-balanced lanes without
+   Poppler.
+6. `pdf-typst-proof` runs real Typst/PDF tests with only their required fonts
+   and Poppler tools.
+7. macOS PDF, Windows sink, neutral browser, and packed MV3 gates are selected
+   by affected capabilities or by full-run policy.
+8. The aggregate job uses a mode-dependent name: `draft-fast` for draft
+   feedback, `superseded` for stale events, and the stable `required` name only
+   for merge-ready/full evidence.
+
+Two general-purpose unit lanes are the starting point, not an immutable count.
+The measured payload remaining after package-contract and real-Typst work is
+removed is expected to be about 269 seconds, or about 135 seconds per balanced
+lane. This preserves current job-count pressure while moving the outliers into
+explicit lanes. Increase the lane count only if post-change measurements prove
+that runner availability, rather than job fan-out, is not the limiting factor.
+
+## Performance and safety acceptance gates
+
+Evaluate performance only on successful, non-cancelled, merge-ready product
+runs. Keep correctness gates independent from performance gates.
+
+### Promotion gates
+
+| Gate | Required evidence |
+| --- | --- |
+| Weighted-lane completeness | Three consecutive scheduled/manual comparisons with identical discovered file sets, zero duplicates, and zero missing test cases |
+| Weighted-lane balance | Slowest general unit lane no more than 1.5 times the fastest general unit lane |
+| Selective routing | At least 20 representative product PRs or 14 calendar days in shadow mode, zero under-selection findings |
+| Consumer retry | Synthetic signature tests pass; exact known failure retries once; every adjacent/nonmatching failure does not retry |
+| System Chrome canary | Nonblocking only in this plan; record ten distinct runner Image Version values, and require a separate Playwright-upgrade/compatibility plan before any promotion |
+| Merge queue | Repository is organization-owned, queue is enabled, `merge_group` full proof is green for at least ten merges |
+
+### Outcome targets
+
+| Metric | Target |
+| --- | ---: |
+| Merge-ready p50 wall time over at least 10 product PRs | at most 3 min 30 s |
+| Merge-ready p95 wall time over at least 20 product PRs | at most 5 min |
+| Slowest required Linux test lane p95 | at most 2 min 45 s |
+| Draft-fast p50 wall time | at most 2 min |
+| Runner-minute reduction for comparable product PRs | at least 25% |
+| Classified infrastructure false failures over 30 merge-ready runs | zero |
+| Selective-routing misses | zero |
+| Test files omitted or duplicated in a full run | zero |
+| Typical targeted product jobs after routing promotion | at most 6 |
+
+If the correctness promotion gates pass but the performance target does not,
+stop and measure job setup, runner queue time, and artifact transfer separately.
+Do not add shards or caches based only on intuition.
+
+## Commands required by the executor
+
+Run all repository tests through the root command:
+
+| Purpose | Command | Expected result |
+| --- | --- | --- |
+| Focused CI policy | `bun run test scripts/ci/classify-changes.test.ts scripts/ci/workflow-policy.test.ts` | exit 0, all tests pass |
+| Timing/lane logic | `bun run test scripts/ci/test-inventory.test.ts scripts/ci/test-lanes.test.ts scripts/ci/test-timings.test.ts scripts/ci/actions-timings.test.ts` | exit 0, all tests pass |
+| Package artifact | `bun run test scripts/ci/package-build-artifact.test.ts` | exit 0, all closure/integrity fixtures pass |
+| Consumer policy | `bun run test scripts/consumer-smoke.test.ts scripts/install-matrix.test.ts` | exit 0 when smoke opt-in is absent; unit policy tests still execute |
+| Opt-in consumer E2E | `ATLCLI_CONSUMER_SMOKE=1 bun run test scripts/consumer-smoke.test.ts scripts/install-matrix.test.ts` | exit 0; every consumer shape passes |
+| Full suite | `bun run test` | exit 0, no failed tests |
+| Typecheck | `bun run typecheck` | exit 0, no TypeScript errors |
+| Build | `bun run build` | exit 0 |
+| Neutral browser | `bun run test:browser-export-harness` | exit 0 |
+| Packed worker | `bun run --cwd apps/extension test:worker-extension-browser` | exit 0 |
+| Packed durable jobs | `bun run --cwd apps/extension test:jobs-extension-browser` | exit 0 |
+| Docs | `bun run docs:check && bun run docs:build` | both commands exit 0 |
+| Diff hygiene | `git diff --check` | no output, exit 0 |
+
+The executor must use `bun run test`, never bare `bun test`, for the complete
+suite.
+
+## Scope
+
+### In scope
+
+The implementation may modify or create files in these areas only:
+
+- `.github/workflows/ci.yml`
+- `.github/workflows/reusable-quality.yml`
+- `.github/workflows/reusable-consumer-smoke.yml`
+- a new `.github/workflows/reusable-package-build.yml`
+- a new `.github/workflows/reusable-package-contract.yml`
+- `.github/workflows/security-attestation.yml`
+- `.github/workflows/consumer-smoke.yml`
+- `.github/workflows/release-core.yml`
+- `.github/workflows/release-cli.yml`
+- `.github/workflows/release.yml`, limited to wiring the existing preflight to
+  the shared package-build producer
+- a new reusable browser or package-build workflow only if the final topology
+  is clearer than extending the files above
+- `scripts/ci/**`
+- `scripts/ci/classify-changes.ts`
+- `scripts/ci/classify-changes.test.ts`
+- `scripts/ci/workflow-policy.test.ts`
+- `scripts/api-report.test.ts`
+- `scripts/dist-hygiene.test.ts`
+- `scripts/consumer-smoke.ts`
+- `scripts/consumer-smoke-filelink.ts`
+- `scripts/consumer-smoke.test.ts`
+- `scripts/install-matrix.test.ts`
+- `package.json`
+- `turbo.json`
+- test/package manifests needed to expose explicit CI commands
+- `apps/browser-export-harness/playwright.config.ts`
+- browser-harness and packed-extension Playwright configs/tests only when
+  needed to remove cross-test state before changing worker topology
+- `src/content/docs/contributing.md`
+- this spec and a future `specs/github-ci-throughput/EVIDENCE.md`
+
+Every task below further narrows this list. Do not touch all listed files by
+default.
+
+### Out of scope
+
+- product implementation under export, Jira, Confluence, DOCX, PDF, extension,
+  or Forge adapter source directories;
+- public package APIs or generated API reports except when an implementation
+  mistake accidentally changes them, in which case stop;
+- release behavior, versions, changelog, publishing steps, and publishing
+  credentials; only the existing release-quality caller wiring is in scope;
+- repository ownership, branch-protection settings, or GitHub billing;
+- unrelated dependency upgrades;
+- live customer or private test artifacts.
+
+## Git and delivery workflow
+
+- Use branches prefixed `codex/`.
+- Use Conventional Commits, for example:
+  `perf(ci): balance test lanes by duration`.
+- Keep logical changes separately reviewable:
+  telemetry, consumer flake, test lanes, routing, draft/ready behavior, and
+  browser optimization must not be one opaque commit.
+- Do not push until the operator explicitly authorizes it.
+- Do not make a release.
+- Keep the PR Draft until every promotion gate required by its current phase is
+  recorded.
+- Each logical implementation task must add or update tests that would catch
+  its regression.
+- Before committing implementation, run the applicable automated gates and the
+  repository-required live/read-only E2E described in T9. Clean every created
+  test resource.
+
+## Implementation order
+
+| Task | Title | Depends on |
+| --- | --- | --- |
+| T0 | Establish exact timing and selection telemetry | none |
+| T1 | Make the Bun file-link smoke deterministically retry only the known flake | T0 |
+| T2 | Build a fail-closed test inventory and duration-aware lane planner | T0 |
+| T3 | Reuse one package build and promote weighted full-test lanes | T1, T2 |
+| T4 | Shadow package/capability-aware change routing | T0 |
+| T5 | Promote safe selective routing | T3, T4 |
+| T6 | Separate draft-fast feedback from merge-ready proof | T5 |
+| T7 | Optimize neutral-browser and packed-MV3 provisioning | T3, T5 |
+| T8 | Prepare merge-queue support without changing repository ownership | T6 |
+| T9 | Document, validate, and record rollout evidence | T1–T8 as selected |
+
+T1 and T2 may be implemented in parallel after T0. T4 may collect shadow data
+while T2/T3 are being implemented. T5 must not land before the shadow gate is
+met. T8 is conditional and must not activate a queue.
+
+## T0 — Establish exact timing and selection telemetry
+
+### Purpose
+
+Create a trustworthy measurement surface before changing topology. The current
+JUnit files are uploaded per shard, but no checked logic reconstructs file
+coverage, lane balance, critical path, or selected-versus-skipped gates.
+
+### Changes
+
+1. Add `scripts/ci/test-timings.ts` with pure functions that:
+   - parse Bun JUnit XML without evaluating repository content;
+   - count leaf `testcase` elements and aggregate duration by their
+     repository-relative file;
+   - accept Bun 1.3.14's legitimate repetition of the same file on outer and
+     nested `testsuite` plus `testcase` elements;
+   - retain pass/fail/skip counts;
+   - reject absolute paths, paths outside the repository, duplicate file
+     assignments across lane artifacts in the same topology namespace,
+     duplicate testcase identities within the same leaf scope, invalid numbers,
+     and negative durations;
+   - allow the same file once in `legacy` and once in `candidate` only when a
+     comparison run labels those as separate topology namespaces;
+   - emit a versioned JSON schema containing baseline SHA, source run, samples,
+     and per-file duration.
+2. Add `scripts/ci/test-timings.test.ts` with synthetic XML fixtures covering:
+   - normal files and durations;
+   - skipped tests;
+   - legitimate nested suite/file repetition;
+   - duplicate leaf testcases and duplicate file ownership across lanes;
+   - malformed XML/numbers;
+   - absolute/path-traversal inputs;
+   - two shards containing the same file.
+   Check in one small, synthetic/redacted Bun 1.3.14 JUnit golden fixture and
+   parse it in the tests so the implementation follows Bun's real nesting.
+3. Add `scripts/ci/actions-timings.ts` plus API-response fixtures. The script
+   uses the same repository/run-attempt Actions Jobs API with
+   `actions: read` to calculate:
+   - workflow wall time;
+   - per-job queue time (`started_at - created_at`);
+   - per-job runner time (`completed_at - started_at`);
+   - critical path from actual job timestamps/dependencies;
+   - total runner-minutes, including started jobs later cancelled.
+   Keep skipped/unstarted jobs out of runner-minute totals, and label
+   cancelled/failed attempts separately so they cannot enter green-run
+   p50/p95 samples.
+4. Add a workflow summary job or step that downloads same-run JUnit artifacts,
+   writes:
+   - selected proof mode and routes;
+   - per-lane setup and test duration;
+   - slowest files;
+   - total files and test cases;
+   - critical-path wall time;
+   - total runner time;
+   to `$GITHUB_STEP_SUMMARY` and a JSON artifact.
+   Do not derive checkout, setup, queue, artifact-transfer, critical-path, or
+   runner-minute values from JUnit.
+5. Upload JUnit XML on every run. Upload full raw test logs only on failure;
+   timing evidence must not depend on retaining successful console logs.
+6. Do not automatically commit timings from a PR. A scheduled/manual main run
+   may emit a candidate timing artifact for explicit review.
+7. Bootstrap the first checked timing snapshot from the final PR #135 artifacts
+   if still available. If they have expired, run one complete baseline and use
+   that result. Do not fabricate missing durations.
+8. Remove the `bun install --frozen-lockfile` step from
+   `.github/workflows/security-attestation.yml` after adding a workflow-policy
+   assertion that `scripts/security/attest.ts` remains dependency-free. Its
+   current imports are all `node:` built-ins and the script reads repository
+   files directly. If a future external import is added, that policy test must
+   require the install step again.
+
+### Verification
+
+```bash
+bun run test scripts/ci/test-timings.test.ts scripts/ci/actions-timings.test.ts scripts/ci/workflow-policy.test.ts
+```
+
+Expected: all tests pass; malformed and duplicate timing fixtures fail in the
+tested manner, and the attestation workflow has no unnecessary dependency
+install while its script remains dependency-free.
+
+Trigger one manual full workflow. Expected:
+
+- all legacy gates still run;
+- `required` remains green only when all selected gates pass;
+- the summary lists 405 test files at the planning baseline, subject only to
+  legitimate test additions after that baseline;
+- no source, environment secret, absolute home path, or private identifier
+  appears in the timing artifact.
+
+### Commit
+
+`perf(ci): record test and gate timing evidence`
+
+## T1 — Make the Bun file-link smoke retry only the known flake
+
+### Purpose
+
+Prevent a transient, already observed Bun file-link `EEXIST` from invalidating
+an otherwise fully green merge candidate while preserving fail-closed behavior
+for genuine consumer failures.
+
+### Changes
+
+1. In `scripts/consumer-smoke-filelink.ts`, separate:
+   - install execution;
+   - output classification;
+   - cleanup/recreation;
+   - smoke assertions.
+2. Add a pure predicate such as `isKnownBunFilelinkEexist(result)` that returns
+   true only when all of these are present:
+   - the executing Bun version exactly matches the separately reviewed version
+     recorded with the retry signature (initially 1.3.14);
+   - non-zero install exit;
+   - one normalized, anchored line matching a sanitized golden from the real
+     PR #135 `EEXIST: File exists: failed to link package @atlcli/...`
+     failure;
+   - the captured package name is in the allowlist derived from current
+     publishable `@atlcli/*` manifests;
+   - after known Bun progress/boilerplate lines are removed, no second line
+     matches the closed fatal markers `error`, `failed`, `panic`, `fatal`,
+     `ENOENT`, integrity/checksum failure, or process signal.
+   Do not use a loose collection of `includes()` checks.
+3. On the first exact match:
+   - log one GitHub warning without copying arbitrary install output;
+   - remove and recreate the throwaway consumer root;
+   - regenerate its manifest and overrides;
+   - execute `bun install` once more.
+4. If the second install fails, throw the normal consumer error. Never perform
+   a third attempt.
+5. For all nonmatching failures, throw immediately without retry.
+6. Preserve local self-contained behavior and the current file-link,
+   tarball/Node, DOCX, PDF, and resolution assertions.
+7. If the underlying duplicate package-identity cause can be removed without
+   weakening the direct plus transitive file-link shape, prefer that fix and
+   retain the predicate as a regression guard. Do not remove the consumer shape
+   merely because Bun is flaky.
+8. A Bun version change disables the retry until a real failure on that version
+   is classified, a sanitized golden is reviewed, and these tests are updated.
+
+### Tests
+
+Add injectable install execution or a small pure retry coordinator so
+`scripts/consumer-smoke.test.ts` can prove:
+
+- success performs one install;
+- the exact known signature performs exactly two installs and one cleanup;
+- a second exact failure remains fatal;
+- generic `EEXIST` without `failed to link package` does not retry;
+- an npm/pnpm error does not retry;
+- a Bun file-link error for a non-`@atlcli/` target does not retry;
+- mixed output containing a second independent error does not retry;
+- logged warnings redact the temporary absolute path and package detail beyond
+  the safe package name.
+- a different Bun version does not retry;
+- an `@atlcli/*` name absent from the publishable allowlist does not retry;
+- the sanitized real Bun 1.3.14 golden retries, while one-token mutations of its
+  error class do not.
+
+### Verification
+
+```bash
+bun run test scripts/consumer-smoke.test.ts scripts/install-matrix.test.ts
+ATLCLI_CONSUMER_SMOKE=1 bun run test scripts/consumer-smoke.test.ts scripts/install-matrix.test.ts
+```
+
+Expected: unit policy and real consumer shapes pass; the injected known failure
+retries exactly once.
+
+### Commit
+
+`fix(ci): bound the known Bun filelink retry`
+
+## T2 — Build a fail-closed test inventory and duration-aware lane planner
+
+### Purpose
+
+Replace Bun's file-count shard selection with deterministic longest-processing-
+time assignment based on measured test-file duration.
+
+### Changes
+
+1. Add `scripts/ci/test-inventory.ts`:
+   - mirror Bun's documented repository test discovery for
+     `*.test.{js,jsx,ts,tsx}`, `*_test.{js,jsx,ts,tsx}`,
+     `*.spec.{js,jsx,ts,tsx}`, and `*_spec.{js,jsx,ts,tsx}`;
+   - normalize paths relative to repository root;
+   - exclude dependency, generated, build-output, browser-only Playwright, and
+     ignored directories explicitly;
+   - expose one pure inventory function and one CLI;
+   - sort deterministically.
+2. Add `scripts/ci/test-inventory.test.ts` using a synthetic directory tree.
+   Prove inclusion, exclusion, normalization, stable ordering, and rejection of
+   paths outside the root. Include all four Bun naming families, hidden
+   directories, `node_modules`, generated output, and colliding base names.
+3. Add a checked `scripts/ci/test-lanes.json` metadata file. It must contain:
+   - schema version and timing baseline SHA;
+   - per-file historical duration when measured;
+   - exactly one optional lane override:
+     `general`, `package-contract`, or `pdf-typst`;
+   - zero or more orthogonal setup requirements such as `fonts`, `poppler`,
+     or `typst-runtime`;
+   - no test outcome or private data.
+4. Add `scripts/ci/test-lanes.ts`:
+   - assign every inventory file to exactly one lane, defaulting a new
+     unannotated file to `general`;
+   - assign `package-contract` and `pdf-typst` files to their explicit lanes;
+   - assign remaining files to two general lanes with deterministic
+     longest-processing-time bin packing;
+   - give a newly discovered file without timing the larger of the historical
+     p95 duration and a conservative fixed default;
+   - reject duplicate, stale, conflicting, or invalid metadata;
+   - emit a compact JSON matrix and human-readable explanation;
+   - expose the validated file arrays to an argv-safe runner; never
+     shell-evaluate a path.
+5. Add `scripts/ci/run-test-lane.ts`. It must:
+   - load one already validated lane by identifier;
+   - spawn `bun run test -- ./repo-relative-file...` with an argv array, never a
+     constructed shell string or command substitution;
+   - preserve the root `development` condition and JUnit reporter arguments;
+   - reject an empty, unknown, duplicate, absolute, or escaping path before
+     spawning Bun.
+6. Add `scripts/ci/test-lanes.test.ts` covering:
+   - deterministic assignment;
+   - expected balancing;
+   - identical output independent of input ordering;
+   - new-file conservative weighting and default `general` ownership;
+   - duplicate/stale paths;
+   - lane conflicts;
+   - combined requirements such as `fonts` plus `poppler`;
+   - zero-file lanes;
+   - spaces/special characters and colliding filename filters;
+   - exact union and pairwise-disjoint lane sets.
+7. Add a coverage assertion that compares inventory with the union of planned
+   lanes before tests start. The assertion must fail before a zero-test lane can
+   be accepted.
+8. On scheduled/manual runs only, run the legacy four shards and candidate lanes
+   side by side until the promotion gate is satisfied. Compare file identities
+   and JUnit test cases, not only totals.
+
+### Initial capability ownership
+
+At minimum, assign:
+
+- `scripts/api-report.test.ts` and `scripts/dist-hygiene.test.ts` as
+  lane `package-contract`;
+- real Typst/compiler integration and PDF inspection tests requiring the
+  compiler runtime as lane `pdf-typst`;
+- tests that invoke `pdftotext`, `pdftoppm`, or equivalent proof tools as
+  requiring `poppler`;
+- tests that resolve pinned PDF fonts as requiring `fonts`;
+- all other Bun tests as `general`.
+
+Search actual imports and subprocess calls before finalizing the list. Do not
+infer setup needs from filenames alone. A file may have one lane and multiple
+requirements, for example lane `pdf-typst` with both `fonts` and `poppler`.
+
+### Verification
+
+```bash
+bun run test scripts/ci/test-inventory.test.ts scripts/ci/test-lanes.test.ts scripts/ci/test-timings.test.ts
+bun scripts/ci/test-lanes.ts --check
+```
+
+Expected:
+
+- every discovered test file is assigned exactly once;
+- no stale metadata remains;
+- two general lanes have an estimated duration ratio at or below 1.5;
+- explicit package and Typst lanes contain their known heavy tests.
+
+Run three scheduled/manual legacy-versus-candidate comparisons. Record workflow
+URLs and exact coverage comparison in
+`specs/github-ci-throughput/EVIDENCE.md`.
+
+### Commit
+
+`perf(ci): plan tests by measured duration`
+
+## T3 — Reuse one package build and promote weighted full-test lanes
+
+### Purpose
+
+Remove repeated package builds and repeated PDF tool setup from general unit
+workers, then make the duration-aware lanes the required full proof.
+
+### Changes
+
+1. Add `.github/workflows/reusable-package-build.yml` as the single-purpose
+   build producer. `ci.yml` calls it as a top-level `package-build` job directly
+   after `changes`. Build-independent reusable quality starts after `changes`
+   in parallel; only package-contract and consumer jobs declare
+   `needs: [changes, package-build]`. The producer:
+   - installs pinned dependencies;
+   - restores the existing Bun and Turbo caches;
+   - owns the workflow's single full `bun run build` invocation;
+   - runs build-dependent output checks such as
+     `bun run check:extension-output`;
+   - stages the complete generated consumer closure, not only `dist/**`:
+     publishable JS/declarations/maps, package `files` assets, PDF fonts and
+     licenses, DOCX fonts, compiler vendor/WASM files, and the tarballs produced
+     by real prepack/pack hooks;
+   - derives that closure from the publishable package manifests and actual
+     pack output, with explicit regression fixtures for
+     `packages/pdf`, `packages/docx`, and
+     `packages/pdf-compiler-browser`;
+   - writes a manifest containing exact workflow SHA, Bun version, `bun.lock`
+     digest, package names, artifact role (`workspace-overlay` or `tarball`),
+     and a SHA-256 for every regular artifact file;
+   - uploads the closed closure plus the manifest under an exact-SHA artifact
+     name;
+   - exposes the immutable v4 upload's `artifact-id` and `artifact-digest` as
+     caller outputs.
+2. Add `scripts/ci/package-build-artifact.ts` and
+   `scripts/ci/package-build-artifact.test.ts`.
+   - Reject a different SHA or lock digest.
+   - Verify every listed regular file's SHA-256.
+   - Reject missing/unexpected package directories, files not listed in the
+     closed manifest, and missing JS/declaration output.
+   - Reject path traversal, symlinks, sockets, devices, and other special files.
+   - Verify before any artifact file is imported, packed, linked, or passed to
+     `bun install`.
+   - Accept artifacts only by the `needs: package-build` same-run ID/digest;
+     prohibit cross-run and `workflow_run` downloads.
+3. Refactor `scripts/api-report.test.ts` and
+   `scripts/dist-hygiene.test.ts` so:
+   - local/default execution still builds packages first;
+   - the `package-contract` CI job may skip only the build step after the
+     verified artifact is present;
+   - all API report, closure, dist-path, Node-import, and publication
+     assertions remain unchanged.
+4. Apply the same verified-prebuilt contract to consumer helpers. Do not
+   recognize a bare boolean such as `CI=1` as proof; require the manifest.
+   `ci.yml` must make reusable package-contract and reusable consumer calls
+   depend directly on `package-build` and pass the artifact ID/digest. The
+   build-independent quality caller must not depend on package-build. Do not
+   express this as `consumer-smoke needs: test`, which would serialize the
+   consumer behind the complete reusable quality workflow.
+   - File-link tests overlay the verified generated package files onto their
+     checkout before linking the real package directories.
+   - Tarball/Node tests consume the verified tarballs produced by the real pack
+     hooks.
+   - Consumer assertions still prove installed `/dist/` resolution and package
+     contents; reuse must not turn packaging into a mocked shape.
+5. Add `.github/workflows/reusable-package-contract.yml` to consume and verify
+   the build artifact before running API reports, closure, dist hygiene, and
+   package assertions. Replace the four `--shard=N/4` jobs in
+   `.github/workflows/reusable-quality.yml` with:
+   - two general unit lanes;
+   - one `pdf-typst-proof` lane.
+   Package-contract is a separate caller-level reusable job so it can wait for
+   the build without delaying static, unit, or PDF lanes.
+6. General lanes:
+   - do not install Poppler;
+   - do not provision fonts unless their exact file list requires them;
+   - invoke the root test contract with explicit file arguments;
+   - upload JUnit XML always and raw logs on failure.
+7. The PDF/Typst lane installs only its proved OS tools and fonts.
+8. The package-contract reusable workflow downloads/verifies the build artifact
+   before running its explicit files.
+9. Consumer smoke downloads/verifies the same exact-run artifact instead of
+   rebuilding it.
+10. Remove the full build from `static-quality`; otherwise the new build owner
+    would still duplicate publishable builds on another runner. Keep its
+    non-build static/type checks parallel with package build, unit, and PDF
+    lanes whenever there is no artifact dependency.
+11. Update `scripts/ci/workflow-policy.test.ts` to prove:
+    - there are no legacy `--shard=N/4` required jobs after promotion;
+    - the selected full topology contains exactly one `bun run build` owner;
+    - each planned lane has a unique report;
+    - Poppler appears only in the PDF proof lane;
+    - package/consumer jobs depend directly on the caller-level build and
+      require same-run manifest verification;
+    - aggregates remain fail closed.
+12. Keep a manual `workflow_dispatch` legacy-full topology that is independent
+    of the new planner and artifact path. Retain it through T5/T6 promotion and
+    at least 30 subsequent green merge-ready full runs. Remove it only in a
+    separate PR after its rollback value is explicitly reviewed.
+13. Update every in-repository caller atomically:
+    - `ci.yml` starts build-independent reusable quality beside the pinned
+      package build, then passes build outputs only to reusable
+      package-contract and pinned consumer smoke;
+    - `release-core.yml`, `release-cli.yml`, and `release.yml` start
+      build-independent quality beside the pinned producer and make their
+      package-contract/preflight aggregate depend on both;
+    - `consumer-smoke.yml` adds a producer using the selected `latest` Bun leg
+      so the floating canary remains a latest-runtime build and install test.
+    Add workflow-policy tests that enumerate every `uses:
+    ./.github/workflows/reusable-quality.yml` and
+    `uses: ./.github/workflows/reusable-package-contract.yml` or
+    `uses: ./.github/workflows/reusable-consumer-smoke.yml` caller. Fail if a
+    package-contract/consumer caller lacks its build inputs/`needs` edge, or if
+    build-independent quality incorrectly waits for package-build.
+14. Do not change release publishing jobs or execute a release. Run only the
+    documented release dry-run if release-preflight wiring needs end-to-end
+    validation.
+
+### Artifact safety tests
+
+Create synthetic manifests covering:
+
+- correct SHA, lock digest, packages, and files;
+- correct per-file hashes plus the immutable upload ID/digest;
+- stale SHA;
+- mismatched Bun version or artifact role;
+- changed lock digest;
+- missing package or declaration;
+- missing PDF/DOCX font, license, compiler vendor/WASM, or tarball required by a
+  publishable manifest;
+- extra unexpected top-level path;
+- extra unmanifested file inside an otherwise valid package directory;
+- modified file with a stale manifest hash;
+- absolute and `../` paths;
+- symlink escape and other special-file types;
+- corrupt JSON.
+
+No consumer or contract test may skip its build on any rejected manifest.
+
+### Verification
+
+```bash
+bun run test scripts/ci/test-inventory.test.ts scripts/ci/test-lanes.test.ts scripts/ci/package-build-artifact.test.ts scripts/ci/workflow-policy.test.ts scripts/api-report.test.ts scripts/dist-hygiene.test.ts
+bun run test
+bun run typecheck
+bun run build
+```
+
+Expected: all commands pass. In the first promoted full workflow:
+
+- the lane coverage guard reports every current test file exactly once;
+- the slowest general lane is no more than 1.5 times the fastest;
+- Poppler installation occurs only in its owning lane;
+- package build executes once;
+- the consumer and package-contract jobs verify and reuse that artifact;
+- `required` is green.
+
+### Commit
+
+`perf(ci): reuse package builds across balanced lanes`
+
+## T4 — Shadow package/capability-aware change routing
+
+### Purpose
+
+Learn what the workflow would safely skip for real pull requests before
+allowing any new route to affect the required aggregate.
+
+### Design
+
+Extend the classifier from four broad booleans to an explicit versioned route
+object containing at least:
+
+- `proofMode`;
+- `full`;
+- `affectedPackages`;
+- `generalTests`;
+- `packageContract`;
+- `consumer`;
+- `pdfTypst`;
+- `macosPdf`;
+- `windowsPdf`;
+- `browserHarness`;
+- `extensionMv3`;
+- `docs`;
+- `readmeMedia`;
+- `reason` and `failOpenReason`.
+
+The classifier should derive workspace ownership and transitive reverse
+dependencies from every relevant dependency field in real
+`apps/*/package.json` and `packages/*/package.json` manifests, including test
+and development edges. Manifest edges alone are not authoritative: current
+tests intentionally import across workspace boundaries in ways not fully
+described by runtime dependencies. Add a static import scan for test files plus
+a small, reviewed test-dependency/capability override registry for dynamic,
+generated, root-script, host, and platform edges. Fail open if an import cannot
+be resolved or a workspace manifest was deleted.
+
+Do not make Bun `--changed` or Turborepo `--affected` the sole required
+selector. They may be recorded as comparison signals, but root scripts,
+generated contracts, host gates, and global inputs need explicit fail-open
+policy.
+
+### Minimum route policy
+
+| Change | Candidate selected proof |
+| --- | --- |
+| `packages/jira/**` | Jira-owned tests plus CLI and extension reverse dependents; the current extension imports `@atlcli/jira/browser`, so relevant extension proof is not optional |
+| `packages/plugin-api/**` | Package-contract proof and real reverse dependents; the package currently has no owned test file, so do not claim a nonexistent Plugin API unit gate |
+| `apps/extension/**` | Extension tests and the affected packed MV3 suite |
+| `apps/browser-export-harness/**` | Harness unit/build and neutral-browser E2E |
+| common export/PDF packages | Package/reverse-dependent tests, PDF proof, relevant browser/host gates |
+| publishable package manifest/export changes | Package contract and consumer smoke |
+| CLI PDF sink/build-mode paths | Relevant Linux proof plus macOS/Windows platform gate |
+| docs/spec-only paths | Existing docs/media policy; no product proof |
+| root dependency/config, workflow, CI scripts, patches, vendored runtime, fonts, unknown paths | Full fail-open matrix |
+
+Mixed changes take the union of every route. An empty or unresolvable diff runs
+full.
+
+### Changes
+
+1. Refactor `scripts/ci/classify-changes.ts` into pure path normalization,
+   workspace graph, capability mapping, and route-union functions.
+2. Change the workflow diff protocol from `git diff --name-only -z` to
+   `git diff --name-status -z` and parse additions, modifications, deletions,
+   and both sides of renames without shell word splitting. For a deleted or
+   renamed workspace manifest, load the base graph as well as the head graph;
+   fail open if either side cannot be reconstructed.
+3. Preserve a compact CLI that writes GitHub outputs.
+4. Add table-driven tests for every workspace/capability family, mixed changes,
+   renamed/deleted files, Windows separators, empty input, workflow changes,
+   unknown roots, dependency cycles, static cross-package test imports, dynamic
+   override edges, and deleted manifests.
+5. In shadow mode, workflows continue running the existing full selected
+   product proof but display:
+   - candidate gates;
+   - gates that would have been skipped;
+   - affected packages;
+   - fail-open reason.
+6. For each shadow PR, compare the candidate lane file set against the full
+   inventory and package graph. Record any test failure that would have occurred
+   outside the candidate set as an under-selection finding.
+7. Add counterfactual route tests before collecting passive shadow evidence:
+   - for every route family, mutate a synthetic workspace/capability fixture
+     so one owning gate is the only failing gate;
+   - assert that the candidate route necessarily selects that gate;
+   - assert that removing the relevant dependency/capability edge makes the
+     regression test fail.
+8. Replay the changed-path sets from known historical red commits/runs:
+   - PR #135 API report/closure failure
+     [run 30515886454](https://github.com/BjoernSchotte/atlcli/actions/runs/30515886454)
+     must select package-contract proof;
+   - PR #135 corpus/API failure
+     [run 30516534738](https://github.com/BjoernSchotte/atlcli/actions/runs/30516534738)
+     must select the owning corpus and package gates;
+   - PR #135 packed-MV3 regression
+     [run 30517692670](https://github.com/BjoernSchotte/atlcli/actions/runs/30517692670)
+     must select `extensionMv3` for the actual shared
+     Confluence/export-path diff.
+   Fetch exact paths/SHAs from the public run/PR evidence; do not encode
+   abbreviated or guessed commit IDs.
+9. Keep scheduled, manual, and `main` runs full regardless of candidate output.
+10. Add a manual `workflow_dispatch` full run as the operator's recovery path.
+
+### Promotion gate
+
+First pass every counterfactual and historical-red replay. Then collect at
+least 20 representative product PRs or 14 calendar days, whichever provides
+broader surface coverage. The observation window is drift evidence, not proof
+by itself that skipped gates would catch a future regression. Evidence must
+include CLI, Jira, Confluence/export, publishable-package, extension, browser
+harness, PDF, workflow/global, and mixed changes.
+
+If any under-selection is found:
+
+1. keep shadow mode;
+2. add the missing dependency/capability rule and regression fixture;
+3. restart the zero-miss observation window for that capability.
+
+### Verification
+
+```bash
+bun run test scripts/ci/classify-changes.test.ts scripts/ci/workflow-policy.test.ts
+bun scripts/ci/classify-changes.ts --full
+```
+
+Expected: full output selects every gate; fixtures produce the documented
+candidate routes; unknown inputs fail open.
+
+### Commit
+
+`perf(ci): shadow dependency-aware gate routing`
+
+## T5 — Promote safe selective routing
+
+### Purpose
+
+Turn the evidence-backed candidate routes into required-job selection while
+preserving full proof for global or ambiguous changes.
+
+### Changes
+
+1. Promote only capability families that passed T4's observation gate.
+   Unproven families remain full.
+2. Update job `if` expressions and the `required` aggregate to consume each
+   explicit route output.
+3. Keep one stable aggregate and test both sides of every route:
+   - selected plus `success` passes;
+   - selected plus `skipped`, `cancelled`, or `failure` fails;
+   - unselected plus `skipped` passes;
+   - unselected plus `success` fails because it indicates classifier/workflow
+     disagreement.
+4. Make route decisions visible in job summaries, including fail-open reasons.
+5. Continue full weekly/manual/main proof.
+6. For the first two weeks after promotion, add a nonblocking scheduled
+   comparison that exercises full inventory and reports any drift.
+7. Do not reduce typecheck/build scope until test/gate routing has met its
+   performance and safety targets. That can be a later measured optimization.
+
+### Verification
+
+Use classifier fixtures to run at least:
+
+- docs-only;
+- Jira-only;
+- plugin-API-only;
+- extension-only;
+- browser-harness-only;
+- common PDF/export;
+- publishable manifest;
+- lockfile/global;
+- workflow;
+- unknown;
+- mixed docs plus product.
+
+For each fixture, assert exact job selection and `required` behavior in
+`scripts/ci/workflow-policy.test.ts`.
+
+Expected on live PR probes:
+
+- docs-only stays lightweight;
+- narrow package PRs do not start unrelated browser/PDF/platform/consumer jobs;
+- common/global changes still run full;
+- no required status is missing or renamed.
+
+### Commit
+
+`perf(ci): run only proven affected product gates`
+
+## T6 — Separate draft-fast feedback from merge-ready proof
+
+### Purpose
+
+Stop spending full-proof runner minutes on every draft synchronization while
+ensuring Ready always produces a fresh, complete required result.
+
+### Changes
+
+1. Add an explicit `proofMode` decision:
+   - draft PR: `draft-fast`;
+   - ready PR: `merge-ready`;
+   - main/schedule/manual: `full`.
+2. Add `pull-requests: read` and make `changes` compare the event SHA/state to
+   the current PR head SHA/draft state through the GitHub API. Emit
+   `superseded` when an old synchronize/draft event no longer describes the
+   live PR. Fail closed to merge-ready/full if current state cannot be read.
+3. Include `converted_to_draft` in the PR event policy so superseded full work
+   can be cancelled on a best-effort basis and replaced with the fast lane.
+4. Add a `final-pr-state` job after selected proof gates and immediately before
+   the aggregate. It re-reads current head/draft state and exposes the final
+   display mode. Use one always-running aggregate with a name derived from this
+   final-state output:
+   - `draft-fast` for draft evidence;
+   - `superseded` for stale events;
+   - `required` only for non-draft merge-ready/full proof.
+   A skipped job named `required` is not acceptable because GitHub can treat a
+   skipped required check as successful.
+5. `draft-fast` runs:
+   - change classification;
+   - impacted general unit tests;
+   - the complete existing static/typecheck gate initially;
+   - docs/media gates when selected;
+   - no consumer, platform, real-Typst, or packed MV3 gate unless the operator
+     starts a manual full run.
+   Affected static/typecheck selection requires its own future shadow and
+   promotion evidence; T4/T5 test routing does not prove it.
+6. `ready_for_review` always switches to `merge-ready` and selects the complete
+   evidence required by T5. It must not reuse the prior draft `required`
+   result.
+7. Every synchronization while the PR remains non-draft runs merge-ready proof.
+8. Inside the merge-ready aggregate, query the PR once more immediately before
+   reporting success and require:
+   - the same current head SHA;
+   - `draft == false`;
+   - the run's proof mode is merge-ready;
+   - every selected gate succeeded.
+   If state changed or cannot be read, fail the already named check. A run that
+   became stale in the narrow interval after `final-pr-state` may therefore
+   produce a red `required`, but never a green one. The live race probe must
+   prove that a later valid run can replace that red result.
+9. Treat GitHub concurrency cancellation as a cost optimization only; GitHub
+   does not guarantee run ordering inside one concurrency group. Correctness
+   comes from the live-state/head guards and mode-dependent check names. Add
+   fixtures for delayed old synchronize/converted events and a live race probe.
+10. Document the operational sequence:
+   - finish draft commits;
+   - synchronize `main`;
+   - mark Ready;
+   - avoid toggling Ready merely to restart CI;
+   - use "rerun failed jobs" only for a classified infrastructure failure.
+11. Add workflow-policy fixtures for opened draft, draft synchronization,
+   converted-to-draft, ready-for-review, ready synchronization, reopened ready,
+   delayed/superseded events, main push, schedule, and dispatch.
+
+### Acceptance
+
+- A draft push followed immediately by Ready may discard only fast-lane work,
+  not a complete full run.
+- Ready starts every required merge-proof gate for the current merge candidate.
+- A Draft run never creates `required`; a superseded run never creates a green
+  `required`; and the PR remains unmergeable from the Ready transition until
+  the fresh current-head `required` run succeeds.
+- Draft p50 is at most two minutes over ten representative runs.
+- The required context name remains `required`.
+
+### Verification
+
+```bash
+bun run test scripts/ci/classify-changes.test.ts scripts/ci/workflow-policy.test.ts
+```
+
+Open a disposable Draft PR changing a synthetic test fixture:
+
+1. confirm only draft-fast gates run;
+2. synchronize `main`;
+3. mark Ready;
+4. confirm GitHub reports the PR unmergeable/pending until a fresh merge-ready
+   run selects all appropriate gates and `required` succeeds;
+5. convert back to Draft, then Ready again without a code-SHA change;
+6. confirm the earlier success cannot make the PR mergeable before the new
+   merge-ready proof;
+7. deliver a delayed old-event fixture/probe and confirm it reports
+   `superseded` when detected by final state, and never reports a successful
+   stale `required`.
+
+Do not use customer data or create remote Atlassian resources for this workflow
+probe.
+
+### Commit
+
+`perf(ci): reserve full proof for merge-ready changes`
+
+## T7 — Optimize neutral-browser and packed-MV3 provisioning
+
+### Purpose
+
+Reduce browser setup and allow neutral and extension-specific contracts to run
+independently without confusing system Chrome with hermetic extension proof.
+This task follows the Linux critical-path work because the current 1 minute
+55 second browser job is not the bottleneck.
+
+### Decisions
+
+GitHub-hosted Ubuntu images currently include Google Chrome and Chromium, but
+the image changes weekly. Playwright is still required as the runner/API.
+Playwright's extension guidance requires bundled Chromium for side-loaded
+extensions because stable Chrome/Edge removed the relevant command-line flags.
+
+References:
+
+- [GitHub-hosted runner images](https://docs.github.com/en/actions/concepts/runners/github-hosted-runners#runner-images)
+- [Playwright Chrome extension testing](https://playwright.dev/docs/chrome-extensions)
+- [Playwright Chromium headless modes](https://playwright.dev/docs/browsers#chromium-new-headless-mode)
+
+### Changes
+
+1. First implement a non-required same-SHA A/B experiment:
+   - A keeps the current combined browser job;
+   - B separates neutral and MV3 setup.
+   Measure workflow wall time, each setup/test phase, and summed runner-minutes
+   for full/global, harness-only, and extension-only route fixtures.
+2. Promote the split only if all hold over at least ten comparisons:
+   - full/global browser critical path does not regress;
+   - full/global browser runner-minutes increase by no more than 10%;
+   - representative narrow harness/extension routes save at least 25% browser
+     runner-minutes.
+   Otherwise keep one job and use step-level route selection; do not duplicate
+   checkout, Bun install, fonts, browser provisioning, and caches for no
+   measured gain.
+3. If the split passes, use:
+   - `browser-neutral`: harness build/output/conformance/E2E followed by shape
+     parity, because `check:parity` consumes the harness-produced
+     `test-results/digests.json`;
+   - `browser-extension-mv3`: one packed extension build, worker proof, and
+     durable-job proof.
+   Do not place shape parity in the MV3 job or run it without the neutral digest
+   artifact.
+4. Keep both jobs selected for full/global changes. T5 may select them
+   independently for narrow changes.
+5. Keep the required MV3 job on `channel: "chromium"` with Playwright's matched
+   full Chromium and persistent contexts.
+6. Use Playwright's supported `install --no-shell chromium` form when the job
+   needs the full browser for extension loading and does not need the separate
+   headless shell.
+7. Benchmark, rather than assume, Playwright browser cache value:
+   - cache restore plus dependency install;
+   - fresh browser install;
+   - `--with-deps` versus runner-provided libraries in a nonblocking canary.
+   Do not remove `--with-deps` from the required lane until ten **distinct**
+   recorded GitHub runner Image Version values pass.
+8. Add a permanently nonblocking neutral-harness compatibility project using
+   `ATLCLI_PLAYWRIGHT_CHANNEL=chrome` and the runner's system Google Chrome.
+   At the planning baseline Playwright 1.55 is matched to Chromium 140/tested
+   stable Chrome 139 while the observed runner image carried Chrome 150.
+   Empirical passes do not make that pairing supported. Any proposal to promote
+   system Chrome requires a separate Playwright-upgrade PR/plan, full hermetic
+   browser proof, and ten distinct runner-image versions. Keep MV3 on bundled
+   Chromium regardless.
+9. Preserve a visible Playwright, bundled Chromium, system Chrome, and runner
+   Image Version summary.
+10. Do not increase Playwright workers while packed tests share persistent
+   profile, cache, service worker, or IndexedDB state.
+11. If parallelism is pursued later, first create independent profile roots and
+   fixtures per test, prove no test depends on state established by an earlier
+   test, then increase workers in a separate PR.
+12. Upload traces only on failure; keep the existing production-build and
+    artifact scans.
+
+### Verification
+
+```bash
+bun run typecheck:browser-export-harness
+bun run build:browser-export-harness
+bun run check:browser-export-harness
+bun run test:browser-export-harness
+bun run --cwd apps/extension test:worker-extension-browser
+bun run --cwd apps/extension test:jobs-extension-browser
+bun run check:parity
+```
+
+Expected: all hermetic gates pass on bundled Chromium. The system-Chrome canary
+is reported separately and cannot satisfy or replace any required result in
+this plan. If the split does not meet its A/B gate, the combined job remains.
+
+### Commit
+
+`perf(ci): separate neutral and MV3 browser proof`
+
+## T8 — Prepare merge-queue support without changing repository ownership
+
+### Purpose
+
+Eliminate repeated manual main synchronization when daily merge volume becomes
+high enough, without weakening strict compatibility proof.
+
+### Constraint
+
+The repository is currently public and personally owned. GitHub merge queues
+for public repositories require organization ownership. Repository transfer,
+organization policy, billing, and queue activation are external decisions and
+are not authorized by this plan.
+
+Reference:
+[GitHub merge queue](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue).
+
+### Code readiness before queue activation
+
+The workflow support must land on the default branch **before** a merge queue
+is enabled; otherwise GitHub cannot request the required check for the merge
+group and the queue blocks indefinitely. The inactive trigger is harmless while
+the repository has no queue.
+
+1. Add `merge_group: { types: [checks_requested] }` to CI triggers while the
+   repository is still personally owned.
+2. Resolve comparison SHAs from:
+   - `github.event.merge_group.base_sha`;
+   - `github.event.merge_group.head_sha`;
+   with fail-open full behavior if either is absent.
+3. Run full merge-ready proof for every merge group.
+4. Keep the exact stable `required` context.
+5. Update workflow-policy tests for merge-group routing and aggregation.
+6. Merge this code-readiness change to the default branch and prove the
+   workflow still behaves identically for PR/main/manual events.
+7. Only then may the operator transfer ownership and enable the queue.
+8. Retain full `main` push proof until at least ten queue merges demonstrate
+   that the tested merge-group SHA and landed main SHA provide equivalent
+   evidence.
+9. Only then evaluate whether redundant post-merge product jobs can be reduced.
+   Security attestation and release evidence remain exact-SHA requirements.
+
+### Personal-repository fallback
+
+If the repository stays personally owned:
+
+- retain strict branch protection;
+- synchronize `main` immediately before Ready;
+- serialize final merge-ready candidates operationally;
+- consider a separately reviewed merge-train bot only when manual serialization
+  becomes the measured bottleneck.
+
+Do not switch required checks from strict to loose merely to save runs.
+
+### Verification
+
+Before any queue activation, land and test merge-group event fixtures locally
+in `scripts/ci/workflow-policy.test.ts`. Confirm the default branch contains
+the inactive `checks_requested` trigger.
+
+After activation, record ten queue workflow URLs and prove:
+
+- each group ran full required evidence;
+- superseded groups were cancelled safely;
+- the merged SHA corresponds to the proven candidate;
+- no PR author had to merge/rebase `main` manually.
+
+### Commit
+
+`ci: validate merge queue candidates`
+
+This commit is conditional and must not be created before the external
+repository decision.
+
+## T9 — Document, validate, and record rollout evidence
+
+### Documentation
+
+Update `src/content/docs/contributing.md` with a concise CI section covering:
+
+- draft-fast versus merge-ready proof;
+- the stable `required` check;
+- how affected routes fail open;
+- how to run the full suite locally;
+- when to synchronize `main`;
+- how to start a manual full run;
+- what qualifies for a targeted infrastructure retry;
+- how to inspect timing/selection summaries.
+
+Create `specs/github-ci-throughput/EVIDENCE.md` during implementation. It may
+contain public workflow URLs, aggregate durations, test counts, and synthetic
+route fixtures only. Do not record private repository settings, tokens,
+customer identifiers, or local absolute paths.
+
+### Full automated validation
+
+```bash
+bun run test scripts/ci/classify-changes.test.ts scripts/ci/workflow-policy.test.ts scripts/ci/test-inventory.test.ts scripts/ci/test-lanes.test.ts scripts/ci/test-timings.test.ts scripts/ci/actions-timings.test.ts scripts/ci/package-build-artifact.test.ts
+bun run test scripts/consumer-smoke.test.ts scripts/install-matrix.test.ts
+ATLCLI_CONSUMER_SMOKE=1 bun run test scripts/consumer-smoke.test.ts scripts/install-matrix.test.ts
+bun run test
+bun run typecheck
+bun run build
+bun run docs:check
+bun run docs:build
+bun run test:browser-export-harness
+bun run --cwd apps/extension test:worker-extension-browser
+bun run --cwd apps/extension test:jobs-extension-browser
+git diff --check
+```
+
+Expected: every command exits 0. Record exact pass/fail/skipped totals and
+environment-independent artifact names in `EVIDENCE.md`.
+
+### Required live/read-only E2E before implementation commits
+
+The CI implementation does not alter Atlassian product behavior, and GitHub CI
+must never receive live credentials. Repository policy still requires a
+pre-commit E2E. Use the retained synthetic/private DOCSY fixture through the
+local `mayflower` profile:
+
+```bash
+test -n "${ATLCLI_E2E_PAGE_ID:-}"
+ATLCLI_E2E=1 \
+ATLCLI_E2E_PROFILE=mayflower \
+bun run test apps/cli/src/commands/export-pdf.e2e.test.ts
+```
+
+The operator must export `ATLCLI_E2E_PAGE_ID` from the private local
+environment before running the block. Do not paste it into the command, spec,
+evidence, shell history artifact, commit, or PR. Prefer an existing retained
+fixture and a read-only export. If a task creates any page, attachment, or Jira
+issue, delete it and record cleanup before committing.
+
+If credentials or the retained fixture are unavailable, stop before claiming
+the repository's E2E requirement passed. Record the limitation and obtain an
+explicit operator decision; do not substitute mocked or neutral-browser proof.
+
+### Rollout evidence
+
+For each promoted phase record:
+
+- baseline and candidate workflow URLs;
+- exact SHA and event/proof mode;
+- selected gates and fail-open reason;
+- discovered/assigned test files;
+- per-lane setup/test/wall duration;
+- workflow critical path and runner-minutes;
+- retries and their exact classification;
+- p50/p95 window calculation;
+- correctness promotion-gate result;
+- decision to promote, hold, or roll back.
+
+## Rollback strategy
+
+| Symptom | Immediate action | Do not do |
+| --- | --- | --- |
+| Missing or duplicate test file | Restore full legacy topology and fail the planner check | Patch the count or ignore the file |
+| Selective route misses a relevant failure | Force that capability to full, add regression fixture, restart shadow window | Leave selective routing active while investigating |
+| Package artifact verification fails | Rebuild locally in the owning job or fail | Set a generic skip-build flag |
+| Consumer exact retry fails twice | Keep the gate red and diagnose Bun/package identity | Add more retries |
+| General lanes remain imbalanced | Refresh real timings and recompute | Add random shards |
+| System Chrome canary flakes | Keep it nonblocking or remove it | Replace MV3 bundled Chromium |
+| Runner queue time rises from job fan-out | Reduce general lane count and keep explicit heavy lanes | Buy larger runners without measurement |
+| Ready PR displays only draft proof | Disable merge until event/aggregate policy is fixed | Merge based on stale green status |
+| Merge-group SHA cannot be mapped | Keep strict manual synchronization | Turn strict protection off |
+
+Every workflow topology change must be independently revertible without
+reverting product code.
+
+## Done criteria
+
+All applicable boxes must be satisfied before this initiative is declared
+complete:
+
+- [ ] Timing summaries expose file coverage, slow files, setup/test duration,
+      critical path, and runner-minutes.
+- [ ] The known Bun file-link `EEXIST` retries exactly once and every other
+      error remains fail closed.
+- [ ] Package build output is produced once and consumed only after exact-SHA
+      manifest verification.
+- [ ] Every full-run Bun test file is assigned exactly once.
+- [ ] Three legacy-versus-weighted comparisons show no coverage difference.
+- [ ] General unit lane duration ratio is at most 1.5.
+- [ ] Poppler and font setup occur only in owning lanes.
+- [ ] Selective routing has at least 20 PRs or 14 days of zero-miss shadow
+      evidence.
+- [ ] Global, unknown, scheduled, manual, and main events run full.
+- [ ] Draft-fast and merge-ready modes are structurally and live proven.
+- [ ] The required branch-protection status remains exactly `required`.
+- [ ] Packed MV3 proof uses Playwright-matched Chromium.
+- [ ] System Chrome, if used, remains a separate compatibility signal until its
+      separately planned Playwright-upgrade/compatibility promotion is approved.
+- [ ] Merge-queue support is either proven after an approved organization move
+      or explicitly recorded as deferred.
+- [ ] Merge-ready p50 is at most 3 minutes 30 seconds and p95 at most 5 minutes
+      over the required sample windows, or the initiative remains open with
+      measured blockers.
+- [ ] Comparable product PR runner-minutes fall by at least 25%.
+- [ ] Full test, typecheck, build, docs, browser, consumer, and required local
+      E2E gates pass.
+- [ ] `EVIDENCE.md` contains only public/synthetic, privacy-safe evidence.
+- [ ] No release was performed.
+
+## STOP conditions
+
+Stop and report instead of improvising if:
+
+- the live workflow/test topology no longer matches the current-state map;
+- Bun's discovered test set cannot be reconciled exactly with the inventory;
+- a required test depends on execution order or state from a different lane;
+- GitHub treats an older same-SHA `required` success as mergeable after a
+  Draft-to-Ready transition before the fresh run is pending; do not promote
+  draft-fast in that state—retain full draft CI or require a new head SHA;
+- weighted selection changes product assertions or test semantics;
+- package output cannot be safely reused without weakening local self-contained
+  tests;
+- the consumer failure signature is broader or mixed with another real error;
+- a route cannot be derived confidently from package/capability ownership;
+- shadow mode finds any under-selection;
+- the stable `required` context would need to be renamed;
+- system Chrome would be required for packed MV3 extension loading;
+- Playwright or GitHub runner image drift makes the canary unreliable;
+- completion requires a remote cache token, larger-runner purchase, repository
+  transfer, branch-protection change, or other new external authority;
+- live E2E requires committing or logging private identifiers;
+- any task changes product output, public API, or release behavior.
+
+## Maintenance notes
+
+- Timing metadata will drift as tests are added or become heavier. Refresh it
+  from successful main/scheduled evidence, review the diff, and keep unknown
+  files conservatively weighted.
+- A package dependency change can expand reverse-dependent tests and gates.
+  Classifier tests must be updated in the same PR as new workspaces or
+  capabilities.
+- Workflow additions are global inputs and must default to full until
+  explicitly classified.
+- Do not equate green selective CI with permanent completeness. The full weekly
+  drift guard is the backstop that detects selector assumptions becoming stale.
+- GitHub runner images and system Chrome update independently of this
+  repository. Keep the version visible and the MV3 gate hermetic.
+- Revisit remote Turbo cache only after local build reuse and routing are
+  measured. If the remaining wall time is predominantly repeated uncached
+  builds, write a separate threat/cost/availability plan before adding a
+  service or secret.
+
+## Unresolved operator decisions
+
+1. **Repository ownership for merge queue** — recommended default: defer the
+   organization transfer; implement T0–T7 first and measure whether strict
+   manual serialization remains a material bottleneck.
+2. **System Chrome promotion** — recommended default: keep runner Chrome as a
+   scheduled, nonblocking compatibility canary. Any promotion needs a separate
+   Playwright upgrade plus ten distinct runner Image Version values; it is not
+   completed by this plan.
+3. **Remote Turbo cache** — recommended default: out of scope. Reassess only
+   after single-build reuse and weighted lanes have produced at least 20
+   merge-ready samples.
+4. **Performance threshold adjustment** — recommended default: keep the
+   proposed 3 minute 30 second p50 and 5 minute p95. Change them only from
+   measured runner availability, not to declare an underperforming rollout
+   complete.

--- a/src/content/docs/contributing.md
+++ b/src/content/docs/contributing.md
@@ -35,23 +35,53 @@ workspace imports resolve to live source instead of stale `dist/` output.
 
 ### CI cadence
 
-CI classifies the changed paths before starting expensive jobs. Product,
-consumer-package, and documentation gates run only when their surface is
-affected; an unknown path or global build file deliberately enables every
-gate. The always-present **required** job aggregates the selected results and
-is the check that branch protection should require.
+CI classifies changed paths before starting expensive jobs. Documentation-only
+changes can stay lightweight; product, workflow, dependency, and unknown
+changes deliberately fail open to the complete product proof. The
+always-present **required** job aggregates the selected results and is the
+single check that branch protection should require.
+
+The required test topology remains the legacy four-shard suite while three
+duration-aware candidates collect same-SHA comparison evidence:
+`general-2x1`, `general-3x1`, and `general-2x2-workers`. Worker count is fixed
+at one or two; CI never uses global `--concurrent`. Real Typst/PDF and
+package-contract tests are explicit serial lanes, and stateful isolation probes
+remain serial.
 
 | Cadence | Gates |
 |---------|-------|
-| Pull request | Affected product/platform gates, pinned consumer smoke, and documentation build |
+| Pull request | Selected product/platform gates, pinned consumer smoke, and documentation build |
 | Push to `main` | Affected product/platform gates, security attestation, and documentation deployment when relevant |
 | Daily | Blocking M1 cross-host acceptance, performance trend, and floating-Bun consumer canary |
-| Weekly | Full unfiltered CI matrix to detect routing drift |
+| Weekly | Full unfiltered CI matrix, one rotating topology comparison, and a non-required system-Chrome compatibility signal |
 | Release tag | Shared SHA-bound quality preflight and attestation before binary publication |
 
 Superseded pull-request runs and Pages deployments are cancelled. Product CI
 on `main`, nightly runs, and release evidence are never cancelled by a newer
 commit.
+
+Draft pull requests currently receive the same required product proof as Ready
+pull requests. The proposed `draft-fast` mode is not active until its
+live-state and affected-test promotion gates have passed. Before marking a PR
+Ready, finish draft commits and synchronize `main`; do not toggle Ready merely
+to restart CI.
+
+Run the complete local suite with:
+
+```bash
+bun run test
+```
+
+Start **CI topology comparison** manually in GitHub Actions to compare one
+duration-aware candidate with all four legacy shards on the same SHA. The
+workflow is non-required and cannot replace **required**. Timing JSON is
+available from the `ci-timing-<attempt>-<sha>` artifact and the run summary.
+The system Google Chrome job is also a compatibility canary only; required
+packed MV3 proof continues to use Playwright-matched Chromium.
+
+Use **Re-run failed jobs** only after a failure has been classified as
+infrastructure-related. Product failures and a second failure after the narrow
+Bun file-link retry require diagnosis.
 
 ### README media
 


### PR DESCRIPTION
## What changed

- adds always-on CI telemetry for test inventory, JUnit timings, critical-path data, queue time, and runner consumption
- adds deterministic duration-aware candidate test lanes plus a same-SHA topology canary, without changing the required topology yet
- keeps Playwright-matched Chromium for required MV3 coverage and adds a nonblocking system-Chrome compatibility canary
- adds `merge_group`-compatible full-suite classification while preserving the stable `required` check contract
- makes the known Bun 1.3.14 file-link `EEXIST` workaround exact and bounded to one retry
- removes an unnecessary dependency installation from security attestation and documents evidence gates, rollback, and ownership

## Why

PR throughput was constrained by file-count shard imbalance, duplicated setup/build work, limited timing evidence, and repeated full runs after `main` advanced. The new foundations let us measure and trial faster layouts safely before promoting them to required CI.

## Impact and rollout

- Required PR checks retain the current four-shard topology.
- Candidate layouts run only in the nonrequired scheduled/manual canary.
- Selective routing, artifact fanout, browser parallelism, and topology promotion remain blocked on the evidence gates in `specs/github-ci-throughput/PLAN.md`.
- Merge-queue event handling is code-ready, but no repository setting or ownership change is made by this PR.

## Validation

- focused CI and consumer tests: 58 passed, 7 skipped
- full suite: 5,938 passed, 15 skipped across 410 files
- typecheck: passed
- full build: passed
- docs check and docs build: passed, 78 pages built
- consumer smoke: 12 passed
- neutral browser harness: 6 passed
- packed MV3 worker: 2 passed
- packed MV3 durable jobs: 23 passed
- browser shape parity: passed
- lane inventory/balance checks and workflow-policy tests: passed
- `git diff --check`: passed

The Atlassian live E2E was not run because `ATLCLI_E2E_PAGE_ID` is unavailable in this environment. This is an explicit operator-approved exception and is not reported as a passed test.
