### PR TITLE
fix(ci): retry transient consumer dependency fetches

### DIFF
--- a/scripts/consumer-smoke-filelink.ts
+++ b/scripts/consumer-smoke-filelink.ts
@@ -52,6 +52,7 @@ export interface FilelinkInstallCoordinator {
   allowedPackages: ReadonlySet<string>;
   install: () => InstallResult;
   recreate: () => void;
+  delay?: (milliseconds: number) => void;
   warn?: (message: string) => void;
 }
 
@@ -74,6 +75,14 @@ const KNOWN_FILELINK_EEXIST = [
 const KNOWN_FILELINK_INSTALL_SUMMARY = /^(?:Failed to install \d+ packages?|Saved lockfile)$/;
 const SECOND_FATAL_MARKER =
   /\b(?:error|failed|panic|fatal|ENOENT|integrity|checksum|signal)\b/i;
+const TYPST_WEB_COMPILER_RELEASE_URL =
+  "https://github.com/BjoernSchotte/typst.ts/releases/download/" +
+  "web-compiler-v0.8.0-rc3.typst0151.1/" +
+  "myriaddreamin-typst-ts-web-compiler-0.8.0-rc3.typst0151.1.tgz";
+const TYPST_WEB_COMPILER_RESOLUTION_FAILURE =
+  `error: @myriaddreamin/typst-ts-web-compiler@${TYPST_WEB_COMPILER_RELEASE_URL} failed to resolve`;
+const TRANSIENT_HTTP_STATUSES = new Set([429, 502, 503, 504]);
+const MAX_TRANSIENT_INSTALL_ATTEMPTS = 3;
 
 function normalizedInstallLines(result: InstallResult): string[] {
   return `${result.stdout}\n${result.stderr}`
@@ -111,6 +120,24 @@ export function knownFilelinkEexistPackage(
   return packageName;
 }
 
+export function isKnownTransientFilelinkInstallFailure(result: InstallResult): boolean {
+  if (result.exitCode === 0) return false;
+
+  const lines = normalizedInstallLines(result);
+  const matchingFailures = lines.filter((line) => {
+    const match = /^error: GET (https:\/\/\S+) - (\d{3})$/.exec(line);
+    return match?.[1] === TYPST_WEB_COMPILER_RELEASE_URL
+      && TRANSIENT_HTTP_STATUSES.has(Number(match[2]));
+  });
+  if (matchingFailures.length !== 1) return false;
+
+  const unrelatedFatalLines = lines.filter((line) =>
+    SECOND_FATAL_MARKER.test(line)
+    && !matchingFailures.includes(line)
+    && line !== TYPST_WEB_COMPILER_RESOLUTION_FAILURE);
+  return unrelatedFatalLines.length === 0;
+}
+
 function installFailure(result: InstallResult): Error {
   return new Error(
     `bun install (filelink consumer) failed:\n${result.stdout}\n${result.stderr}`,
@@ -118,24 +145,41 @@ function installFailure(result: InstallResult): Error {
 }
 
 export function installFilelinkWithKnownRetry(coordinator: FilelinkInstallCoordinator): void {
-  const first = coordinator.install();
-  if (first.exitCode === 0) return;
+  let eexistRetried = false;
 
-  const packageName = knownFilelinkEexistPackage(
-    first,
-    coordinator.bunVersion,
-    coordinator.allowedPackages,
-  );
-  if (!packageName) throw installFailure(first);
+  for (let attempt = 1; attempt <= MAX_TRANSIENT_INSTALL_ATTEMPTS; attempt++) {
+    const result = coordinator.install();
+    if (result.exitCode === 0) return;
 
-  coordinator.warn?.(
-    `Bun ${coordinator.bunVersion} hit the known file-link EEXIST for ${packageName}; ` +
-      "recreating the throwaway consumer and retrying once",
-  );
-  coordinator.recreate();
+    const packageName = knownFilelinkEexistPackage(
+      result,
+      coordinator.bunVersion,
+      coordinator.allowedPackages,
+    );
+    if (packageName && !eexistRetried) {
+      eexistRetried = true;
+      coordinator.warn?.(
+        `Bun ${coordinator.bunVersion} hit the known file-link EEXIST for ${packageName}; ` +
+          "recreating the throwaway consumer and retrying once",
+      );
+      coordinator.recreate();
+      continue;
+    }
 
-  const second = coordinator.install();
-  if (second.exitCode !== 0) throw installFailure(second);
+    if (isKnownTransientFilelinkInstallFailure(result)
+      && attempt < MAX_TRANSIENT_INSTALL_ATTEMPTS) {
+      const delayMs = attempt * 5_000;
+      coordinator.warn?.(
+        `The pinned Typst release download failed transiently on attempt ${attempt}; ` +
+          `recreating the throwaway consumer and retrying in ${delayMs / 1_000}s`,
+      );
+      coordinator.recreate();
+      (coordinator.delay ?? Bun.sleepSync)(delayMs);
+      continue;
+    }
+
+    throw installFailure(result);
+  }
 }
 
 export async function runFilelinkSmoke(baseDir?: string): Promise<FilelinkSmokeResult> {

--- a/scripts/consumer-smoke.test.ts
+++ b/scripts/consumer-smoke.test.ts
@@ -4,6 +4,7 @@ import {
   FILELINK_SMOKE_ENV,
   KNOWN_FILELINK_EEXIST_BUN_VERSION,
   installFilelinkWithKnownRetry,
+  isKnownTransientFilelinkInstallFailure,
   knownFilelinkEexistPackage,
   runFilelinkSmoke,
   type InstallResult,
@@ -141,6 +142,73 @@ describe("known Bun file-link EEXIST retry", () => {
       ).toThrow();
       expect(installs).toBe(1);
     }
+  });
+});
+
+describe("pinned Typst release transport retry", () => {
+  const typstUrl =
+    "https://github.com/BjoernSchotte/typst.ts/releases/download/" +
+    "web-compiler-v0.8.0-rc3.typst0151.1/" +
+    "myriaddreamin-typst-ts-web-compiler-0.8.0-rc3.typst0151.1.tgz";
+  const transientFailure = (status = 503): InstallResult => ({
+    exitCode: 1,
+    stdout: "bun install v1.3.14\nResolving dependencies\nResolved, downloaded and extracted [39]\n",
+    stderr:
+      `error: GET ${typstUrl} - ${status}\n` +
+      `error: @myriaddreamin/typst-ts-web-compiler@${typstUrl} failed to resolve\n`,
+  });
+
+  it("recognizes only the pinned URL and bounded transient HTTP statuses", () => {
+    for (const status of [429, 502, 503, 504]) {
+      expect(isKnownTransientFilelinkInstallFailure(transientFailure(status))).toBeTrue();
+    }
+    expect(isKnownTransientFilelinkInstallFailure(transientFailure(404))).toBeFalse();
+    expect(isKnownTransientFilelinkInstallFailure({
+      ...transientFailure(),
+      stderr:
+        "error: GET https://example.com/package.tgz - 503\n" +
+        "error: @myriaddreamin/typst-ts-web-compiler@https://example.com/package.tgz failed to resolve\n",
+    })).toBeFalse();
+    expect(isKnownTransientFilelinkInstallFailure({
+      ...transientFailure(),
+      stderr: `error: GET ${typstUrl} - 503\nfatal: checksum verification failed\n`,
+    })).toBeFalse();
+  });
+
+  it("recreates with bounded backoff and succeeds on a later transport attempt", () => {
+    const attempts = [transientFailure(), transientFailure(502), success];
+    const delays: number[] = [];
+    let installs = 0;
+    let recreates = 0;
+    const warnings: string[] = [];
+    installFilelinkWithKnownRetry({
+      bunVersion: KNOWN_FILELINK_EEXIST_BUN_VERSION,
+      allowedPackages,
+      install: () => attempts[installs++]!,
+      recreate: () => recreates++,
+      delay: (milliseconds) => delays.push(milliseconds),
+      warn: (message) => warnings.push(message),
+    });
+    expect(installs).toBe(3);
+    expect(recreates).toBe(2);
+    expect(delays).toEqual([5_000, 10_000]);
+    expect(warnings).toHaveLength(2);
+    expect(warnings.join("\n")).not.toContain(typstUrl);
+  });
+
+  it("keeps the third transient failure fatal", () => {
+    let installs = 0;
+    expect(() => installFilelinkWithKnownRetry({
+      bunVersion: KNOWN_FILELINK_EEXIST_BUN_VERSION,
+      allowedPackages,
+      install: () => {
+        installs++;
+        return transientFailure();
+      },
+      recreate: () => {},
+      delay: () => {},
+    })).toThrow("bun install (filelink consumer) failed");
+    expect(installs).toBe(3);
   });
 });
 


### PR DESCRIPTION
## Summary
- retry the pinned Typst GitHub release download only for HTTP 429/502/503/504
- keep unknown URLs, permanent statuses, and integrity/checksum failures fatal
- bound the file-link consumer install to three attempts with tested backoff

## Proof
- bun run test scripts/consumer-smoke.test.ts
- bun run typecheck

## Context
The canonical main CI run 31642664839 failed its pinned consumer smoke on an HTTP 503 from the immutable Typst release asset. This hardens that second install seam without weakening source-SHA eligibility or required checks.