### PR TITLE
fix(release): isolate tap credentials in environment

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -718,6 +718,7 @@ jobs:
       (github.event_name == 'schedule' || inputs.dry_run == false) &&
       (github.event_name == 'schedule' || inputs.publish_homebrew)
     runs-on: ubuntu-24.04
+    environment: dev-release
     permissions:
       contents: read
     steps:

--- a/scripts/ci/workflow-policy.test.ts
+++ b/scripts/ci/workflow-policy.test.ts
@@ -338,6 +338,7 @@ describe("CI workflow policy", () => {
       "needs: [resolve-source, publication-decision, create-draft, verify-published]",
     );
     expect(homebrew).toContain("github.event_name == 'schedule' || inputs.publish_homebrew");
+    expect(homebrew).toContain("environment: dev-release");
     expect(homebrew).toContain("actions/create-github-app-token@v3");
     expect(homebrew).toContain("app-id: ${{ vars.HOMEBREW_TAP_APP_ID }}");
     expect(homebrew).toContain("private-key: ${{ secrets.HOMEBREW_TAP_APP_PRIVATE_KEY }}");
@@ -348,6 +349,20 @@ describe("CI workflow policy", () => {
     expect(homebrew).toContain("HOMEBREW_TAP_TOKEN: ${{ steps.tap-token.outputs.token }}");
     expect(homebrew).not.toContain("contents: write");
     expect(homebrew).not.toContain("secrets.HOMEBREW_TAP_TOKEN");
+    for (const name of [
+      "resolve-source",
+      "publication-decision",
+      "eligible-source",
+      "preflight",
+      "artifacts",
+      "create-draft",
+      "verify-downloaded-draft",
+      "native-cli-consumer",
+      "publish-draft",
+      "verify-published",
+    ]) {
+      expect(block(dev, new RegExp(`^ {2}${name}:\\s*$`), 2)).not.toContain("environment: dev-release");
+    }
   });
 
   it("keeps retention dry-run read-only and rechecks fixed protection pointers before apply", async () => {

--- a/src/content/docs/contributing.md
+++ b/src/content/docs/contributing.md
@@ -432,6 +432,15 @@ workflow with Homebrew enabled and `dry_run=false`. Scheduled runs use the same
 live publication graph and are
 accepted only after `DEV_RELEASE_SCHEDULE_ENABLED=true` is set.
 
+The cross-repository Homebrew job is the only job bound to the `dev-release`
+GitHub Environment. Store `HOMEBREW_TAP_APP_PRIVATE_KEY` as an Environment
+secret and restrict the Environment deployment branch to `main`. The first
+live run requires the explicit maintainer authorization recorded with DR-09.
+After that one-time gate, do not configure permanent required reviewers: a
+reviewer gate would leave every scheduled nightly waiting for manual approval.
+Repository administrators own App-key rotation and review the Environment and
+App installation quarterly.
+
 ### Diagnose and recover
 
 - **Existing successful release for the SHA:** the normal run is a no-op. Use


### PR DESCRIPTION
## Summary
- bind only the cross-repository Homebrew job to the dev-release environment
- prove no build, GitHub publish, or consumer job can access that environment
- document branch restriction, one-time first-live approval, and quarterly key ownership

## Proof
- bun run test scripts/ci/workflow-policy.test.ts scripts/ci/dev-release-evidence-policy.test.ts (36 passed)
- bun run typecheck
- actionlint .github/workflows/dev-release.yml
- git diff --check