### PR TITLE
fix(ci): preserve release proof identity across reruns

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -195,7 +195,11 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: source-eligibility-${{ needs.resolve-source.outputs.source_sha }}-${{ github.run_id }}-${{ github.run_attempt }}
+          # release_attempt is frozen by resolve-source. On "rerun failed jobs",
+          # GitHub increments github.run_attempt without rerunning this already
+          # successful producer, so downstream consumers must keep addressing
+          # the original proof identity.
+          name: source-eligibility-${{ needs.resolve-source.outputs.source_sha }}-${{ github.run_id }}-${{ needs.resolve-source.outputs.release_attempt }}
           path: source-eligibility.json
           if-no-files-found: error
           retention-days: 30
@@ -222,8 +226,8 @@ jobs:
       build_id: ${{ needs.resolve-source.outputs.build_id }}
       created_at: ${{ needs.resolve-source.outputs.created_at }}
       release_attempt: ${{ fromJSON(needs.resolve-source.outputs.release_attempt) }}
-      security_attestation_artifact: security-attestation-${{ needs.resolve-source.outputs.source_sha }}-${{ github.run_id }}-${{ github.run_attempt }}
-      source_eligibility_artifact: source-eligibility-${{ needs.resolve-source.outputs.source_sha }}-${{ github.run_id }}-${{ github.run_attempt }}
+      security_attestation_artifact: security-attestation-${{ needs.resolve-source.outputs.source_sha }}-${{ github.run_id }}-${{ needs.resolve-source.outputs.release_attempt }}
+      source_eligibility_artifact: source-eligibility-${{ needs.resolve-source.outputs.source_sha }}-${{ github.run_id }}-${{ needs.resolve-source.outputs.release_attempt }}
 
   shadow-plan:
     name: Verify bundle and plan publication without writes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,7 @@ jobs:
       source_sha: ${{ steps.identity.outputs.source_sha }}
       source_ref: ${{ steps.identity.outputs.source_ref }}
       created_at: ${{ steps.identity.outputs.created_at }}
+      release_attempt: ${{ steps.identity.outputs.release_attempt }}
       stable_latest: ${{ steps.identity.outputs.stable_latest }}
     steps:
       - uses: actions/checkout@v7
@@ -69,6 +70,7 @@ jobs:
             echo "source_sha=$GITHUB_SHA"
             echo "source_ref=$GITHUB_REF"
             echo "created_at=$(git show -s --format=%cI "$GITHUB_SHA")"
+            echo "release_attempt=$GITHUB_RUN_ATTEMPT"
             echo "stable_latest=$stable_latest"
           } >> "$GITHUB_OUTPUT"
 
@@ -83,8 +85,8 @@ jobs:
       version: ${{ needs.resolve.outputs.version }}
       build_id: ${{ needs.resolve.outputs.build_id }}
       created_at: ${{ needs.resolve.outputs.created_at }}
-      release_attempt: ${{ github.run_attempt }}
-      security_attestation_artifact: security-attestation-${{ needs.resolve.outputs.source_sha }}-${{ github.run_id }}-${{ github.run_attempt }}
+      release_attempt: ${{ fromJSON(needs.resolve.outputs.release_attempt) }}
+      security_attestation_artifact: security-attestation-${{ needs.resolve.outputs.source_sha }}-${{ github.run_id }}-${{ needs.resolve.outputs.release_attempt }}
 
   create-draft:
     name: Create complete stable draft

--- a/scripts/ci/workflow-policy.test.ts
+++ b/scripts/ci/workflow-policy.test.ts
@@ -84,7 +84,10 @@ describe("CI workflow policy", () => {
     const release = await workflow("release.yml");
     const reusable = await workflow("reusable-release-artifacts.yml");
     expect(release).toContain("uses: ./.github/workflows/reusable-release-artifacts.yml");
-    expect(release).toContain("security_attestation_artifact: security-attestation-${{ needs.resolve.outputs.source_sha }}-${{ github.run_id }}-${{ github.run_attempt }}");
+    expect(release).toContain("release_attempt: ${{ steps.identity.outputs.release_attempt }}");
+    expect(release).toContain('echo "release_attempt=$GITHUB_RUN_ATTEMPT"');
+    expect(release).toContain("release_attempt: ${{ fromJSON(needs.resolve.outputs.release_attempt) }}");
+    expect(release).toContain("security_attestation_artifact: security-attestation-${{ needs.resolve.outputs.source_sha }}-${{ github.run_id }}-${{ needs.resolve.outputs.release_attempt }}");
     expect(release).toContain("name: ${{ needs.artifacts.outputs.bundle_artifact }}");
     expect(release).toContain("scripts/ci/github-release-transaction.ts create-draft");
     expect(release).toContain("scripts/ci/github-release-transaction.ts download-draft");
@@ -102,7 +105,6 @@ describe("CI workflow policy", () => {
     expect(reusable).toContain("--skip-cli");
     expect(reusable).toContain("release_attempt:");
     expect(reusable.match(/--run-attempt \"\$\{\{ inputs\.release_attempt \}\}\"/g)).toHaveLength(3);
-    expect(release).toContain("release_attempt: ${{ github.run_attempt }}");
     const extensionBuild = block(reusable, /^ {2}build-extension:\s*$/, 2);
     expect(extensionBuild).not.toBeNull();
     expect(extensionBuild).toContain("bun run fonts:ensure");
@@ -236,7 +238,11 @@ describe("CI workflow policy", () => {
     expect(preflight).not.toContain("always()");
     expect(artifacts).not.toBeNull();
     expect(artifacts).toContain("needs: [resolve-source, publication-decision, eligible-source, preflight]");
-    expect(artifacts).toContain("source_eligibility_artifact: source-eligibility-");
+    expect(eligibility).toContain("source-eligibility-${{ needs.resolve-source.outputs.source_sha }}-${{ github.run_id }}-${{ needs.resolve-source.outputs.release_attempt }}");
+    expect(artifacts).toContain("security-attestation-${{ needs.resolve-source.outputs.source_sha }}-${{ github.run_id }}-${{ needs.resolve-source.outputs.release_attempt }}");
+    expect(artifacts).toContain("source-eligibility-${{ needs.resolve-source.outputs.source_sha }}-${{ github.run_id }}-${{ needs.resolve-source.outputs.release_attempt }}");
+    expect(artifacts).not.toContain("security-attestation-${{ needs.resolve-source.outputs.source_sha }}-${{ github.run_id }}-${{ github.run_attempt }}");
+    expect(artifacts).not.toContain("source-eligibility-${{ needs.resolve-source.outputs.source_sha }}-${{ github.run_id }}-${{ github.run_attempt }}");
     expect(artifacts).not.toContain("always()");
   });
 


### PR DESCRIPTION
## Summary
- freeze the release-attempt identity at source resolution
- make failed-job reruns reuse the exact successful attestation and eligibility artifacts
- cover stable and dev release workflows with regression policy tests

## Proof
- bun run test scripts/ci/workflow-policy.test.ts scripts/bun-version-pin.test.ts (36 passed)
- bun run typecheck
- git diff --check