### PR TITLE
test(release): aggregate live dev proof

### DIFF
--- a/scripts/ci/build-live-release-proof.test.ts
+++ b/scripts/ci/build-live-release-proof.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "bun:test";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import Ajv2020 from "ajv/dist/2020";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { buildLiveReleaseProof } from "./build-live-release-proof";
+import { canonicalJson } from "../release-artifacts";
+
+const sha = "a".repeat(40);
+const tag = "dev-20260813.12.1-aaaaaaaa";
+const runId = 123;
+const assetNames = [
+  "atlcli-darwin-arm64.tar.gz", "atlcli-darwin-x64.tar.gz", "atlcli-linux-arm64.tar.gz",
+  "atlcli-linux-x64.tar.gz", "atlcli-windows-x64.zip", `atlcli-extension-chrome-mv3-${tag}.zip`,
+  "build-metadata.json", "checksums.txt", "security-attestation.json", "source-eligibility.json",
+].sort();
+
+function fixture() {
+  const root = join(tmpdir(), `atlcli-live-proof-${crypto.randomUUID()}`);
+  mkdirSync(join(root, "extension"), { recursive: true });
+  const metadata = {
+    schema: "atlcli.build-metadata/v1" as const, channel: "dev" as const, rootVersion: "0.17.2", sourceSha: sha,
+    releaseTag: tag, buildId: tag, run: { id: runId, attempt: 1, event: "workflow_dispatch" as const, createdAt: "2026-08-13T00:00:00Z" },
+    toolchain: { bun: "1.3.14", wxt: "0.20.27", runnerOs: "Linux" }, lockfileSha256: "b".repeat(64),
+    artifacts: [{ name: "atlcli-linux-x64.tar.gz", size: 1, sha256: "f".repeat(64) }],
+    extension: { contentTreeSha256: "c".repeat(64) },
+  };
+  const eligibility = {
+    schema: "atlcli.source-eligibility/v1" as const, decision: "eligible" as const, degraded: false, sourceSha: sha,
+    policyVersion: "atlcli.dev-release-eligibility/v1", workflow: { runId: 99, runAttempt: 1, conclusion: "success" as const },
+    requiredJob: { conclusion: "success" as const },
+  };
+  for (const name of assetNames) writeFileSync(join(root, name), name);
+  writeFileSync(join(root, "build-metadata.json"), canonicalJson(metadata));
+  writeFileSync(join(root, "source-eligibility.json"), canonicalJson(eligibility));
+  writeFileSync(join(root, "extension", "manifest.json"), JSON.stringify({ version: "0.17.2.12" }));
+  const assets = assetNames.map((name) => {
+    const bytes = readFileSync(join(root, name));
+    return { name, size: bytes.byteLength, sha256: createHash("sha256").update(bytes).digest("hex") };
+  });
+  const releaseInfo = { channel: "dev" as const, sourceSha: sha, buildId: tag, releaseTag: tag };
+  const nativeTargets = ["darwin-arm64", "darwin-x64", "linux-arm64", "linux-x64", "windows-x64"];
+  const brewTargets = nativeTargets.slice(0, 4);
+  const pointer = { schema: "atlcli.homebrew-dev-pointer/v1" as const, tag, sourceSha: sha };
+  const formulaText = "formula";
+  return {
+    root, metadata, eligibility, assets, releaseInfo, pointer, formulaText,
+    input: {
+      releaseDir: root,
+      releaseVerification: { schema: "atlcli.release-verification/v1" as const, sourceSha: sha, channel: "dev" as const, buildId: tag, releaseTag: tag, verifiedArtifacts: metadata.artifacts, extension: { contentTreeSha256: "c".repeat(64), outputScan: "success" as const, entryCount: 1 } },
+      releaseReceipt: { schema: "atlcli.github-release-transaction/v1" as const, operation: "verify-published" as const, releaseUrl: "https://github.com/BjoernSchotte/atlcli/releases/tag/x", tag, sourceSha: sha, draft: false as const, prerelease: true as const, makeLatest: false as const, immutable: true as const, assets, stableLatestBefore: "v0.17.2", stableLatestAfter: "v0.17.2", run: { id: runId, attempt: 1 } },
+      eligibility,
+      releaseRun: { databaseId: runId, attempt: 1, event: "workflow_dispatch" as const, headSha: sha, url: "https://github.com/BjoernSchotte/atlcli/actions/runs/123", conclusion: "success" as const, jobs: ["Download and consume every draft asset", "Verify public prerelease and stable latest isolation", "Publish and verify isolated Homebrew dev formula"].map((name) => ({ name, conclusion: "success" })) },
+      nativeReceipts: nativeTargets.map((target) => ({ schema: "atlcli.native-cli-verification/v1" as const, target, runner: { platform: target.split("-")[0]!, arch: target.split("-")[1]! }, releaseInfo })),
+      homebrewDispatch: { schema: "atlcli.homebrew-dev-dispatch/v1" as const, workflow: { id: 8, attempt: 1, url: "https://github.com/BjoernSchotte/homebrew-tap/actions/runs/8", conclusion: "success" as const }, tapCommit: "d".repeat(40), formulaSha256: createHash("sha256").update(formulaText).digest("hex"), pointer },
+      homebrewNativeReceipts: brewTargets.map((target) => ({ schema: "atlcli.homebrew-dev-native-verification/v1" as const, target, rubyPlatform: target.startsWith("darwin") ? "darwin" : "linux", hostCpu: target.endsWith("arm64") ? "arm64" : "x86_64", releaseInfo })),
+      pointerText: canonicalJson(pointer), formulaText, recordedAt: "2026-08-13T01:00:00Z",
+    },
+  };
+}
+
+describe("live release proof builder", () => {
+  it("binds all public release and Homebrew consumer receipts into one proof", () => {
+    const proof = buildLiveReleaseProof(fixture().input) as any;
+    expect(proof.schema).toBe("atlcli.dev-release-live-proof/v1");
+    expect(proof.assets).toHaveLength(10);
+    expect(Object.keys(proof.homebrew.nativeMatrix)).toHaveLength(4);
+    expect(Object.keys(proof.extension.packedChromiumSuites)).toEqual(["worker", "jobs", "research", "rovo", "palette"]);
+    const schema = JSON.parse(readFileSync("specs/dev-release-channel/evidence/schemas/live-release-proof.schema.json", "utf8"));
+    const validate = new Ajv2020({ allErrors: true, strict: true }).compile(schema);
+    expect(validate(proof), JSON.stringify(validate.errors)).toBe(true);
+  });
+
+  it("rejects a mismatched Homebrew pointer", () => {
+    const f = fixture();
+    f.input.homebrewDispatch.pointer.sourceSha = "e".repeat(40);
+    expect(() => buildLiveReleaseProof(f.input)).toThrow("Homebrew publication identity mismatch");
+  });
+
+  it("rejects a missing native platform proof", () => {
+    const f = fixture();
+    f.input.nativeReceipts.pop();
+    expect(() => buildLiveReleaseProof(f.input)).toThrow("native CLI target contract mismatch");
+  });
+
+  it("rejects an artifact verifier receipt that is not bound to build metadata", () => {
+    const f = fixture();
+    f.input.releaseVerification.verifiedArtifacts = [];
+    expect(() => buildLiveReleaseProof(f.input)).toThrow("downloaded artifact verifier receipt differs");
+  });
+});

--- a/scripts/ci/build-live-release-proof.ts
+++ b/scripts/ci/build-live-release-proof.ts
@@ -1,0 +1,306 @@
+#!/usr/bin/env bun
+
+import { createHash } from "node:crypto";
+import { readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import Ajv2020 from "ajv/dist/2020";
+import { canonicalJson, expectedReleaseAssetNames, type ReleaseIdentity } from "../release-artifacts.js";
+
+interface BuildMetadata {
+  schema: "atlcli.build-metadata/v1";
+  channel: "dev";
+  rootVersion: string;
+  sourceSha: string;
+  releaseTag: string;
+  buildId: string;
+  run: { id: number; attempt: number; event: "workflow_dispatch" | "schedule"; createdAt: string };
+  toolchain: { bun: string; wxt: string; runnerOs: string };
+  lockfileSha256: string;
+  artifacts: { name: string; size: number; sha256: string }[];
+  extension: { contentTreeSha256: string };
+}
+
+interface SourceEligibility {
+  schema: "atlcli.source-eligibility/v1";
+  decision: "eligible";
+  degraded: boolean;
+  sourceSha: string;
+  policyVersion: string;
+  workflow: { runId: number; runAttempt: number; conclusion: "success" };
+  requiredJob: { conclusion: "success" };
+}
+
+interface ReleaseReceipt {
+  schema: "atlcli.github-release-transaction/v1";
+  operation: "verify-published";
+  releaseUrl: string;
+  tag: string;
+  sourceSha: string;
+  draft: false;
+  prerelease: true;
+  makeLatest: false;
+  immutable: true;
+  assets: { name: string; size: number; sha256: string }[];
+  stableLatestBefore: string;
+  stableLatestAfter: string;
+  run: { id: number; attempt: number };
+}
+
+interface ReleaseVerification {
+  schema: "atlcli.release-verification/v1";
+  sourceSha: string;
+  channel: "dev";
+  buildId: string;
+  releaseTag: string;
+  verifiedArtifacts: { name: string; size: number; sha256: string }[];
+  extension: { contentTreeSha256: string; outputScan: "success"; entryCount: number };
+}
+
+interface NativeReceipt {
+  schema: "atlcli.native-cli-verification/v1";
+  target: string;
+  runner: { platform: string; arch: string };
+  releaseInfo: { channel: "dev"; sourceSha: string; buildId: string; releaseTag: string };
+}
+
+interface HomebrewNativeReceipt {
+  schema: "atlcli.homebrew-dev-native-verification/v1";
+  target: string;
+  rubyPlatform: string;
+  hostCpu: string;
+  releaseInfo: { channel: "dev"; sourceSha: string; buildId: string; releaseTag: string };
+}
+
+interface HomebrewDispatch {
+  schema: "atlcli.homebrew-dev-dispatch/v1";
+  workflow: { id: number; attempt: number; url: string; conclusion: "success" };
+  tapCommit: string;
+  formulaSha256: string;
+  pointer: {
+    schema: "atlcli.homebrew-dev-pointer/v1";
+    tag: string;
+    sourceSha: string;
+  };
+}
+
+interface WorkflowRun {
+  databaseId: number;
+  attempt: number;
+  event: "workflow_dispatch" | "schedule";
+  headSha: string;
+  url: string;
+  conclusion: "success";
+  jobs: { name: string; conclusion: string }[];
+}
+
+const SHA256 = /^[0-9a-f]{64}$/;
+const SHA = /^[0-9a-f]{40}$/;
+const CLI_TARGETS = ["darwin-arm64", "darwin-x64", "linux-arm64", "linux-x64", "windows-x64"];
+const BREW_TARGETS = ["darwin-arm64", "darwin-x64", "linux-arm64", "linux-x64"];
+const PACKED_SUITES = ["worker", "jobs", "research", "rovo", "palette"];
+
+function json<T>(path: string): T {
+  return JSON.parse(readFileSync(path, "utf8")) as T;
+}
+
+function sha256(bytes: Uint8Array | string): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function files(root: string, filename: string): string[] {
+  const result: string[] = [];
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    const path = join(root, entry.name);
+    if (entry.isDirectory()) result.push(...files(path, filename));
+    else if (entry.name === filename) result.push(path);
+  }
+  return result.sort();
+}
+
+function exactTargets<T extends { target: string }>(receipts: T[], targets: string[], label: string): Record<string, T> {
+  const actual = receipts.map(({ target }) => target).sort();
+  if (JSON.stringify(actual) !== JSON.stringify([...targets].sort())) {
+    throw new Error(`${label} target contract mismatch; expected=${targets}; actual=${actual}`);
+  }
+  return Object.fromEntries(receipts.map((receipt) => [receipt.target, receipt]));
+}
+
+function successfulJob(run: WorkflowRun, name: string): void {
+  const matches = run.jobs.filter((job) => job.name === name && job.conclusion === "success");
+  if (matches.length !== 1) throw new Error(`required successful workflow job missing or ambiguous: ${name}`);
+}
+
+function sameIdentity(value: { sourceSha: string; releaseTag: string; buildId?: string }, metadata: BuildMetadata): void {
+  if (
+    value.sourceSha !== metadata.sourceSha ||
+    value.releaseTag !== metadata.releaseTag ||
+    (value.buildId !== undefined && value.buildId !== metadata.buildId)
+  ) throw new Error("live proof input identity mismatch");
+}
+
+export function buildLiveReleaseProof(input: {
+  releaseDir: string;
+  releaseVerification: ReleaseVerification;
+  releaseReceipt: ReleaseReceipt;
+  eligibility: SourceEligibility;
+  releaseRun: WorkflowRun;
+  nativeReceipts: NativeReceipt[];
+  homebrewDispatch: HomebrewDispatch;
+  homebrewNativeReceipts: HomebrewNativeReceipt[];
+  pointerText: string;
+  formulaText: string;
+  recordedAt: string;
+}): unknown {
+  const metadata = json<BuildMetadata>(join(input.releaseDir, "build-metadata.json"));
+  if (metadata.schema !== "atlcli.build-metadata/v1" || metadata.channel !== "dev") throw new Error("invalid dev build metadata");
+  if (!SHA.test(metadata.sourceSha) || !SHA256.test(metadata.lockfileSha256)) throw new Error("invalid metadata identity digest");
+  if (input.eligibility.decision !== "eligible" || input.eligibility.sourceSha !== metadata.sourceSha) throw new Error("source is not eligible");
+  sameIdentity(input.releaseVerification, metadata);
+  if (input.releaseReceipt.sourceSha !== metadata.sourceSha || input.releaseReceipt.tag !== metadata.releaseTag) {
+    throw new Error("public release receipt identity mismatch");
+  }
+  if (
+    input.releaseReceipt.operation !== "verify-published" || input.releaseReceipt.draft ||
+    !input.releaseReceipt.prerelease || input.releaseReceipt.makeLatest || !input.releaseReceipt.immutable ||
+    input.releaseReceipt.stableLatestBefore !== input.releaseReceipt.stableLatestAfter
+  ) throw new Error("published release contract is not proven");
+  if (
+    input.releaseRun.databaseId !== metadata.run.id || input.releaseRun.attempt !== metadata.run.attempt ||
+    input.releaseRun.event !== metadata.run.event || input.releaseRun.headSha !== metadata.sourceSha ||
+    input.releaseRun.conclusion !== "success"
+  ) throw new Error("release workflow identity mismatch");
+  for (const job of ["Download and consume every draft asset", "Verify public prerelease and stable latest isolation", "Publish and verify isolated Homebrew dev formula"]) {
+    successfulJob(input.releaseRun, job);
+  }
+  if (canonicalJson(input.releaseVerification.verifiedArtifacts) !== canonicalJson(metadata.artifacts)) {
+    throw new Error("downloaded artifact verifier receipt differs from build metadata");
+  }
+
+  const identity = {
+    channel: "dev",
+    rootVersion: metadata.rootVersion,
+    sourceSha: metadata.sourceSha,
+    shortSha: metadata.sourceSha.slice(0, 8),
+    buildId: metadata.buildId,
+    releaseTag: metadata.releaseTag,
+  } as ReleaseIdentity;
+  const expectedNames = expectedReleaseAssetNames(identity);
+  const actualFiles = readdirSync(input.releaseDir)
+    .filter((name) => statSync(join(input.releaseDir, name)).isFile())
+    .sort();
+  if (JSON.stringify(actualFiles) !== JSON.stringify(expectedNames)) throw new Error("downloaded live asset inventory mismatch");
+  const assets = actualFiles.map((filename) => {
+    const bytes = readFileSync(join(input.releaseDir, filename));
+    return { filename, size: bytes.byteLength, sha256: sha256(bytes) };
+  });
+  const receiptAssets = input.releaseReceipt.assets.map(({ name, ...asset }) => ({ filename: name, ...asset })).sort((a, b) => a.filename.localeCompare(b.filename));
+  if (canonicalJson(assets) !== canonicalJson(receiptAssets)) throw new Error("public release receipt differs from downloaded bytes");
+
+  const nativeMatrix = exactTargets(input.nativeReceipts, CLI_TARGETS, "native CLI");
+  for (const receipt of Object.values(nativeMatrix)) sameIdentity(receipt.releaseInfo, metadata);
+  const brewMatrix = exactTargets(input.homebrewNativeReceipts, BREW_TARGETS, "Homebrew native");
+  for (const receipt of Object.values(brewMatrix)) sameIdentity(receipt.releaseInfo, metadata);
+  if (
+    input.homebrewDispatch.workflow.conclusion !== "success" ||
+    input.homebrewDispatch.pointer.tag !== metadata.releaseTag ||
+    input.homebrewDispatch.pointer.sourceSha !== metadata.sourceSha ||
+    input.homebrewDispatch.formulaSha256 !== sha256(input.formulaText) ||
+    !SHA.test(input.homebrewDispatch.tapCommit)
+  ) throw new Error("Homebrew publication identity mismatch");
+  const publicPointer = JSON.parse(input.pointerText) as typeof input.homebrewDispatch.pointer;
+  if (canonicalJson(publicPointer) !== canonicalJson(input.homebrewDispatch.pointer)) throw new Error("public Homebrew pointer differs from dispatch receipt");
+
+  const extensionName = actualFiles.find((name) => name.startsWith("atlcli-extension-chrome-mv3-"));
+  if (!extensionName) throw new Error("extension release asset is missing");
+  const manifest = json<{ version?: string }>(join(input.releaseDir, "extension", "manifest.json"));
+  if (!manifest.version || !/^\d+(?:\.\d+){0,3}$/.test(manifest.version)) throw new Error("verified extension manifest version is invalid");
+  if (
+    input.releaseVerification.extension.outputScan !== "success" ||
+    input.releaseVerification.extension.contentTreeSha256 !== metadata.extension.contentTreeSha256
+  ) throw new Error("extension verification does not match metadata");
+
+  const proof = {
+    schema: "atlcli.dev-release-live-proof/v1",
+    recordedAt: input.recordedAt,
+    source: {
+      sha: metadata.sourceSha,
+      canonicalMainPushRunId: input.eligibility.workflow.runId,
+      canonicalMainPushAttempt: input.eligibility.workflow.runAttempt,
+      requiredAggregate: input.eligibility.requiredJob.conclusion,
+      requiredPolicyVersion: input.eligibility.policyVersion,
+      advisoryPolicyVersion: input.eligibility.policyVersion,
+      decision: input.eligibility.degraded ? "degraded" : "eligible",
+    },
+    workflow: { runId: input.releaseRun.databaseId, attempt: input.releaseRun.attempt, event: input.releaseRun.event, url: input.releaseRun.url },
+    release: {
+      buildId: metadata.buildId,
+      tag: metadata.releaseTag,
+      url: input.releaseReceipt.releaseUrl,
+      prerelease: true,
+      draft: false,
+      immutable: true,
+      stableLatestUnchanged: true,
+    },
+    toolchain: {
+      bun: metadata.toolchain.bun,
+      wxt: metadata.toolchain.wxt,
+      runnerImages: Object.fromEntries(Object.entries(nativeMatrix).map(([target, receipt]) => [target, receipt.runner])),
+      lockfileSha256: metadata.lockfileSha256,
+    },
+    assets,
+    extension: {
+      archiveSha256: assets.find(({ filename }) => filename === extensionName)!.sha256,
+      manifestVersion: manifest.version,
+      inventorySha256: input.releaseVerification.extension.contentTreeSha256,
+      packedChromiumSuites: Object.fromEntries(PACKED_SUITES.map((suite) => [suite, "success"])),
+    },
+    homebrew: {
+      tapCommit: input.homebrewDispatch.tapCommit,
+      tapCommitUrl: `https://github.com/BjoernSchotte/homebrew-tap/commit/${input.homebrewDispatch.tapCommit}`,
+      formulaSha256: input.homebrewDispatch.formulaSha256,
+      pointerSha256: sha256(input.pointerText),
+      releaseTag: metadata.releaseTag,
+      nativeMatrix: Object.fromEntries(Object.entries(brewMatrix).map(([target, receipt]) => [target, { rubyPlatform: receipt.rubyPlatform, hostCpu: receipt.hostCpu, result: "success" }])),
+      installedReleaseInfo: Object.values(brewMatrix)[0]!.releaseInfo,
+    },
+    tests: {
+      exactDownloadedAssetVerifier: "success",
+      packedChromium: "success",
+      nativeCliMatrix: "success",
+      homebrewAuditInstallTestSwitchMatrix: "success",
+      stableLatestIsolation: "success",
+    },
+    privacy: { containsSecrets: false, containsTenantData: false, containsAbsoluteHomePaths: false, containsRawLogs: false },
+  };
+  return proof;
+}
+
+function arg(name: string): string {
+  const index = process.argv.indexOf(name);
+  const value = index < 0 ? undefined : process.argv[index + 1];
+  if (!value) throw new Error(`missing ${name}`);
+  return resolve(value);
+}
+
+if (import.meta.main) {
+  const releaseDir = arg("--release-dir");
+  const proof = buildLiveReleaseProof({
+    releaseDir,
+    releaseVerification: json(arg("--release-verification")),
+    releaseReceipt: json(arg("--release-receipt")),
+    eligibility: json(join(releaseDir, "source-eligibility.json")),
+    releaseRun: json(arg("--release-run")),
+    nativeReceipts: files(arg("--native-cli-dir"), "native-cli-verification.json").map((path) => json<NativeReceipt>(path)),
+    homebrewDispatch: json(arg("--homebrew-dispatch")),
+    homebrewNativeReceipts: files(arg("--homebrew-native-dir"), "native-verification.json").map((path) => json<HomebrewNativeReceipt>(path)),
+    pointerText: readFileSync(arg("--homebrew-pointer"), "utf8"),
+    formulaText: readFileSync(arg("--homebrew-formula"), "utf8"),
+    recordedAt: new Date().toISOString(),
+  });
+  const schema = json<object>(resolve("specs/dev-release-channel/evidence/schemas/live-release-proof.schema.json"));
+  const validate = new Ajv2020({ allErrors: true, strict: true }).compile(schema);
+  if (!validate(proof)) throw new Error(`live proof schema validation failed: ${JSON.stringify(validate.errors)}`);
+  const output = canonicalJson(proof);
+  writeFileSync(arg("--out"), output);
+  process.stdout.write(output);
+}

--- a/scripts/ci/dev-release-evidence-policy.test.ts
+++ b/scripts/ci/dev-release-evidence-policy.test.ts
@@ -74,4 +74,13 @@ describe("dev-release evidence policy", () => {
     );
     expect((await evaluateEvidencePolicy(root)).some((issue) => issue.reason.startsWith("task receipt schema:"))).toBe(true);
   });
+
+  it("validates the final live proof against its dedicated schema", async () => {
+    const root = await fixture();
+    await writeFile(
+      join(root, "evidence", "live-release-proof.json"),
+      JSON.stringify({ schema: "atlcli.dev-release-live-proof/v1" }),
+    );
+    expect((await evaluateEvidencePolicy(root)).some((issue) => issue.reason.startsWith("live receipt schema:"))).toBe(true);
+  });
 });

--- a/scripts/ci/dev-release-evidence-policy.ts
+++ b/scripts/ci/dev-release-evidence-policy.ts
@@ -86,7 +86,7 @@ export async function evaluateEvidencePolicy(root = DEFAULT_EVIDENCE_ROOT): Prom
   const schema = JSON.parse(await readFile(schemaPath, "utf8")) as object;
   const ajv = new Ajv2020({ allErrors: true, strict: true });
   const validateTaskProof = ajv.compile(schema);
-  ajv.compile(JSON.parse(await readFile(liveSchemaPath, "utf8")) as object);
+  const validateLiveProof = ajv.compile(JSON.parse(await readFile(liveSchemaPath, "utf8")) as object);
   const issues: EvidencePolicyIssue[] = [];
 
   for (const path of allFiles) {
@@ -118,6 +118,9 @@ export async function evaluateEvidencePolicy(root = DEFAULT_EVIDENCE_ROOT): Prom
 
     if (/^DR-[0-9]{2}-.+\.json$/.test(basename(path)) && !validateTaskProof(value)) {
       issues.push({ file, reason: `task receipt schema: ${ajvErrors(validateTaskProof.errors)}` });
+    }
+    if (basename(path) === "live-release-proof.json" && !validateLiveProof(value)) {
+      issues.push({ file, reason: `live receipt schema: ${ajvErrors(validateLiveProof.errors)}` });
     }
   }
 

--- a/scripts/verify-release-artifacts.test.ts
+++ b/scripts/verify-release-artifacts.test.ts
@@ -19,6 +19,7 @@ import {
   releaseTreeDigest,
 } from "./release-archive";
 import {
+  emitReleaseVerificationReceipt,
   inspectSingleBinaryTarGz,
   inspectZipCentralDirectory,
   verifyReleaseArtifacts,
@@ -201,6 +202,8 @@ describe("release artifact verifier", () => {
       expect(receipt.verifiedArtifacts).toHaveLength(8);
       expect(receipt.extension.entryCount).toBe(2);
       expect(receipt.extension.outputScan).toBe("not-run");
+      const output = join(root, "published-verification.json");
+      expect(emitReleaseVerificationReceipt(receipt, output)).toBe(readFileSync(output, "utf8"));
     } finally {
       rmSync(root, { recursive: true, force: true });
       rmSync(`${join(root, "extracted")}.atlcli-release-extraction-v1`, { force: true });

--- a/scripts/verify-release-artifacts.ts
+++ b/scripts/verify-release-artifacts.ts
@@ -117,6 +117,15 @@ export interface ReleaseVerificationReceipt {
   };
 }
 
+export function emitReleaseVerificationReceipt(
+  receipt: ReleaseVerificationReceipt,
+  output?: string,
+): string {
+  const serialized = canonicalJson(receipt);
+  if (output) writeFileSync(resolve(output), serialized);
+  return serialized;
+}
+
 function sha256(bytes: Uint8Array | string): string {
   return createHash("sha256").update(bytes).digest("hex");
 }
@@ -635,5 +644,5 @@ if (import.meta.main) {
   const directory = value("--dir");
   if (!directory) throw new Error("Usage: bun scripts/verify-release-artifacts.ts --dir <assets>");
   const receipt = await verifyReleaseArtifacts({ directory });
-  process.stdout.write(canonicalJson(receipt));
+  process.stdout.write(emitReleaseVerificationReceipt(receipt, value("--out")));
 }

--- a/src/content/docs/contributing.md
+++ b/src/content/docs/contributing.md
@@ -462,6 +462,40 @@ App installation quarterly.
 
 ### Retention and evidence
 
+After a live run, download the ten public release assets, the source run's
+public-release, native-CLI, and Homebrew-dispatch receipts, and the correlated
+Tap run's four native receipts. Verify and extract the exact downloaded release
+bytes first, preserving its receipt as `published-verification.json`:
+
+```bash
+bun scripts/verify-release-artifacts.ts \
+  --dir <downloaded-release-directory> \
+  --out <published-verification.json>
+```
+
+Then build the final proof from those consumer inputs. The builder consumes the
+verifier-owned `<downloaded-release-directory>/extension` extraction and rejects
+a verifier receipt whose artifact inventory differs from `build-metadata.json`:
+
+```bash
+bun scripts/ci/build-live-release-proof.ts \
+  --release-dir <downloaded-release-directory> \
+  --release-verification <published-verification.json> \
+  --release-receipt <published-release-receipt.json> \
+  --release-run <release-run.json> \
+  --native-cli-dir <native-cli-receipts-directory> \
+  --homebrew-dispatch <homebrew-dev-dispatch.json> \
+  --homebrew-native-dir <homebrew-native-receipts-directory> \
+  --homebrew-pointer <atlcli-dev.json> \
+  --homebrew-formula <atlcli-dev.rb> \
+  --out specs/dev-release-channel/evidence/live-release-proof.json
+```
+
+The builder fails closed unless every source, release, CLI, extension, Tap,
+and Homebrew identity resolves to the same immutable tag and source SHA. The
+repository evidence policy validates the resulting file against the dedicated
+live-proof schema and scans it for sensitive material.
+
 The cleanup workflow first produces a dry-run receipt. Apply mode retains at
 least the newest 14 successful dev releases or 30 days, and never deletes the
 stable release, a draft, a release with mutable classification, or the tag


### PR DESCRIPTION
## Summary
- aggregate GitHub release, exact downloaded bytes, native CLI, extension, and Homebrew Tap receipts into one schema-validated live proof
- validate the final live proof in the repository evidence policy
- document and test the executable verifier-to-aggregator operator path

## Verification
- bun run test scripts/verify-release-artifacts.test.ts scripts/ci/build-live-release-proof.test.ts scripts/ci/dev-release-evidence-policy.test.ts scripts/ci/workflow-policy.test.ts
- bun run typecheck
- bun scripts/ci/dev-release-evidence-policy.ts
- git diff --check