### PR TITLE
fix(release): freeze identity across retries

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -44,6 +44,7 @@ jobs:
       version: ${{ steps.identity.outputs.version }}
       build_id: ${{ steps.identity.outputs.build_id }}
       created_at: ${{ steps.identity.outputs.created_at }}
+      release_attempt: ${{ steps.identity.outputs.release_attempt }}
       stable_latest: ${{ steps.identity.outputs.stable_latest }}
     steps:
       - uses: actions/checkout@v7
@@ -88,6 +89,7 @@ jobs:
             --run-number "$GITHUB_RUN_NUMBER" \
             --run-attempt "$GITHUB_RUN_ATTEMPT" > dev-release-identity.json
           build_id="$(bun -e 'console.log((await Bun.file("dev-release-identity.json").json()).buildId)')"
+          release_attempt="$(bun -e 'console.log((await Bun.file("dev-release-identity.json").json()).runAttempt)')"
           stable_latest="$(gh api "repos/$GITHUB_REPOSITORY/releases/latest" --jq .tag_name)"
           {
             echo "source_sha=$source_sha"
@@ -95,6 +97,7 @@ jobs:
             echo "version=$version"
             echo "build_id=$build_id"
             echo "created_at=$created_at"
+            echo "release_attempt=$release_attempt"
             echo "stable_latest=$stable_latest"
           } >> "$GITHUB_OUTPUT"
 
@@ -135,7 +138,7 @@ jobs:
             --source-sha "${{ needs.resolve-source.outputs.source_sha }}" \
             --created-at "${{ needs.resolve-source.outputs.created_at }}" \
             --run-number "$GITHUB_RUN_NUMBER" \
-            --run-attempt "$GITHUB_RUN_ATTEMPT" \
+            --run-attempt "${{ needs.resolve-source.outputs.release_attempt }}" \
             --force-rebuild "${{ inputs.force_rebuild || false }}" \
             --out dev-publication-decision.json
 
@@ -218,6 +221,7 @@ jobs:
       version: ${{ needs.resolve-source.outputs.version }}
       build_id: ${{ needs.resolve-source.outputs.build_id }}
       created_at: ${{ needs.resolve-source.outputs.created_at }}
+      release_attempt: ${{ fromJSON(needs.resolve-source.outputs.release_attempt) }}
       security_attestation_artifact: security-attestation-${{ needs.resolve-source.outputs.source_sha }}-${{ github.run_id }}-${{ github.run_attempt }}
       source_eligibility_artifact: source-eligibility-${{ needs.resolve-source.outputs.source_sha }}-${{ github.run_id }}-${{ github.run_attempt }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,6 +83,7 @@ jobs:
       version: ${{ needs.resolve.outputs.version }}
       build_id: ${{ needs.resolve.outputs.build_id }}
       created_at: ${{ needs.resolve.outputs.created_at }}
+      release_attempt: ${{ github.run_attempt }}
       security_attestation_artifact: security-attestation-${{ needs.resolve.outputs.source_sha }}-${{ github.run_id }}-${{ github.run_attempt }}
 
   create-draft:

--- a/.github/workflows/reusable-release-artifacts.yml
+++ b/.github/workflows/reusable-release-artifacts.yml
@@ -21,6 +21,9 @@ on:
       created_at:
         required: true
         type: string
+      release_attempt:
+        required: true
+        type: number
       security_attestation_artifact:
         required: true
         type: string
@@ -75,7 +78,7 @@ jobs:
             --source-sha "${{ inputs.source_sha }}" \
             --timestamp "${{ inputs.created_at }}" \
             --run-number "$GITHUB_RUN_NUMBER" \
-            --run-attempt "$GITHUB_RUN_ATTEMPT" \
+            --run-attempt "${{ inputs.release_attempt }}" \
             --target "${{ matrix.target }}" \
             --skip-extension \
             --output release \
@@ -129,7 +132,7 @@ jobs:
             --source-sha "${{ inputs.source_sha }}" \
             --timestamp "${{ inputs.created_at }}" \
             --run-number "$GITHUB_RUN_NUMBER" \
-            --run-attempt "$GITHUB_RUN_ATTEMPT" \
+            --run-attempt "${{ inputs.release_attempt }}" \
             --skip-cli \
             --output release \
             --receipt build-receipt.json
@@ -208,7 +211,7 @@ jobs:
             --created-at "${{ inputs.created_at }}"
             --run-id "$GITHUB_RUN_ID"
             --run-number "$GITHUB_RUN_NUMBER"
-            --run-attempt "$GITHUB_RUN_ATTEMPT"
+            --run-attempt "${{ inputs.release_attempt }}"
             --event "$GITHUB_EVENT_NAME"
             --build-id "${{ inputs.build_id }}"
             --security-attestation bundle/security-attestation.json

--- a/scripts/ci/workflow-policy.test.ts
+++ b/scripts/ci/workflow-policy.test.ts
@@ -99,6 +99,9 @@ describe("CI workflow policy", () => {
     expect(reusable).toContain('--target "${{ matrix.target }}"');
     expect(reusable).toContain("--skip-extension");
     expect(reusable).toContain("--skip-cli");
+    expect(reusable).toContain("release_attempt:");
+    expect(reusable.match(/--run-attempt \"\$\{\{ inputs\.release_attempt \}\}\"/g)).toHaveLength(3);
+    expect(release).toContain("release_attempt: ${{ github.run_attempt }}");
     const extensionBuild = block(reusable, /^ {2}build-extension:\s*$/, 2);
     expect(extensionBuild).not.toBeNull();
     expect(extensionBuild).toContain("bun run fonts:ensure");
@@ -219,6 +222,7 @@ describe("CI workflow policy", () => {
     expect(eligibility).toContain("checks: read");
     expect(eligibility).toContain("contents: read");
     expect(eligibility).toContain("scripts/ci/release-eligibility.ts");
+    expect(dev).toContain('--run-attempt "${{ needs.resolve-source.outputs.release_attempt }}"');
     expect(eligibility).toContain('--source-sha "${{ needs.resolve-source.outputs.source_sha }}"');
     expect(preflight).not.toBeNull();
     expect(preflight).toContain("needs: [resolve-source, publication-decision, eligible-source]");


### PR DESCRIPTION
## Summary
- freeze the first resolved release attempt as part of source identity
- pass it to publication decisions, every CLI/extension builder, and bundle metadata
- keep stable release calls explicit too

## Proof
- bun run test scripts/ci/workflow-policy.test.ts scripts/release-artifacts.test.ts scripts/assemble-release-bundle.test.ts
- bun run typecheck
- shadow run 31630818214 reproduced the previous attempt-1/attempt-2 identity mismatch without publication