### PR TITLE
fix(release): retry transient dependency installs

### DIFF
--- a/.github/workflows/reusable-release-artifacts.yml
+++ b/.github/workflows/reusable-release-artifacts.yml
@@ -65,7 +65,16 @@ jobs:
           bun-version: ${{ env.BUN_VERSION }}
 
       - name: Install frozen dependencies
-        run: bun install --frozen-lockfile
+        run: |
+          for attempt in 1 2 3; do
+            if bun install --frozen-lockfile; then
+              exit 0
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              exit 1
+            fi
+            sleep "$((attempt * 5))"
+          done
 
       - name: Provision pinned PDF fonts
         run: bun run fonts:ensure
@@ -119,7 +128,16 @@ jobs:
           bun-version: ${{ env.BUN_VERSION }}
 
       - name: Install frozen dependencies
-        run: bun install --frozen-lockfile
+        run: |
+          for attempt in 1 2 3; do
+            if bun install --frozen-lockfile; then
+              exit 0
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              exit 1
+            fi
+            sleep "$((attempt * 5))"
+          done
 
       - name: Provision pinned PDF fonts
         run: bun run fonts:ensure
@@ -172,7 +190,16 @@ jobs:
           bun-version: ${{ env.BUN_VERSION }}
 
       - name: Install frozen dependencies
-        run: bun install --frozen-lockfile
+        run: |
+          for attempt in 1 2 3; do
+            if bun install --frozen-lockfile; then
+              exit 0
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              exit 1
+            fi
+            sleep "$((attempt * 5))"
+          done
 
       - name: Download this run's CLI artifacts only
         uses: actions/download-artifact@v8

--- a/scripts/ci/workflow-policy.test.ts
+++ b/scripts/ci/workflow-policy.test.ts
@@ -94,7 +94,10 @@ describe("CI workflow policy", () => {
     expect(release).not.toContain("source_eligibility_artifact:");
 
     expect(reusable).toContain("target: [linux-x64, linux-arm64, darwin-x64, darwin-arm64, windows-x64]");
-    expect(reusable).toContain("bun install --frozen-lockfile");
+    expect(reusable.match(/for attempt in 1 2 3; do/g)).toHaveLength(3);
+    expect(reusable.match(/if bun install --frozen-lockfile; then/g)).toHaveLength(3);
+    expect(reusable.match(/if \[ "\$attempt" -eq 3 \]; then/g)).toHaveLength(3);
+    expect(reusable.match(/sleep "\$\(\(attempt \* 5\)\)"/g)).toHaveLength(3);
     expect(reusable).toContain("bun scripts/release-artifacts.ts build");
     expect(reusable).toContain('--target "${{ matrix.target }}"');
     expect(reusable).toContain("--skip-extension");


### PR DESCRIPTION
## Summary
- retry frozen Bun installs up to three times in all shared release artifact jobs
- keep lockfile and release bytes unchanged while tolerating transient upstream 503/connection failures
- add policy regression coverage for the bounded retry contract

## Verification
- bun run test scripts/ci/workflow-policy.test.ts scripts/release-artifacts.test.ts scripts/assemble-release-bundle.test.ts
- bun run typecheck