### PR TITLE
fix(research): forward browser subagent config

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -478,6 +478,7 @@
     },
   },
   "patchedDependencies": {
+    "deepagents@1.12.1": "patches/deepagents@1.12.1.patch",
     "@langchain/anthropic@1.5.2": "patches/@langchain%2Fanthropic@1.5.2.patch",
   },
   "overrides": {

--- a/package.json
+++ b/package.json
@@ -97,7 +97,8 @@
     "typescript": "^5.9.3"
   },
   "patchedDependencies": {
-    "@langchain/anthropic@1.5.2": "patches/@langchain%2Fanthropic@1.5.2.patch"
+    "@langchain/anthropic@1.5.2": "patches/@langchain%2Fanthropic@1.5.2.patch",
+    "deepagents@1.12.1": "patches/deepagents@1.12.1.patch"
   },
   "overrides": {
     "deepagents": "1.12.1"

--- a/packages/research/src/pinned-runtime-contract.test.ts
+++ b/packages/research/src/pinned-runtime-contract.test.ts
@@ -64,7 +64,10 @@ describe("pinned DeepAgentsJS and QuickJS runtime contract", () => {
     ).json()) as { dependencies?: Record<string, string> };
     const rootPackage = (await Bun.file(
       new URL("../../../package.json", import.meta.url),
-    ).json()) as { overrides?: Record<string, string> };
+    ).json()) as {
+      overrides?: Record<string, string>;
+      patchedDependencies?: Record<string, string>;
+    };
     const lockfile = await Bun.file(
       new URL("../../../bun.lock", import.meta.url),
     ).text();
@@ -74,13 +77,29 @@ describe("pinned DeepAgentsJS and QuickJS runtime contract", () => {
     expect(researchPackage.dependencies?.deepagents).toBe("1.12.1");
     expect(researchPackage.dependencies?.["@langchain/quickjs"]).toBe("1.0.0");
     expect(rootPackage.overrides?.deepagents).toBe("1.12.1");
+    expect(rootPackage.patchedDependencies?.["deepagents@1.12.1"]).toBe(
+      "patches/deepagents@1.12.1.patch",
+    );
     expect(deepagentsPackage.version).toBe("1.12.1");
     expect(quickjsPackage.version).toBe("1.0.0");
     expect(lockfile).not.toContain("pkg.pr.new");
     expect(lockfile).toContain('"deepagents": ["deepagents@1.12.1"');
     expect(lockfile).toContain(DEEPAGENTS_INTEGRITY);
+    expect(lockfile).toContain(
+      '"deepagents@1.12.1": "patches/deepagents@1.12.1.patch"',
+    );
     expect(lockfile).toContain('"@langchain/quickjs": ["@langchain/quickjs@1.0.0"');
     expect(lockfile).toContain(QUICKJS_INTEGRITY);
+  });
+
+  test("keeps the upstream browser config-forwarding fix pinned locally", async () => {
+    const patch = await Bun.file(
+      new URL("../../../patches/deepagents@1.12.1.patch", import.meta.url),
+    ).text();
+
+    expect(patch).toContain("getCurrentTaskInput(config)");
+    expect(patch).toContain("getCurrentTaskInput)(config)");
+    expect(patch).not.toContain("pkg.pr.new");
   });
 
   test("keeps the Node and browser entry points on the same typed runtime surface", () => {

--- a/patches/deepagents@1.12.1.patch
+++ b/patches/deepagents@1.12.1.patch
@@ -1,0 +1,14 @@
+diff --git a/dist/langsmith-DdOXam6Z.cjs b/dist/langsmith-DdOXam6Z.cjs
+index c090b41705a055a4a2ef44a19137867f5c0ccdd2..94112c0b735b0f43dc5f0021e85c1ffaf571544d 100644
+--- a/dist/langsmith-DdOXam6Z.cjs
++++ b/dist/langsmith-DdOXam6Z.cjs
+@@ -2412 +2412 @@ function createTaskTool(options) {
+-		const subagentState = filterStateForSubagent((0, _langchain_langgraph.getCurrentTaskInput)());
++		const subagentState = filterStateForSubagent((0, _langchain_langgraph.getCurrentTaskInput)(config));
+diff --git a/dist/langsmith-DgbmWtWj.js b/dist/langsmith-DgbmWtWj.js
+index cacc475192aba4d5afce8c925170f305d86c91e1..547b56e35ce37b9d365103d4ef083b5a9e2a5f07 100644
+--- a/dist/langsmith-DgbmWtWj.js
++++ b/dist/langsmith-DgbmWtWj.js
+@@ -2388 +2388 @@ function createTaskTool(options) {
+-		const subagentState = filterStateForSubagent(getCurrentTaskInput());
++		const subagentState = filterStateForSubagent(getCurrentTaskInput(config));


### PR DESCRIPTION
## Summary
- pin the upstream DeepAgents browser config-forwarding fix as a Bun patch
- bind the patch to the runtime contract and lockfile
- restore packed MV3 subagent dispatch after moving from the expired preview package to stable DeepAgents 1.12.1

## Proof
- bun install --frozen-lockfile
- bun run test packages/research/src/pinned-runtime-contract.test.ts apps/extension/tests/research-dispatch-adapter.test.ts
- bun run typecheck
- bun run --cwd apps/extension build
- bun run --cwd apps/extension test:research-extension-browser:prebuilt (45 passed)