### PR TITLE
fix(release): provision extension fonts

### DIFF
--- a/.github/workflows/reusable-release-artifacts.yml
+++ b/.github/workflows/reusable-release-artifacts.yml
@@ -118,6 +118,9 @@ jobs:
       - name: Install frozen dependencies
         run: bun install --frozen-lockfile
 
+      - name: Provision pinned PDF fonts
+        run: bun run fonts:ensure
+
       - name: Build deterministic extension archive
         run: |
           bun scripts/release-artifacts.ts build \

--- a/scripts/ci/workflow-policy.test.ts
+++ b/scripts/ci/workflow-policy.test.ts
@@ -99,6 +99,12 @@ describe("CI workflow policy", () => {
     expect(reusable).toContain('--target "${{ matrix.target }}"');
     expect(reusable).toContain("--skip-extension");
     expect(reusable).toContain("--skip-cli");
+    const extensionBuild = block(reusable, /^ {2}build-extension:\s*$/, 2);
+    expect(extensionBuild).not.toBeNull();
+    expect(extensionBuild).toContain("bun run fonts:ensure");
+    expect(extensionBuild!.indexOf("bun run fonts:ensure")).toBeLessThan(
+      extensionBuild!.indexOf("bun scripts/release-artifacts.ts build"),
+    );
     expect(reusable).toContain("bun scripts/assemble-release-bundle.ts");
     expect(reusable).toContain("bun scripts/verify-release-artifacts.ts --dir bundle");
     for (const suite of ["worker", "jobs", "research", "rovo", "palette"]) {


### PR DESCRIPTION
## Summary
- provision the SHA-256-pinned PDF font set in the isolated extension release job
- assert via workflow policy that provisioning occurs before the release-artifact builder

## Proof
- bun run test scripts/ci/workflow-policy.test.ts scripts/bun-version-pin.test.ts
- bun run typecheck
- bun run --cwd apps/extension zip
- remote shadow run 31628596584 reproduced the missing-font failure before any publication