### PR TITLE
fix(release): honor required aggregate eligibility

### DIFF
--- a/scripts/ci/release-eligibility.test.ts
+++ b/scripts/ci/release-eligibility.test.ts
@@ -127,6 +127,30 @@ describe("dev release source eligibility", () => {
     expect(unknown.reason).toContain("unclassified-failed-job");
   });
 
+  test("accepts a failed workflow conclusion only when required passed and the sole failure is advisory", () => {
+    const result = terminal({
+      runs: [run({ conclusion: "failure", run_attempt: 2 })],
+      jobs: [
+        job(),
+        job({ id: 201, name: "Non-required CI timing telemetry", conclusion: "failure" }),
+      ],
+    });
+    expect(result).toMatchObject({
+      decision: "eligible",
+      reason: "eligible-with-advisory-failures",
+      degraded: true,
+      workflow: { runAttempt: 2, conclusion: "failure" },
+      requiredJob: { conclusion: "success" },
+      advisory: [{ name: "Non-required CI timing telemetry", conclusion: "failure" }],
+    });
+
+    const unexplained = terminal({
+      runs: [run({ conclusion: "failure" })],
+      jobs: [job()],
+    });
+    expect(unexplained.reason).toBe("canonical-run-failure-without-advisory-failure");
+  });
+
   test("polls pending state and emits a blocked timeout receipt without publishing", async () => {
     let clock = 0;
     const client: EligibilityClient = {

--- a/scripts/ci/release-eligibility.ts
+++ b/scripts/ci/release-eligibility.ts
@@ -11,6 +11,7 @@ import {
 export const RELEASE_ELIGIBILITY_POLICY = "atlcli.dev-release-eligibility/v1";
 export const REQUIRED_JOB_NAME = "required";
 export const ADVISORY_JOB_NAMES = new Set([
+  "Non-required CI timing telemetry",
   "Non-required system Chrome compatibility",
   "Product quality / Astro Windows compatibility canary (Astro 7.1.6, Node 24)",
   "Product quality / Astro platform canary (latest Astro 7, Node 24)",
@@ -168,7 +169,7 @@ export function evaluateEligibilitySnapshot(input: {
   if (!run) return { state: "pending", reason: "missing-run" };
   const workflow = workflowReceipt(run);
   if (run.status !== "completed") return { state: "pending", reason: "run-pending" };
-  if (run.conclusion !== "success") {
+  if (!input.jobs && run.conclusion !== "success") {
     return {
       state: "terminal",
       receipt: receipt({
@@ -228,6 +229,18 @@ export function evaluateEligibilitySnapshot(input: {
   const advisory = failedJobs
     .filter((job) => ADVISORY_JOB_NAMES.has(job.name))
     .map((job) => ({ name: job.name, conclusion: job.conclusion! }));
+  if (run.conclusion !== "success" && advisory.length === 0) {
+    return {
+      state: "terminal",
+      receipt: receipt({
+        sourceSha,
+        decision: "blocked",
+        reason: `canonical-run-${run.conclusion ?? "missing-conclusion"}-without-advisory-failure`,
+        workflow,
+        requiredJob: jobReceipt(required),
+      }),
+    };
+  }
   return {
     state: "terminal",
     receipt: receipt({
@@ -259,7 +272,7 @@ export async function resolveSourceEligibility(input: {
   while (true) {
     const runs = await input.client.listCanonicalRuns(sourceSha);
     lastRun = canonicalRuns(runs, sourceSha)[0];
-    const jobs = lastRun?.status === "completed" && lastRun.conclusion === "success"
+    const jobs = lastRun?.status === "completed"
       ? await input.client.listAttemptJobs(lastRun.id, lastRun.run_attempt)
       : undefined;
     lastEvaluation = evaluateEligibilitySnapshot({ sourceSha, runs, jobs });


### PR DESCRIPTION
## Summary
- allow a canonical main CI run to be release-eligible when the required aggregate passed and only explicitly non-required jobs failed
- classify timing telemetry as advisory and retain degraded evidence
- keep unknown failures and unexplained failed workflow conclusions fail-closed

## Proof
- bun run test scripts/ci/release-eligibility.test.ts scripts/ci/workflow-policy.test.ts
- bun run typecheck
- remote dry-run 31627317113 proved the previous false-negative without publishing