### PR TITLE
fix(release): send asset content type and rollback drafts

### DIFF
--- a/scripts/ci/github-release-transaction.test.ts
+++ b/scripts/ci/github-release-transaction.test.ts
@@ -12,6 +12,7 @@ import {
   createDraftRelease,
   downloadAndVerifyRelease,
   downloadNativeReleaseAsset,
+  GitHubReleaseApi,
   publishDraftRelease,
   type ReleaseApi,
 } from "./github-release-transaction";
@@ -71,6 +72,8 @@ class FakeApi implements ReleaseApi {
   publishCalls = 0;
   corruptUpload = false;
   corruptDownload = false;
+  deletedDrafts: number[] = [];
+  deletedTags: string[] = [];
 
   async reference() { return this.tag; }
   async referenceCommit(reference: NonNullable<FakeApi["tag"]>) { return reference.object.sha; }
@@ -79,6 +82,14 @@ class FakeApi implements ReleaseApi {
     return this.tag;
   }
   async createDraft() { return structuredClone(this.draft); }
+  async deleteDraft(releaseId: number) {
+    this.deletedDrafts.push(releaseId);
+    this.draft.assets = [];
+  }
+  async deleteReference(tag: string) {
+    this.deletedTags.push(tag);
+    this.tag = null;
+  }
   async uploadAsset(_uploadUrl: string, name: string, bytes: Uint8Array) {
     const stored = new Uint8Array(bytes);
     const asset = {
@@ -172,6 +183,46 @@ describe("exclusive GitHub release transaction", () => {
       body: "",
       stableLatestBefore: STABLE,
     })).rejects.toThrow("upload digest mismatch");
+    expect(corrupt.deletedDrafts).toEqual([77]);
+    expect(corrupt.deletedTags).toEqual([requested.releaseTag]);
+    expect(corrupt.tag).toBeNull();
+  });
+
+  test("sends release bytes with Content-Type and preserves GitHub upload diagnostics", async () => {
+    const requests: { url: string; init: RequestInit }[] = [];
+    const request = async (url: string | URL | Request, init?: RequestInit) => {
+      requests.push({ url: String(url), init: init ?? {} });
+      return new Response(JSON.stringify({
+        id: 1,
+        name: "artifact.tar.gz",
+        size: 3,
+        digest: `sha256:${"0".repeat(64)}`,
+        state: "uploaded",
+        url: "https://api.github.test/assets/1",
+        browser_download_url: "https://github.test/artifact.tar.gz",
+      }), { status: 201, headers: { "Content-Type": "application/json" } });
+    };
+    const api = new GitHubReleaseApi("owner/repo", "token", "https://api.github.test", request as typeof fetch);
+    await api.uploadAsset(
+      "https://uploads.github.test/releases/77/assets{?name,label}",
+      "artifact.tar.gz",
+      new Uint8Array([1, 2, 3]),
+    );
+    expect(requests[0]?.url).toBe("https://uploads.github.test/releases/77/assets?name=artifact.tar.gz");
+    expect(new Headers(requests[0]?.init.headers).get("Accept")).toBe("application/vnd.github+json");
+    expect(new Headers(requests[0]?.init.headers).get("Content-Type")).toBe("application/gzip");
+
+    const failing = new GitHubReleaseApi(
+      "owner/repo",
+      "token",
+      "https://api.github.test",
+      (async () => new Response('{"message":"bad content type"}', { status: 400 })) as unknown as typeof fetch,
+    );
+    await expect(failing.uploadAsset(
+      "https://uploads.github.test/releases/77/assets{?name,label}",
+      "artifact.zip",
+      new Uint8Array([1]),
+    )).rejects.toThrow('400 for artifact.zip: {"message":"bad content type"}');
   });
 
   test("downloads every draft asset again and blocks byte or stable-latest drift", async () => {

--- a/scripts/ci/github-release-transaction.ts
+++ b/scripts/ci/github-release-transaction.ts
@@ -83,6 +83,8 @@ export interface ReleaseApi {
     body: string;
     prerelease: boolean;
   }): Promise<GitHubRelease>;
+  deleteDraft(releaseId: number): Promise<void>;
+  deleteReference(tag: string): Promise<void>;
   uploadAsset(uploadUrl: string, name: string, bytes: Uint8Array): Promise<ReleaseAsset>;
   release(releaseId: number): Promise<GitHubRelease>;
   publish(releaseId: number, prerelease: boolean, makeLatest: boolean): Promise<GitHubRelease>;
@@ -133,6 +135,14 @@ export class GitHubReleaseApi implements ReleaseApi {
     });
     if (!response.ok) throw new Error(`GitHub API ${response.status} for ${init.method ?? "GET"} ${path}`);
     return await response.json() as T;
+  }
+
+  private async delete(path: string): Promise<void> {
+    const response = await this.request(`${this.apiUrl}${path}`, {
+      method: "DELETE",
+      headers: this.headers(),
+    });
+    if (!response.ok) throw new Error(`GitHub API ${response.status} for DELETE ${path}`);
   }
 
   async reference(tag: string): Promise<GitReference | null> {
@@ -187,11 +197,22 @@ export class GitHubReleaseApi implements ReleaseApi {
     const body = Uint8Array.from(bytes).buffer;
     const response = await this.request(`${endpoint}?name=${encodeURIComponent(name)}`, {
       method: "POST",
-      headers: this.headers(contentType(name)),
+      headers: { ...this.headers(), "Content-Type": contentType(name) },
       body,
     });
-    if (!response.ok) throw new Error(`GitHub upload API ${response.status} for ${name}`);
+    if (!response.ok) {
+      const detail = (await response.text()).replace(/\s+/g, " ").trim().slice(0, 500);
+      throw new Error(`GitHub upload API ${response.status} for ${name}${detail ? `: ${detail}` : ""}`);
+    }
     return await response.json() as ReleaseAsset;
+  }
+
+  async deleteDraft(releaseId: number): Promise<void> {
+    await this.delete(`/repos/${this.repository}/releases/${releaseId}`);
+  }
+
+  async deleteReference(tag: string): Promise<void> {
+    await this.delete(`/repos/${this.repository}/git/refs/tags/${encodeURIComponent(tag)}`);
   }
 
   async release(releaseId: number): Promise<GitHubRelease> {
@@ -301,30 +322,53 @@ export async function createDraftRelease(input: {
   const expected = expectedNames(input.channel, input.version, input.tag, input.sourceSha);
   const assets = localAssets(input.directory, expected);
   const existingRef = await input.api.reference(input.tag);
-  if (!existingRef) {
+  const createdReference = !existingRef;
+  if (createdReference) {
     await input.api.createReference(input.tag, input.sourceSha);
   } else if (input.channel === "dev") {
     throw new Error(`immutable dev tag already exists: ${input.tag}`);
   } else if (await input.api.referenceCommit(existingRef) !== input.sourceSha) {
     throw new Error("stable release tag does not point at the exact source SHA");
   }
-  const draft = await input.api.createDraft({
-    tag: input.tag,
-    sourceSha: input.sourceSha,
-    title: input.title,
-    body: input.body,
-    prerelease: input.channel === "dev",
-  });
-  if (!draft.draft || draft.tag_name !== input.tag || draft.assets.length !== 0) {
-    throw new Error("new release was not an empty exclusive draft");
-  }
-  for (const asset of assets) {
-    const uploaded = await input.api.uploadAsset(draft.upload_url, asset.name, asset.bytes);
-    const digest = uploaded.digest?.replace(/^sha256:/, "");
-    if (uploaded.name !== asset.name || uploaded.size !== asset.bytes.byteLength || digest !== sha256(asset.bytes)) {
-      throw new Error(`server upload digest mismatch: ${asset.name}`);
+  let draft: GitHubRelease | null = null;
+  try {
+    draft = await input.api.createDraft({
+      tag: input.tag,
+      sourceSha: input.sourceSha,
+      title: input.title,
+      body: input.body,
+      prerelease: input.channel === "dev",
+    });
+    if (!draft.draft || draft.tag_name !== input.tag || draft.assets.length !== 0) {
+      throw new Error("new release was not an empty exclusive draft");
     }
+    for (const asset of assets) {
+      const uploaded = await input.api.uploadAsset(draft.upload_url, asset.name, asset.bytes);
+      const digest = uploaded.digest?.replace(/^sha256:/, "");
+      if (uploaded.name !== asset.name || uploaded.size !== asset.bytes.byteLength || digest !== sha256(asset.bytes)) {
+        throw new Error(`server upload digest mismatch: ${asset.name}`);
+      }
+    }
+  } catch (error) {
+    try {
+      const reference = await input.api.reference(input.tag);
+      if (!createdReference || !reference || await input.api.referenceCommit(reference) !== input.sourceSha) {
+        throw new Error("rollback refused because the release tag is not owned by this transaction");
+      }
+      if (draft) {
+        const current = await input.api.release(draft.id);
+        if (!current.draft || current.tag_name !== input.tag || current.id !== draft.id) {
+          throw new Error("rollback refused because the release draft is no longer exclusively owned");
+        }
+        await input.api.deleteDraft(draft.id);
+      }
+      await input.api.deleteReference(input.tag);
+    } catch (rollbackError) {
+      throw new AggregateError([error, rollbackError], "release creation failed and safe rollback did not complete");
+    }
+    throw error;
   }
+  if (!draft) throw new Error("release draft was not created");
   const complete = await input.api.release(draft.id);
   assertRelease({
     release: complete,


### PR DESCRIPTION
## Summary
- send GitHub release assets with the required Content-Type header
- retain bounded GitHub upload diagnostics
- safely roll back transaction-owned draft releases and tags after pre-publication failures

## Proof
- bun run test scripts/ci/github-release-transaction.test.ts scripts/ci/workflow-policy.test.ts
- bun run typecheck
- bun run build

The full local suite reached 7,869 passing tests; loopback/tempdir cases were blocked only by the local Codex sandbox and remain covered by required GitHub CI.