### PR TITLE
feat(release): verify immutable dev attestations

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -719,6 +719,28 @@ jobs:
             --out published-release-receipt.json
           bun scripts/verify-release-artifacts.ts --dir published-download > published-verification.json
 
+      - name: Verify GitHub release and downloaded asset attestations
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DEV_TAG: ${{ needs.resolve-source.outputs.build_id }}
+        run: |
+          for attempt in $(seq 1 12); do
+            if gh release verify "$DEV_TAG" --repo "$GITHUB_REPOSITORY" --format json > github-release-attestation.json 2>/dev/null; then
+              break
+            fi
+            if [ "$attempt" -eq 12 ]; then
+              echo "GitHub release attestation was not verifiable before timeout" >&2
+              exit 1
+            fi
+            sleep 10
+          done
+          gh release verify-asset "$DEV_TAG" published-download/build-metadata.json \
+            --repo "$GITHUB_REPOSITORY" \
+            --format json > github-release-asset-attestation.json
+          test -s github-release-attestation.json
+          test -s github-release-asset-attestation.json
+
       - name: Upload public release verification receipt
         uses: actions/upload-artifact@v7
         with:
@@ -726,6 +748,8 @@ jobs:
           path: |
             published-release-receipt.json
             published-verification.json
+            github-release-attestation.json
+            github-release-asset-attestation.json
           if-no-files-found: error
           retention-days: 90
 

--- a/scripts/ci/build-live-release-proof.test.ts
+++ b/scripts/ci/build-live-release-proof.test.ts
@@ -44,6 +44,20 @@ function fixture() {
   const brewTargets = nativeTargets.slice(0, 4);
   const pointer = { schema: "atlcli.homebrew-dev-pointer/v1" as const, tag, sourceSha: sha };
   const formulaText = "formula";
+  const attestation = {
+    verificationResult: {
+      signature: { certificate: { subjectAlternativeName: "https://dotcom.releases.github.com" } },
+      statement: {
+        predicateType: "https://in-toto.io/attestation/release/v0.2",
+        predicate: { repository: "BjoernSchotte/atlcli", tag },
+        subject: [
+          { uri: `pkg:github/BjoernSchotte/atlcli@${tag}`, digest: { sha1: sha } },
+          ...assets.map(({ name, sha256 }) => ({ name, digest: { sha256 } })),
+        ],
+      },
+      verifiedTimestamps: [{ timestamp: "2026-08-13T00:30:00Z", type: "TimestampAuthority", uri: "timestamp.githubapp.com" }],
+    },
+  };
   return {
     root, metadata, eligibility, assets, releaseInfo, pointer, formulaText,
     input: {
@@ -52,6 +66,8 @@ function fixture() {
       releaseReceipt: { schema: "atlcli.github-release-transaction/v1" as const, operation: "verify-published" as const, releaseUrl: "https://github.com/BjoernSchotte/atlcli/releases/tag/x", tag, sourceSha: sha, draft: false as const, prerelease: true as const, makeLatest: false as const, immutable: true as const, assets, stableLatestBefore: "v0.17.2", stableLatestAfter: "v0.17.2", run: { id: runId, attempt: 1 } },
       eligibility,
       releaseRun: { databaseId: runId, attempt: 1, event: "workflow_dispatch" as const, headSha: sha, url: "https://github.com/BjoernSchotte/atlcli/actions/runs/123", conclusion: "success" as const, jobs: ["Download and consume every draft asset", "Verify public prerelease and stable latest isolation", "Publish and verify isolated Homebrew dev formula"].map((name) => ({ name, conclusion: "success" })) },
+      githubReleaseAttestation: structuredClone(attestation),
+      githubAssetAttestation: structuredClone(attestation),
       nativeReceipts: nativeTargets.map((target) => ({ schema: "atlcli.native-cli-verification/v1" as const, target, runner: { platform: target.split("-")[0]!, arch: target.split("-")[1]! }, releaseInfo })),
       homebrewDispatch: { schema: "atlcli.homebrew-dev-dispatch/v1" as const, workflow: { id: 8, attempt: 1, url: "https://github.com/BjoernSchotte/homebrew-tap/actions/runs/8", conclusion: "success" as const }, tapCommit: "d".repeat(40), formulaSha256: createHash("sha256").update(formulaText).digest("hex"), pointer },
       homebrewNativeReceipts: brewTargets.map((target) => ({ schema: "atlcli.homebrew-dev-native-verification/v1" as const, target, rubyPlatform: target.startsWith("darwin") ? "darwin" : "linux", hostCpu: target.endsWith("arm64") ? "arm64" : "x86_64", releaseInfo })),
@@ -66,6 +82,8 @@ describe("live release proof builder", () => {
     expect(proof.schema).toBe("atlcli.dev-release-live-proof/v1");
     expect(proof.assets).toHaveLength(10);
     expect(Object.keys(proof.homebrew.nativeMatrix)).toHaveLength(4);
+    expect(proof.release.attestation.assetCount).toBe(10);
+    expect(proof.tests.githubBuildMetadataAssetAttestation).toBe("success");
     expect(Object.keys(proof.extension.packedChromiumSuites)).toEqual(["worker", "jobs", "research", "rovo", "palette"]);
     const schema = JSON.parse(readFileSync("specs/dev-release-channel/evidence/schemas/live-release-proof.schema.json", "utf8"));
     const validate = new Ajv2020({ allErrors: true, strict: true }).compile(schema);
@@ -88,5 +106,21 @@ describe("live release proof builder", () => {
     const f = fixture();
     f.input.releaseVerification.verifiedArtifacts = [];
     expect(() => buildLiveReleaseProof(f.input)).toThrow("downloaded artifact verifier receipt differs");
+  });
+
+  it("rejects an attestation for a different source commit", () => {
+    const f = fixture();
+    const source = f.input.githubReleaseAttestation.verificationResult.statement.subject[0] as { digest: { sha1: string } };
+    source.digest.sha1 = "e".repeat(40);
+    expect(() => buildLiveReleaseProof(f.input)).toThrow("GitHub release attestation identity mismatch");
+  });
+
+  it("rejects an attestation whose asset digest differs from the downloaded bytes", () => {
+    const f = fixture();
+    const subject = f.input.githubAssetAttestation.verificationResult.statement.subject.find(
+      (candidate): candidate is { name: string; digest: { sha256: string } } => "name" in candidate && candidate.name === "build-metadata.json",
+    )!;
+    subject.digest.sha256 = "e".repeat(64);
+    expect(() => buildLiveReleaseProof(f.input)).toThrow("GitHub release attestation asset inventory mismatch");
   });
 });

--- a/scripts/ci/build-live-release-proof.ts
+++ b/scripts/ci/build-live-release-proof.ts
@@ -93,6 +93,18 @@ interface WorkflowRun {
   jobs: { name: string; conclusion: string }[];
 }
 
+interface GitHubReleaseAttestation {
+  verificationResult: {
+    signature: { certificate: { subjectAlternativeName: string } };
+    statement: {
+      predicateType: string;
+      predicate: { repository: string; tag: string };
+      subject: { name?: string; uri?: string; digest: { sha1?: string; sha256?: string } }[];
+    };
+    verifiedTimestamps: { timestamp: string; type: string; uri: string }[];
+  };
+}
+
 const SHA256 = /^[0-9a-f]{64}$/;
 const SHA = /^[0-9a-f]{40}$/;
 const CLI_TARGETS = ["darwin-arm64", "darwin-x64", "linux-arm64", "linux-x64", "windows-x64"];
@@ -138,12 +150,58 @@ function sameIdentity(value: { sourceSha: string; releaseTag: string; buildId?: 
   ) throw new Error("live proof input identity mismatch");
 }
 
+function verifyGitHubAttestation(
+  receipt: GitHubReleaseAttestation,
+  metadata: BuildMetadata,
+  assets: { filename: string; size: number; sha256: string }[],
+): { predicateType: string; signer: string; verifiedAt: string; assetCount: number; buildMetadataSha256: string } {
+  const result = receipt.verificationResult;
+  const statement = result?.statement;
+  const expectedPurl = `pkg:github/BjoernSchotte/atlcli@${metadata.releaseTag}`;
+  const source = statement?.subject?.find((subject) => subject.uri === expectedPurl);
+  if (
+    statement?.predicateType !== "https://in-toto.io/attestation/release/v0.2" ||
+    statement.predicate.repository !== "BjoernSchotte/atlcli" ||
+    statement.predicate.tag !== metadata.releaseTag ||
+    source?.digest.sha1 !== metadata.sourceSha
+  ) throw new Error("GitHub release attestation identity mismatch");
+
+  const attestedAssets = statement.subject
+    .filter((subject): subject is { name: string; digest: { sha256: string } } =>
+      typeof subject.name === "string" && typeof subject.digest.sha256 === "string")
+    .map((subject) => ({ filename: subject.name, sha256: subject.digest.sha256 }))
+    .sort((a, b) => a.filename.localeCompare(b.filename));
+  const expectedAssets = assets
+    .map(({ filename, sha256 }) => ({ filename, sha256 }))
+    .sort((a, b) => a.filename.localeCompare(b.filename));
+  if (canonicalJson(attestedAssets) !== canonicalJson(expectedAssets)) {
+    throw new Error("GitHub release attestation asset inventory mismatch");
+  }
+
+  const signer = result.signature?.certificate?.subjectAlternativeName;
+  const timestamp = result.verifiedTimestamps?.find(({ type }) => type === "TimestampAuthority");
+  if (signer !== "https://dotcom.releases.github.com" || !timestamp || Number.isNaN(Date.parse(timestamp.timestamp))) {
+    throw new Error("GitHub release attestation trust identity mismatch");
+  }
+  const buildMetadata = attestedAssets.find(({ filename }) => filename === "build-metadata.json");
+  if (!buildMetadata) throw new Error("GitHub release attestation does not bind build-metadata.json");
+  return {
+    predicateType: statement.predicateType,
+    signer,
+    verifiedAt: timestamp.timestamp,
+    assetCount: attestedAssets.length,
+    buildMetadataSha256: buildMetadata.sha256,
+  };
+}
+
 export function buildLiveReleaseProof(input: {
   releaseDir: string;
   releaseVerification: ReleaseVerification;
   releaseReceipt: ReleaseReceipt;
   eligibility: SourceEligibility;
   releaseRun: WorkflowRun;
+  githubReleaseAttestation: GitHubReleaseAttestation;
+  githubAssetAttestation: GitHubReleaseAttestation;
   nativeReceipts: NativeReceipt[];
   homebrewDispatch: HomebrewDispatch;
   homebrewNativeReceipts: HomebrewNativeReceipt[];
@@ -195,6 +253,15 @@ export function buildLiveReleaseProof(input: {
   });
   const receiptAssets = input.releaseReceipt.assets.map(({ name, ...asset }) => ({ filename: name, ...asset })).sort((a, b) => a.filename.localeCompare(b.filename));
   if (canonicalJson(assets) !== canonicalJson(receiptAssets)) throw new Error("public release receipt differs from downloaded bytes");
+  const githubAttestation = verifyGitHubAttestation(input.githubReleaseAttestation, metadata, assets);
+  const githubAssetAttestation = verifyGitHubAttestation(input.githubAssetAttestation, metadata, assets);
+  if (canonicalJson(input.githubReleaseAttestation.verificationResult.statement) !== canonicalJson(input.githubAssetAttestation.verificationResult.statement)) {
+    throw new Error("GitHub release and asset attestation statements differ");
+  }
+  const downloadedMetadataSha256 = assets.find(({ filename }) => filename === "build-metadata.json")?.sha256;
+  if (githubAssetAttestation.buildMetadataSha256 !== downloadedMetadataSha256) {
+    throw new Error("GitHub asset attestation does not match downloaded build-metadata.json");
+  }
 
   const nativeMatrix = exactTargets(input.nativeReceipts, CLI_TARGETS, "native CLI");
   for (const receipt of Object.values(nativeMatrix)) sameIdentity(receipt.releaseInfo, metadata);
@@ -240,6 +307,7 @@ export function buildLiveReleaseProof(input: {
       draft: false,
       immutable: true,
       stableLatestUnchanged: true,
+      attestation: githubAttestation,
     },
     toolchain: {
       bun: metadata.toolchain.bun,
@@ -269,6 +337,8 @@ export function buildLiveReleaseProof(input: {
       nativeCliMatrix: "success",
       homebrewAuditInstallTestSwitchMatrix: "success",
       stableLatestIsolation: "success",
+      githubReleaseAttestation: "success",
+      githubBuildMetadataAssetAttestation: "success",
     },
     privacy: { containsSecrets: false, containsTenantData: false, containsAbsoluteHomePaths: false, containsRawLogs: false },
   };
@@ -290,6 +360,8 @@ if (import.meta.main) {
     releaseReceipt: json(arg("--release-receipt")),
     eligibility: json(join(releaseDir, "source-eligibility.json")),
     releaseRun: json(arg("--release-run")),
+    githubReleaseAttestation: json(arg("--github-release-attestation")),
+    githubAssetAttestation: json(arg("--github-asset-attestation")),
     nativeReceipts: files(arg("--native-cli-dir"), "native-cli-verification.json").map((path) => json<NativeReceipt>(path)),
     homebrewDispatch: json(arg("--homebrew-dispatch")),
     homebrewNativeReceipts: files(arg("--homebrew-native-dir"), "native-verification.json").map((path) => json<HomebrewNativeReceipt>(path)),

--- a/scripts/ci/github-release-transaction.test.ts
+++ b/scripts/ci/github-release-transaction.test.ts
@@ -98,6 +98,7 @@ class FakeApi implements ReleaseApi {
   async publish(_releaseId: number, _prerelease: boolean, makeLatest: boolean) {
     this.publishCalls++;
     this.draft.draft = false;
+    this.draft.immutable = true;
     if (makeLatest) this.latest = this.draft.tag_name;
     return structuredClone(this.draft);
   }
@@ -268,6 +269,74 @@ describe("exclusive GitHub release transaction", () => {
       stableLatestBefore: STABLE,
     })).rejects.toThrow("state");
     expect(api.publishCalls).toBe(1);
+  });
+
+  test("waits for GitHub to enforce dev release immutability and fails closed on timeout", async () => {
+    const requested = identity();
+    const delayed = new FakeApi();
+    await createDraftRelease({
+      api: delayed,
+      channel: "dev",
+      version: "0.17.2",
+      tag: requested.releaseTag,
+      sourceSha: SHA,
+      directory: assetDirectory(),
+      title: requested.releaseTag,
+      body: "",
+      stableLatestBefore: STABLE,
+    });
+    let polls = 0;
+    delayed.publish = async function(_releaseId: number, _prerelease: boolean, _makeLatest: boolean) {
+      this.publishCalls++;
+      this.draft.draft = false;
+      this.draft.immutable = false;
+      return structuredClone(this.draft);
+    };
+    delayed.release = async function() {
+      polls++;
+      if (this.publishCalls > 0 && polls >= 2) this.draft.immutable = true;
+      return structuredClone(this.draft);
+    };
+    const result = await publishDraftRelease({
+      api: delayed,
+      channel: "dev",
+      version: "0.17.2",
+      tag: requested.releaseTag,
+      sourceSha: SHA,
+      releaseId: 77,
+      stableLatestBefore: STABLE,
+      immutablePollIntervalMs: 0,
+      immutableTimeoutMs: 1_000,
+      sleep: async () => {},
+    });
+    expect(result.immutable).toBe(true);
+
+    const never = new FakeApi();
+    await createDraftRelease({
+      api: never,
+      channel: "dev",
+      version: "0.17.2",
+      tag: requested.releaseTag,
+      sourceSha: SHA,
+      directory: assetDirectory(),
+      title: requested.releaseTag,
+      body: "",
+      stableLatestBefore: STABLE,
+    });
+    never.publish = delayed.publish;
+    never.release = async function() { return structuredClone(this.draft); };
+    await expect(publishDraftRelease({
+      api: never,
+      channel: "dev",
+      version: "0.17.2",
+      tag: requested.releaseTag,
+      sourceSha: SHA,
+      releaseId: 77,
+      stableLatestBefore: STABLE,
+      immutablePollIntervalMs: 0,
+      immutableTimeoutMs: 0,
+      sleep: async () => {},
+    })).rejects.toThrow("did not become immutable");
   });
 
   test("downloads one native archive only after rechecking the complete draft", async () => {

--- a/scripts/ci/github-release-transaction.ts
+++ b/scripts/ci/github-release-transaction.ts
@@ -377,6 +377,9 @@ export async function downloadAndVerifyRelease(input: {
     prerelease: input.channel === "dev",
     expectedNames: expected,
   });
+  if (input.operation === "verify-published" && input.channel === "dev" && release.immutable !== true) {
+    throw new Error("published dev release is not immutable");
+  }
   const ref = await input.api.reference(input.tag);
   if (!ref || await input.api.referenceCommit(ref) !== input.sourceSha) {
     throw new Error("release tag is not bound to the exact source SHA");
@@ -486,6 +489,9 @@ export async function publishDraftRelease(input: {
   sourceSha: string;
   releaseId: number;
   stableLatestBefore: string | null;
+  immutablePollIntervalMs?: number;
+  immutableTimeoutMs?: number;
+  sleep?: (milliseconds: number) => Promise<void>;
 }): Promise<ReleaseTransactionReceipt> {
   const ref = await input.api.reference(input.tag);
   if (!ref || await input.api.referenceCommit(ref) !== input.sourceSha) {
@@ -499,7 +505,7 @@ export async function publishDraftRelease(input: {
     prerelease: input.channel === "dev",
     expectedNames: expectedNames(input.channel, input.version, input.tag, input.sourceSha),
   });
-  const published = await input.api.publish(
+  let published = await input.api.publish(
     input.releaseId,
     input.channel === "dev",
     input.channel === "stable",
@@ -511,6 +517,22 @@ export async function publishDraftRelease(input: {
     prerelease: input.channel === "dev",
     expectedNames: expectedNames(input.channel, input.version, input.tag, input.sourceSha),
   });
+  if (input.channel === "dev" && published.immutable !== true) {
+    const sleep = input.sleep ?? ((milliseconds: number) => Bun.sleep(milliseconds));
+    const deadline = Date.now() + (input.immutableTimeoutMs ?? 2 * 60 * 1_000);
+    do {
+      if (Date.now() >= deadline) throw new Error("published dev release did not become immutable before timeout");
+      await sleep(input.immutablePollIntervalMs ?? 5_000);
+      published = await input.api.release(input.releaseId);
+      assertRelease({
+        release: published,
+        tag: input.tag,
+        draft: false,
+        prerelease: true,
+        expectedNames: expectedNames(input.channel, input.version, input.tag, input.sourceSha),
+      });
+    } while (published.immutable !== true);
+  }
   const latest = (await input.api.latestStable())?.tag_name ?? null;
   if (input.channel === "dev" && latest !== input.stableLatestBefore) {
     throw new Error("stable latest changed while publishing dev prerelease");

--- a/scripts/ci/workflow-policy.test.ts
+++ b/scripts/ci/workflow-policy.test.ts
@@ -320,6 +320,10 @@ describe("CI workflow policy", () => {
     expect(published).toContain("verify-release-artifacts.ts --dir published-download");
     expect(dev.match(/contents: write/g)).toHaveLength(2);
     expect(dev).not.toContain("--clobber");
+    expect(dev).toContain('gh release verify "$DEV_TAG"');
+    expect(dev).toContain('gh release verify-asset "$DEV_TAG" published-download/build-metadata.json');
+    expect(dev).toContain("github-release-attestation.json");
+    expect(dev).toContain("github-release-asset-attestation.json");
     expect(dev).not.toContain("softprops/action-gh-release");
   });
 

--- a/specs/dev-release-channel/evidence/schemas/live-release-proof.schema.json
+++ b/specs/dev-release-channel/evidence/schemas/live-release-proof.schema.json
@@ -34,7 +34,7 @@
     },
     "release": {
       "type": "object",
-      "required": ["buildId", "tag", "url", "prerelease", "draft", "immutable", "stableLatestUnchanged"],
+      "required": ["buildId", "tag", "url", "prerelease", "draft", "immutable", "stableLatestUnchanged", "attestation"],
       "properties": {
         "buildId": { "type": "string", "minLength": 1 },
         "tag": { "type": "string", "pattern": "^dev-" },
@@ -42,7 +42,19 @@
         "prerelease": { "const": true },
         "draft": { "const": false },
         "immutable": { "const": true },
-        "stableLatestUnchanged": { "const": true }
+        "stableLatestUnchanged": { "const": true },
+        "attestation": {
+          "type": "object",
+          "required": ["predicateType", "signer", "verifiedAt", "assetCount", "buildMetadataSha256"],
+          "properties": {
+            "predicateType": { "const": "https://in-toto.io/attestation/release/v0.2" },
+            "signer": { "const": "https://dotcom.releases.github.com" },
+            "verifiedAt": { "type": "string", "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T" },
+            "assetCount": { "type": "integer", "minimum": 10 },
+            "buildMetadataSha256": { "$ref": "#/$defs/sha256" }
+          },
+          "additionalProperties": false
+        }
       },
       "additionalProperties": true
     },

--- a/src/content/docs/contributing.md
+++ b/src/content/docs/contributing.md
@@ -487,6 +487,8 @@ bun scripts/ci/build-live-release-proof.ts \
   --release-verification <published-verification.json> \
   --release-receipt <published-release-receipt.json> \
   --release-run <release-run.json> \
+  --github-release-attestation <github-release-attestation.json> \
+  --github-asset-attestation <github-release-asset-attestation.json> \
   --native-cli-dir <native-cli-receipts-directory> \
   --homebrew-dispatch <homebrew-dev-dispatch.json> \
   --homebrew-native-dir <homebrew-native-receipts-directory> \
@@ -495,8 +497,10 @@ bun scripts/ci/build-live-release-proof.ts \
   --out specs/dev-release-channel/evidence/live-release-proof.json
 ```
 
-The builder fails closed unless every source, release, CLI, extension, Tap,
-and Homebrew identity resolves to the same immutable tag and source SHA. The
+The builder fails closed unless GitHub's cryptographically verified in-toto
+statement binds the repository, release tag, source commit, and every downloaded
+asset SHA-256, and every source, release, CLI, extension, Tap, and Homebrew
+identity resolves to the same immutable tag and source SHA. The
 repository evidence policy validates the resulting file against the dedicated
 live-proof schema and scans it for sensitive material.
 


### PR DESCRIPTION
## Summary
- wait until a published dev release is observably immutable
- verify GitHub release and asset attestations after publication
- bind the cryptographic in-toto statement to tag, source SHA, and every downloaded asset in the final live proof

## Verification
- `bun run test scripts/ci/build-live-release-proof.test.ts scripts/ci/github-release-transaction.test.ts scripts/ci/workflow-policy.test.ts`
- `bun run typecheck`
- `bun scripts/ci/dev-release-evidence-policy.ts`
- `git diff --check`