### PR TITLE
perf(ci): reduce draft and merge-ready latency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
     # newest run still points at an outdated moment in time. Every
     # `pull_request`-triggered workflow in this repo carries this same list;
     # scripts/ci/workflow-policy.test.ts enforces it.
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
   # Inactive until a repository merge queue is enabled. Keeping the trigger on
   # the default branch first prevents a future queue from waiting forever for
   # a required context that no workflow can create.
@@ -25,6 +25,7 @@ on:
 permissions:
   contents: read
   actions: read
+  pull-requests: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -38,8 +39,19 @@ jobs:
     outputs:
       code: ${{ steps.routes.outputs.code }}
       consumer: ${{ steps.routes.outputs.consumer }}
+      staticQuality: ${{ steps.routes.outputs.staticQuality }}
+      unitTests: ${{ steps.routes.outputs.unitTests }}
+      packageContracts: ${{ steps.routes.outputs.packageContracts }}
+      astroPublishing: ${{ steps.routes.outputs.astroPublishing }}
+      astroPlatform: ${{ steps.routes.outputs.astroPlatform }}
+      pdfPlatform: ${{ steps.routes.outputs.pdfPlatform }}
+      browserHarness: ${{ steps.routes.outputs.browserHarness }}
       docs: ${{ steps.routes.outputs.docs }}
       readmeMedia: ${{ steps.routes.outputs.readmeMedia }}
+      researchPrivacy: ${{ steps.routes.outputs.researchPrivacy }}
+      proofMode: ${{ steps.proof.outputs.mode }}
+      aggregateStatusName: ${{ steps.proof.outputs.aggregateStatusName }}
+      validatedHeadSha: ${{ steps.proof.outputs.validatedHeadSha }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -57,7 +69,7 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
           MERGE_GROUP_BASE_SHA: ${{ github.event.merge_group.base_sha }}
           MERGE_GROUP_HEAD_SHA: ${{ github.event.merge_group.head_sha }}
-          FULL_RUN: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'merge_group' }}
+          FULL_RUN: ${{ github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'merge_group' }}
         run: |
           if [[ "${{ github.event_name }}" == "merge_group" ]] && \
              { [[ -z "$MERGE_GROUP_BASE_SHA" ]] || [[ -z "$MERGE_GROUP_HEAD_SHA" ]]; }; then
@@ -82,9 +94,37 @@ jobs:
           git diff --name-only -z "$BASE_SHA" "$HEAD_SHA" | \
             bun scripts/ci/classify-changes.ts --null >> "$GITHUB_OUTPUT"
 
+      - name: Read current pull request state
+        id: current-pr
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const { data: pull } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+            core.setOutput("number", String(pull.number));
+            core.setOutput("headSha", pull.head.sha);
+            core.setOutput("draft", String(pull.draft));
+
+      - name: Select live-state-aware proof mode
+        id: proof
+        env:
+          CI_EVENT_NAME: ${{ github.event_name }}
+          CI_EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}
+          CI_EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
+          CI_EVENT_PR_DRAFT: ${{ github.event.pull_request.draft }}
+          CI_CURRENT_PR_NUMBER: ${{ steps.current-pr.outputs.number }}
+          CI_CURRENT_PR_HEAD_SHA: ${{ steps.current-pr.outputs.headSha }}
+          CI_CURRENT_PR_DRAFT: ${{ steps.current-pr.outputs.draft }}
+        run: bun scripts/ci/proof-mode.ts
+
   research-privacy:
     name: Tracked research privacy
     needs: changes
+    if: needs.changes.outputs.proofMode != 'superseded'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -101,7 +141,7 @@ jobs:
   docs:
     name: Documentation
     needs: changes
-    if: needs.changes.outputs.docs == 'true' && github.event_name != 'push'
+    if: needs.changes.outputs.docs == 'true' && github.event_name != 'push' && needs.changes.outputs.proofMode != 'superseded'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -129,7 +169,7 @@ jobs:
   readme-media:
     name: README media
     needs: changes
-    if: needs.changes.outputs.readmeMedia == 'true'
+    if: needs.changes.outputs.readmeMedia == 'true' && needs.changes.outputs.proofMode != 'superseded'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -143,25 +183,67 @@ jobs:
       - name: Validate README media
         run: bun run check:readme-media
 
+  draft-quality:
+    name: Draft type and CI policy feedback
+    needs: changes
+    if: needs.changes.outputs.proofMode == 'draft-fast' && (needs.changes.outputs.staticQuality == 'true' || needs.changes.outputs.unitTests == 'true')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Restore Bun package cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+
+      - name: Restore Turbo cache
+        uses: actions/cache/restore@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-quality-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-quality-
+            ${{ runner.os }}-turbo-
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Type check draft
+        run: bun run typecheck
+
+      - name: Check CI policy contracts
+        run: bun run test scripts/ci/classify-changes.test.ts scripts/ci/proof-mode.test.ts scripts/ci/workflow-policy.test.ts
+
   test:
     name: Product quality
     needs: changes
-    if: needs.changes.outputs.code == 'true'
+    if: needs.changes.outputs.proofMode == 'required' && (needs.changes.outputs.staticQuality == 'true' || needs.changes.outputs.unitTests == 'true' || needs.changes.outputs.astroPlatform == 'true')
     uses: ./.github/workflows/reusable-quality.yml
+    with:
+      run_static_quality: ${{ needs.changes.outputs.staticQuality == 'true' }}
+      run_tests: ${{ needs.changes.outputs.unitTests == 'true' }}
+      run_astro_platform: ${{ needs.changes.outputs.astroPlatform == 'true' }}
 
   consumer-smoke:
     name: Pinned consumer smoke
     needs: changes
-    if: needs.changes.outputs.consumer == 'true'
+    if: needs.changes.outputs.proofMode == 'required' && needs.changes.outputs.consumer == 'true'
     uses: ./.github/workflows/reusable-consumer-smoke.yml
     with:
       leg: pinned
 
-  # Platform gates stay complete for every product change. Path-level pruning
-  # can be added later only after the dependency closures are machine-derived.
+  # Platform gates follow conservative, tested dependency closures. Global,
+  # workflow, lockfile, and unknown paths still fail open to every gate.
   pdf-cli-macos:
     needs: changes
-    if: needs.changes.outputs.code == 'true'
+    if: needs.changes.outputs.proofMode == 'required' && needs.changes.outputs.pdfPlatform == 'true'
     runs-on: macos-latest
     timeout-minutes: 10
     steps:
@@ -171,6 +253,12 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.14
+
+      - name: Restore pinned PDF fonts
+        uses: actions/cache@v4
+        with:
+          path: packages/pdf/.fonts
+          key: ${{ runner.os }}-pdf-fonts-v1-${{ hashFiles('packages/pdf/src/runtime-assets.ts', 'packages/pdf/scripts/ensure-fonts.ts') }}
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -186,7 +274,7 @@ jobs:
 
   pdf-sink-windows:
     needs: changes
-    if: needs.changes.outputs.code == 'true'
+    if: needs.changes.outputs.proofMode == 'required' && needs.changes.outputs.pdfPlatform == 'true'
     runs-on: windows-latest
     timeout-minutes: 15
     steps:
@@ -211,7 +299,7 @@ jobs:
 
   browser-export-harness:
     needs: changes
-    if: needs.changes.outputs.code == 'true'
+    if: needs.changes.outputs.proofMode == 'required' && needs.changes.outputs.browserHarness == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -227,6 +315,12 @@ jobs:
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+
+      - name: Restore pinned PDF fonts
+        uses: actions/cache@v4
+        with:
+          path: packages/pdf/.fonts
+          key: ${{ runner.os }}-pdf-fonts-v1-${{ hashFiles('packages/pdf/src/runtime-assets.ts', 'packages/pdf/scripts/ensure-fonts.ts') }}
 
       - name: Restore Turbo cache
         uses: actions/cache@v4
@@ -287,7 +381,7 @@ jobs:
   browser-system-chrome-canary:
     name: Non-required system Chrome compatibility
     needs: changes
-    if: needs.changes.outputs.code == 'true' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+    if: needs.changes.outputs.proofMode == 'required' && needs.changes.outputs.browserHarness == 'true' && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
     continue-on-error: true
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -304,6 +398,12 @@ jobs:
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+
+      - name: Restore pinned PDF fonts
+        uses: actions/cache@v4
+        with:
+          path: packages/pdf/.fonts
+          key: ${{ runner.os }}-pdf-fonts-v1-${{ hashFiles('packages/pdf/src/runtime-assets.ts', 'packages/pdf/scripts/ensure-fonts.ts') }}
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -340,12 +440,14 @@ jobs:
         run: bun run test:browser-export-harness
 
   required:
-    name: required
+    name: ${{ needs.changes.outputs.aggregateStatusName }}
     if: always()
     needs:
       - changes
+      - research-privacy
       - docs
       - readme-media
+      - draft-quality
       - test
       - consumer-smoke
       - pdf-cli-macos
@@ -353,17 +455,46 @@ jobs:
       - browser-export-harness
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
+      - name: Revalidate current merge-ready pull request
+        if: github.event_name == 'pull_request' && needs.changes.outputs.proofMode == 'required'
+        uses: actions/github-script@v8
+        env:
+          EXPECTED_HEAD_SHA: ${{ needs.changes.outputs.validatedHeadSha }}
+        with:
+          script: |
+            const { data: pull } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+            if (pull.draft) {
+              core.setFailed("Pull request returned to Draft before required proof completed");
+            }
+            if (pull.head.sha !== process.env.EXPECTED_HEAD_SHA) {
+              core.setFailed(`Pull request head changed from ${process.env.EXPECTED_HEAD_SHA} to ${pull.head.sha}`);
+            }
+
       - name: Require every selected gate to pass
         env:
           CHANGES: ${{ needs.changes.result }}
-          CODE_REQUIRED: ${{ needs.changes.outputs.code }}
+          PROOF_MODE: ${{ needs.changes.outputs.proofMode }}
+          STATIC_REQUIRED: ${{ needs.changes.outputs.staticQuality }}
+          UNIT_REQUIRED: ${{ needs.changes.outputs.unitTests }}
+          ASTRO_REQUIRED: ${{ needs.changes.outputs.astroPlatform }}
           CONSUMER_REQUIRED: ${{ needs.changes.outputs.consumer }}
+          PDF_REQUIRED: ${{ needs.changes.outputs.pdfPlatform }}
+          BROWSER_REQUIRED: ${{ needs.changes.outputs.browserHarness }}
           DOCS_REQUIRED: ${{ needs.changes.outputs.docs }}
           README_MEDIA_REQUIRED: ${{ needs.changes.outputs.readmeMedia }}
           EVENT_NAME: ${{ github.event_name }}
+          PRIVACY: ${{ needs.research-privacy.result }}
           DOCS: ${{ needs.docs.result }}
           README_MEDIA: ${{ needs.readme-media.result }}
+          DRAFT_QUALITY: ${{ needs.draft-quality.result }}
           TEST: ${{ needs.test.result }}
           CONSUMER: ${{ needs.consumer-smoke.result }}
           MACOS: ${{ needs.pdf-cli-macos.result }}
@@ -389,6 +520,18 @@ jobs:
             exit 1
           fi
 
+          if [[ "$PROOF_MODE" == "superseded" ]]; then
+            for result in "$PRIVACY" "$DOCS" "$README_MEDIA" "$DRAFT_QUALITY" "$TEST" "$CONSUMER" "$MACOS" "$WINDOWS" "$BROWSER"; do
+              if [[ "$result" != "skipped" ]]; then
+                echo "::error::Superseded proof unexpectedly executed a product gate with result=$result"
+                exit 1
+              fi
+            done
+            exit 0
+          fi
+
+          require_result "Tracked research privacy" "true" "$PRIVACY"
+
           DOCS_SELECTED="$DOCS_REQUIRED"
           if [[ "$EVENT_NAME" == "push" ]]; then
             # docs.yml owns main-push deployment; CI's docs job intentionally
@@ -398,11 +541,32 @@ jobs:
 
           require_result "Documentation" "$DOCS_SELECTED" "$DOCS"
           require_result "README media" "$README_MEDIA_REQUIRED" "$README_MEDIA"
-          require_result "Product quality" "$CODE_REQUIRED" "$TEST"
+
+          QUALITY_REQUIRED="false"
+          if [[ "$STATIC_REQUIRED" == "true" || "$UNIT_REQUIRED" == "true" || "$ASTRO_REQUIRED" == "true" ]]; then
+            QUALITY_REQUIRED="true"
+          fi
+
+          if [[ "$PROOF_MODE" == "draft-fast" ]]; then
+            DRAFT_REQUIRED="false"
+            if [[ "$STATIC_REQUIRED" == "true" || "$UNIT_REQUIRED" == "true" ]]; then
+              DRAFT_REQUIRED="true"
+            fi
+            require_result "Draft quality" "$DRAFT_REQUIRED" "$DRAFT_QUALITY"
+            require_result "Product quality" "false" "$TEST"
+            require_result "Pinned consumer smoke" "false" "$CONSUMER"
+            require_result "macOS PDF" "false" "$MACOS"
+            require_result "Windows PDF sink" "false" "$WINDOWS"
+            require_result "Browser export harness" "false" "$BROWSER"
+            exit 0
+          fi
+
+          require_result "Draft quality" "false" "$DRAFT_QUALITY"
+          require_result "Product quality" "$QUALITY_REQUIRED" "$TEST"
           require_result "Pinned consumer smoke" "$CONSUMER_REQUIRED" "$CONSUMER"
-          require_result "macOS PDF" "$CODE_REQUIRED" "$MACOS"
-          require_result "Windows PDF sink" "$CODE_REQUIRED" "$WINDOWS"
-          require_result "Browser export harness" "$CODE_REQUIRED" "$BROWSER"
+          require_result "macOS PDF" "$PDF_REQUIRED" "$MACOS"
+          require_result "Windows PDF sink" "$PDF_REQUIRED" "$WINDOWS"
+          require_result "Browser export harness" "$BROWSER_REQUIRED" "$BROWSER"
 
   # Measurement is deliberately downstream from, and non-blocking for, the
   # stable required check. A telemetry failure stays visible without delaying
@@ -428,7 +592,7 @@ jobs:
         run: mkdir -p test-results
 
       - name: Download same-run JUnit artifacts
-        if: needs.changes.outputs.code == 'true'
+        if: needs.changes.outputs.proofMode == 'required' && needs.changes.outputs.unitTests == 'true'
         uses: actions/download-artifact@v5
         with:
           pattern: bun-test-shard-*-${{ github.sha }}
@@ -455,11 +619,20 @@ jobs:
 
       - name: Summarize timing evidence
         env:
-          CI_TEST_TOPOLOGY: legacy-4-shard
+          CI_TEST_TOPOLOGY: ${{ needs.changes.outputs.proofMode == 'required' && needs.changes.outputs.unitTests == 'true' && 'legacy-4-shard' || 'not-run' }}
+          CI_PROOF_MODE: ${{ needs.changes.outputs.proofMode }}
           CI_ROUTE_CODE: ${{ needs.changes.outputs.code }}
           CI_ROUTE_CONSUMER: ${{ needs.changes.outputs.consumer }}
+          CI_ROUTE_STATIC_QUALITY: ${{ needs.changes.outputs.staticQuality }}
+          CI_ROUTE_UNIT_TESTS: ${{ needs.changes.outputs.unitTests }}
+          CI_ROUTE_PACKAGE_CONTRACTS: ${{ needs.changes.outputs.packageContracts }}
+          CI_ROUTE_ASTRO_PUBLISHING: ${{ needs.changes.outputs.astroPublishing }}
+          CI_ROUTE_ASTRO_PLATFORM: ${{ needs.changes.outputs.astroPlatform }}
+          CI_ROUTE_PDF_PLATFORM: ${{ needs.changes.outputs.pdfPlatform }}
+          CI_ROUTE_BROWSER_HARNESS: ${{ needs.changes.outputs.browserHarness }}
           CI_ROUTE_DOCS: ${{ needs.changes.outputs.docs }}
           CI_ROUTE_README_MEDIA: ${{ needs.changes.outputs.readmeMedia }}
+          CI_ROUTE_RESEARCH_PRIVACY: ${{ needs.changes.outputs.researchPrivacy }}
         run: |
           bun scripts/ci/telemetry-summary.ts \
             --junit test-results \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       aggregateStatusName: ${{ steps.proof.outputs.aggregateStatusName }}
       validatedHeadSha: ${{ steps.proof.outputs.validatedHeadSha }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -97,7 +97,7 @@ jobs:
       - name: Read current pull request state
         id: current-pr
         if: github.event_name == 'pull_request'
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const { data: pull } = await github.rest.pulls.get({
@@ -128,7 +128,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -145,10 +145,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: "22.12.0"
 
@@ -173,7 +173,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -190,7 +190,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -198,13 +198,13 @@ jobs:
           bun-version: 1.3.14
 
       - name: Restore Bun package cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
 
       - name: Restore Turbo cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v6
         with:
           path: .turbo
           key: ${{ runner.os }}-turbo-quality-${{ github.sha }}
@@ -247,7 +247,7 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -255,7 +255,7 @@ jobs:
           bun-version: 1.3.14
 
       - name: Restore pinned PDF fonts
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: packages/pdf/.fonts
           key: ${{ runner.os }}-pdf-fonts-v1-${{ hashFiles('packages/pdf/src/runtime-assets.ts', 'packages/pdf/scripts/ensure-fonts.ts') }}
@@ -278,18 +278,12 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.14
-
-      - name: Restore Bun package cache
-        uses: actions/cache@v4
-        with:
-          path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -303,7 +297,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -311,19 +305,19 @@ jobs:
           bun-version: 1.3.14
 
       - name: Restore Bun package cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
 
       - name: Restore pinned PDF fonts
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: packages/pdf/.fonts
           key: ${{ runner.os }}-pdf-fonts-v1-${{ hashFiles('packages/pdf/src/runtime-assets.ts', 'packages/pdf/scripts/ensure-fonts.ts') }}
 
       - name: Restore Turbo cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: .turbo
           key: ${{ runner.os }}-turbo-browser-${{ github.sha }}
@@ -332,7 +326,7 @@ jobs:
             ${{ runner.os }}-turbo-
 
       - name: Restore Playwright Chromium
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-chromium-1.55.0
@@ -386,7 +380,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -394,13 +388,13 @@ jobs:
           bun-version: 1.3.14
 
       - name: Restore Bun package cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
 
       - name: Restore pinned PDF fonts
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: packages/pdf/.fonts
           key: ${{ runner.os }}-pdf-fonts-v1-${{ hashFiles('packages/pdf/src/runtime-assets.ts', 'packages/pdf/scripts/ensure-fonts.ts') }}
@@ -461,7 +455,7 @@ jobs:
     steps:
       - name: Revalidate current merge-ready pull request
         if: github.event_name == 'pull_request' && needs.changes.outputs.proofMode == 'required'
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         env:
           EXPECTED_HEAD_SHA: ${{ needs.changes.outputs.validatedHeadSha }}
         with:
@@ -581,7 +575,7 @@ jobs:
       actions: read
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -593,13 +587,13 @@ jobs:
 
       - name: Download same-run JUnit artifacts
         if: needs.changes.outputs.proofMode == 'required' && needs.changes.outputs.unitTests == 'true'
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           pattern: bun-test-shard-*-${{ github.sha }}
           path: test-results
 
       - name: Read same-attempt Actions jobs
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const jobs = await github.paginate(
@@ -641,7 +635,7 @@ jobs:
 
       - name: Upload timing evidence
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ci-timing-${{ github.run_attempt }}-${{ github.sha }}
           path: ci-timing.json

--- a/.github/workflows/reusable-quality.yml
+++ b/.github/workflows/reusable-quality.yml
@@ -3,6 +3,21 @@ name: Reusable product quality
 on:
   workflow_call:
     inputs:
+      run_static_quality:
+        description: Run repository typecheck and build contracts
+        required: false
+        default: true
+        type: boolean
+      run_tests:
+        description: Run the complete required Bun test inventory
+        required: false
+        default: true
+        type: boolean
+      run_astro_platform:
+        description: Run pinned Astro platform compatibility contracts
+        required: false
+        default: true
+        type: boolean
       emit_security_attestation:
         description: Emit and upload a security attestation for this exact SHA
         required: false
@@ -15,6 +30,7 @@ permissions:
 jobs:
   static-quality:
     name: Linux typecheck, browser checks, and build
+    if: inputs.run_static_quality
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -30,6 +46,12 @@ jobs:
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+
+      - name: Restore pinned PDF fonts
+        uses: actions/cache@v4
+        with:
+          path: packages/pdf/.fonts
+          key: ${{ runner.os }}-pdf-fonts-v1-${{ hashFiles('packages/pdf/src/runtime-assets.ts', 'packages/pdf/scripts/ensure-fonts.ts') }}
 
       - name: Cache Turbo
         uses: actions/cache@v4
@@ -63,6 +85,7 @@ jobs:
 
   tests:
     name: Linux Bun tests (${{ matrix.shard }}/4)
+    if: inputs.run_tests
     runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:
@@ -82,6 +105,12 @@ jobs:
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+
+      - name: Restore pinned PDF fonts
+        uses: actions/cache@v4
+        with:
+          path: packages/pdf/.fonts
+          key: ${{ runner.os }}-pdf-fonts-v1-${{ hashFiles('packages/pdf/src/runtime-assets.ts', 'packages/pdf/scripts/ensure-fonts.ts') }}
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -150,49 +179,9 @@ jobs:
           path: test-results/bun-test-shard-${{ matrix.shard }}.log
           if-no-files-found: error
 
-  publishing:
-    name: Astro publishing package and consumer gates
-    needs: static-quality
-    runs-on: ubuntu-latest
-    timeout-minutes: 45
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Setup Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: "22.12.0"
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.3.14
-
-      - name: Restore Bun package cache
-        uses: actions/cache@v4
-        with:
-          path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-
-      - name: Run publishing package, pack, and consumer gates
-        env:
-          ATLCLI_CONSUMER_SMOKE: "1"
-        run: >-
-          bun --conditions=development test
-          packages/export-blocks-astro/src/packed-consumer.test.ts
-          packages/web-publish-astro/src/astro-consumer.test.ts
-          packages/web-publish-starlight/src/starlight-renderer.test.ts
-          scripts/pack-check.test.ts
-          scripts/publishable-deps.test.ts
-          scripts/dist-hygiene.test.ts
-          scripts/consumer-smoke.test.ts
-
   publishing-platform:
     name: Astro platform (${{ matrix.lane }}, ${{ matrix.os }}, Node ${{ matrix.node }})
-    needs: publishing
+    if: inputs.run_astro_platform
     runs-on: ${{ matrix.os }}
     timeout-minutes: 45
     strategy:
@@ -203,10 +192,6 @@ jobs:
             os: ubuntu-latest
             node: "22.12.0"
             astro: "7.1.6"
-          - lane: latest-astro-7
-            os: ubuntu-latest
-            node: "24"
-            astro: "latest-7"
           - lane: windows-astro
             os: windows-latest
             node: "24"
@@ -233,27 +218,6 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Resolve latest supported Astro 7.x
-        if: matrix.astro == 'latest-7'
-        shell: bash
-        run: |
-          node <<'NODE'
-          const fs = require('node:fs');
-          const paths = [
-            'packages/web-publish-astro/fixtures/astro-consumer/package.json',
-            'packages/web-publish-starlight/fixtures/published-consumer/package.json',
-          ];
-          for (const file of paths) {
-            const packageJson = JSON.parse(fs.readFileSync(file, 'utf8'));
-            packageJson.dependencies.astro = '^7.1.6';
-            fs.writeFileSync(file, `${JSON.stringify(packageJson, null, 2)}\n`);
-          }
-          NODE
-          # Resolve from the repository workspace so local workspace:* packages
-          # remain resolvable; running `bun add --cwd <fixture>` treats the
-          # fixture as an isolated workspace and fails before Astro is tested.
-          bun install --no-progress
-
       - name: Verify Astro version lane
         shell: bash
         env:
@@ -272,9 +236,7 @@ jobs:
           });
           if (new Set(versions).size !== 1) throw new Error(`Astro fixture versions diverged: ${versions.join(', ')}`);
           const actual = versions[0];
-          if (process.env.EXPECTED_ASTRO === 'latest-7') {
-            if (!/^7\./.test(actual)) throw new Error(`latest Astro 7.x lane resolved ${actual}`);
-          } else if (actual !== process.env.EXPECTED_ASTRO) {
+          if (actual !== process.env.EXPECTED_ASTRO) {
             throw new Error(`expected Astro ${process.env.EXPECTED_ASTRO}, got ${actual}`);
           }
           console.log(`Astro ${actual} verified for ${process.env.EXPECTED_ASTRO} lane`);
@@ -289,9 +251,84 @@ jobs:
           packages/web-publish-astro/src/astro-consumer.test.ts
           packages/web-publish-starlight/src/starlight-renderer.test.ts
 
+  # A floating dependency lane is useful drift evidence, not per-commit proof.
+  # Keep it off pull requests and ordinary main pushes so it cannot lengthen
+  # merge-ready feedback or make a merge depend on registry drift.
+  publishing-platform-latest:
+    name: Astro platform canary (latest Astro 7, Node 24)
+    if: inputs.run_astro_platform && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.ref_type == 'tag')
+    continue-on-error: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Restore Bun package cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Resolve latest supported Astro 7.x
+        shell: bash
+        run: |
+          node <<'NODE'
+          const fs = require('node:fs');
+          const paths = [
+            'packages/web-publish-astro/fixtures/astro-consumer/package.json',
+            'packages/web-publish-starlight/fixtures/published-consumer/package.json',
+          ];
+          for (const file of paths) {
+            const packageJson = JSON.parse(fs.readFileSync(file, 'utf8'));
+            packageJson.dependencies.astro = '^7.1.6';
+            fs.writeFileSync(file, `${JSON.stringify(packageJson, null, 2)}\n`);
+          }
+          NODE
+          bun install --no-progress
+
+      - name: Verify Astro 7.x resolution
+        shell: bash
+        run: |
+          node <<'NODE'
+          const fs = require('node:fs');
+          const path = require('node:path');
+          const fixtures = [
+            'packages/web-publish-astro/fixtures/astro-consumer',
+            'packages/web-publish-starlight/fixtures/published-consumer',
+          ];
+          const versions = fixtures.map((fixture) => {
+            const packagePath = require.resolve('astro/package.json', { paths: [path.resolve(fixture)] });
+            return JSON.parse(fs.readFileSync(packagePath, 'utf8')).version;
+          });
+          if (new Set(versions).size !== 1) throw new Error(`Astro fixture versions diverged: ${versions.join(', ')}`);
+          if (!/^7\./.test(versions[0])) throw new Error(`latest Astro 7.x lane resolved ${versions[0]}`);
+          console.log(`Astro ${versions[0]} verified for latest Astro 7.x lane`);
+          NODE
+
+      - name: Run packed Astro and Starlight consumers
+        env:
+          ATLCLI_CONSUMER_SMOKE: "1"
+        run: >-
+          bun --conditions=development test
+          packages/export-blocks-astro/src/packed-consumer.test.ts
+          packages/web-publish-astro/src/astro-consumer.test.ts
+          packages/web-publish-starlight/src/starlight-renderer.test.ts
+
   security-attestation:
     name: Exact-SHA security attestation
-    needs: [static-quality, tests, publishing]
     if: inputs.emit_security_attestation
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -312,6 +349,7 @@ jobs:
 
       - name: Verify security attestation SHA
         run: |
+          # shellcheck disable=SC2016
           bun -e '
             const attestation = await Bun.file("security-attestation.json").json();
             if (attestation.commit !== process.env.GITHUB_SHA) {
@@ -327,44 +365,3 @@ jobs:
           name: security-attestation-${{ github.sha }}
           path: security-attestation.json
           if-no-files-found: error
-
-  quality-complete:
-    name: Linux quality complete
-    if: always()
-    needs: [static-quality, tests, publishing, publishing-platform, security-attestation]
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - name: Require every quality gate to pass
-        env:
-          STATIC_QUALITY: ${{ needs.static-quality.result }}
-          TESTS: ${{ needs.tests.result }}
-          PUBLISHING: ${{ needs.publishing.result }}
-          PUBLISHING_PLATFORM: ${{ needs.publishing-platform.result }}
-          ATTESTATION: ${{ needs.security-attestation.result }}
-          ATTESTATION_REQUIRED: ${{ inputs.emit_security_attestation }}
-        run: |
-          if [[ "$STATIC_QUALITY" != "success" ]]; then
-            echo "::error::Static quality finished with result: $STATIC_QUALITY"
-            exit 1
-          fi
-          if [[ "$TESTS" != "success" ]]; then
-            echo "::error::One or more Bun test shards finished with result: $TESTS"
-            exit 1
-          fi
-          if [[ "$PUBLISHING" != "success" ]]; then
-            echo "::error::Astro publishing package/consumer gates finished with result: $PUBLISHING"
-            exit 1
-          fi
-          if [[ "$PUBLISHING_PLATFORM" != "success" ]]; then
-            echo "::error::Astro platform matrix finished with result: $PUBLISHING_PLATFORM"
-            exit 1
-          fi
-          if [[ "$ATTESTATION_REQUIRED" == "true" && "$ATTESTATION" != "success" ]]; then
-            echo "::error::The required exact-SHA attestation finished with result: $ATTESTATION"
-            exit 1
-          fi
-          if [[ "$ATTESTATION_REQUIRED" != "true" && "$ATTESTATION" != "skipped" ]]; then
-            echo "::error::The unselected attestation finished with unexpected result: $ATTESTATION"
-            exit 1
-          fi

--- a/.github/workflows/reusable-quality.yml
+++ b/.github/workflows/reusable-quality.yml
@@ -192,10 +192,6 @@ jobs:
             os: ubuntu-latest
             node: "22.12.0"
             astro: "7.1.6"
-          - lane: windows-astro
-            os: windows-latest
-            node: "24"
-            astro: "7.1.6"
     steps:
       - uses: actions/checkout@v7
 
@@ -210,7 +206,6 @@ jobs:
           bun-version: 1.3.14
 
       - name: Restore Bun package cache
-        if: runner.os != 'Windows'
         uses: actions/cache@v6
         with:
           path: ~/.bun/install/cache
@@ -241,6 +236,64 @@ jobs:
             throw new Error(`expected Astro ${process.env.EXPECTED_ASTRO}, got ${actual}`);
           }
           console.log(`Astro ${actual} verified for ${process.env.EXPECTED_ASTRO} lane`);
+          NODE
+
+      - name: Run packed Astro and Starlight consumers
+        env:
+          ATLCLI_CONSUMER_SMOKE: "1"
+        run: >-
+          bun --conditions=development test
+          packages/export-blocks-astro/src/packed-consumer.test.ts
+          packages/web-publish-astro/src/astro-consumer.test.ts
+          packages/web-publish-starlight/src/starlight-renderer.test.ts
+
+  # Windows remains a supported local `wiki publish build` host, but its
+  # compatibility proof does not need to extend every merge-ready PR. Run it
+  # as drift evidence and keep it blocking for release tags.
+  publishing-platform-windows:
+    name: Astro Windows compatibility canary (Astro 7.1.6, Node 24)
+    if: inputs.run_astro_platform && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.ref_type == 'tag')
+    continue-on-error: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+    runs-on: windows-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: "24"
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Verify pinned Astro version
+        shell: bash
+        env:
+          EXPECTED_ASTRO: "7.1.6"
+        run: |
+          node <<'NODE'
+          const fs = require('node:fs');
+          const path = require('node:path');
+          const paths = [
+            'packages/web-publish-astro/fixtures/astro-consumer',
+            'packages/web-publish-starlight/fixtures/published-consumer',
+          ];
+          const versions = paths.map((fixture) => {
+            const packagePath = require.resolve('astro/package.json', { paths: [path.resolve(fixture)] });
+            return JSON.parse(fs.readFileSync(packagePath, 'utf8')).version;
+          });
+          if (new Set(versions).size !== 1) throw new Error(`Astro fixture versions diverged: ${versions.join(', ')}`);
+          const actual = versions[0];
+          if (actual !== process.env.EXPECTED_ASTRO) {
+            throw new Error(`expected Astro ${process.env.EXPECTED_ASTRO}, got ${actual}`);
+          }
+          console.log(`Astro ${actual} verified for Windows compatibility`);
           NODE
 
       - name: Run packed Astro and Starlight consumers

--- a/.github/workflows/reusable-quality.yml
+++ b/.github/workflows/reusable-quality.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -42,19 +42,19 @@ jobs:
           bun-version: 1.3.14
 
       - name: Restore Bun package cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
 
       - name: Restore pinned PDF fonts
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: packages/pdf/.fonts
           key: ${{ runner.os }}-pdf-fonts-v1-${{ hashFiles('packages/pdf/src/runtime-assets.ts', 'packages/pdf/scripts/ensure-fonts.ts') }}
 
       - name: Cache Turbo
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: .turbo
           key: ${{ runner.os }}-turbo-quality-${{ github.sha }}
@@ -93,7 +93,7 @@ jobs:
       matrix:
         shard: [1, 2, 3, 4]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -101,13 +101,13 @@ jobs:
           bun-version: 1.3.14
 
       - name: Restore Bun package cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
 
       - name: Restore pinned PDF fonts
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: packages/pdf/.fonts
           key: ${{ runner.os }}-pdf-fonts-v1-${{ hashFiles('packages/pdf/src/runtime-assets.ts', 'packages/pdf/scripts/ensure-fonts.ts') }}
@@ -165,7 +165,7 @@ jobs:
 
       - name: Upload test shard JUnit
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: bun-test-shard-${{ matrix.shard }}-${{ github.sha }}
           path: test-results/bun-test-shard-${{ matrix.shard }}.xml
@@ -173,7 +173,7 @@ jobs:
 
       - name: Upload failed test shard log
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: bun-test-shard-${{ matrix.shard }}-failure-log-${{ github.sha }}
           path: test-results/bun-test-shard-${{ matrix.shard }}.log
@@ -197,10 +197,10 @@ jobs:
             node: "24"
             astro: "7.1.6"
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node }}
 
@@ -210,7 +210,7 @@ jobs:
           bun-version: 1.3.14
 
       - name: Restore Bun package cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
@@ -261,10 +261,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: "24"
 
@@ -274,7 +274,7 @@ jobs:
           bun-version: 1.3.14
 
       - name: Restore Bun package cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
@@ -333,7 +333,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           # attest.ts compares HEAD with its parent. Keep the exact release SHA
           # plus one parent so the delta cannot silently become indeterminate.
@@ -360,7 +360,7 @@ jobs:
 
       - name: Upload security attestation
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: security-attestation-${{ github.sha }}
           path: security-attestation.json

--- a/.github/workflows/reusable-quality.yml
+++ b/.github/workflows/reusable-quality.yml
@@ -210,6 +210,7 @@ jobs:
           bun-version: 1.3.14
 
       - name: Restore Bun package cache
+        if: runner.os != 'Windows'
         uses: actions/cache@v6
         with:
           path: ~/.bun/install/cache

--- a/scripts/ci/classify-changes.test.ts
+++ b/scripts/ci/classify-changes.test.ts
@@ -1,101 +1,202 @@
 import { describe, expect, it } from "bun:test";
-import { classifyChanges } from "./classify-changes.js";
+import { classifyChanges, type CiRoutes } from "./classify-changes.js";
+
+const narrow = (overrides: Partial<CiRoutes> = {}): CiRoutes => ({
+  code: false,
+  consumer: false,
+  staticQuality: false,
+  unitTests: false,
+  packageContracts: false,
+  astroPublishing: false,
+  astroPlatform: false,
+  pdfPlatform: false,
+  browserHarness: false,
+  docs: false,
+  readmeMedia: false,
+  researchPrivacy: true,
+  ...overrides,
+});
+
+const all: CiRoutes = Object.fromEntries(
+  Object.keys(narrow()).map((name) => [name, true]),
+) as unknown as CiRoutes;
 
 describe("classifyChanges", () => {
-  it("routes published documentation without product gates", () => {
-    expect(classifyChanges(["src/content/docs/contributing.md"])).toEqual({
-      code: false,
-      consumer: false,
-      docs: true,
-      readmeMedia: false,
-    });
-  });
+  const cases: Array<{ name: string; paths: string[]; expected: CiRoutes }> = [
+    {
+      name: "published documentation",
+      paths: ["src/content/docs/contributing.md"],
+      expected: narrow({ docs: true }),
+    },
+    {
+      name: "plans plus root README",
+      paths: ["specs/export-expansion/012-ci/PLAN.md", "README.md"],
+      expected: narrow({ readmeMedia: true }),
+    },
+    {
+      name: "CLI-only research code",
+      paths: ["apps/cli/src/commands/research.ts"],
+      expected: narrow({ code: true, staticQuality: true, unitTests: true }),
+    },
+    {
+      name: "CLI PDF adapter",
+      paths: ["apps/cli/src/commands/export-pdf.ts"],
+      expected: narrow({
+        code: true,
+        staticQuality: true,
+        unitTests: true,
+        pdfPlatform: true,
+      }),
+    },
+    {
+      name: "Node export adapter",
+      paths: ["packages/export-node/src/index.ts"],
+      expected: narrow({
+        code: true,
+        consumer: true,
+        staticQuality: true,
+        unitTests: true,
+        packageContracts: true,
+        pdfPlatform: true,
+      }),
+    },
+    {
+      name: "extension surface",
+      paths: ["apps/extension/components/app/AppShell.tsx"],
+      expected: narrow({
+        code: true,
+        staticQuality: true,
+        unitTests: true,
+        browserHarness: true,
+      }),
+    },
+    {
+      name: "research package",
+      paths: ["packages/research/src/index.ts"],
+      expected: narrow({
+        code: true,
+        consumer: true,
+        staticQuality: true,
+        unitTests: true,
+        packageContracts: true,
+        browserHarness: true,
+      }),
+    },
+    {
+      name: "PDF package documentation",
+      paths: ["packages/docx/README.md"],
+      expected: narrow({
+        code: true,
+        consumer: true,
+        staticQuality: true,
+        unitTests: true,
+        packageContracts: true,
+        pdfPlatform: true,
+        browserHarness: true,
+      }),
+    },
+    {
+      name: "Astro publishing package",
+      paths: ["packages/web-publish-astro/src/index.ts"],
+      expected: narrow({
+        code: true,
+        consumer: true,
+        staticQuality: true,
+        unitTests: true,
+        packageContracts: true,
+        astroPublishing: true,
+        astroPlatform: true,
+      }),
+    },
+    {
+      name: "shared Confluence renderer",
+      paths: ["packages/confluence/src/export-blocks.ts"],
+      expected: narrow({
+        code: true,
+        consumer: true,
+        staticQuality: true,
+        unitTests: true,
+        packageContracts: true,
+        astroPublishing: true,
+        astroPlatform: true,
+        pdfPlatform: true,
+        browserHarness: true,
+      }),
+    },
+    {
+      name: "mixed docs and CLI",
+      paths: ["src/content/docs/index.md", "apps/cli/src/index.ts"],
+      expected: narrow({ code: true, staticQuality: true, unitTests: true, docs: true }),
+    },
+    {
+      name: "README media",
+      paths: ["README.md", "assets/readme/example.png", "assets/readme/reference.pdf"],
+      expected: narrow({ readmeMedia: true }),
+    },
+    {
+      name: "browser build script",
+      paths: ["scripts/check-browser-build.ts"],
+      expected: narrow({
+        code: true,
+        consumer: true,
+        staticQuality: true,
+        unitTests: true,
+        packageContracts: true,
+        browserHarness: true,
+      }),
+    },
+  ];
 
-  it("keeps plans and root prose out of product and site builds", () => {
-    expect(classifyChanges(["specs/export-expansion/012-ci/PLAN.md", "README.md"])).toEqual({
-      code: false,
-      consumer: false,
-      docs: false,
-      readmeMedia: true,
+  for (const { name, paths, expected } of cases) {
+    it(`routes ${name}`, () => {
+      expect(classifyChanges(paths)).toEqual(expected);
     });
-  });
+  }
 
-  it("routes package documentation through product and consumer gates", () => {
-    expect(classifyChanges(["packages/docx/README.md"])).toEqual({
-      code: true,
-      consumer: true,
-      docs: false,
-      readmeMedia: false,
-    });
-  });
-
-  it("routes root dependency changes through every dependent gate", () => {
-    expect(classifyChanges(["bun.lock"])).toEqual({
-      code: true,
-      consumer: true,
-      docs: true,
-      readmeMedia: false,
-    });
-  });
-
-  it("fails open for workflow and unknown top-level paths", () => {
-    expect(classifyChanges([".github/workflows/ci.yml"])).toEqual({
-      code: true,
-      consumer: true,
-      docs: true,
-      readmeMedia: true,
-    });
-    expect(classifyChanges(["new-runtime/config.toml"])).toEqual({
-      code: true,
-      consumer: true,
-      docs: true,
-      readmeMedia: true,
-    });
+  it("fails open for global, workflow, and unknown paths", () => {
+    for (const path of [
+      "bun.lock",
+      ".github/workflows/ci.yml",
+      "new-runtime/config.toml",
+      "assets/runtime/example.png",
+      "assets/readme-preview/example.png",
+    ]) {
+      expect(classifyChanges([path]), path).toEqual(all);
+    }
   });
 
   it("runs every gate for manual, scheduled, or indeterminate changes", () => {
-    expect(classifyChanges([], true)).toEqual({ code: true, consumer: true, docs: true, readmeMedia: true });
-    expect(classifyChanges([])).toEqual({ code: true, consumer: true, docs: true, readmeMedia: true });
+    expect(classifyChanges([], true)).toEqual(all);
+    expect(classifyChanges([])).toEqual(all);
   });
 
-  it("unions independent route decisions", () => {
-    expect(classifyChanges(["src/content/docs/index.md", "apps/cli/src/index.ts"])).toEqual({
-      code: true,
-      consumer: false,
-      docs: true,
-      readmeMedia: false,
-    });
-  });
-
-  it("routes only the exact README media prefix through its lightweight gate", () => {
+  it("unions independent capability closures", () => {
     expect(
       classifyChanges([
-        "README.md",
-        "assets/readme/example.png",
-        "assets/readme/reference.pdf",
-      ])
-    ).toEqual({ code: false, consumer: false, docs: false, readmeMedia: true });
-
-    expect(classifyChanges(["assets/runtime/example.png"])).toEqual({
+        "packages/web-publish-astro/src/index.ts",
+        "apps/cli/src/commands/export-pdf.ts",
+        "apps/extension/components/app/AppShell.tsx",
+      ]),
+    ).toEqual(narrow({
       code: true,
       consumer: true,
-      docs: true,
-      readmeMedia: true,
-    });
-    expect(classifyChanges(["assets/readme-preview/example.png"])).toEqual({
-      code: true,
-      consumer: true,
-      docs: true,
-      readmeMedia: true,
-    });
+      staticQuality: true,
+      unitTests: true,
+      packageContracts: true,
+      astroPublishing: true,
+      astroPlatform: true,
+      pdfPlatform: true,
+      browserHarness: true,
+    }));
   });
 
-  it("keeps product-owned assets on product gates", () => {
-    expect(classifyChanges(["apps/extension/assets/example.png"])).toEqual({
-      code: true,
-      consumer: false,
-      docs: false,
-      readmeMedia: false,
-    });
+  it("normalizes repository-relative Windows paths", () => {
+    expect(classifyChanges([".\\apps\\extension\\assets\\example.png"]))
+      .toEqual(narrow({
+        code: true,
+        staticQuality: true,
+        unitTests: true,
+        browserHarness: true,
+      }));
   });
 });

--- a/scripts/ci/classify-changes.ts
+++ b/scripts/ci/classify-changes.ts
@@ -2,15 +2,26 @@
  * Conservative CI routing for GitHub Actions.
  *
  * Documentation-only changes may skip product gates. Anything unknown, global,
- * or workflow-related fails open and runs every gate. Keep this module pure so
- * path policy changes are reviewable and covered by unit tests.
+ * or workflow-related fails open and runs every gate. Capability closures are
+ * explicit so an unrelated product surface does not silently acquire an
+ * expensive platform gate merely because it lives below `packages/`.
  */
 
 export interface CiRoutes {
+  /** Compatibility aggregate for callers that have not adopted granular routes. */
   code: boolean;
+  /** Compatibility aggregate for the pinned package-consumer gate. */
   consumer: boolean;
+  staticQuality: boolean;
+  unitTests: boolean;
+  packageContracts: boolean;
+  astroPublishing: boolean;
+  astroPlatform: boolean;
+  pdfPlatform: boolean;
+  browserHarness: boolean;
   docs: boolean;
   readmeMedia: boolean;
+  researchPrivacy: boolean;
 }
 
 const SITE_DOC_PREFIXES = ["src/content/", "src/components/", "src/styles/", "public/"];
@@ -20,6 +31,88 @@ const DOCUMENTATION_PREFIXES = ["docs/", "spec/", "specs/", ".github/ISSUE_TEMPL
 const DOCUMENTATION_FILES = new Set(["README.md", "CHANGELOG.md", "LICENSE", "NOTICE", ".impeccable.md"]);
 const README_MEDIA_PREFIX = "assets/readme/";
 const PRODUCT_PREFIXES = ["apps/", "packages/", "patches/", "plugins/", "scripts/", "services/"];
+
+/** Transitive workspace inputs of the three Astro publishing packages. */
+const ASTRO_PACKAGE_PREFIXES = [
+  "packages/confluence/",
+  "packages/core/",
+  "packages/export-blocks/",
+  "packages/export-blocks-astro/",
+  "packages/export-charts-tanstack/",
+  "packages/export-macros/",
+  "packages/web-publish/",
+  "packages/web-publish-astro/",
+  "packages/web-publish-starlight/",
+];
+
+/** Transitive workspace inputs of the PDF/compiler/template platform surface. */
+const PDF_PACKAGE_PREFIXES = [
+  "packages/code-highlight/",
+  "packages/confluence/",
+  "packages/core/",
+  "packages/diagram/",
+  "packages/docx/",
+  "packages/docx-template-intake/",
+  "packages/export-blocks/",
+  "packages/export-charts-tanstack/",
+  "packages/export-fixtures/",
+  "packages/export-jobs/",
+  "packages/export-macros/",
+  "packages/export-media/",
+  "packages/export-node/",
+  "packages/export-wiring/",
+  "packages/pdf/",
+  "packages/pdf-compiler-browser/",
+  "packages/pdf-template-authoring/",
+  "packages/template-pack/",
+];
+
+/** Transitive workspace inputs of the extension and browser export harness. */
+const BROWSER_PACKAGE_PREFIXES = [
+  "packages/code-highlight/",
+  "packages/confluence/",
+  "packages/core/",
+  "packages/diagram/",
+  "packages/docx/",
+  "packages/docx-template-intake/",
+  "packages/export-blocks/",
+  "packages/export-charts-tanstack/",
+  "packages/export-fixtures/",
+  "packages/export-jobs/",
+  "packages/export-macros/",
+  "packages/export-media/",
+  "packages/export-wiring/",
+  "packages/jira/",
+  "packages/pdf/",
+  "packages/pdf-compiler-browser/",
+  "packages/pdf-template-authoring/",
+  "packages/research/",
+  "packages/template-pack/",
+  "packages/web-publish/",
+];
+
+function noRoutes(): CiRoutes {
+  return {
+    code: false,
+    consumer: false,
+    staticQuality: false,
+    unitTests: false,
+    packageContracts: false,
+    astroPublishing: false,
+    astroPlatform: false,
+    pdfPlatform: false,
+    browserHarness: false,
+    docs: false,
+    readmeMedia: false,
+    researchPrivacy: false,
+  };
+}
+
+function allRoutes(): CiRoutes {
+  return Object.fromEntries(
+    Object.keys(noRoutes()).map((name) => [name, true]),
+  ) as unknown as CiRoutes;
+}
 
 function normalized(path: string): string {
   return path.trim().replaceAll("\\", "/").replace(/^\.\//, "");
@@ -41,39 +134,101 @@ function isDocumentationOnly(path: string): boolean {
 }
 
 function affectsSiteDocs(path: string): boolean {
-  return SITE_DOC_FILES.has(path) || startsWithAny(path, SITE_DOC_PREFIXES) || GLOBAL_FILES.has(path);
+  return SITE_DOC_FILES.has(path) || startsWithAny(path, SITE_DOC_PREFIXES);
 }
 
 function affectsConsumers(path: string): boolean {
-  return (
-    startsWithAny(path, ["packages/", "patches/", "scripts/"]) ||
-    GLOBAL_FILES.has(path) ||
-    path === ".github/workflows/ci.yml" ||
-    path === ".github/workflows/consumer-smoke.yml" ||
-    path === ".github/workflows/reusable-consumer-smoke.yml"
-  );
+  return startsWithAny(path, ["packages/", "patches/", "scripts/"]);
+}
+
+function enableProductQuality(routes: CiRoutes): void {
+  routes.code = true;
+  routes.staticQuality = true;
+  routes.unitTests = true;
+}
+
+function enablePackageContracts(routes: CiRoutes): void {
+  routes.consumer = true;
+  routes.packageContracts = true;
+}
+
+function enableAstro(routes: CiRoutes): void {
+  routes.astroPublishing = true;
+  routes.astroPlatform = true;
+}
+
+function enableEveryProductCapability(routes: CiRoutes): void {
+  enableProductQuality(routes);
+  enablePackageContracts(routes);
+  enableAstro(routes);
+  routes.pdfPlatform = true;
+  routes.browserHarness = true;
+}
+
+function classifyProductCapability(path: string, routes: CiRoutes): void {
+  enableProductQuality(routes);
+  if (affectsConsumers(path)) enablePackageContracts(routes);
+
+  if (startsWithAny(path, ASTRO_PACKAGE_PREFIXES)) enableAstro(routes);
+  if (startsWithAny(path, PDF_PACKAGE_PREFIXES)) routes.pdfPlatform = true;
+  if (startsWithAny(path, BROWSER_PACKAGE_PREFIXES)) routes.browserHarness = true;
+
+  if (path.startsWith("apps/extension/") || path.startsWith("apps/browser-export-harness/")) {
+    routes.browserHarness = true;
+  }
+  if (
+    path.startsWith("apps/cli/src/commands/export-pdf") ||
+    path.startsWith("apps/cli/src/commands/export-rasterizer") ||
+    path.startsWith("apps/cli/build") ||
+    path === "apps/cli/package.json" ||
+    path === "apps/cli/turbo.json"
+  ) {
+    routes.pdfPlatform = true;
+  }
+
+  // Dependency patches can affect any runtime even when their package name is
+  // not represented by a workspace directory.
+  if (path.startsWith("patches/")) {
+    enableEveryProductCapability(routes);
+  }
+
+  // CI orchestration changes must exercise every candidate capability. Other
+  // scripts stay on static/unit/package proof unless they own a named surface.
+  if (path.startsWith("scripts/ci/")) {
+    enableEveryProductCapability(routes);
+  }
+  if (
+    path.startsWith("scripts/check-browser-build") ||
+    path.startsWith("scripts/clean-browser-artifacts")
+  ) {
+    routes.browserHarness = true;
+  }
+  if (path.startsWith("scripts/verapdf/")) routes.pdfPlatform = true;
 }
 
 export function classifyChanges(paths: readonly string[], full = false): CiRoutes {
-  if (full || paths.length === 0) {
-    return { code: true, consumer: true, docs: true, readmeMedia: true };
-  }
+  if (full || paths.length === 0) return allRoutes();
 
-  const routes: CiRoutes = { code: false, consumer: false, docs: false, readmeMedia: false };
+  const routes = noRoutes();
   for (const rawPath of paths) {
     const path = normalized(rawPath);
     if (!path) continue;
 
-    if (path.startsWith(".github/workflows/")) {
-      return { code: true, consumer: true, docs: true, readmeMedia: true };
+    // The privacy scanner protects the complete tracked tree, so every real
+    // change receives the lightweight gate irrespective of its product route.
+    routes.researchPrivacy = true;
+
+    if (path.startsWith(".github/workflows/") || GLOBAL_FILES.has(path)) {
+      return allRoutes();
     }
 
-    if (path === "README.md" || path.startsWith(README_MEDIA_PREFIX)) routes.readmeMedia = true;
+    if (path === "README.md" || path.startsWith(README_MEDIA_PREFIX)) {
+      routes.readmeMedia = true;
+    }
     if (affectsSiteDocs(path)) routes.docs = true;
-    if (affectsConsumers(path)) routes.consumer = true;
 
-    if (GLOBAL_FILES.has(path) || startsWithAny(path, PRODUCT_PREFIXES)) {
-      routes.code = true;
+    if (startsWithAny(path, PRODUCT_PREFIXES)) {
+      classifyProductCapability(path, routes);
       continue;
     }
 
@@ -81,7 +236,7 @@ export function classifyChanges(paths: readonly string[], full = false): CiRoute
 
     // Unknown paths are deliberately fail-open. A new top-level build surface
     // must receive full CI until this policy explicitly classifies it.
-    return { code: true, consumer: true, docs: true, readmeMedia: true };
+    return allRoutes();
   }
 
   return routes;

--- a/scripts/ci/proof-mode.test.ts
+++ b/scripts/ci/proof-mode.test.ts
@@ -1,0 +1,296 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  ProofModeContractError,
+  selectProofMode,
+  validateAggregateProof,
+  validateMergeReady,
+  type PullRequestSnapshotInput,
+} from "./proof-mode.js";
+
+const HEAD_A = "a".repeat(40);
+const HEAD_B = "b".repeat(40);
+
+function pullRequestInput(options: {
+  eventDraft: boolean;
+  currentDraft?: boolean;
+  eventHeadSha?: string;
+  currentHeadSha?: string;
+  currentPullRequest?: PullRequestSnapshotInput;
+}) {
+  return {
+    eventName: "pull_request",
+    eventHeadSha: options.eventHeadSha ?? HEAD_A,
+    eventPullRequest: { number: 139, draft: options.eventDraft },
+    currentPullRequest: options.currentPullRequest ?? {
+      number: 139,
+      headSha: options.currentHeadSha ?? HEAD_A,
+      draft: options.currentDraft ?? options.eventDraft,
+    },
+  };
+}
+
+describe("CI proof mode", () => {
+  test("selects draft-fast only when event and current PR agree on the current draft head", () => {
+    expect(selectProofMode(pullRequestInput({ eventDraft: true }))).toMatchObject({
+      mode: "draft-fast",
+      aggregateStatusName: "draft-fast",
+      reason: "verified-draft",
+      eventHeadSha: HEAD_A,
+      validatedHeadSha: HEAD_A,
+      pullRequestNumber: 139,
+    });
+  });
+
+  test("selects required for a verified ready PR", () => {
+    expect(selectProofMode(pullRequestInput({ eventDraft: false }))).toMatchObject({
+      mode: "required",
+      aggregateStatusName: "required",
+      reason: "verified-ready",
+    });
+  });
+
+  test("classifies an event for an old PR head as superseded", () => {
+    expect(
+      selectProofMode(
+        pullRequestInput({
+          eventDraft: false,
+          currentHeadSha: HEAD_B,
+        }),
+      ),
+    ).toMatchObject({
+      mode: "superseded",
+      aggregateStatusName: "superseded",
+      reason: "head-superseded",
+      eventHeadSha: HEAD_A,
+      validatedHeadSha: HEAD_B,
+    });
+  });
+
+  test("fails closed to required when event and current draft state disagree", () => {
+    for (const [eventDraft, currentDraft] of [
+      [true, false],
+      [false, true],
+    ] as const) {
+      expect(
+        selectProofMode(pullRequestInput({ eventDraft, currentDraft })),
+      ).toMatchObject({
+        mode: "required",
+        aggregateStatusName: "required",
+        reason: "draft-state-disagrees",
+      });
+    }
+  });
+
+  test("requires full proof for push, schedule, dispatch, and merge-group events", () => {
+    for (const eventName of [
+      "push",
+      "schedule",
+      "workflow_dispatch",
+      "merge_group",
+    ] as const) {
+      expect(
+        selectProofMode({ eventName, eventHeadSha: HEAD_A }),
+      ).toMatchObject({
+        eventName,
+        mode: "required",
+        aggregateStatusName: "required",
+        reason: "non-pr-full-proof",
+        validatedHeadSha: HEAD_A,
+      });
+    }
+  });
+
+  test("rejects missing or malformed current PR identity and draft state", () => {
+    for (const currentPullRequest of [
+      undefined,
+      { number: 139, headSha: "short", draft: true },
+      { number: 139, headSha: HEAD_A, draft: "true" },
+      { number: 140, headSha: HEAD_A, draft: true },
+    ]) {
+      expect(() =>
+        selectProofMode({
+          ...pullRequestInput({ eventDraft: true }),
+          currentPullRequest,
+        }),
+      ).toThrow(ProofModeContractError);
+    }
+
+    expect(() =>
+      selectProofMode({ eventName: "repository_dispatch", eventHeadSha: HEAD_A }),
+    ).toThrow("unsupported proof event");
+  });
+
+  test("validates the exact aggregate status selected by each mode", () => {
+    const draft = selectProofMode(pullRequestInput({ eventDraft: true }));
+    const superseded = selectProofMode(
+      pullRequestInput({ eventDraft: false, currentHeadSha: HEAD_B }),
+    );
+    const required = selectProofMode(pullRequestInput({ eventDraft: false }));
+
+    expect(validateAggregateProof(draft, { name: "draft-fast", conclusion: "success" })).toEqual({
+      mode: "draft-fast",
+      statusName: "draft-fast",
+      conclusion: "success",
+    });
+    expect(
+      validateAggregateProof(superseded, { name: "superseded", conclusion: "success" }),
+    ).toMatchObject({ mode: "superseded", statusName: "superseded" });
+    expect(validateAggregateProof(required, { name: "required", conclusion: "success" })).toMatchObject({
+      mode: "required",
+      statusName: "required",
+    });
+
+    expect(() =>
+      validateAggregateProof(draft, { name: "required", conclusion: "success" }),
+    ).toThrow("does not match selected proof mode");
+    expect(() =>
+      validateAggregateProof(required, { name: "required", conclusion: "failure" }),
+    ).toThrow("is not successful");
+  });
+
+  test("accepts a full successful proof for the same ready PR head as merge-ready", () => {
+    const decision = selectProofMode(pullRequestInput({ eventDraft: false }));
+    expect(
+      validateMergeReady({
+        decision,
+        aggregate: { name: "required", conclusion: "success" },
+        currentPullRequest: { number: 139, headSha: HEAD_A, draft: false },
+      }),
+    ).toEqual({
+      eventName: "pull_request",
+      headSha: HEAD_A,
+      pullRequestNumber: 139,
+      aggregateStatusName: "required",
+      mergeReady: true,
+    });
+  });
+
+  test("rejects draft, superseded, changed-head, re-drafted, and failed proof as merge-ready", () => {
+    const draftDecision = selectProofMode(pullRequestInput({ eventDraft: true }));
+    const supersededDecision = selectProofMode(
+      pullRequestInput({ eventDraft: false, currentHeadSha: HEAD_B }),
+    );
+    const requiredDecision = selectProofMode(pullRequestInput({ eventDraft: false }));
+
+    expect(() =>
+      validateMergeReady({
+        decision: draftDecision,
+        aggregate: { name: "draft-fast", conclusion: "success" },
+      }),
+    ).toThrow("is not merge-ready");
+    expect(() =>
+      validateMergeReady({
+        decision: supersededDecision,
+        aggregate: { name: "superseded", conclusion: "success" },
+      }),
+    ).toThrow("is not merge-ready");
+    expect(() =>
+      validateMergeReady({
+        decision: requiredDecision,
+        aggregate: { name: "required", conclusion: "success" },
+        currentPullRequest: { number: 139, headSha: HEAD_B, draft: false },
+      }),
+    ).toThrow("head has superseded");
+    expect(() =>
+      validateMergeReady({
+        decision: requiredDecision,
+        aggregate: { name: "required", conclusion: "success" },
+        currentPullRequest: { number: 139, headSha: HEAD_A, draft: true },
+      }),
+    ).toThrow("still a draft");
+    expect(() =>
+      validateMergeReady({
+        decision: requiredDecision,
+        aggregate: { name: "required", conclusion: "failure" },
+        currentPullRequest: { number: 139, headSha: HEAD_A, draft: false },
+      }),
+    ).toThrow("is not successful");
+  });
+
+  test("accepts merge-group required proof but never treats push or dispatch as merge-ready", () => {
+    const mergeGroup = selectProofMode({
+      eventName: "merge_group",
+      eventHeadSha: HEAD_A,
+    });
+    expect(
+      validateMergeReady({
+        decision: mergeGroup,
+        aggregate: { name: "required", conclusion: "success" },
+      }),
+    ).toMatchObject({
+      eventName: "merge_group",
+      headSha: HEAD_A,
+      aggregateStatusName: "required",
+      mergeReady: true,
+    });
+
+    for (const eventName of ["push", "schedule", "workflow_dispatch"] as const) {
+      const decision = selectProofMode({ eventName, eventHeadSha: HEAD_A });
+      expect(() =>
+        validateMergeReady({
+          decision,
+          aggregate: { name: "required", conclusion: "success" },
+        }),
+      ).toThrow("is not a merge-ready candidate");
+    }
+  });
+
+  test("CLI appends validated proof-mode fields to GITHUB_OUTPUT", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "atlcli-proof-mode-"));
+    const outputPath = join(directory, "github-output");
+    try {
+      const result = Bun.spawnSync([process.execPath, join(import.meta.dir, "proof-mode.ts")], {
+        env: {
+          ...process.env,
+          CI_EVENT_NAME: "pull_request",
+          CI_EVENT_HEAD_SHA: HEAD_A,
+          CI_EVENT_PR_NUMBER: "139",
+          CI_EVENT_PR_DRAFT: "true",
+          CI_CURRENT_PR_NUMBER: "139",
+          CI_CURRENT_PR_HEAD_SHA: HEAD_A,
+          CI_CURRENT_PR_DRAFT: "true",
+          GITHUB_OUTPUT: outputPath,
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      expect(result.exitCode, result.stderr.toString()).toBe(0);
+      expect(await readFile(outputPath, "utf8")).toBe(
+        [
+          "mode=draft-fast",
+          "aggregateStatusName=draft-fast",
+          "reason=verified-draft",
+          `eventHeadSha=${HEAD_A}`,
+          `validatedHeadSha=${HEAD_A}`,
+          "pullRequestNumber=139",
+          "",
+        ].join("\n"),
+      );
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  test("CLI exits non-zero instead of accepting malformed live draft state", () => {
+    const result = Bun.spawnSync([process.execPath, join(import.meta.dir, "proof-mode.ts")], {
+      env: {
+        ...process.env,
+        CI_EVENT_NAME: "pull_request",
+        CI_EVENT_HEAD_SHA: HEAD_A,
+        CI_EVENT_PR_NUMBER: "139",
+        CI_EVENT_PR_DRAFT: "true",
+        CI_CURRENT_PR_NUMBER: "139",
+        CI_CURRENT_PR_HEAD_SHA: HEAD_A,
+        CI_CURRENT_PR_DRAFT: "yes",
+        GITHUB_OUTPUT: join(tmpdir(), "must-not-be-written-proof-mode-output"),
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr.toString()).toContain("current pull request draft state must be a boolean");
+  });
+});

--- a/scripts/ci/proof-mode.ts
+++ b/scripts/ci/proof-mode.ts
@@ -1,0 +1,355 @@
+/**
+ * Pure policy for selecting and validating the amount of CI proof a run owes.
+ *
+ * A pull-request event is not authoritative after it has been queued. Callers
+ * must provide a freshly fetched pull-request snapshot both when selecting the
+ * proof mode and before accepting a run as merge-ready. Missing or malformed
+ * state is a contract failure; it must never silently select the cheap lane.
+ */
+
+import { appendFile } from "node:fs/promises";
+
+export type ProofEventName =
+  | "pull_request"
+  | "push"
+  | "schedule"
+  | "workflow_dispatch"
+  | "merge_group";
+
+export type ProofMode = "draft-fast" | "superseded" | "required";
+export type AggregateStatusName = ProofMode;
+
+export interface PullRequestEventInput {
+  number: unknown;
+  draft: unknown;
+}
+
+export interface PullRequestSnapshotInput {
+  number: unknown;
+  headSha: unknown;
+  draft: unknown;
+}
+
+export interface SelectProofModeInput {
+  eventName: unknown;
+  eventHeadSha: unknown;
+  eventPullRequest?: unknown;
+  currentPullRequest?: unknown;
+}
+
+export interface ProofModeDecision {
+  eventName: ProofEventName;
+  eventHeadSha: string;
+  validatedHeadSha: string;
+  pullRequestNumber: number | null;
+  mode: ProofMode;
+  aggregateStatusName: AggregateStatusName;
+  reason:
+    | "verified-draft"
+    | "verified-ready"
+    | "head-superseded"
+    | "draft-state-disagrees"
+    | "non-pr-full-proof";
+}
+
+export interface AggregateProofInput {
+  name: unknown;
+  conclusion: unknown;
+}
+
+export interface ValidatedAggregateProof {
+  mode: ProofMode;
+  statusName: AggregateStatusName;
+  conclusion: "success";
+}
+
+export interface ValidateMergeReadyInput {
+  decision: ProofModeDecision;
+  aggregate: AggregateProofInput;
+  currentPullRequest?: unknown;
+}
+
+export interface MergeReadyProof {
+  eventName: "pull_request" | "merge_group";
+  headSha: string;
+  pullRequestNumber: number | null;
+  aggregateStatusName: "required";
+  mergeReady: true;
+}
+
+interface PullRequestEvent {
+  number: number;
+  draft: boolean;
+}
+
+interface PullRequestSnapshot extends PullRequestEvent {
+  headSha: string;
+}
+
+const EVENT_NAMES = new Set<ProofEventName>([
+  "pull_request",
+  "push",
+  "schedule",
+  "workflow_dispatch",
+  "merge_group",
+]);
+const STATUS_NAMES = new Set<AggregateStatusName>([
+  "draft-fast",
+  "superseded",
+  "required",
+]);
+const SHA_PATTERN = /^[0-9a-f]{40}$/i;
+
+export class ProofModeContractError extends Error {
+  override readonly name = "ProofModeContractError";
+}
+
+function record(value: unknown, label: string): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new ProofModeContractError(`${label} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function eventName(value: unknown): ProofEventName {
+  if (typeof value !== "string" || !EVENT_NAMES.has(value as ProofEventName)) {
+    throw new ProofModeContractError(`unsupported proof event: ${String(value)}`);
+  }
+  return value as ProofEventName;
+}
+
+function sha(value: unknown, label: string): string {
+  if (typeof value !== "string" || !SHA_PATTERN.test(value)) {
+    throw new ProofModeContractError(`${label} must be a 40-character commit SHA`);
+  }
+  return value.toLowerCase();
+}
+
+function pullRequestNumber(value: unknown, label: string): number {
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value <= 0) {
+    throw new ProofModeContractError(`${label} must be a positive integer`);
+  }
+  return value;
+}
+
+function draft(value: unknown, label: string): boolean {
+  if (typeof value !== "boolean") {
+    throw new ProofModeContractError(`${label} must be a boolean`);
+  }
+  return value;
+}
+
+function parsePullRequestEvent(value: unknown): PullRequestEvent {
+  const input = record(value, "event pull request");
+  return {
+    number: pullRequestNumber(input.number, "event pull request number"),
+    draft: draft(input.draft, "event pull request draft state"),
+  };
+}
+
+function parsePullRequestSnapshot(value: unknown, label: string): PullRequestSnapshot {
+  const input = record(value, label);
+  return {
+    number: pullRequestNumber(input.number, `${label} number`),
+    headSha: sha(input.headSha, `${label} head SHA`),
+    draft: draft(input.draft, `${label} draft state`),
+  };
+}
+
+/** Selects exactly one stable aggregate status for a CI run. */
+export function selectProofMode(input: SelectProofModeInput): ProofModeDecision {
+  const name = eventName(input.eventName);
+  const eventHeadSha = sha(input.eventHeadSha, "event head SHA");
+
+  if (name !== "pull_request") {
+    return {
+      eventName: name,
+      eventHeadSha,
+      validatedHeadSha: eventHeadSha,
+      pullRequestNumber: null,
+      mode: "required",
+      aggregateStatusName: "required",
+      reason: "non-pr-full-proof",
+    };
+  }
+
+  const eventPr = parsePullRequestEvent(input.eventPullRequest);
+  const currentPr = parsePullRequestSnapshot(input.currentPullRequest, "current pull request");
+  if (eventPr.number !== currentPr.number) {
+    throw new ProofModeContractError(
+      `current pull request number ${currentPr.number} does not match event pull request ${eventPr.number}`,
+    );
+  }
+
+  if (eventHeadSha !== currentPr.headSha) {
+    return {
+      eventName: name,
+      eventHeadSha,
+      validatedHeadSha: currentPr.headSha,
+      pullRequestNumber: eventPr.number,
+      mode: "superseded",
+      aggregateStatusName: "superseded",
+      reason: "head-superseded",
+    };
+  }
+
+  if (eventPr.draft && currentPr.draft) {
+    return {
+      eventName: name,
+      eventHeadSha,
+      validatedHeadSha: currentPr.headSha,
+      pullRequestNumber: eventPr.number,
+      mode: "draft-fast",
+      aggregateStatusName: "draft-fast",
+      reason: "verified-draft",
+    };
+  }
+
+  const draftStateDisagrees = eventPr.draft !== currentPr.draft;
+  return {
+    eventName: name,
+    eventHeadSha,
+    validatedHeadSha: currentPr.headSha,
+    pullRequestNumber: eventPr.number,
+    mode: "required",
+    aggregateStatusName: "required",
+    reason: draftStateDisagrees ? "draft-state-disagrees" : "verified-ready",
+  };
+}
+
+/**
+ * Validates the one aggregate check emitted by the chosen lane. A successful
+ * stale or draft aggregate is intentionally not the same as merge readiness.
+ */
+export function validateAggregateProof(
+  decision: ProofModeDecision,
+  aggregate: AggregateProofInput,
+): ValidatedAggregateProof {
+  if (
+    typeof aggregate.name !== "string" ||
+    !STATUS_NAMES.has(aggregate.name as AggregateStatusName)
+  ) {
+    throw new ProofModeContractError(`unknown aggregate status: ${String(aggregate.name)}`);
+  }
+  if (aggregate.name !== decision.aggregateStatusName || aggregate.name !== decision.mode) {
+    throw new ProofModeContractError(
+      `aggregate status ${aggregate.name} does not match selected proof mode ${decision.mode}`,
+    );
+  }
+  if (aggregate.conclusion !== "success") {
+    throw new ProofModeContractError(
+      `aggregate status ${aggregate.name} is not successful: ${String(aggregate.conclusion)}`,
+    );
+  }
+  return {
+    mode: decision.mode,
+    statusName: aggregate.name as AggregateStatusName,
+    conclusion: "success",
+  };
+}
+
+/**
+ * Produces a merge-ready receipt only for full proof on the current PR head or
+ * for a fully proved merge-group candidate. PR state is fetched and checked a
+ * second time to close the race between mode selection and final aggregation.
+ */
+export function validateMergeReady(input: ValidateMergeReadyInput): MergeReadyProof {
+  const aggregate = validateAggregateProof(input.decision, input.aggregate);
+  if (aggregate.mode !== "required") {
+    throw new ProofModeContractError(
+      `${aggregate.statusName} proof is successful but is not merge-ready`,
+    );
+  }
+
+  if (input.decision.eventName === "merge_group") {
+    return {
+      eventName: "merge_group",
+      headSha: input.decision.validatedHeadSha,
+      pullRequestNumber: null,
+      aggregateStatusName: "required",
+      mergeReady: true,
+    };
+  }
+
+  if (input.decision.eventName !== "pull_request") {
+    throw new ProofModeContractError(
+      `${input.decision.eventName} proof is not a merge-ready candidate`,
+    );
+  }
+
+  const currentPr = parsePullRequestSnapshot(
+    input.currentPullRequest,
+    "final current pull request",
+  );
+  if (currentPr.number !== input.decision.pullRequestNumber) {
+    throw new ProofModeContractError("final pull request number does not match selected proof");
+  }
+  if (currentPr.headSha !== input.decision.eventHeadSha) {
+    throw new ProofModeContractError("final pull request head has superseded selected proof");
+  }
+  if (currentPr.draft) {
+    throw new ProofModeContractError("final pull request is still a draft");
+  }
+
+  return {
+    eventName: "pull_request",
+    headSha: currentPr.headSha,
+    pullRequestNumber: currentPr.number,
+    aggregateStatusName: "required",
+    mergeReady: true,
+  };
+}
+
+function requiredEnvironment(name: string): string {
+  const value = process.env[name];
+  if (value === undefined || value === "") {
+    throw new ProofModeContractError(`${name} is required`);
+  }
+  return value;
+}
+
+function environmentNumber(name: string): unknown {
+  const value = requiredEnvironment(name);
+  return /^\d+$/.test(value) ? Number(value) : value;
+}
+
+function environmentBoolean(name: string): unknown {
+  const value = requiredEnvironment(name);
+  if (value === "true") return true;
+  if (value === "false") return false;
+  return value;
+}
+
+async function main(): Promise<void> {
+  const ciEventName = requiredEnvironment("CI_EVENT_NAME");
+  const pullRequest = ciEventName === "pull_request";
+  const decision = selectProofMode({
+    eventName: ciEventName,
+    eventHeadSha: requiredEnvironment("CI_EVENT_HEAD_SHA"),
+    eventPullRequest: pullRequest
+      ? {
+          number: environmentNumber("CI_EVENT_PR_NUMBER"),
+          draft: environmentBoolean("CI_EVENT_PR_DRAFT"),
+        }
+      : undefined,
+    currentPullRequest: pullRequest
+      ? {
+          number: environmentNumber("CI_CURRENT_PR_NUMBER"),
+          headSha: requiredEnvironment("CI_CURRENT_PR_HEAD_SHA"),
+          draft: environmentBoolean("CI_CURRENT_PR_DRAFT"),
+        }
+      : undefined,
+  });
+  const githubOutput = requiredEnvironment("GITHUB_OUTPUT");
+  const outputs = [
+    `mode=${decision.mode}`,
+    `aggregateStatusName=${decision.aggregateStatusName}`,
+    `reason=${decision.reason}`,
+    `eventHeadSha=${decision.eventHeadSha}`,
+    `validatedHeadSha=${decision.validatedHeadSha}`,
+    `pullRequestNumber=${decision.pullRequestNumber ?? ""}`,
+  ];
+  await appendFile(githubOutput, `${outputs.join("\n")}\n`, "utf8");
+}
+
+if (import.meta.main) await main();

--- a/scripts/ci/run-test-lane.ts
+++ b/scripts/ci/run-test-lane.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env bun
+import { readFileSync, rmSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { discoverTestFiles, normalizeRepositoryTestPath } from "./test-inventory.js";
 import {
@@ -46,6 +47,38 @@ export function buildTestLaneCommand(
   return args;
 }
 
+export function executionPhases(groups: readonly TestExecutionGroup[]): TestExecutionGroup[] {
+  if (groups.length === 0) throw new Error("logical test job has no execution groups");
+  const jobs = new Set(groups.map((group) => group.job));
+  if (jobs.size !== 1) throw new Error("execution groups must share one logical job");
+  if (groups.every((group) => group.workers === 1)) {
+    return [
+      {
+        id: groups[0]!.job,
+        job: groups[0]!.job,
+        lane: groups[0]!.lane,
+        mode: "serial",
+        workers: 1,
+        files: groups.flatMap((group) => group.files),
+        requirements: [...new Set(groups.flatMap((group) => group.requirements))].sort(),
+        atomicGroups: [...new Set(groups.flatMap((group) => group.atomicGroups))].sort(),
+        estimatedSeconds: groups.reduce((total, group) => total + group.estimatedSeconds, 0),
+      },
+    ];
+  }
+  return [...groups];
+}
+
+export function mergeJunitDocuments(documents: readonly string[]): string {
+  if (documents.length === 0) throw new Error("at least one JUnit document is required");
+  const bodies = documents.map((document) => {
+    const match = document.match(/<testsuites\b[^>]*>([\s\S]*)<\/testsuites\s*>\s*$/u);
+    if (!match) throw new Error("malformed JUnit XML: missing testsuites envelope");
+    return match[1]!.trim();
+  });
+  return `<?xml version="1.0" encoding="UTF-8"?>\n<testsuites>\n${bodies.join("\n")}\n</testsuites>\n`;
+}
+
 function option(args: readonly string[], name: string): string {
   const index = args.indexOf(name);
   const value = index >= 0 ? args[index + 1] : undefined;
@@ -59,16 +92,40 @@ async function main(): Promise<void> {
   const groupId = option(args, "--group");
   const junitFile = option(args, "--junit");
   const plan = planTestLanes(discoverTestFiles(), loadTestLaneMetadata(), topology);
-  const group = plan.groups.find((candidate) => candidate.id === groupId);
-  if (!group) throw new Error(`unknown execution group for ${topology}: ${groupId}`);
-
-  const child = Bun.spawn(buildTestLaneCommand(group, junitFile), {
-    cwd: resolve(import.meta.dir, "../.."),
-    stdin: "inherit",
-    stdout: "inherit",
-    stderr: "inherit",
+  const selected = plan.groups.filter(
+    (candidate) => candidate.job === groupId || candidate.id === groupId,
+  );
+  if (selected.length === 0) throw new Error(`unknown execution group for ${topology}: ${groupId}`);
+  const phases = executionPhases(selected);
+  const partFiles = phases.map((_, index) =>
+    phases.length === 1 ? junitFile : `${junitFile}.part-${index + 1}.xml`,
+  );
+  let exitCode = 0;
+  for (const [index, phase] of phases.entries()) {
+    const child = Bun.spawn(buildTestLaneCommand(phase, partFiles[index]!), {
+      cwd: resolve(import.meta.dir, "../.."),
+      stdin: "inherit",
+      stdout: "inherit",
+      stderr: "inherit",
+    });
+    exitCode = await child.exited;
+    if (exitCode !== 0) break;
+  }
+  const completedParts = partFiles.filter((path) => {
+    try {
+      readFileSync(path);
+      return true;
+    } catch {
+      return false;
+    }
   });
-  const exitCode = await child.exited;
+  if (phases.length > 1 && completedParts.length > 0) {
+    writeFileSync(
+      junitFile,
+      mergeJunitDocuments(completedParts.map((path) => readFileSync(path, "utf8"))),
+    );
+    for (const path of completedParts) rmSync(path);
+  }
   if (exitCode !== 0) process.exit(exitCode);
 }
 

--- a/scripts/ci/telemetry-summary.test.ts
+++ b/scripts/ci/telemetry-summary.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   buildCiTelemetrySummary,
+  routesFromEnvironment,
   telemetryMarkdown,
 } from "./telemetry-summary.js";
 
@@ -13,10 +14,27 @@ function junit(file: string, seconds: number): string {
 }
 
 describe("CI telemetry summary", () => {
+  test("records every granular route without treating missing values as selected", () => {
+    expect(
+      routesFromEnvironment({
+        CI_ROUTE_CODE: "true",
+        CI_ROUTE_ASTRO_PLATFORM: "true",
+        CI_ROUTE_PDF_PLATFORM: "false",
+      }),
+    ).toMatchObject({
+      code: true,
+      astroPlatform: true,
+      pdfPlatform: false,
+      browserHarness: false,
+      researchPrivacy: false,
+    });
+  });
+
   test("combines disjoint lane JUnit with Actions timing data", () => {
     const summary = buildCiTelemetrySummary({
       commitSha: "a".repeat(40),
       sourceRun: "run-1",
+      proofMode: "required",
       topology: "legacy-4-shard",
       routes: { code: true },
       junit: [
@@ -37,12 +55,19 @@ describe("CI telemetry summary", () => {
     });
     expect(summary).toMatchObject({
       schema: 1,
+      proofMode: "required",
       files: 2,
       testcases: 2,
     });
     expect(summary.slowestFiles[0]).toMatchObject({
       file: "pkg/slow.test.ts",
       durationSeconds: 2,
+    });
+    expect(summary.timingSnapshot).toMatchObject({
+      schema: 1,
+      baselineSha: "a".repeat(40),
+      sourceRun: "run-1",
+      samples: 2,
     });
     expect(telemetryMarkdown(summary)).toContain("legacy-4-shard");
   });
@@ -52,6 +77,7 @@ describe("CI telemetry summary", () => {
       buildCiTelemetrySummary({
         commitSha: "a".repeat(40),
         sourceRun: "run-1",
+        proofMode: "required",
         topology: "candidate",
         routes: {},
         junit: [

--- a/scripts/ci/telemetry-summary.ts
+++ b/scripts/ci/telemetry-summary.ts
@@ -14,14 +14,17 @@ import {
 } from "./actions-timings.js";
 import {
   assertDisjointLaneOwnership,
+  createTimingSnapshot,
   parseBunJUnit,
   type FileTiming,
+  type TimingSnapshot,
 } from "./test-timings.js";
 
 export interface CiTelemetrySummary {
   schema: 1;
   commitSha: string;
   sourceRun: string;
+  proofMode: string;
   topology: string;
   routes: Record<string, boolean>;
   files: number;
@@ -33,12 +36,37 @@ export interface CiTelemetrySummary {
     durationSeconds: number;
   }>;
   slowestFiles: FileTiming[];
+  timingSnapshot: TimingSnapshot;
   actions: ActionsTimingSummary;
+}
+
+const ROUTE_ENVIRONMENT: ReadonlyArray<readonly [string, string]> = [
+  ["code", "CI_ROUTE_CODE"],
+  ["consumer", "CI_ROUTE_CONSUMER"],
+  ["staticQuality", "CI_ROUTE_STATIC_QUALITY"],
+  ["unitTests", "CI_ROUTE_UNIT_TESTS"],
+  ["packageContracts", "CI_ROUTE_PACKAGE_CONTRACTS"],
+  ["astroPublishing", "CI_ROUTE_ASTRO_PUBLISHING"],
+  ["astroPlatform", "CI_ROUTE_ASTRO_PLATFORM"],
+  ["pdfPlatform", "CI_ROUTE_PDF_PLATFORM"],
+  ["browserHarness", "CI_ROUTE_BROWSER_HARNESS"],
+  ["docs", "CI_ROUTE_DOCS"],
+  ["readmeMedia", "CI_ROUTE_README_MEDIA"],
+  ["researchPrivacy", "CI_ROUTE_RESEARCH_PRIVACY"],
+];
+
+export function routesFromEnvironment(
+  environment: Readonly<Record<string, string | undefined>>,
+): Record<string, boolean> {
+  return Object.fromEntries(
+    ROUTE_ENVIRONMENT.map(([route, variable]) => [route, environment[variable] === "true"]),
+  );
 }
 
 export function buildCiTelemetrySummary(options: {
   commitSha: string;
   sourceRun: string;
+  proofMode: string;
   topology: string;
   routes: Record<string, boolean>;
   junit: Array<{ lane: string; xml: string }>;
@@ -57,6 +85,7 @@ export function buildCiTelemetrySummary(options: {
     schema: 1,
     commitSha: options.commitSha.toLowerCase(),
     sourceRun: options.sourceRun,
+    proofMode: options.proofMode,
     topology: options.topology,
     routes: options.routes,
     files: files.length,
@@ -80,6 +109,11 @@ export function buildCiTelemetrySummary(options: {
           left.file.localeCompare(right.file),
       )
       .slice(0, 20),
+    timingSnapshot: createTimingSnapshot({
+      baselineSha: options.commitSha,
+      sourceRun: options.sourceRun,
+      artifacts,
+    }),
     actions: summarizeActionsJobs(options.jobs, options.dependencies),
   };
 }
@@ -88,6 +122,7 @@ export function telemetryMarkdown(summary: CiTelemetrySummary): string {
   const lines = [
     "## CI timing telemetry",
     "",
+    `- Proof mode: \`${summary.proofMode}\``,
     `- Topology: \`${summary.topology}\``,
     `- Test files / cases: ${summary.files} / ${summary.testcases}`,
     `- Workflow wall time: ${summary.actions.workflowWallSeconds ?? "unavailable"}s`,
@@ -153,13 +188,9 @@ async function main(): Promise<void> {
       process.env.GITHUB_RUN_ID
         ? `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`
         : "local",
+    proofMode: process.env.CI_PROOF_MODE ?? "unknown",
     topology: process.env.CI_TEST_TOPOLOGY ?? "legacy-4-shard",
-    routes: {
-      code: process.env.CI_ROUTE_CODE === "true",
-      consumer: process.env.CI_ROUTE_CONSUMER === "true",
-      docs: process.env.CI_ROUTE_DOCS === "true",
-      readmeMedia: process.env.CI_ROUTE_README_MEDIA === "true",
-    },
+    routes: routesFromEnvironment(process.env),
     junit,
     jobs: jobsPayload.jobs,
     dependencies: jobsPayload.dependencies,

--- a/scripts/ci/test-lanes.json
+++ b/scripts/ci/test-lanes.json
@@ -22,6 +22,76 @@
       "requirements": ["stateful"]
     },
     {
+      "path": "apps/browser-export-harness/tests/boundaries.test.ts",
+      "lane": "pdf-typst",
+      "requirements": ["fonts", "typst-runtime"]
+    },
+    {
+      "path": "apps/cli/src/commands/export-pdf-assets.test.ts",
+      "lane": "pdf-typst",
+      "requirements": ["fonts", "typst-runtime"]
+    },
+    {
+      "path": "apps/cli/src/commands/export-pdf-build-modes.test.ts",
+      "lane": "pdf-typst",
+      "requirements": ["fonts", "typst-runtime"]
+    },
+    {
+      "path": "apps/cli/src/commands/export-pdf-integration.test.ts",
+      "lane": "pdf-typst",
+      "requirements": ["fonts", "typst-runtime"]
+    },
+    {
+      "path": "apps/cli/src/commands/export-pdf.e2e.test.ts",
+      "lane": "pdf-typst",
+      "requirements": ["poppler", "typst-runtime"]
+    },
+    {
+      "path": "apps/cli/src/commands/export-report-parity.test.ts",
+      "lane": "pdf-typst",
+      "requirements": ["fonts", "typst-runtime"]
+    },
+    {
+      "path": "apps/cli/src/commands/export-report.test.ts",
+      "lane": "pdf-typst",
+      "requirements": ["fonts", "typst-runtime"]
+    },
+    {
+      "path": "apps/cli/src/commands/export-source-contract.test.ts",
+      "lane": "pdf-typst",
+      "requirements": ["fonts", "typst-runtime"]
+    },
+    {
+      "path": "apps/cli/src/commands/export-strict-severity.test.ts",
+      "lane": "pdf-typst",
+      "requirements": ["fonts", "typst-runtime"]
+    },
+    {
+      "path": "apps/extension/tests/pdf/compiler.test.ts",
+      "lane": "pdf-typst",
+      "requirements": ["fonts", "poppler", "typst-runtime"]
+    },
+    {
+      "path": "packages/docx/src/emoji-font-coverage.libreoffice.test.ts",
+      "lane": "pdf-typst",
+      "requirements": ["poppler"]
+    },
+    {
+      "path": "packages/docx/src/header-libreoffice.smoke.test.ts",
+      "lane": "pdf-typst",
+      "requirements": ["poppler"]
+    },
+    {
+      "path": "packages/export-node/src/a5-example.test.ts",
+      "lane": "pdf-typst",
+      "requirements": ["fonts", "typst-runtime"]
+    },
+    {
+      "path": "packages/export-node/src/pdf-env.test.ts",
+      "lane": "pdf-typst",
+      "requirements": ["fonts", "typst-runtime"]
+    },
+    {
       "path": "packages/pdf-compiler-browser/src/callout-accessibility.test.ts",
       "lane": "pdf-typst",
       "requirements": ["fonts", "typst-runtime"]
@@ -72,14 +142,64 @@
       "requirements": ["fonts", "typst-runtime"]
     },
     {
+      "path": "packages/pdf-compiler-browser/src/pdf-output-options.test.ts",
+      "lane": "pdf-typst",
+      "requirements": ["fonts", "typst-runtime"]
+    },
+    {
+      "path": "packages/pdf-compiler-browser/src/pdf-output-standards.test.ts",
+      "lane": "pdf-typst",
+      "requirements": ["fonts", "typst-runtime"]
+    },
+    {
       "path": "packages/pdf-compiler-browser/src/second-template.test.ts",
       "lane": "pdf-typst",
       "requirements": ["fonts", "typst-runtime"]
     },
     {
+      "path": "packages/pdf-compiler-browser/src/template-capabilities-v5.test.ts",
+      "lane": "pdf-typst",
+      "requirements": ["fonts", "poppler", "typst-runtime"]
+    },
+    {
+      "path": "packages/pdf-compiler-browser/src/template-composition-v4-pipeline.test.ts",
+      "lane": "pdf-typst",
+      "requirements": ["poppler", "typst-runtime"]
+    },
+    {
+      "path": "packages/pdf-compiler-browser/src/template-composition-v4-renderer.test.ts",
+      "lane": "pdf-typst",
+      "requirements": ["fonts", "poppler", "typst-runtime"]
+    },
+    {
+      "path": "packages/pdf-compiler-browser/src/template-composition-v4.test.ts",
+      "lane": "pdf-typst",
+      "requirements": ["fonts", "poppler", "typst-runtime"]
+    },
+    {
       "path": "packages/pdf-compiler-browser/src/template-migration-parity.test.ts",
       "lane": "pdf-typst",
       "requirements": ["fonts", "typst-runtime"]
+    },
+    {
+      "path": "packages/pdf-compiler-browser/src/vendor.test.ts",
+      "lane": "pdf-typst",
+      "requirements": ["fonts", "typst-runtime"]
+    },
+    {
+      "path": "packages/pdf/scripts/ensure-fonts.test.ts",
+      "lane": "pdf-typst",
+      "requirements": ["fonts"]
+    },
+    {
+      "path": "packages/pdf/src/fonts.test.ts",
+      "lane": "pdf-typst",
+      "requirements": ["fonts"]
+    },
+    {
+      "path": "scripts/adf-rendered-goldens.test.ts",
+      "lane": "pdf-typst",
+      "requirements": ["poppler"]
     }
   ]
 }

--- a/scripts/ci/test-lanes.test.ts
+++ b/scripts/ci/test-lanes.test.ts
@@ -1,12 +1,23 @@
 import { describe, expect, test } from "bun:test";
-import { buildTestLaneCommand } from "./run-test-lane.js";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import {
+  buildTestLaneCommand,
+  executionPhases,
+  mergeJunitDocuments,
+} from "./run-test-lane.js";
+import {
+  detectDirectSetupRequirements,
+  loadTestLaneMetadata,
   planTestLanes,
+  testLaneMatrix,
+  validateDirectSetupOwnership,
   type TestExecutionGroup,
   type TestLaneMetadata,
   type TestLaneMetadataEntry,
   type TestTopology,
 } from "./test-lanes.js";
+import { discoverTestFiles } from "./test-inventory.js";
 
 const SHA = "a".repeat(40);
 
@@ -138,6 +149,47 @@ describe("duration-aware test lanes", () => {
     ]);
   });
 
+  test("detects and fail-closes direct Poppler and pinned-font setup ownership", () => {
+    const popplerSource = `Bun.spawn(["${"pdf" + "toppm"}"]);`;
+    const fontSource = `${"ensure" + "PdfFonts"}();`;
+    expect(
+      detectDirectSetupRequirements(`${popplerSource} ${fontSource}`),
+    ).toEqual(["poppler", "fonts"]);
+    expect(() =>
+      validateDirectSetupOwnership({
+        inventory: ["pkg/proof.test.ts"],
+        metadata: metadata([{ path: "pkg/proof.test.ts", requirements: ["poppler"] }]),
+        sourceFor: () => `${popplerSource} ${fontSource}`,
+      }),
+    ).toThrow("fonts");
+    expect(() =>
+      validateDirectSetupOwnership({
+        inventory: ["pkg/proof.test.ts"],
+        metadata: metadata([
+          { path: "pkg/proof.test.ts", requirements: ["fonts", "poppler"] },
+        ]),
+        sourceFor: () => `${popplerSource} ${fontSource}`,
+      }),
+    ).not.toThrow();
+  });
+
+  test("keeps every directly detected repository setup in its owning lane", () => {
+    const inventory = discoverTestFiles();
+    const realMetadata = loadTestLaneMetadata();
+    validateDirectSetupOwnership({
+      inventory,
+      metadata: realMetadata,
+      sourceFor: (path) => readFileSync(resolve(import.meta.dir, "../..", path), "utf8"),
+    });
+    const result = planTestLanes(inventory, realMetadata, "general-3x1");
+    expect(
+      result.groups
+        .filter(({ lane }) => lane === "general")
+        .flatMap(({ requirements }) => requirements)
+        .filter((requirement) => requirement === "fonts" || requirement === "poppler"),
+    ).toEqual([]);
+  });
+
   test("keeps atomic groups indivisible in a separate serial execution group", () => {
     const result = plan(
       ["pkg/a.test.ts", "pkg/b.test.ts", "pkg/safe.test.ts"],
@@ -207,6 +259,49 @@ describe("duration-aware test lanes", () => {
     expect(
       buildTestLaneCommand(group(), "junit/general-1.xml"),
     ).not.toContain("--parallel=2");
+  });
+
+  test("keeps safe and serial phases on one logical matrix runner", () => {
+    const result = plan(
+      ["pkg/safe-a.test.ts", "pkg/safe-b.test.ts", "pkg/stateful.test.ts"],
+      [
+        {
+          path: "pkg/stateful.test.ts",
+          durationSeconds: 2,
+          atomicGroup: "stateful",
+          requirements: ["stateful"],
+        },
+      ],
+      "general-2x2-workers",
+    );
+    const matrix = testLaneMatrix(result);
+    expect(matrix.include).toHaveLength(2);
+    expect(matrix.include.find(({ executionGroups }) => executionGroups.length === 2)).toMatchObject({
+      group: "general-1",
+      workers: 2,
+      executionGroups: ["general-1-parallel", "general-1-serial"],
+    });
+    const shared = result.groups.filter(({ job }) => job === "general-1");
+    expect(executionPhases(shared)).toHaveLength(2);
+
+    expect(executionPhases(shared.map((phase) => ({ ...phase, workers: 1 })))).toMatchObject([
+      {
+        id: "general-1",
+        workers: 1,
+        files: expect.arrayContaining(["pkg/stateful.test.ts"]),
+      },
+    ]);
+  });
+
+  test("merges bounded JUnit phase documents for one logical runner", () => {
+    const merged = mergeJunitDocuments([
+      '<?xml version="1.0"?><testsuites><testsuite name="safe" /></testsuites>',
+      '<testsuites tests="1"><testsuite name="serial" /></testsuites>',
+    ]);
+    expect(merged).toContain('<testsuite name="safe" />');
+    expect(merged).toContain('<testsuite name="serial" />');
+    expect(merged.match(/<testsuites>/g)).toHaveLength(1);
+    expect(() => mergeJunitDocuments(["<testsuite />"])).toThrow("testsuites envelope");
   });
 
   test("rejects empty, duplicate, escaping, implicit, and unsafe parallel groups", () => {

--- a/scripts/ci/test-lanes.ts
+++ b/scripts/ci/test-lanes.ts
@@ -49,6 +49,16 @@ export interface TestLanePlan {
   groups: TestExecutionGroup[];
 }
 
+export interface TestLaneMatrixEntry {
+  topology: TestTopology;
+  group: string;
+  lane: TestLane;
+  workers: 1 | 2;
+  fonts: boolean;
+  poppler: boolean;
+  executionGroups: string[];
+}
+
 const TOPOLOGIES = new Set<TestTopology>([
   "general-2x1",
   "general-3x1",
@@ -62,6 +72,20 @@ const REQUIREMENTS = new Set<SetupRequirement>([
   "typst-runtime",
 ]);
 
+const DIRECT_SETUP_PATTERNS: ReadonlyArray<{
+  requirement: Extract<SetupRequirement, "fonts" | "poppler">;
+  pattern: RegExp;
+}> = [
+  {
+    requirement: "poppler",
+    pattern: /\b(?:pdffonts|pdfinfo|pdftoppm|pdftotext)\b/u,
+  },
+  {
+    requirement: "fonts",
+    pattern: /(?:ensurePdfFonts|packageBytes\s*\(\s*[`"']@atlcli\/pdf\/fonts\/)/u,
+  },
+];
+
 interface ValidatedEntry extends TestLaneMetadataEntry {
   path: string;
   lane: TestLane;
@@ -74,6 +98,33 @@ interface AssignmentUnit {
   weight: number;
   requirements: SetupRequirement[];
   atomicGroup?: string;
+}
+
+export function detectDirectSetupRequirements(source: string): SetupRequirement[] {
+  return DIRECT_SETUP_PATTERNS
+    .filter(({ pattern }) => pattern.test(source))
+    .map(({ requirement }) => requirement);
+}
+
+export function validateDirectSetupOwnership(options: {
+  inventory: readonly string[];
+  metadata: TestLaneMetadata;
+  sourceFor: (path: string) => string;
+}): void {
+  const entries = new Map(
+    options.metadata.files.map((entry) => [normalizeRepositoryTestPath(entry.path), entry]),
+  );
+  const failures: string[] = [];
+  for (const path of options.inventory) {
+    const detected = detectDirectSetupRequirements(options.sourceFor(path));
+    if (detected.length === 0) continue;
+    const declared = new Set(entries.get(path)?.requirements ?? []);
+    const missing = detected.filter((requirement) => !declared.has(requirement));
+    if (missing.length > 0) failures.push(`${path}: ${missing.join(",")}`);
+  }
+  if (failures.length > 0) {
+    throw new Error(`direct test setup ownership is incomplete: ${failures.join("; ")}`);
+  }
 }
 
 function percentile95(values: readonly number[]): number {
@@ -358,6 +409,33 @@ export function explainTestLanePlan(plan: TestLanePlan): string {
   return lines.join("\n");
 }
 
+export function testLaneMatrix(plan: TestLanePlan): { include: TestLaneMatrixEntry[] } {
+  const byJob = new Map<string, TestExecutionGroup[]>();
+  for (const group of plan.groups) {
+    const groups = byJob.get(group.job) ?? [];
+    groups.push(group);
+    byJob.set(group.job, groups);
+  }
+  return {
+    include: [...byJob.entries()].map(([job, groups]) => {
+      const requirements = new Set(groups.flatMap((group) => group.requirements));
+      const lanes = uniqueSorted(groups.map((group) => group.lane));
+      if (lanes.length !== 1) {
+        throw new Error(`logical test job spans multiple lanes: ${job}`);
+      }
+      return {
+        topology: plan.topology,
+        group: job,
+        lane: lanes[0]!,
+        workers: Math.max(...groups.map((group) => group.workers)) as 1 | 2,
+        fonts: requirements.has("fonts"),
+        poppler: requirements.has("poppler"),
+        executionGroups: groups.map((group) => group.id),
+      };
+    }),
+  };
+}
+
 export function loadTestLaneMetadata(
   path = resolve(import.meta.dir, "test-lanes.json"),
 ): TestLaneMetadata {
@@ -377,24 +455,20 @@ function topologyFromArgs(args: readonly string[]): TestTopology {
 
 async function main(): Promise<void> {
   const args = process.argv.slice(2);
+  const inventory = discoverTestFiles();
+  const metadata = loadTestLaneMetadata();
+  validateDirectSetupOwnership({
+    inventory,
+    metadata,
+    sourceFor: (path) => readFileSync(resolve(import.meta.dir, "../..", path), "utf8"),
+  });
   const plan = planTestLanes(
-    discoverTestFiles(),
-    loadTestLaneMetadata(),
+    inventory,
+    metadata,
     topologyFromArgs(args),
   );
   if (args.includes("--matrix")) {
-    process.stdout.write(
-      `${JSON.stringify({
-        include: plan.groups.map((group) => ({
-          topology: plan.topology,
-          group: group.id,
-          lane: group.lane,
-          workers: group.workers,
-          fonts: group.requirements.includes("fonts"),
-          poppler: group.requirements.includes("poppler"),
-        })),
-      })}\n`,
-    );
+    process.stdout.write(`${JSON.stringify(testLaneMatrix(plan))}\n`);
   } else if (args.includes("--json")) {
     process.stdout.write(`${JSON.stringify(plan, null, 2)}\n`);
   } else {

--- a/scripts/ci/test-timings.test.ts
+++ b/scripts/ci/test-timings.test.ts
@@ -1,10 +1,19 @@
 import { describe, expect, test } from "bun:test";
-import { readFileSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { join } from "node:path";
+import { tmpdir } from "node:os";
 import {
   assertDisjointLaneOwnership,
+  compareTopologyTimings,
   createTimingSnapshot,
   parseBunJUnit,
+  topologyComparisonMarkdown,
 } from "./test-timings.js";
 
 function junit(testcases: string): string {
@@ -113,5 +122,112 @@ describe("Bun JUnit timings", () => {
         artifacts: [artifact],
       }),
     ).toThrow("baseline SHA");
+  });
+
+  test("compares exact legacy and candidate testcase identities and timings", () => {
+    const legacy = parseBunJUnit(
+      junit(
+        '<testcase name="a" classname="suite" time="2" file="pkg/a.test.ts" />' +
+          '<testcase name="b" classname="suite" time="1" file="pkg/b.test.ts"><skipped /></testcase>',
+      ),
+      { namespace: "legacy-4-shard", lane: "legacy-1" },
+    );
+    const candidate = parseBunJUnit(
+      junit(
+        '<testcase name="b" classname="suite" time="0.5" file="pkg/b.test.ts"><skipped /></testcase>' +
+          '<testcase name="a" classname="suite" time="1" file="pkg/a.test.ts" />',
+      ),
+      { namespace: "general-3x1", lane: "candidate-1" },
+    );
+    const comparison = compareTopologyTimings({ legacy: [legacy], candidate: [candidate] });
+    expect(comparison).toMatchObject({
+      schema: 1,
+      files: 2,
+      testcases: 2,
+      legacyDurationSeconds: 3,
+      candidateDurationSeconds: 1.5,
+      deltaSeconds: -1.5,
+      ratio: 0.5,
+    });
+    expect(topologyComparisonMarkdown(comparison)).toContain("Identity proof: 2 files / 2 testcases");
+  });
+
+  test("rejects topology coverage and outcome drift before comparing speed", () => {
+    const legacy = parseBunJUnit(
+      junit('<testcase name="a" time="1" file="pkg/a.test.ts" />'),
+      { namespace: "legacy", lane: "one" },
+    );
+    const missing = parseBunJUnit(
+      junit('<testcase name="b" time="1" file="pkg/b.test.ts" />'),
+      { namespace: "candidate", lane: "one" },
+    );
+    expect(() => compareTopologyTimings({ legacy: [legacy], candidate: [missing] })).toThrow(
+      "identity mismatch",
+    );
+    const failed = parseBunJUnit(
+      junit('<testcase name="a" time="1" file="pkg/a.test.ts"><failure /></testcase>'),
+      { namespace: "candidate", lane: "one" },
+    );
+    expect(() => compareTopologyTimings({ legacy: [legacy], candidate: [failed] })).toThrow(
+      "outcome mismatch",
+    );
+  });
+
+  test("writes reviewable snapshot and comparison JSON from JUnit directories", () => {
+    const directory = mkdtempSync(join(tmpdir(), "atlcli-test-timings-"));
+    try {
+      const legacy = join(directory, "legacy");
+      const candidate = join(directory, "candidate");
+      mkdirSync(legacy);
+      mkdirSync(candidate);
+      writeFileSync(
+        join(legacy, "one.xml"),
+        junit('<testcase name="a" time="2" file="pkg/a.test.ts" />'),
+      );
+      writeFileSync(
+        join(candidate, "one.xml"),
+        junit('<testcase name="a" time="1" file="pkg/a.test.ts" />'),
+      );
+      const snapshot = join(directory, "snapshot.json");
+      const comparison = join(directory, "comparison.json");
+      const script = join(import.meta.dir, "test-timings.ts");
+      const snapshotRun = Bun.spawnSync([
+        "bun",
+        script,
+        "snapshot",
+        "--junit",
+        legacy,
+        "--namespace",
+        "legacy",
+        "--baseline-sha",
+        "a".repeat(40),
+        "--source-run",
+        "run-1",
+        "--out",
+        snapshot,
+      ]);
+      expect(snapshotRun.exitCode).toBe(0);
+      expect(JSON.parse(readFileSync(snapshot, "utf8"))).toMatchObject({ samples: 1 });
+      const compareRun = Bun.spawnSync([
+        "bun",
+        script,
+        "compare",
+        "--legacy-junit",
+        legacy,
+        "--legacy-namespace",
+        "legacy",
+        "--candidate-junit",
+        candidate,
+        "--candidate-namespace",
+        "candidate",
+        "--out",
+        comparison,
+      ]);
+      expect(compareRun.exitCode).toBe(0);
+      expect(JSON.parse(readFileSync(comparison, "utf8"))).toMatchObject({ ratio: 0.5 });
+      expect(compareRun.stdout.toString()).toContain("Identity proof: 1 files / 1 testcases");
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
   });
 });

--- a/scripts/ci/test-timings.ts
+++ b/scripts/ci/test-timings.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env bun
-import { readFileSync } from "node:fs";
+import { mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { basename, dirname, extname, join, resolve } from "node:path";
 import { normalizeRepositoryTestPath } from "./test-inventory.js";
 
 export type TestOutcome = "passed" | "failed" | "skipped";
@@ -36,6 +37,24 @@ export interface TimingSnapshot {
   sourceRun: string;
   samples: number;
   files: FileTiming[];
+}
+
+export interface TopologyTimingComparison {
+  schema: 1;
+  legacyNamespace: string;
+  candidateNamespace: string;
+  files: number;
+  testcases: number;
+  legacyDurationSeconds: number;
+  candidateDurationSeconds: number;
+  deltaSeconds: number;
+  ratio: number | null;
+  fileDeltas: Array<{
+    file: string;
+    legacyDurationSeconds: number;
+    candidateDurationSeconds: number;
+    deltaSeconds: number;
+  }>;
 }
 
 const ATTRIBUTE_PATTERN =
@@ -206,8 +225,183 @@ export function createTimingSnapshot(options: {
   };
 }
 
+function artifactsByIdentity(artifacts: readonly LaneTimingArtifact[]): Map<string, TestcaseTiming> {
+  assertDisjointLaneOwnership(artifacts);
+  const result = new Map<string, TestcaseTiming>();
+  for (const testcase of artifacts.flatMap((artifact) => artifact.testcases)) {
+    if (result.has(testcase.identity)) {
+      throw new Error(`duplicate testcase identity across lanes: ${testcase.identity}`);
+    }
+    result.set(testcase.identity, testcase);
+  }
+  return result;
+}
+
+function singleNamespace(artifacts: readonly LaneTimingArtifact[], label: string): string {
+  const namespaces = [...new Set(artifacts.map((artifact) => artifact.namespace))];
+  if (namespaces.length !== 1) throw new Error(`${label} must contain exactly one namespace`);
+  return namespaces[0]!;
+}
+
+export function compareTopologyTimings(options: {
+  legacy: readonly LaneTimingArtifact[];
+  candidate: readonly LaneTimingArtifact[];
+}): TopologyTimingComparison {
+  const legacyNamespace = singleNamespace(options.legacy, "legacy artifacts");
+  const candidateNamespace = singleNamespace(options.candidate, "candidate artifacts");
+  if (legacyNamespace === candidateNamespace) {
+    throw new Error("legacy and candidate namespaces must differ");
+  }
+  const legacy = artifactsByIdentity(options.legacy);
+  const candidate = artifactsByIdentity(options.candidate);
+  const legacyIds = [...legacy.keys()].sort((left, right) => left.localeCompare(right));
+  const candidateIds = [...candidate.keys()].sort((left, right) => left.localeCompare(right));
+  const missing = legacyIds.filter((identity) => !candidate.has(identity));
+  const extra = candidateIds.filter((identity) => !legacy.has(identity));
+  if (missing.length > 0 || extra.length > 0) {
+    throw new Error(
+      `topology testcase identity mismatch: missing=${missing.length}, extra=${extra.length}`,
+    );
+  }
+  for (const identity of legacyIds) {
+    const left = legacy.get(identity)!;
+    const right = candidate.get(identity)!;
+    if (left.outcome !== right.outcome) {
+      throw new Error(`topology testcase outcome mismatch: ${identity}`);
+    }
+  }
+
+  const aggregate = (testcases: Iterable<TestcaseTiming>): Map<string, number> => {
+    const files = new Map<string, number>();
+    for (const testcase of testcases) {
+      files.set(testcase.file, (files.get(testcase.file) ?? 0) + testcase.durationSeconds);
+    }
+    return files;
+  };
+  const legacyFiles = aggregate(legacy.values());
+  const candidateFiles = aggregate(candidate.values());
+  const fileDeltas = [...legacyFiles.entries()]
+    .map(([file, legacyDurationSeconds]) => {
+      const candidateDurationSeconds = candidateFiles.get(file);
+      if (candidateDurationSeconds === undefined) {
+        throw new Error(`topology file identity mismatch: ${file}`);
+      }
+      return {
+        file,
+        legacyDurationSeconds,
+        candidateDurationSeconds,
+        deltaSeconds: candidateDurationSeconds - legacyDurationSeconds,
+      };
+    })
+    .sort(
+      (left, right) =>
+        right.deltaSeconds - left.deltaSeconds || left.file.localeCompare(right.file),
+    );
+  const legacyDurationSeconds = fileDeltas.reduce(
+    (total, file) => total + file.legacyDurationSeconds,
+    0,
+  );
+  const candidateDurationSeconds = fileDeltas.reduce(
+    (total, file) => total + file.candidateDurationSeconds,
+    0,
+  );
+  return {
+    schema: 1,
+    legacyNamespace,
+    candidateNamespace,
+    files: fileDeltas.length,
+    testcases: legacyIds.length,
+    legacyDurationSeconds,
+    candidateDurationSeconds,
+    deltaSeconds: candidateDurationSeconds - legacyDurationSeconds,
+    ratio: legacyDurationSeconds === 0 ? null : candidateDurationSeconds / legacyDurationSeconds,
+    fileDeltas,
+  };
+}
+
+export function topologyComparisonMarkdown(comparison: TopologyTimingComparison): string {
+  const ratio = comparison.ratio === null ? "unavailable" : comparison.ratio.toFixed(3);
+  return [
+    "## Legacy vs candidate test timing",
+    "",
+    `- Identity proof: ${comparison.files} files / ${comparison.testcases} testcases`,
+    `- Legacy testcase time: ${comparison.legacyDurationSeconds.toFixed(3)}s`,
+    `- Candidate testcase time: ${comparison.candidateDurationSeconds.toFixed(3)}s`,
+    `- Candidate / legacy ratio: ${ratio}`,
+    "",
+    "### Largest candidate regressions",
+    "",
+    ...comparison.fileDeltas
+      .slice(0, 20)
+      .map((file) => `- \`${file.file}\`: ${file.deltaSeconds.toFixed(3)}s`),
+    "",
+  ].join("\n");
+}
+
+function filesRecursively(directory: string): string[] {
+  const result: string[] = [];
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) result.push(...filesRecursively(path));
+    else if (entry.isFile()) result.push(path);
+  }
+  return result.sort((left, right) => left.localeCompare(right));
+}
+
+function junitArtifacts(directory: string, namespace: string): LaneTimingArtifact[] {
+  return filesRecursively(directory)
+    .filter((path) => extname(path) === ".xml")
+    .map((path) =>
+      parseBunJUnit(readFileSync(path, "utf8"), {
+        namespace,
+        lane: basename(path, ".xml"),
+      }),
+    );
+}
+
+function option(args: readonly string[], name: string): string {
+  const index = args.indexOf(name);
+  const value = index >= 0 ? args[index + 1] : undefined;
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+function writeJson(path: string, value: unknown): void {
+  const resolved = resolve(path);
+  mkdirSync(dirname(resolved), { recursive: true });
+  writeFileSync(resolved, `${JSON.stringify(value, null, 2)}\n`);
+}
+
 async function main(): Promise<void> {
-  const [path, namespace = "legacy", lane = "lane"] = process.argv.slice(2);
+  const args = process.argv.slice(2);
+  if (args[0] === "snapshot") {
+    const artifacts = junitArtifacts(option(args, "--junit"), option(args, "--namespace"));
+    writeJson(
+      option(args, "--out"),
+      createTimingSnapshot({
+        baselineSha: option(args, "--baseline-sha"),
+        sourceRun: option(args, "--source-run"),
+        artifacts,
+      }),
+    );
+    return;
+  }
+  if (args[0] === "compare") {
+    const comparison = compareTopologyTimings({
+      legacy: junitArtifacts(
+        option(args, "--legacy-junit"),
+        option(args, "--legacy-namespace"),
+      ),
+      candidate: junitArtifacts(
+        option(args, "--candidate-junit"),
+        option(args, "--candidate-namespace"),
+      ),
+    });
+    writeJson(option(args, "--out"), comparison);
+    process.stdout.write(topologyComparisonMarkdown(comparison));
+    return;
+  }
+  const [path, namespace = "legacy", lane = "lane"] = args;
   if (!path) throw new Error("usage: bun scripts/ci/test-timings.ts <junit.xml> [namespace] [lane]");
   process.stdout.write(
     `${JSON.stringify(parseBunJUnit(readFileSync(path, "utf8"), { namespace, lane }), null, 2)}\n`,

--- a/scripts/ci/workflow-policy.test.ts
+++ b/scripts/ci/workflow-policy.test.ts
@@ -289,6 +289,27 @@ describe("CI workflow policy", () => {
     expect(required).not.toContain("browser-system-chrome-canary");
   });
 
+  it("uses Node 24 action runtimes and keeps the isolated Windows sink cacheless", async () => {
+    const ci = await workflow("ci.yml");
+    const reusable = await workflow("reusable-quality.yml");
+    const workflows = `${ci}\n${reusable}`;
+    const windowsSink = block(ci, /^ {2}pdf-sink-windows:\s*$/, 2);
+
+    expect(workflows).toContain("actions/checkout@v7");
+    expect(workflows).toContain("actions/setup-node@v7");
+    expect(workflows).toContain("actions/github-script@v9");
+    expect(workflows).toContain("actions/cache@v6");
+    expect(workflows).toContain("actions/upload-artifact@v7");
+    expect(workflows).toContain("actions/download-artifact@v8");
+    expect(workflows).not.toMatch(
+      /actions\/(?:checkout@v6|setup-node@v6|github-script@v8|cache(?:\/restore)?@v4|upload-artifact@v4|download-artifact@v5)/,
+    );
+
+    expect(windowsSink).not.toBeNull();
+    expect(windowsSink).not.toContain("Restore Bun package cache");
+    expect(windowsSink).not.toContain("actions/cache@");
+  });
+
   it("keeps required quality branches parallel and removes duplicate publishing and aggregate tails", async () => {
     const reusable = await workflow("reusable-quality.yml");
     const staticQuality = block(reusable, /^ {2}static-quality:\s*$/, 2);
@@ -356,7 +377,7 @@ describe("CI workflow policy", () => {
     expect(telemetry).toContain("name: Non-required CI timing telemetry");
     expect(telemetry).toContain("needs: [changes, required]");
     expect(telemetry).toContain("if: always()");
-    expect(telemetry).toContain("actions/download-artifact@v5");
+    expect(telemetry).toContain("actions/download-artifact@v8");
     expect(telemetry).toContain("bun scripts/ci/telemetry-summary.ts");
     expect(required).not.toBeNull();
     expect(required).not.toContain("telemetry");

--- a/scripts/ci/workflow-policy.test.ts
+++ b/scripts/ci/workflow-policy.test.ts
@@ -289,11 +289,12 @@ describe("CI workflow policy", () => {
     expect(required).not.toContain("browser-system-chrome-canary");
   });
 
-  it("uses Node 24 action runtimes and keeps the isolated Windows sink cacheless", async () => {
+  it("uses Node 24 action runtimes and keeps Windows platform lanes cacheless", async () => {
     const ci = await workflow("ci.yml");
     const reusable = await workflow("reusable-quality.yml");
     const workflows = `${ci}\n${reusable}`;
     const windowsSink = block(ci, /^ {2}pdf-sink-windows:\s*$/, 2);
+    const windowsAstro = block(reusable, /^ {2}publishing-platform-windows:\s*$/, 2);
 
     expect(workflows).toContain("actions/checkout@v7");
     expect(workflows).toContain("actions/setup-node@v7");
@@ -308,6 +309,9 @@ describe("CI workflow policy", () => {
     expect(windowsSink).not.toBeNull();
     expect(windowsSink).not.toContain("Restore Bun package cache");
     expect(windowsSink).not.toContain("actions/cache@");
+    expect(windowsAstro).not.toBeNull();
+    expect(windowsAstro).not.toContain("Restore Bun package cache");
+    expect(windowsAstro).not.toContain("actions/cache@");
   });
 
   it("keeps required quality branches parallel and removes duplicate publishing and aggregate tails", async () => {
@@ -315,6 +319,7 @@ describe("CI workflow policy", () => {
     const staticQuality = block(reusable, /^ {2}static-quality:\s*$/, 2);
     const tests = block(reusable, /^ {2}tests:\s*$/, 2);
     const publishing = block(reusable, /^ {2}publishing-platform:\s*$/, 2);
+    const windows = block(reusable, /^ {2}publishing-platform-windows:\s*$/, 2);
     const latest = block(reusable, /^ {2}publishing-platform-latest:\s*$/, 2);
     const attestation = block(reusable, /^ {2}security-attestation:\s*$/, 2);
     const complete = block(reusable, /^ {2}quality-complete:\s*$/, 2);
@@ -349,9 +354,18 @@ describe("CI workflow policy", () => {
     expect(publishing).toContain("packages/web-publish-starlight/src/starlight-renderer.test.ts");
     expect(publishing).toContain('ATLCLI_CONSUMER_SMOKE: "1"');
     expect(publishing).toContain("minimum-astro");
-    expect(publishing).toContain("windows-astro");
-    expect(publishing).toContain("if: runner.os != 'Windows'");
+    expect(publishing).not.toContain("windows-latest");
     expect(publishing).not.toContain("latest-astro-7");
+
+    expect(windows).not.toBeNull();
+    expect(windows).toContain("runs-on: windows-latest");
+    expect(windows).toContain("github.event_name == 'schedule'");
+    expect(windows).toContain("github.ref_type == 'tag'");
+    expect(windows).toContain(
+      "continue-on-error: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}",
+    );
+    expect(windows).toContain("packages/web-publish-astro/src/astro-consumer.test.ts");
+    expect(windows).toContain("packages/web-publish-starlight/src/starlight-renderer.test.ts");
 
     expect(latest).not.toBeNull();
     expect(latest).toContain("github.event_name == 'schedule'");

--- a/scripts/ci/workflow-policy.test.ts
+++ b/scripts/ci/workflow-policy.test.ts
@@ -350,6 +350,7 @@ describe("CI workflow policy", () => {
     expect(publishing).toContain('ATLCLI_CONSUMER_SMOKE: "1"');
     expect(publishing).toContain("minimum-astro");
     expect(publishing).toContain("windows-astro");
+    expect(publishing).toContain("if: runner.os != 'Windows'");
     expect(publishing).not.toContain("latest-astro-7");
 
     expect(latest).not.toBeNull();

--- a/scripts/ci/workflow-policy.test.ts
+++ b/scripts/ci/workflow-policy.test.ts
@@ -42,13 +42,20 @@ const yamlLiteral = (source: string, header: RegExp): string | null => {
 
 const requiredGateEnv = {
   CHANGES: "success",
-  CODE_REQUIRED: "true",
+  PROOF_MODE: "required",
+  STATIC_REQUIRED: "true",
+  UNIT_REQUIRED: "true",
+  ASTRO_REQUIRED: "true",
   CONSUMER_REQUIRED: "true",
+  PDF_REQUIRED: "true",
+  BROWSER_REQUIRED: "true",
   DOCS_REQUIRED: "true",
   README_MEDIA_REQUIRED: "true",
   EVENT_NAME: "pull_request",
+  PRIVACY: "success",
   DOCS: "success",
   README_MEDIA: "success",
+  DRAFT_QUALITY: "skipped",
   TEST: "success",
   CONSUMER: "success",
   MACOS: "success",
@@ -72,11 +79,12 @@ function runRequiredGate(
 }
 
 describe("CI workflow policy", () => {
-  it("keeps one stable required check around selectively skipped jobs", async () => {
+  it("emits exactly one mode-named aggregate around selectively skipped jobs", async () => {
     const ci = await workflow("ci.yml");
     expect(ci).toContain("bun scripts/ci/classify-changes.ts --full");
     expect(ci).toContain("bun scripts/ci/classify-changes.ts --null");
-    expect(ci).toContain("name: required");
+    expect(ci).toContain("bun scripts/ci/proof-mode.ts");
+    expect(ci).toContain("name: ${{ needs.changes.outputs.aggregateStatusName }}");
     expect(ci).toContain("if: always()");
     expect(ci).toContain("uses: ./.github/workflows/reusable-quality.yml");
     expect(ci).toContain("uses: ./.github/workflows/reusable-consumer-smoke.yml");
@@ -85,18 +93,25 @@ describe("CI workflow policy", () => {
     expect(readmeMedia).toContain("if: needs.changes.outputs.readmeMedia == 'true'");
     expect(readmeMedia).toContain("bun run check:readme-media");
     const required = ci.slice(ci.indexOf("  required:"));
+    expect(required).toContain("- research-privacy");
     expect(required).toContain("- readme-media");
-    expect(required).toContain("CODE_REQUIRED: ${{ needs.changes.outputs.code }}");
+    expect(required).toContain("PROOF_MODE: ${{ needs.changes.outputs.proofMode }}");
+    expect(required).toContain("STATIC_REQUIRED: ${{ needs.changes.outputs.staticQuality }}");
+    expect(required).toContain("UNIT_REQUIRED: ${{ needs.changes.outputs.unitTests }}");
+    expect(required).toContain("ASTRO_REQUIRED: ${{ needs.changes.outputs.astroPlatform }}");
     expect(required).toContain("CONSUMER_REQUIRED: ${{ needs.changes.outputs.consumer }}");
+    expect(required).toContain("PDF_REQUIRED: ${{ needs.changes.outputs.pdfPlatform }}");
+    expect(required).toContain("BROWSER_REQUIRED: ${{ needs.changes.outputs.browserHarness }}");
     expect(required).toContain("DOCS_REQUIRED: ${{ needs.changes.outputs.docs }}");
     expect(required).toContain("README_MEDIA_REQUIRED: ${{ needs.changes.outputs.readmeMedia }}");
     expect(required).toContain("EVENT_NAME: ${{ github.event_name }}");
-    expect(required).toContain('require_result "Product quality" "$CODE_REQUIRED" "$TEST"');
+    expect(required).toContain('require_result "Tracked research privacy" "true" "$PRIVACY"');
+    expect(required).toContain('require_result "Product quality" "$QUALITY_REQUIRED" "$TEST"');
     expect(required).toContain('require_result "Pinned consumer smoke" "$CONSUMER_REQUIRED" "$CONSUMER"');
     expect(required).toContain('require_result "Documentation" "$DOCS_SELECTED" "$DOCS"');
   });
 
-  it("accepts skipped jobs only when their route is genuinely unselected", async () => {
+  it("accepts only the exact gate result set selected by required, draft, or stale proof", async () => {
     const ci = await workflow("ci.yml");
     const required = ci.slice(ci.indexOf("  required:"));
     const script = yamlLiteral(required, /^ {8}run: \|$/);
@@ -105,8 +120,12 @@ describe("CI workflow policy", () => {
     expect(runRequiredGate(script!).exitCode).toBe(0);
     expect(
       runRequiredGate(script!, {
-        CODE_REQUIRED: "false",
+        STATIC_REQUIRED: "false",
+        UNIT_REQUIRED: "false",
+        ASTRO_REQUIRED: "false",
         CONSUMER_REQUIRED: "false",
+        PDF_REQUIRED: "false",
+        BROWSER_REQUIRED: "false",
         DOCS_REQUIRED: "true",
         README_MEDIA_REQUIRED: "false",
         TEST: "skipped",
@@ -121,7 +140,35 @@ describe("CI workflow policy", () => {
     // Main pushes intentionally delegate docs build/deploy to docs.yml.
     expect(runRequiredGate(script!, { EVENT_NAME: "push", DOCS: "skipped" }).exitCode).toBe(0);
 
+    expect(
+      runRequiredGate(script!, {
+        PROOF_MODE: "draft-fast",
+        DRAFT_QUALITY: "success",
+        TEST: "skipped",
+        CONSUMER: "skipped",
+        MACOS: "skipped",
+        WINDOWS: "skipped",
+        BROWSER: "skipped",
+      }).exitCode,
+    ).toBe(0);
+
+    expect(
+      runRequiredGate(script!, {
+        PROOF_MODE: "superseded",
+        PRIVACY: "skipped",
+        DOCS: "skipped",
+        README_MEDIA: "skipped",
+        DRAFT_QUALITY: "skipped",
+        TEST: "skipped",
+        CONSUMER: "skipped",
+        MACOS: "skipped",
+        WINDOWS: "skipped",
+        BROWSER: "skipped",
+      }).exitCode,
+    ).toBe(0);
+
     for (const overrides of [
+      { PRIVACY: "skipped" },
       { TEST: "skipped" },
       { CONSUMER: "skipped" },
       { DOCS: "skipped" },
@@ -130,7 +177,17 @@ describe("CI workflow policy", () => {
       { BROWSER: "skipped" },
       { README_MEDIA: "skipped" },
       { CHANGES: "skipped" },
-      { CODE_REQUIRED: "false", TEST: "success" },
+      {
+        STATIC_REQUIRED: "false",
+        UNIT_REQUIRED: "false",
+        ASTRO_REQUIRED: "false",
+        TEST: "success",
+      },
+      {
+        PROOF_MODE: "draft-fast",
+        DRAFT_QUALITY: "success",
+        TEST: "success",
+      },
     ]) {
       const result = runRequiredGate(script!, overrides);
       expect(result.exitCode, `unexpectedly accepted ${JSON.stringify(overrides)}`).not.toBe(0);
@@ -143,13 +200,18 @@ describe("CI workflow policy", () => {
     expect(ci).toContain("group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}");
     expect(ci).toContain("cancel-in-progress: ${{ github.event_name == 'pull_request' }}");
     expect(ci).toMatch(/schedule:\n\s+# Full unfiltered drift guard/);
+    expect(ci).toContain("FULL_RUN: ${{ github.event_name == 'push'");
   });
 
   it("revalidates a pull request when it leaves draft", async () => {
     const ci = await workflow("ci.yml");
     const trigger = pullRequestTrigger(ci);
     expect(trigger).not.toBeNull();
-    expect(trigger).toContain("types: [opened, synchronize, reopened, ready_for_review]");
+    expect(trigger).toContain(
+      "types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]",
+    );
+    expect(ci).toContain("pull.draft");
+    expect(ci).toContain("pull.head.sha !== process.env.EXPECTED_HEAD_SHA");
   });
 
   it("is ready to run full proof for merge-queue candidates", async () => {
@@ -161,7 +223,7 @@ describe("CI workflow policy", () => {
     expect(ci).toContain("github.event_name == 'merge_group'");
     const required = block(ci, /^ {2}required:\s*$/, 2);
     expect(required).not.toBeNull();
-    expect(required).toContain("name: required");
+    expect(required).toContain("name: ${{ needs.changes.outputs.aggregateStatusName }}");
   });
 
   it("spells out the same trigger types on every pull_request workflow", async () => {
@@ -227,15 +289,17 @@ describe("CI workflow policy", () => {
     expect(required).not.toContain("browser-system-chrome-canary");
   });
 
-  it("keeps four complete blocking Bun shards with unique reports and a fail-closed aggregate", async () => {
+  it("keeps required quality branches parallel and removes duplicate publishing and aggregate tails", async () => {
     const reusable = await workflow("reusable-quality.yml");
     const staticQuality = block(reusable, /^ {2}static-quality:\s*$/, 2);
     const tests = block(reusable, /^ {2}tests:\s*$/, 2);
-    const publishing = block(reusable, /^ {2}publishing:\s*$/, 2);
+    const publishing = block(reusable, /^ {2}publishing-platform:\s*$/, 2);
+    const latest = block(reusable, /^ {2}publishing-platform-latest:\s*$/, 2);
     const attestation = block(reusable, /^ {2}security-attestation:\s*$/, 2);
     const complete = block(reusable, /^ {2}quality-complete:\s*$/, 2);
 
     expect(staticQuality).not.toBeNull();
+    expect(staticQuality).toContain("if: inputs.run_static_quality");
     expect(staticQuality).toContain("bun run typecheck");
     expect(staticQuality).toContain("bun run check:browser");
     expect(staticQuality).toContain("bun run build");
@@ -243,6 +307,7 @@ describe("CI workflow policy", () => {
     expect(staticQuality).not.toContain("bun run test");
 
     expect(tests).not.toBeNull();
+    expect(tests).toContain("if: inputs.run_tests");
     expect(tests).toContain("fail-fast: false");
     expect(tests).toContain("shard: [1, 2, 3, 4]");
     expect(tests).toContain('bun run test --shard="${SHARD}/4"');
@@ -258,28 +323,29 @@ describe("CI workflow policy", () => {
     expect(tests).not.toContain("continue-on-error:");
 
     expect(publishing).not.toBeNull();
-    expect(publishing).toContain("Astro publishing package and consumer gates");
+    expect(publishing).toContain("if: inputs.run_astro_platform");
     expect(publishing).toContain("packages/web-publish-astro/src/astro-consumer.test.ts");
     expect(publishing).toContain("packages/web-publish-starlight/src/starlight-renderer.test.ts");
-    expect(publishing).toContain("scripts/consumer-smoke.test.ts");
     expect(publishing).toContain('ATLCLI_CONSUMER_SMOKE: "1"');
+    expect(publishing).toContain("minimum-astro");
+    expect(publishing).toContain("windows-astro");
+    expect(publishing).not.toContain("latest-astro-7");
+
+    expect(latest).not.toBeNull();
+    expect(latest).toContain("github.event_name == 'schedule'");
+    expect(latest).toContain(
+      "continue-on-error: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}",
+    );
 
     expect(attestation).not.toBeNull();
-    expect(attestation).toContain("needs: [static-quality, tests, publishing]");
+    expect(attestation).not.toContain("needs:");
     expect(attestation).toContain("if: inputs.emit_security_attestation");
     expect(attestation).toContain("fetch-depth: 2");
     expect(attestation).toContain("attestation.commit !== process.env.GITHUB_SHA");
     expect(attestation).toContain("security-attestation-${{ github.sha }}");
 
-    expect(complete).not.toBeNull();
-    expect(complete).toContain("if: always()");
-    expect(complete).toContain("needs: [static-quality, tests, publishing, publishing-platform, security-attestation]");
-    expect(complete).toContain('[[ "$STATIC_QUALITY" != "success" ]]');
-    expect(complete).toContain('[[ "$TESTS" != "success" ]]');
-    expect(complete).toContain('[[ "$PUBLISHING" != "success" ]]');
-    expect(complete).toContain(
-      '[[ "$ATTESTATION_REQUIRED" == "true" && "$ATTESTATION" != "success" ]]',
-    );
+    expect(complete).toBeNull();
+    expect(block(reusable, /^ {2}publishing:\s*$/, 2)).toBeNull();
   });
 
   it("keeps timing telemetry outside every required status dependency graph", async () => {

--- a/specs/github-ci-throughput/EVIDENCE.md
+++ b/specs/github-ci-throughput/EVIDENCE.md
@@ -24,6 +24,12 @@ open until the live sample gates in `PLAN.md` are satisfied.
   aggregate tail are removed
 - Floating latest Astro 7: scheduled/manual advisory canary; release tags keep
   the compatibility check blocking
+- Official GitHub Actions in the touched workflows use their current Node 24
+  majors (`checkout@v7`, `setup-node@v7`, `github-script@v9`, `cache@v6`,
+  `upload-artifact@v7`, and `download-artifact@v8`)
+- The isolated Windows PDF sink deliberately skips the shared Bun package
+  cache after a live restore stalled longer than the complete Linux/browser
+  proof paths
 
 ## PR #139 observed bottleneck
 
@@ -44,6 +50,23 @@ The final critical path was structurally serial:
 The workflow changes in this branch remove that serial publishing/platform
 chain, remove the inner aggregate runner, and move floating-latest Astro away
 from ordinary PR/main proof. No post-change GitHub timing is claimed yet.
+
+## PR #150 live rollout observation
+
+The first full ready-PR run on rebased head `d09d8e3`
+([Actions run 31401969872](https://github.com/BjoernSchotte/atlcli/actions/runs/31401969872))
+confirmed that classification completed in 12 seconds and all selected product
+branches started in parallel. Static quality completed in 1 minute 29 seconds,
+the packed browser proof in 2 minutes 22 seconds, the pinned consumer proof in
+3 minutes 43 seconds, and the slowest complete Bun shard in 5 minutes 37
+seconds.
+
+That run was intentionally superseded before aggregation: `pdf-sink-windows`
+remained inside the legacy `actions/cache@v4` Bun-cache restore for more than
+eight minutes after every other selected job was green. This is diagnostic
+evidence, not a final post-change timing. The follow-up removes that cache from
+the isolated sink and updates the official GitHub Actions runtimes before the
+merge proof is repeated.
 
 ## Local synthetic proof
 

--- a/specs/github-ci-throughput/EVIDENCE.md
+++ b/specs/github-ci-throughput/EVIDENCE.md
@@ -6,8 +6,8 @@ open until the live sample gates in `PLAN.md` are satisfied.
 ## Implementation snapshot
 
 - Planning baseline SHA: `9ffbe22e604413226a863064da31dc6981f76ce0`
-- Baseline Bun inventory: 405 test files
-- Current implementation inventory: 410 test files
+- PR #139 merge baseline SHA: `5310e90e696697d4f61e0f4c22836e0c826c5b4d`
+- Duration-aware topology inventory: 609 eligible test files
 - Required topology: `legacy-4-shard` (unchanged)
 - Candidate topologies: `general-2x1`, `general-3x1`,
   `general-2x2-workers`
@@ -15,6 +15,35 @@ open until the live sample gates in `PLAN.md` are satisfied.
 - System Chrome: scheduled/manual non-required compatibility canary
 - Merge queue: workflow trigger ready; repository transfer and queue activation
   remain external and deferred
+- PR proof modes: live-state-validated `draft-fast`, `superseded`, and
+  merge-ready `required`
+- Ready-PR routing: conservative package/capability closures; workflow,
+  lockfile, global, unknown, main-push, scheduled, and manual inputs fail open
+- Quality DAG: static quality, Bun shards, pinned Astro platforms, and optional
+  attestation start independently; the duplicate publishing job and reusable
+  aggregate tail are removed
+- Floating latest Astro 7: scheduled/manual advisory canary; release tags keep
+  the compatibility check blocking
+
+## PR #139 observed bottleneck
+
+The final green PR run
+([Actions run 31395422582](https://github.com/BjoernSchotte/atlcli/actions/runs/31395422582))
+started classification at 13:55:55 UTC and completed the stable `required`
+check at 14:07:51 UTC: 11 minutes 56 seconds from first runner start to green.
+It consumed about 42.6 runner-minutes.
+
+The final critical path was structurally serial:
+
+1. static quality completed at 13:58:21;
+2. the duplicate Astro publishing job ran until 14:02:22;
+3. only then did the Astro platform matrix start;
+4. the Windows Astro leg completed at 14:07:37;
+5. two aggregate runner jobs followed before telemetry.
+
+The workflow changes in this branch remove that serial publishing/platform
+chain, remove the inner aggregate runner, and move floating-latest Astro away
+from ordinary PR/main proof. No post-change GitHub timing is claimed yet.
 
 ## Local synthetic proof
 
@@ -27,14 +56,15 @@ open until the live sample gates in `PLAN.md` are satisfied.
 | Deterministic LPT lanes and argv-safe runner | Passed focused tests |
 | Workflow dependency and non-required telemetry policy | Passed focused tests |
 | Security attestation dependency-free policy | Passed focused tests |
-| Complete root suite | 5,938 passed, 15 skipped, 0 failed across 410 files |
+| Complete root suite | 7,711 passed, 16 skipped, 0 failed across 611 files (four CI shards) |
 | TypeScript typecheck (root, extension, compiler, harness) | Passed |
-| Complete build | Passed, 20 Turbo tasks |
+| Complete build | Passed, 27 Turbo tasks |
 | Full Bun/npm/pnpm consumer proof | 12 passed, 0 failed |
-| Documentation check/build | Passed, 78 pages built |
+| Documentation check/build | Passed, 90 pages built |
 | Neutral bundled-Chromium harness | 6 passed, 0 failed |
 | Packed MV3 PDF.js worker proof | 2 passed, 0 failed |
-| Packed MV3 durable-jobs proof | 23 passed, 0 failed |
+| Packed MV3 durable-jobs proof | 24 passed, 0 failed |
+| Packed MV3 Rovo visibility proof | 2 passed, 0 failed |
 | Browser/Node shape parity | Passed |
 | Required local Atlassian E2E | Not run: `ATLCLI_E2E_PAGE_ID` is unavailable |
 
@@ -88,7 +118,9 @@ environment. No customer identifier or credential was copied into this file.
 | Duration-aware test topology | Measuring | Required lane remains legacy |
 | System Chrome neutral harness | Canary only | Cannot replace matched Chromium/MV3 proof |
 | Package build reuse | Held | Same-SHA artifact/co-located evidence absent |
-| Selective product routing | Held | Shadow graph and observation gate incomplete |
-| Draft-fast | Held | Depends on selective routing and live PR-state proof |
+| Selective product routing | Implemented, live validation pending | Conservative dependency closures and fail-open overrides are covered locally; post-change PR evidence is still required |
+| Draft-fast | Implemented, live validation pending | Live PR head/draft state is checked at selection; ready proof is checked again inside the final aggregate |
+| Quality DAG flattening | Implemented | Duplicate publishing proof and reusable aggregate tail removed; pinned Astro platforms run in parallel |
+| Pinned PDF font cache | Implemented | Content-addressed per-OS cache; `fonts:ensure` still verifies every restored file |
 | Browser branch parallelism | Held | Isolation and ten-run comparison incomplete |
 | Merge queue activation | Deferred | External repository ownership decision required |

--- a/specs/github-ci-throughput/EVIDENCE.md
+++ b/specs/github-ci-throughput/EVIDENCE.md
@@ -19,11 +19,11 @@ open until the live sample gates in `PLAN.md` are satisfied.
   merge-ready `required`
 - Ready-PR routing: conservative package/capability closures; workflow,
   lockfile, global, unknown, main-push, scheduled, and manual inputs fail open
-- Quality DAG: static quality, Bun shards, pinned Astro platforms, and optional
+- Quality DAG: static quality, Bun shards, pinned Ubuntu Astro, and optional
   attestation start independently; the duplicate publishing job and reusable
   aggregate tail are removed
-- Floating latest Astro 7: scheduled/manual advisory canary; release tags keep
-  the compatibility check blocking
+- Floating latest Astro 7 and pinned Windows Astro: scheduled/manual advisory
+  canaries; release tags keep both compatibility checks blocking
 - Official GitHub Actions in the touched workflows use their current Node 24
   majors (`checkout@v7`, `setup-node@v7`, `github-script@v9`, `cache@v6`,
   `upload-artifact@v7`, and `download-artifact@v8`)
@@ -142,7 +142,7 @@ environment. No customer identifier or credential was copied into this file.
 | Package build reuse | Held | Same-SHA artifact/co-located evidence absent |
 | Selective product routing | Implemented, live validation pending | Conservative dependency closures and fail-open overrides are covered locally; post-change PR evidence is still required |
 | Draft-fast | Implemented, live validation pending | Live PR head/draft state is checked at selection; ready proof is checked again inside the final aggregate |
-| Quality DAG flattening | Implemented | Duplicate publishing proof and reusable aggregate tail removed; pinned Astro platforms run in parallel |
+| Quality DAG flattening | Implemented | Duplicate publishing proof and reusable aggregate tail removed; pinned Ubuntu Astro runs in parallel while Windows compatibility moves off ordinary PRs |
 | Pinned PDF font cache | Implemented | Content-addressed per-OS cache; `fonts:ensure` still verifies every restored file |
 | Browser branch parallelism | Held | Isolation and ten-run comparison incomplete |
 | Merge queue activation | Deferred | External repository ownership decision required |

--- a/specs/github-ci-throughput/EVIDENCE.md
+++ b/specs/github-ci-throughput/EVIDENCE.md
@@ -27,9 +27,8 @@ open until the live sample gates in `PLAN.md` are satisfied.
 - Official GitHub Actions in the touched workflows use their current Node 24
   majors (`checkout@v7`, `setup-node@v7`, `github-script@v9`, `cache@v6`,
   `upload-artifact@v7`, and `download-artifact@v8`)
-- The isolated Windows PDF sink deliberately skips the shared Bun package
-  cache after a live restore stalled longer than the complete Linux/browser
-  proof paths
+- Windows platform lanes deliberately skip the shared Bun package cache after
+  live restores outlasted the complete Linux/browser proof paths
 
 ## PR #139 observed bottleneck
 

--- a/specs/github-ci-throughput/PLAN.md
+++ b/specs/github-ci-throughput/PLAN.md
@@ -1,6 +1,6 @@
 # GitHub CI throughput and merge-ready latency
 
-- Status: proposed
+- Status: implemented locally; live promotion evidence pending
 - Planning baseline: `27d2e95bd90ea0695f5f7442efec807ec1dca155`
   (`main`, 2026-07-30)
 - Investigation reference:

--- a/specs/web-publishing-astro/EVIDENCE.md
+++ b/specs/web-publishing-astro/EVIDENCE.md
@@ -524,11 +524,19 @@ Ubuntu Node 24, Windows Node 24, typecheck/browser/build, publishing consumers, 
 the required aggregator passed in run `30705797902`. Non-required timing telemetry
 is intentionally outside that gate.
 
+That run records the original acceptance proof, not the permanent per-PR
+cadence. The CI-throughput rollout keeps pinned Astro 7.1.6 on Ubuntu Node
+22.12 as ordinary merge-ready proof. Latest Astro 7.x on Ubuntu and pinned
+Astro on Windows run as scheduled/manual compatibility canaries and remain
+blocking on release tags. Windows local publishing support is retained without
+putting the multi-minute Windows runner on every pull request.
+
 ## T11/T12 final verification and cleanup boundary (2026-08-01)
 
-The minimum fixture pins Astro `7.1.6`; the required CI matrix proves the minimum
-Ubuntu Node 22.12 lane, latest supported 7.x on Ubuntu Node 24, and Windows Node 24
-path portability. The real read-only Cloud E2E used `mayflower` against `DOCSY` and
+The minimum fixture pins Astro `7.1.6`; ordinary required CI proves the minimum
+Ubuntu Node 22.12 lane, while release-blocking compatibility canaries prove latest
+supported 7.x on Ubuntu Node 24 and Windows Node 24 path portability. The real
+read-only Cloud E2E used `mayflower` against `DOCSY` and
 the complete 98-page space, with the explicit partial asset policy retaining all
 pages and surfacing three visible blocked-asset fallbacks. No Data Center provider
 was available for a live run; DC behavior is fixture-proven and the live provider


### PR DESCRIPTION
## Summary

- add live-state-aware `draft-fast`, `superseded`, and `required` proof modes
- route ready PR checks through conservative capability closures while keeping main, scheduled, manual, and merge-group runs fail-open
- flatten the reusable quality DAG, remove duplicate publishing/aggregate runners, and move floating Astro to a canary
- add duration-aware topology candidates and same-run timing evidence without promoting an unproven topology
- cache pinned PDF fonts across relevant runners

## Why

PR #139 needed 11m56s from first runner start to the stable `required` check and consumed about 42.6 runner-minutes. Its critical path serialized static quality, duplicate publishing, Astro platform checks, and two aggregate jobs.

## Validation

- 73 focused CI policy and topology tests
- complete four-shard root suite: 7,711 passed, 16 skipped, 0 failed across 611 files
- root typecheck and 27-task build
- actionlint and research privacy scan
- docs check and 90-page build
- browser export harness: 6 passed
- packed MV3 worker/jobs/Rovo: 28 passed
- Browser/Node shape parity

The private read-only Atlassian E2E fixture was not available locally because `ATLCLI_E2E_PAGE_ID` was unset. No tenant identifier or credential was persisted.