### PR TITLE
fix(ci): retry frozen dependency installs

### DIFF
--- a/.github/workflows/reusable-quality.yml
+++ b/.github/workflows/reusable-quality.yml
@@ -70,7 +70,7 @@ jobs:
             ${{ runner.os }}-turbo-
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        run: bash scripts/ci/install-frozen-dependencies.sh
 
       - name: Validate dev-release evidence schemas and privacy
         if: inputs.run_static_quality
@@ -195,7 +195,7 @@ jobs:
           key: ${{ runner.os }}-pdf-fonts-v1-${{ hashFiles('packages/pdf/src/runtime-assets.ts', 'packages/pdf/scripts/ensure-fonts.ts') }}
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        run: bash scripts/ci/install-frozen-dependencies.sh
 
       - name: Install PDF proof tools
         if: matrix.poppler
@@ -295,7 +295,7 @@ jobs:
           key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        run: bash scripts/ci/install-frozen-dependencies.sh
 
       - name: Verify Astro version lane
         shell: bash
@@ -355,7 +355,7 @@ jobs:
           bun-version: 1.3.14
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        run: bash scripts/ci/install-frozen-dependencies.sh
 
       - name: Verify pinned Astro version
         shell: bash
@@ -421,7 +421,7 @@ jobs:
           key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile
+        run: bash scripts/ci/install-frozen-dependencies.sh
 
       - name: Resolve latest supported Astro 7.x
         shell: bash

--- a/.github/workflows/reusable-release-artifacts.yml
+++ b/.github/workflows/reusable-release-artifacts.yml
@@ -65,16 +65,7 @@ jobs:
           bun-version: ${{ env.BUN_VERSION }}
 
       - name: Install frozen dependencies
-        run: |
-          for attempt in 1 2 3; do
-            if bun install --frozen-lockfile; then
-              exit 0
-            fi
-            if [ "$attempt" -eq 3 ]; then
-              exit 1
-            fi
-            sleep "$((attempt * 5))"
-          done
+        run: bash scripts/ci/install-frozen-dependencies.sh
 
       - name: Provision pinned PDF fonts
         run: bun run fonts:ensure
@@ -128,16 +119,7 @@ jobs:
           bun-version: ${{ env.BUN_VERSION }}
 
       - name: Install frozen dependencies
-        run: |
-          for attempt in 1 2 3; do
-            if bun install --frozen-lockfile; then
-              exit 0
-            fi
-            if [ "$attempt" -eq 3 ]; then
-              exit 1
-            fi
-            sleep "$((attempt * 5))"
-          done
+        run: bash scripts/ci/install-frozen-dependencies.sh
 
       - name: Provision pinned PDF fonts
         run: bun run fonts:ensure
@@ -190,16 +172,7 @@ jobs:
           bun-version: ${{ env.BUN_VERSION }}
 
       - name: Install frozen dependencies
-        run: |
-          for attempt in 1 2 3; do
-            if bun install --frozen-lockfile; then
-              exit 0
-            fi
-            if [ "$attempt" -eq 3 ]; then
-              exit 1
-            fi
-            sleep "$((attempt * 5))"
-          done
+        run: bash scripts/ci/install-frozen-dependencies.sh
 
       - name: Download this run's CLI artifacts only
         uses: actions/download-artifact@v8

--- a/scripts/ci/install-frozen-dependencies.sh
+++ b/scripts/ci/install-frozen-dependencies.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+for attempt in 1 2 3; do
+  if bun install --frozen-lockfile; then
+    exit 0
+  fi
+  if [[ "$attempt" -eq 3 ]]; then
+    exit 1
+  fi
+  sleep "$((attempt * 5))"
+done

--- a/scripts/ci/workflow-policy.test.ts
+++ b/scripts/ci/workflow-policy.test.ts
@@ -6,6 +6,7 @@ import { join } from "node:path";
 const REPO_ROOT = fileURLToPath(new URL("../..", import.meta.url));
 const WORKFLOW_DIR = join(REPO_ROOT, ".github", "workflows");
 const workflow = (name: string) => readFile(join(WORKFLOW_DIR, name), "utf8");
+const ciScript = (name: string) => readFile(join(REPO_ROOT, "scripts", "ci", name), "utf8");
 const workflowNames = async () =>
   (await readdir(WORKFLOW_DIR)).filter((entry) => entry.endsWith(".yml"));
 
@@ -94,10 +95,7 @@ describe("CI workflow policy", () => {
     expect(release).not.toContain("source_eligibility_artifact:");
 
     expect(reusable).toContain("target: [linux-x64, linux-arm64, darwin-x64, darwin-arm64, windows-x64]");
-    expect(reusable.match(/for attempt in 1 2 3; do/g)).toHaveLength(3);
-    expect(reusable.match(/if bun install --frozen-lockfile; then/g)).toHaveLength(3);
-    expect(reusable.match(/if \[ "\$attempt" -eq 3 \]; then/g)).toHaveLength(3);
-    expect(reusable.match(/sleep "\$\(\(attempt \* 5\)\)"/g)).toHaveLength(3);
+    expect(reusable.match(/bash scripts\/ci\/install-frozen-dependencies\.sh/g)).toHaveLength(3);
     expect(reusable).toContain("bun scripts/release-artifacts.ts build");
     expect(reusable).toContain('--target "${{ matrix.target }}"');
     expect(reusable).toContain("--skip-extension");
@@ -251,6 +249,20 @@ describe("CI workflow policy", () => {
     expect(reusable).toContain("security-attestation-${{ inputs.source_sha || github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}");
     expect(reusable).toContain("Validate dev-release evidence schemas and privacy");
     expect(reusable).toContain("bun scripts/ci/dev-release-evidence-policy.ts");
+  });
+
+  it("retries only the frozen dependency install in quality and release producers", async () => {
+    const quality = await workflow("reusable-quality.yml");
+    const release = await workflow("reusable-release-artifacts.yml");
+    const installer = await ciScript("install-frozen-dependencies.sh");
+
+    expect(quality.match(/bash scripts\/ci\/install-frozen-dependencies\.sh/g)).toHaveLength(5);
+    expect(release.match(/bash scripts\/ci\/install-frozen-dependencies\.sh/g)).toHaveLength(3);
+    expect(installer).toContain("for attempt in 1 2 3; do");
+    expect(installer).toContain("if bun install --frozen-lockfile; then");
+    expect(installer).toContain('if [[ "$attempt" -eq 3 ]]; then');
+    expect(installer).toContain('sleep "$((attempt * 5))"');
+    expect(installer).not.toContain("bun install --no-progress");
   });
 
   it("publishes dev only through exclusive draft, downloaded proof, and publish jobs", async () => {


### PR DESCRIPTION
## Summary
- share one bounded frozen-install retry helper between canonical quality/preflight and release artifact jobs
- retry only the identical lockfile-pinned Bun install, never tests or publication
- cover all five reusable quality consumers and all three artifact consumers with policy tests

## Verification
- bash -n scripts/ci/install-frozen-dependencies.sh
- bun run test scripts/ci/workflow-policy.test.ts scripts/release-artifacts.test.ts scripts/assemble-release-bundle.test.ts
- bun run typecheck