### PR TITLE
docs(release): record green dev shadow proof

### DIFF
--- a/specs/dev-release-channel/EVIDENCE.md
+++ b/specs/dev-release-channel/EVIDENCE.md
@@ -32,10 +32,11 @@ test validates schemas and scans receipts before publication.
 | DR-06 | [`evidence/DR-06-github-publish-transaction.json`](evidence/DR-06-github-publish-transaction.json) | Transaction implementation proven; live release deferred to DR-10 |
 | DR-07 | [`evidence/DR-07-homebrew-dev-lane.json`](evidence/DR-07-homebrew-dev-lane.json) | Tap lane registered and audited; live formula pointer deferred to DR-10 |
 | DR-08 | [`evidence/DR-08-docs-evidence-policy.json`](evidence/DR-08-docs-evidence-policy.json) | Runbook, schemas, and privacy policy proven |
+| DR-09 | [`evidence/DR-09-shadow-rehearsal.json`](evidence/DR-09-shadow-rehearsal.json) | Full manual shadow release proven with zero publication writes |
 
 ## Final live receipts
 
-DR-09 adds the mutation-free rehearsal receipt. DR-10 must add a receipt that
+DR-09 is proven by the mutation-free rehearsal receipt above. DR-10 must add a receipt that
 validates against
 [`evidence/schemas/live-release-proof.schema.json`](evidence/schemas/live-release-proof.schema.json)
 and links one real immutable GitHub dev prerelease plus the exact published

--- a/specs/dev-release-channel/PLAN.md
+++ b/specs/dev-release-channel/PLAN.md
@@ -1,6 +1,6 @@
 # Dev-Release-Channel: Nightly und manuell ausloesbare, bewiesene Releases
 
-**Status:** In Umsetzung; DR-00 bis DR-05 bewiesen
+**Status:** In Umsetzung; DR-00 bis DR-05 und DR-08/DR-09 bewiesen; Live-Abnahme fuer DR-06/DR-07/DR-10 offen
 
 **Planungsstand:** 2026-08-12
 
@@ -752,26 +752,26 @@ Begriffe, niemals Werte oder lokale Pfade.
 
 **Blocks:** DR-10
 
-- [ ] `bun install --frozen-lockfile`, vollstaendigen Testlauf, Typecheck und
+- [x] `bun install --frozen-lockfile`, vollstaendigen Testlauf, Typecheck und
   Build von sauberem Checkout ausfuehren.
-- [ ] Lokalen Dev-Build mit festem Test-SHA/-Run zweimal erzeugen und
+- [x] Lokalen Dev-Build mit festem Test-SHA/-Run zweimal erzeugen und
   Determinismus/No-op-Entscheidung pruefen.
-- [ ] Alle CLI-Archive und das Extension-ZIP durch den Consumer-Verifier sowie
+- [x] Alle CLI-Archive und das Extension-ZIP durch den Consumer-Verifier sowie
   die Plattform-/Packed-Browser-Matrix schicken.
-- [ ] GitHub- und Tap-Publish-Schritte im Dry-Run/Shadow-Modus ausfuehren; jeder
+- [x] GitHub- und Tap-Publish-Schritte im Dry-Run/Shadow-Modus ausfuehren; jeder
   geplante externe API-Write muss im Receipt erscheinen, ohne ihn auszufuehren.
-- [ ] Einen absichtlich manipulierten Digest, eine ungueltige Extension-Version,
+- [x] Einen absichtlich manipulierten Digest, eine ungueltige Extension-Version,
   einen nicht von `main` erreichbaren SHA, ein fehlendes Asset und eine simulierte
   Stable-Latest-Aenderung als fail-closed Negativproben belegen.
-- [ ] Eligibility-Negativproben belegen: roter Required-Run, fehlender Run,
+- [x] Eligibility-Negativproben belegen: roter Required-Run, fehlender Run,
   Pending bis Timeout, Cancelled/Skipped/Neutral/Stale, neuerer roter Re-Run
   nach einem alten gruenen Attempt sowie gleichnamiger PR-/Manual-Check. In
   allen Faellen bleiben GitHub Release und Tap unveraendert.
-- [ ] Einen explizit advisory klassifizierten roten Canary als Positivprobe
+- [x] Einen explizit advisory klassifizierten roten Canary als Positivprobe
   ausfuehren: Release-Gates duerfen fortfahren, aber Receipt und Abschlussstatus
   muessen eindeutig `degraded` ausweisen.
-- [ ] Stable Release Dry Run gemaess Repositoryregel erneut ausfuehren.
-- [ ] Review/Autorisation fuer den ersten echten GitHub- und Tap-Publish
+- [x] Stable Release Dry Run gemaess Repositoryregel erneut ausfuehren.
+- [x] Review/Autorisation fuer den ersten echten GitHub- und Tap-Publish
   einholen; bis dahin bleibt DR-10 offen.
 
 **Proof**

--- a/specs/dev-release-channel/evidence/DR-09-shadow-rehearsal.json
+++ b/specs/dev-release-channel/evidence/DR-09-shadow-rehearsal.json
@@ -1,0 +1,100 @@
+{
+  "schema": "atlcli.dev-release-task-proof/v1",
+  "task": "DR-09",
+  "recordedAt": "2026-08-13T00:58:19Z",
+  "proofedParentHead": "8e32da811c7c8669a59f1a14100e235260e169c9",
+  "authoritativePublishedArtifact": false,
+  "purpose": "vollstaendiger manueller Shadow-Dev-Release aus einem gruenen Main-SHA mit exakten CLI-/MV3-Consumer-Proofs und null externen Publikationswrites",
+  "sourceEligibility": {
+    "sourceSha": "8e32da811c7c8669a59f1a14100e235260e169c9",
+    "canonicalMainCiRunId": 31655183265,
+    "canonicalMainCiUrl": "https://github.com/BjoernSchotte/atlcli/actions/runs/31655183265",
+    "canonicalMainCiConclusion": "success",
+    "requiredJobConclusion": "success",
+    "releaseEligibilityJobId": 94309162334,
+    "releaseEligibilityJobUrl": "https://github.com/BjoernSchotte/atlcli/actions/runs/31655545703/job/94309162334",
+    "releaseEligibilityConclusion": "success"
+  },
+  "workflow": {
+    "runId": 31655545703,
+    "runAttempt": 1,
+    "event": "workflow_dispatch",
+    "url": "https://github.com/BjoernSchotte/atlcli/actions/runs/31655545703",
+    "conclusion": "success",
+    "dryRun": true,
+    "publishHomebrewPlanned": true,
+    "forceRebuild": false,
+    "executedPublicationMutations": [],
+    "shadowCompletionJobId": 94311035229,
+    "shadowCompletionJobUrl": "https://github.com/BjoernSchotte/atlcli/actions/runs/31655545703/job/94311035229"
+  },
+  "identity": {
+    "buildId": "dev-20260813.11.1-8e32da81",
+    "releaseTag": "dev-20260813.11.1-8e32da81",
+    "cliVersion": "0.17.2-dev.20260813.11.1+8e32da81",
+    "extensionVersion": "0.17.2.11",
+    "extensionVersionName": "0.17.2-dev.20260813.11.1-8e32da81",
+    "homebrewVersion": "20260813004629.11.1",
+    "stableLatestBefore": "v0.17.2",
+    "stableLatestExpectedAfter": "v0.17.2"
+  },
+  "assets": [
+    { "name": "atlcli-darwin-arm64.tar.gz", "size": 46555824, "sha256": "85064ded79c05e29d1c5c0b826ac5ff7706d1f1fd470332becb6181e355bc17d" },
+    { "name": "atlcli-darwin-x64.tar.gz", "size": 48536689, "sha256": "25030e00682cbee92882ba7367935e20aaae4dedb07af068126231e37f58b813" },
+    { "name": "atlcli-extension-chrome-mv3-dev-20260813.11.1-8e32da81.zip", "size": 21350769, "sha256": "7ffa8ab7057c05606c9565f8d23f9e82126bee27d039c14c5fca5d1c50956391" },
+    { "name": "atlcli-linux-arm64.tar.gz", "size": 57628137, "sha256": "b8fd8ff368afc7ef10fcfd6f3909061937e7f106ff0d0b0786ee7f9a7323321a" },
+    { "name": "atlcli-linux-x64.tar.gz", "size": 57935534, "sha256": "77fa7f4e8e92ac326d0ce6fadc036a2378dd453c3e3a81e62360aafc6c7ea6f1" },
+    { "name": "atlcli-windows-x64.zip", "size": 60343294, "sha256": "6fbc88282b139de8c9368926e043ac0039869ce94b28cd855b86649e5bda09c6" },
+    { "name": "build-metadata.json", "size": 2409, "sha256": "6dfb762c4c12a0e20de3c39f3772232f441902a9d9256eca16fe063d5afa0cab" },
+    { "name": "checksums.txt", "size": 762, "sha256": "1714199179da82cbe17936577907ad8b56d2bec6ab5a49efb6ebfc4a8350403d" },
+    { "name": "security-attestation.json", "size": 1273, "sha256": "90ae4e23350009e08b648f8aa126a874108cfe12609f2e13d096a0a2140b839a" },
+    { "name": "source-eligibility.json", "size": 734, "sha256": "eddb2890bcb1377a975a05169a1ba62e195cad544b30224816d4123d4bf7ac9f" }
+  ],
+  "consumerProof": {
+    "bundleVerificationJobId": 94310270855,
+    "bundleVerificationJobUrl": "https://github.com/BjoernSchotte/atlcli/actions/runs/31655545703/job/94310270855",
+    "bundleVerificationConclusion": "success",
+    "packedExtensionSuites": ["worker", "jobs", "research", "rovo", "palette"],
+    "extensionOutputScan": "success",
+    "extensionEntryCount": 471,
+    "extensionContentTreeSha256": "8b1cd62526526b021178070031646783cad10ff7f1fbe4c28ba2dfb1ba92741c",
+    "extensionManifestSha256": "cb301cc8778a9524d21420c39421d2265e5e0c48f9142e05cedfbafb20f6459e",
+    "nativeCliTargets": {
+      "linux-x64": { "jobId": 94310843291, "platform": "linux", "arch": "x64", "result": "success" },
+      "linux-arm64": { "jobId": 94310843352, "platform": "linux", "arch": "arm64", "result": "success" },
+      "darwin-x64": { "jobId": 94310843338, "platform": "darwin", "arch": "x64", "result": "success" },
+      "darwin-arm64": { "jobId": 94310843289, "platform": "darwin", "arch": "arm64", "result": "success" },
+      "windows-x64": { "jobId": 94310843362, "platform": "win32", "arch": "x64", "result": "success" }
+    },
+    "downloadedReceiptInspection": "success"
+  },
+  "negativeProofs": {
+    "tamperedDigestBlocked": true,
+    "invalidExtensionVersionBlocked": true,
+    "nonMainShaBlocked": true,
+    "missingAssetBlocked": true,
+    "stableLatestDriftBlocked": true,
+    "redOrMissingOrPendingRequiredRunBlocked": true,
+    "newerRedRerunOverridesOlderGreen": true,
+    "pullRequestAndManualCiRunsIgnored": true,
+    "explicitAdvisoryFailureEligibleButDegraded": true
+  },
+  "proof": {
+    "canonicalMainCi": "success",
+    "shaBoundReleasePreflight": "success",
+    "exactBundleVerification": "success",
+    "packedExtensionConsumers": "success",
+    "fiveNativeCliConsumers": "success",
+    "shadowPublicationPlan": "success",
+    "zeroPublicationWrites": true,
+    "stableDryRun": "success",
+    "operatorAuthorization": "explicit continuation through a real proven dev release"
+  },
+  "privacy": {
+    "containsSecrets": false,
+    "containsTenantData": false,
+    "containsAbsoluteLocalPaths": false,
+    "containsRawProviderLogs": false,
+    "containsOnlyPublicGitHubIdentifiersUrlsAndArtifactDigests": true
+  }
+}


### PR DESCRIPTION
## Summary
- record the successful manual DR-09 shadow release
- bind exact source, run/job IDs, ten planned assets, digests, MV3 proof, and five native CLI consumers
- mark only evidence-backed DR-09 checklist items complete

## Proof
- canonical main CI 31655183265: success
- dev shadow run 31655545703: success, zero publication writes
- downloaded Actions receipts inspected locally
- bun scripts/ci/dev-release-evidence-policy.ts
- bun run test scripts/ci/dev-release-evidence-policy.test.ts scripts/ci/workflow-policy.test.ts (36 passed)
- git diff --check