### PR TITLE
fix(research): pin QuickJS browser config forwarding

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -480,6 +480,7 @@
   "patchedDependencies": {
     "deepagents@1.12.1": "patches/deepagents@1.12.1.patch",
     "@langchain/anthropic@1.5.2": "patches/@langchain%2Fanthropic@1.5.2.patch",
+    "@langchain/quickjs@1.0.0": "patches/@langchain%2Fquickjs@1.0.0.patch",
   },
   "overrides": {
     "deepagents": "1.12.1",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,8 @@
   },
   "patchedDependencies": {
     "@langchain/anthropic@1.5.2": "patches/@langchain%2Fanthropic@1.5.2.patch",
-    "deepagents@1.12.1": "patches/deepagents@1.12.1.patch"
+    "deepagents@1.12.1": "patches/deepagents@1.12.1.patch",
+    "@langchain/quickjs@1.0.0": "patches/@langchain%2Fquickjs@1.0.0.patch"
   },
   "overrides": {
     "deepagents": "1.12.1"

--- a/packages/research/src/pinned-runtime-contract.test.ts
+++ b/packages/research/src/pinned-runtime-contract.test.ts
@@ -80,6 +80,9 @@ describe("pinned DeepAgentsJS and QuickJS runtime contract", () => {
     expect(rootPackage.patchedDependencies?.["deepagents@1.12.1"]).toBe(
       "patches/deepagents@1.12.1.patch",
     );
+    expect(rootPackage.patchedDependencies?.["@langchain/quickjs@1.0.0"]).toBe(
+      "patches/@langchain%2Fquickjs@1.0.0.patch",
+    );
     expect(deepagentsPackage.version).toBe("1.12.1");
     expect(quickjsPackage.version).toBe("1.0.0");
     expect(lockfile).not.toContain("pkg.pr.new");
@@ -88,18 +91,30 @@ describe("pinned DeepAgentsJS and QuickJS runtime contract", () => {
     expect(lockfile).toContain(
       '"deepagents@1.12.1": "patches/deepagents@1.12.1.patch"',
     );
+    expect(lockfile).toContain(
+      '"@langchain/quickjs@1.0.0": "patches/@langchain%2Fquickjs@1.0.0.patch"',
+    );
     expect(lockfile).toContain('"@langchain/quickjs": ["@langchain/quickjs@1.0.0"');
     expect(lockfile).toContain(QUICKJS_INTEGRITY);
   });
 
   test("keeps the upstream browser config-forwarding fix pinned locally", async () => {
-    const patch = await Bun.file(
+    const deepagentsPatch = await Bun.file(
       new URL("../../../patches/deepagents@1.12.1.patch", import.meta.url),
     ).text();
+    const quickjsPatch = await Bun.file(
+      new URL(
+        "../../../patches/@langchain%252Fquickjs@1.0.0.patch",
+        import.meta.url,
+      ),
+    ).text();
 
-    expect(patch).toContain("getCurrentTaskInput(config)");
-    expect(patch).toContain("getCurrentTaskInput)(config)");
-    expect(patch).not.toContain("pkg.pr.new");
+    expect(deepagentsPatch).toContain("getCurrentTaskInput(config)");
+    expect(deepagentsPatch).toContain("getCurrentTaskInput)(config)");
+    expect(quickjsPatch).toContain("setToolConfig(config)");
+    expect(quickjsPatch).toContain("t.invoke(rawInput, this.toolConfig)");
+    expect(deepagentsPatch).not.toContain("pkg.pr.new");
+    expect(quickjsPatch).not.toContain("pkg.pr.new");
   });
 
   test("keeps the Node and browser entry points on the same typed runtime surface", () => {

--- a/patches/@langchain%2Fquickjs@1.0.0.patch
+++ b/patches/@langchain%2Fquickjs@1.0.0.patch
@@ -1,0 +1,54 @@
+diff --git a/dist/index.cjs b/dist/index.cjs
+index bd141c1..859763a 100644
+--- a/dist/index.cjs
++++ b/dist/index.cjs
+@@ -569,0 +570 @@ var ReplSession = class ReplSession {
++	toolConfig;
+@@ -787,0 +789 @@ var ReplSession = class ReplSession {
++		this.toolConfig = void 0;
+@@ -803,0 +806,3 @@ var ReplSession = class ReplSession {
++	setToolConfig(config) {
++		this.toolConfig = config;
++	}
+@@ -837 +842 @@ var ReplSession = class ReplSession {
+-						let text = extractToolText(await t.invoke(rawInput));
++						let text = extractToolText(await t.invoke(rawInput, this.toolConfig));
+@@ -1330,0 +1336 @@ function createCodeInterpreterMiddleware(options = {}) {
++			session.setToolConfig(config);
+diff --git a/dist/index.d.cts b/dist/index.d.cts
+index 05704ba..01c5820 100644
+--- a/dist/index.d.cts
++++ b/dist/index.d.cts
+@@ -3,0 +4 @@ import { StructuredToolInterface } from "@langchain/core/tools";
++import { RunnableConfig } from "@langchain/core/runnables";
+@@ -197,0 +199 @@ declare class ReplSession {
++  private toolConfig;
+@@ -267,0 +270 @@ declare class ReplSession {
++  setToolConfig(config?: RunnableConfig): void;
+diff --git a/dist/index.d.ts b/dist/index.d.ts
+index 1d8125c..a17ffe2 100644
+--- a/dist/index.d.ts
++++ b/dist/index.d.ts
+@@ -3,0 +4 @@ import { StructuredToolInterface } from "@langchain/core/tools";
++import { RunnableConfig } from "@langchain/core/runnables";
+@@ -197,0 +199 @@ declare class ReplSession {
++  private toolConfig;
+@@ -267,0 +270 @@ declare class ReplSession {
++  setToolConfig(config?: RunnableConfig): void;
+diff --git a/dist/index.js b/dist/index.js
+index 6f66222..51f7a05 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -543,0 +544 @@ var ReplSession = class ReplSession {
++	toolConfig;
+@@ -761,0 +763 @@ var ReplSession = class ReplSession {
++		this.toolConfig = void 0;
+@@ -777,0 +780,3 @@ var ReplSession = class ReplSession {
++	setToolConfig(config) {
++		this.toolConfig = config;
++	}
+@@ -811 +816 @@ var ReplSession = class ReplSession {
+-						let text = extractToolText(await t.invoke(rawInput));
++						let text = extractToolText(await t.invoke(rawInput, this.toolConfig));
+@@ -1304,0 +1310 @@ function createCodeInterpreterMiddleware(options = {}) {
++			session.setToolConfig(config);


### PR DESCRIPTION
## Summary
- pin the missing QuickJS 1.0.0 RunnableConfig forwarding from upstream browser support
- make fresh CI installs match the previously patched local runtime
- bind both DeepAgents and QuickJS patches to the pinned runtime contract

## Root cause
The stable @langchain/quickjs 1.0.0 tarball invokes PTC tools without RunnableConfig. The local node_modules tree still contained the preview implementation, masking the fresh-install failure.

## Proof
- bun install --frozen-lockfile
- bun run test packages/research/src/pinned-runtime-contract.test.ts apps/extension/tests/research-dispatch-adapter.test.ts
- bun run typecheck
- bun run --cwd apps/extension build
- bun run --cwd apps/extension test:research-extension-browser:prebuilt (45 passed)