### PR TITLE
feat(release): fence dev channel rollbacks

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -20,6 +20,11 @@ on:
         required: false
         type: boolean
         default: true
+      rollback_from_tag:
+        description: Optional exact current atlcli-dev tag fencing a manual forward rollback
+        required: false
+        type: string
+        default: ""
       dry_run:
         description: Run the complete source/artifact shadow graph and record all publication writes without executing them
         required: false
@@ -62,11 +67,25 @@ jobs:
         id: identity
         env:
           REQUESTED_SOURCE_SHA: ${{ inputs.source_sha || '' }}
+          ROLLBACK_FROM_TAG: ${{ inputs.rollback_from_tag || '' }}
+          FORCE_REBUILD: ${{ inputs.force_rebuild || false }}
+          PUBLISH_HOMEBREW: ${{ inputs.publish_homebrew || false }}
+          DRY_RUN: ${{ inputs.dry_run || false }}
+          EVENT_NAME: ${{ github.event_name }}
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           git fetch --no-tags origin main
           main_sha="$(git rev-parse origin/main)"
           source_sha="$REQUESTED_SOURCE_SHA"
+          if [ -n "$ROLLBACK_FROM_TAG" ]; then
+            test "$EVENT_NAME" = "workflow_dispatch"
+            test -n "$source_sha"
+            test "$source_sha" != "$main_sha"
+            test "$FORCE_REBUILD" = "true"
+            test "$PUBLISH_HOMEBREW" = "true"
+            test "$DRY_RUN" = "false"
+            [[ "$ROLLBACK_FROM_TAG" =~ ^dev-[0-9]{8}\.[0-9]+\.[0-9]+-[0-9a-f]{8}$ ]]
+          fi
           if [ -z "$source_sha" ]; then
             source_sha="$main_sha"
           fi
@@ -799,6 +818,7 @@ jobs:
             --request-id "${{ steps.release.outputs.request_id }}" \
             --metadata-sha256 "${{ steps.release.outputs.metadata_sha256 }}" \
             --checksums-sha256 "${{ steps.release.outputs.checksums_sha256 }}" \
+            --rollback-from-tag "${{ inputs.rollback_from_tag || '' }}" \
             --out homebrew-dev-dispatch.json
 
       - name: Upload cross-repository publication receipt

--- a/scripts/ci/homebrew-dev-dispatch.test.ts
+++ b/scripts/ci/homebrew-dev-dispatch.test.ts
@@ -11,7 +11,7 @@ const REQUEST = "31599183166-1-dev-20260812.418.2-01234567";
 const METADATA = "a".repeat(64);
 const CHECKSUMS = "b".repeat(64);
 
-async function fixtureApi(options: { conclusion?: string; duplicate?: boolean; drift?: boolean } = {}) {
+async function fixtureApi(options: { conclusion?: string; duplicate?: boolean; drift?: boolean; rollbackFromTag?: string } = {}) {
   const pointer = {
     schema: "atlcli.homebrew-dev-pointer/v1" as const,
     sourceRepository: "BjoernSchotte/atlcli",
@@ -24,7 +24,7 @@ async function fixtureApi(options: { conclusion?: string; duplicate?: boolean; d
     requestId: REQUEST,
     releaseUrl: `https://github.com/BjoernSchotte/atlcli/releases/tag/${TAG}`,
     releasePublishedAt: "2026-08-12T16:00:00Z",
-    rollbackFromTag: null,
+    rollbackFromTag: options.rollbackFromTag ?? null,
     archives: {
       "atlcli-darwin-arm64.tar.gz": "1".repeat(64),
       "atlcli-darwin-x64.tar.gz": "2".repeat(64),
@@ -61,6 +61,7 @@ async function fixtureApi(options: { conclusion?: string; duplicate?: boolean; d
   const api: TapApi = {
     async dispatch(inputs) {
       expect(inputs.dev_tag).toBe(TAG);
+      expect(inputs.rollback_from_tag).toBe(options.rollbackFromTag ?? "");
       dispatched = true;
     },
     async runs() {
@@ -100,6 +101,22 @@ describe("Homebrew dev cross-repository dispatch", () => {
     expect(receipt.tapCommit).toBe("f".repeat(40));
   });
 
+  test("passes and verifies the exact current tag as a rollback fence", async () => {
+    const rollbackFromTag = "dev-20260811.400.1-89abcdef";
+    const receipt = await dispatchAndVerifyHomebrewDev({
+      api: await fixtureApi({ rollbackFromTag }),
+      tag: TAG,
+      sourceSha: SHA,
+      requestId: REQUEST,
+      metadataSha256: METADATA,
+      checksumsSha256: CHECKSUMS,
+      rollbackFromTag,
+      pollIntervalMs: 0,
+      sleep: async () => {},
+    });
+    expect(receipt.pointer.rollbackFromTag).toBe(rollbackFromTag);
+  });
+
   test("blocks red, ambiguous, and remotely drifted workflows", async () => {
     for (const options of [{ conclusion: "failure" }, { duplicate: true }, { drift: true }]) {
       await expect(dispatchAndVerifyHomebrewDev({
@@ -124,5 +141,17 @@ describe("Homebrew dev cross-repository dispatch", () => {
       metadataSha256: METADATA,
       checksumsSha256: CHECKSUMS,
     })).rejects.toThrow("request ID");
+  });
+
+  test("rejects a malformed rollback fence before dispatch", async () => {
+    await expect(dispatchAndVerifyHomebrewDev({
+      api: await fixtureApi(),
+      tag: TAG,
+      sourceSha: SHA,
+      requestId: REQUEST,
+      metadataSha256: METADATA,
+      checksumsSha256: CHECKSUMS,
+      rollbackFromTag: "latest",
+    })).rejects.toThrow("rollback fence tag");
   });
 });

--- a/scripts/ci/homebrew-dev-dispatch.ts
+++ b/scripts/ci/homebrew-dev-dispatch.ts
@@ -75,6 +75,7 @@ function validateRequest(input: {
   requestId: string;
   metadataSha256: string;
   checksumsSha256: string;
+  rollbackFromTag?: string;
 }): void {
   if (!/^dev-\d{8}\.\d+\.\d+-[0-9a-f]{8}$/.test(input.tag)) throw new Error("invalid dev tag");
   if (!/^[0-9a-f]{40}$/.test(input.sourceSha)) throw new Error("invalid source SHA");
@@ -82,6 +83,9 @@ function validateRequest(input: {
   if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/.test(input.requestId)) throw new Error("invalid request ID");
   if (!/^[0-9a-f]{64}$/.test(input.metadataSha256)) throw new Error("invalid metadata SHA-256");
   if (!/^[0-9a-f]{64}$/.test(input.checksumsSha256)) throw new Error("invalid checksums SHA-256");
+  if (input.rollbackFromTag && !/^dev-\d{8}\.\d+\.\d+-[0-9a-f]{8}$/.test(input.rollbackFromTag)) {
+    throw new Error("invalid rollback fence tag");
+  }
 }
 
 function assertPublishedContent(input: {
@@ -93,6 +97,7 @@ function assertPublishedContent(input: {
   requestId: string;
   metadataSha256: string;
   checksumsSha256: string;
+  rollbackFromTag?: string;
 }): void {
   const { receipt } = input;
   if (receipt.schema !== "atlcli.homebrew-dev-publication/v1") throw new Error("tap receipt schema mismatch");
@@ -107,7 +112,7 @@ function assertPublishedContent(input: {
     pointer.requestId !== input.requestId ||
     pointer.metadataSha256 !== input.metadataSha256 ||
     pointer.checksumsSha256 !== input.checksumsSha256 ||
-    pointer.rollbackFromTag !== null
+    pointer.rollbackFromTag !== (input.rollbackFromTag || null)
   ) {
     throw new Error("published Homebrew pointer does not match the dispatched release");
   }
@@ -130,6 +135,7 @@ export async function dispatchAndVerifyHomebrewDev(input: {
   requestId: string;
   metadataSha256: string;
   checksumsSha256: string;
+  rollbackFromTag?: string;
   pollIntervalMs?: number;
   timeoutMs?: number;
   sleep?: (milliseconds: number) => Promise<void>;
@@ -146,7 +152,7 @@ export async function dispatchAndVerifyHomebrewDev(input: {
     request_id: input.requestId,
     metadata_sha256: input.metadataSha256,
     checksums_sha256: input.checksumsSha256,
-    rollback_from_tag: "",
+    rollback_from_tag: input.rollbackFromTag ?? "",
   });
   const sleep = input.sleep ?? ((milliseconds) => Bun.sleep(milliseconds));
   const timeoutMs = input.timeoutMs ?? 60 * 60 * 1_000;
@@ -272,6 +278,7 @@ if (import.meta.main) {
     requestId: required("--request-id"),
     metadataSha256: required("--metadata-sha256"),
     checksumsSha256: required("--checksums-sha256"),
+    rollbackFromTag: value(args, "--rollback-from-tag") || undefined,
   });
   const output = canonicalJson(receipt);
   writeFileSync(resolve(value(args, "--out") ?? "homebrew-dev-dispatch.json"), output);

--- a/scripts/ci/workflow-policy.test.ts
+++ b/scripts/ci/workflow-policy.test.ts
@@ -144,6 +144,7 @@ describe("CI workflow policy", () => {
     expect(triggers).toContain("source_sha:");
     expect(triggers).toContain("force_rebuild:");
     expect(triggers).toContain("publish_homebrew:");
+    expect(triggers).toContain("rollback_from_tag:");
     expect(triggers).toMatch(/dry_run:\n[\s\S]*?default: true/);
     expect(triggers).not.toContain("pull_request:");
     expect(triggers).not.toContain("pull_request_target:");
@@ -211,6 +212,13 @@ describe("CI workflow policy", () => {
     expect(resolve).toContain('git merge-base --is-ancestor "$source_sha" origin/main');
     expect(resolve).toContain('git checkout --detach "$source_sha"');
     expect(resolve).not.toContain("github.ref");
+    expect(resolve).toContain('test "$EVENT_NAME" = "workflow_dispatch"');
+    expect(resolve).toContain('test -n "$source_sha"');
+    expect(resolve).toContain('test "$source_sha" != "$main_sha"');
+    expect(resolve).toContain('test "$FORCE_REBUILD" = "true"');
+    expect(resolve).toContain('test "$PUBLISH_HOMEBREW" = "true"');
+    expect(resolve).toContain('test "$DRY_RUN" = "false"');
+    expect(resolve).toContain('[[ "$ROLLBACK_FROM_TAG" =~ ^dev-');
   });
 
   it("puts no-op inspection and green exact-SHA eligibility before every dev build", async () => {
@@ -346,6 +354,7 @@ describe("CI workflow policy", () => {
     expect(homebrew).toContain("permission-actions: write");
     expect(homebrew).toContain("permission-contents: read");
     expect(homebrew).toContain("homebrew-dev-dispatch.ts");
+    expect(homebrew).toContain('--rollback-from-tag "${{ inputs.rollback_from_tag || \'\' }}"');
     expect(homebrew).toContain("HOMEBREW_TAP_TOKEN: ${{ steps.tap-token.outputs.token }}");
     expect(homebrew).not.toContain("contents: write");
     expect(homebrew).not.toContain("secrets.HOMEBREW_TAP_TOKEN");

--- a/specs/dev-release-channel/PLAN.md
+++ b/specs/dev-release-channel/PLAN.md
@@ -273,6 +273,10 @@ on:
         required: true
         type: boolean
         default: false
+      rollback_from_tag:
+        required: false
+        type: string
+        default: ""
 ```
 
 `02:17 UTC` ist absichtlich nicht zur vollen Stunde. GitHub-Schedules koennen
@@ -283,6 +287,8 @@ einschliessen.
 
 Ein optionaler `source_sha` ist fuer reproduzierbare Rollbacks gedacht, nicht
 fuer beliebige Feature-Branches. Der Workflow prueft `merge-base --is-ancestor`
+und akzeptiert `rollback_from_tag` nur bei einem manuellen Live-Lauf mit einem
+expliziten aelteren `source_sha`, `force_rebuild=true` und aktiviertem Homebrew.
 gegen den frisch geholten `origin/main` und protokolliert den aufgeloesten SHA.
 
 Danach fragt `eligible-source` ueber die GitHub Actions API ausschliesslich den

--- a/src/content/docs/contributing.md
+++ b/src/content/docs/contributing.md
@@ -406,7 +406,7 @@ advisory canary may be red, but the release receipt must then report
 
 - GitHub release immutability is enabled for `BjoernSchotte/atlcli`.
 - `HOMEBREW_TAP_APP_ID` is configured as a repository variable.
-- `HOMEBREW_TAP_APP_PRIVATE_KEY` is configured as a repository secret.
+- `HOMEBREW_TAP_APP_PRIVATE_KEY` is configured as a `dev-release` Environment secret.
 - The GitHub App is installed only where needed and can dispatch Actions in
   `BjoernSchotte/homebrew-tap`; it has no tap contents-write permission.
 - `DEV_RELEASE_SCHEDULE_ENABLED` remains `false` until the first manual live
@@ -424,6 +424,7 @@ Open **Actions → Dev release → Run workflow**. The inputs are:
 | `source_sha` | current `main` | Optional full SHA; it must be an ancestor of current `main` and have a successful canonical `main` push run |
 | `force_rebuild` | `false` | Create a new immutable build identity for an already released SHA; never replace an existing tag or asset |
 | `publish_homebrew` | `true` | Dispatch and verify the separate `atlcli-dev` formula after GitHub publication succeeds |
+| `rollback_from_tag` | empty | Exact currently published `atlcli-dev` tag authorizing a forward rollback; requires an older explicit `source_sha`, `force_rebuild=true`, `publish_homebrew=true`, and `dry_run=false` |
 | `dry_run` | `true` | Run the exact quality/artifact/native-consumer shadow graph and record every publication mutation without creating a tag, release, or formula |
 
 For the first live publication, complete the DR-09 shadow rehearsal and obtain
@@ -456,9 +457,12 @@ App installation quarterly.
   correlated Tap run, then use a new forced build after the fix; never rewrite
   the old release.
 - **Rollback:** select a previously green `main` SHA, run with
-  `force_rebuild=true`, and publish a new forward-moving formula version that
-  references the new tag. The workflow requires the exact current formula tag
-  as a fence. It does not move the pointer backward or overwrite releases.
+  `force_rebuild=true`, `publish_homebrew=true`, `dry_run=false`, and set
+  `rollback_from_tag` to the exact current formula tag. The workflow rejects an
+  implicit/current `source_sha`; the selected older SHA must still pass its
+  canonical green-main eligibility gate. It publishes a new forward-moving
+  formula version referencing a new immutable tag. It does not move the pointer
+  backward or overwrite releases.
 
 ### Retention and evidence
 


### PR DESCRIPTION
## Summary
- add an explicit manual rollback_from_tag input to the dev release workflow
- require an older explicit green-main SHA, force rebuild, live mode, and Homebrew publication before accepting a rollback fence
- pass and verify the exact current tag through the isolated Tap publication receipt

## Verification
- bun run test scripts/ci/homebrew-dev-dispatch.test.ts scripts/ci/workflow-policy.test.ts scripts/ci/build-live-release-proof.test.ts
- bun run typecheck
- bun scripts/ci/dev-release-evidence-policy.ts
- git diff --check