### PR TITLE
fix(release): exclude consumer extraction from bundle

### DIFF
--- a/.github/workflows/reusable-release-artifacts.yml
+++ b/.github/workflows/reusable-release-artifacts.yml
@@ -238,6 +238,9 @@ jobs:
           bun run --cwd apps/extension test:rovo-extension-browser:prebuilt
           bun run --cwd apps/extension test:palette-extension-browser:prebuilt
 
+      - name: Remove owned consumer extraction from release bundle
+        run: bun scripts/verify-release-artifacts.ts cleanup-extension --out bundle/extension
+
       - name: Freeze run-unique bundle artifact name
         id: contract
         run: echo "name=release-bundle-${{ inputs.channel }}-${{ inputs.source_sha }}-${{ github.run_id }}-${{ inputs.release_attempt }}" >> "$GITHUB_OUTPUT"

--- a/scripts/ci/workflow-policy.test.ts
+++ b/scripts/ci/workflow-policy.test.ts
@@ -116,6 +116,9 @@ describe("CI workflow policy", () => {
     for (const suite of ["worker", "jobs", "research", "rovo", "palette"]) {
       expect(reusable).toContain(`test:${suite}-extension-browser:prebuilt`);
     }
+    const cleanup = "bun scripts/verify-release-artifacts.ts cleanup-extension --out bundle/extension";
+    expect(reusable).toContain(cleanup);
+    expect(reusable.indexOf(cleanup)).toBeLessThan(reusable.indexOf("- name: Upload exact release bundle"));
     expect(reusable).not.toContain("bun build apps/cli/src/index.ts");
     expect(reusable).not.toMatch(/^\s+(?:tar|zip)\s+/m);
   });

--- a/scripts/verify-release-artifacts.test.ts
+++ b/scripts/verify-release-artifacts.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { createHash } from "node:crypto";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import JSZip from "jszip";
@@ -19,6 +19,7 @@ import {
   releaseTreeDigest,
 } from "./release-archive";
 import {
+  cleanupVerifiedExtractionDirectory,
   emitReleaseVerificationReceipt,
   inspectSingleBinaryTarGz,
   inspectZipCentralDirectory,
@@ -190,6 +191,32 @@ function replaceAscii(bytes: Uint8Array, from: string, to: string): Uint8Array {
 }
 
 describe("release artifact verifier", () => {
+  test("removes only verifier-owned consumer extraction bytes", async () => {
+    const root = await writeFixture();
+    const extracted = join(root, "consumer-extension");
+    const marker = `${extracted}.atlcli-release-extraction-v1`;
+    try {
+      await verifyReleaseArtifacts({
+        directory: root,
+        extractExtensionDirectory: extracted,
+        verifyExtensionRuntime: false,
+      });
+      expect(existsSync(extracted)).toBe(true);
+      expect(existsSync(marker)).toBe(true);
+      cleanupVerifiedExtractionDirectory(extracted);
+      expect(existsSync(extracted)).toBe(false);
+      expect(existsSync(marker)).toBe(false);
+
+      const unowned = join(root, "unowned-extension");
+      mkdirSync(unowned);
+      expect(() => cleanupVerifiedExtractionDirectory(unowned)).toThrow("unowned extraction directory");
+      expect(existsSync(unowned)).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+      rmSync(marker, { force: true });
+    }
+  });
+
   test("verifies exact CLI, extension, metadata, eligibility, and attestation bytes", async () => {
     const root = await writeFixture();
     try {

--- a/scripts/verify-release-artifacts.ts
+++ b/scripts/verify-release-artifacts.ts
@@ -271,6 +271,16 @@ function prepareExtractionDirectory(directory: string): string {
   return output;
 }
 
+export function cleanupVerifiedExtractionDirectory(directory: string): void {
+  const output = resolve(directory);
+  const marker = `${output}${EXTENSION_MARKER_SUFFIX}`;
+  if (!existsSync(output) || !existsSync(marker)) {
+    throw new Error(`refusing to remove unowned extraction directory: ${output}`);
+  }
+  rmSync(output, { recursive: true, force: true });
+  rmSync(marker, { force: true });
+}
+
 export async function extractVerifiedZip(bytes: Uint8Array, directory: string): Promise<ZipCentralEntry[]> {
   const entries = inspectZipCentralDirectory(bytes);
   const output = prepareExtractionDirectory(directory);
@@ -629,6 +639,14 @@ function value(name: string): string | undefined {
 
 if (import.meta.main) {
   const command = process.argv[2];
+  if (command === "cleanup-extension") {
+    const output = value("--out");
+    if (!output) {
+      throw new Error("Usage: bun scripts/verify-release-artifacts.ts cleanup-extension --out <dir>");
+    }
+    cleanupVerifiedExtractionDirectory(output);
+    process.exit(0);
+  }
   if (command === "extension") {
     const zipPath = value("--zip");
     const output = value("--out");


### PR DESCRIPTION
## Summary
- remove the verifier-owned unpacked extension before uploading release assets
- refuse cleanup without the verifier ownership marker
- cover workflow ordering and cleanup behavior with regression tests

## Verification
- bun run test scripts/verify-release-artifacts.test.ts scripts/ci/workflow-policy.test.ts scripts/ci/github-release-transaction.test.ts
- bun run typecheck

## Live failure addressed
Dev Release run 31670823193 stopped before creating a tag or draft because the internal extraction marker was correctly rejected as an extra release asset.