### PR TITLE
fix(release): authorize and clean draft verification

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -486,8 +486,10 @@ jobs:
       needs.publication-decision.outputs.decision == 'create' &&
       (github.event_name == 'schedule' || inputs.dry_run == false)
     runs-on: ubuntu-latest
+    # GitHub exposes draft releases only to repository writers. The exact-SHA
+    # script is read-only and receives the token only for the download step.
     permissions:
-      contents: read
+      contents: write
     steps:
       - uses: actions/checkout@v7
         with:
@@ -568,8 +570,10 @@ jobs:
             runner: windows-2025
             archive: atlcli-windows-x64.zip
     runs-on: ${{ matrix.runner }}
+    # GitHub exposes draft releases only to repository writers. The token is
+    # not present while the downloaded CLI itself executes.
     permissions:
-      contents: read
+      contents: write
     steps:
       - uses: actions/checkout@v7
         with:
@@ -681,6 +685,49 @@ jobs:
         with:
           name: dev-publish-${{ needs.resolve-source.outputs.source_sha }}-${{ github.run_id }}-${{ github.run_attempt }}
           path: publish-receipt.json
+          if-no-files-found: error
+          retention-days: 30
+
+  rollback-unpublished-draft:
+    name: Remove transaction-owned draft after failed consumer proof
+    needs: [resolve-source, publication-decision, create-draft, verify-downloaded-draft, native-cli-consumer, publish-draft]
+    if: >-
+      always() &&
+      needs.publication-decision.outputs.decision == 'create' &&
+      needs.create-draft.result == 'success' &&
+      needs.publish-draft.result != 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.resolve-source.outputs.source_sha }}
+          persist-credentials: false
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Delete only the exact transaction-owned draft and tag
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          bun scripts/ci/github-release-transaction.ts rollback-draft \
+            --channel dev \
+            --version "${{ needs.resolve-source.outputs.version }}" \
+            --tag "${{ needs.resolve-source.outputs.build_id }}" \
+            --source-sha "${{ needs.resolve-source.outputs.source_sha }}" \
+            --release-id "${{ needs.create-draft.outputs.release_id }}" \
+            --stable-latest-before "${{ needs.resolve-source.outputs.stable_latest }}" \
+            --out rollback-draft-receipt.json
+
+      - name: Upload rollback receipt
+        uses: actions/upload-artifact@v7
+        with:
+          name: dev-rollback-draft-${{ needs.resolve-source.outputs.source_sha }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: rollback-draft-receipt.json
           if-no-files-found: error
           retention-days: 30
 

--- a/scripts/ci/github-release-transaction.test.ts
+++ b/scripts/ci/github-release-transaction.test.ts
@@ -14,6 +14,7 @@ import {
   downloadNativeReleaseAsset,
   GitHubReleaseApi,
   publishDraftRelease,
+  rollbackDraftRelease,
   type ReleaseApi,
 } from "./github-release-transaction";
 
@@ -320,6 +321,83 @@ describe("exclusive GitHub release transaction", () => {
       stableLatestBefore: STABLE,
     })).rejects.toThrow("state");
     expect(api.publishCalls).toBe(1);
+  });
+
+  test("rolls back only the complete draft and exact transaction-owned tag", async () => {
+    const api = new FakeApi();
+    const requested = identity();
+    await createDraftRelease({
+      api,
+      channel: "dev",
+      version: "0.17.2",
+      tag: requested.releaseTag,
+      sourceSha: SHA,
+      directory: assetDirectory(),
+      title: requested.releaseTag,
+      body: "",
+      stableLatestBefore: STABLE,
+    });
+    const result = await rollbackDraftRelease({
+      api,
+      channel: "dev",
+      version: "0.17.2",
+      tag: requested.releaseTag,
+      sourceSha: SHA,
+      releaseId: 77,
+      stableLatestBefore: STABLE,
+    });
+    expect(result).toMatchObject({ operation: "rollback-draft", draft: true, stableLatestAfter: STABLE });
+    expect(result.assets).toHaveLength(10);
+    expect(api.deletedDrafts).toEqual([77]);
+    expect(api.deletedTags).toEqual([requested.releaseTag]);
+
+    const moved = new FakeApi();
+    await createDraftRelease({
+      api: moved,
+      channel: "dev",
+      version: "0.17.2",
+      tag: requested.releaseTag,
+      sourceSha: SHA,
+      directory: assetDirectory(),
+      title: requested.releaseTag,
+      body: "",
+      stableLatestBefore: STABLE,
+    });
+    moved.tag!.object.sha = "f".repeat(40);
+    await expect(rollbackDraftRelease({
+      api: moved,
+      channel: "dev",
+      version: "0.17.2",
+      tag: requested.releaseTag,
+      sourceSha: SHA,
+      releaseId: 77,
+      stableLatestBefore: STABLE,
+    })).rejects.toThrow("not owned");
+    expect(moved.deletedDrafts).toEqual([]);
+
+    const published = new FakeApi();
+    await createDraftRelease({
+      api: published,
+      channel: "dev",
+      version: "0.17.2",
+      tag: requested.releaseTag,
+      sourceSha: SHA,
+      directory: assetDirectory(),
+      title: requested.releaseTag,
+      body: "",
+      stableLatestBefore: STABLE,
+    });
+    published.draft.draft = false;
+    await expect(rollbackDraftRelease({
+      api: published,
+      channel: "dev",
+      version: "0.17.2",
+      tag: requested.releaseTag,
+      sourceSha: SHA,
+      releaseId: 77,
+      stableLatestBefore: STABLE,
+    })).rejects.toThrow("state");
+    expect(published.deletedDrafts).toEqual([]);
   });
 
   test("waits for GitHub to enforce dev release immutability and fails closed on timeout", async () => {

--- a/scripts/ci/github-release-transaction.ts
+++ b/scripts/ci/github-release-transaction.ts
@@ -56,6 +56,7 @@ export interface ReleaseTransactionReceipt {
     | "download-draft"
     | "download-native-asset"
     | "publish-draft"
+    | "rollback-draft"
     | "verify-published";
   releaseId: number;
   releaseUrl: string;
@@ -603,6 +604,59 @@ export async function publishDraftRelease(input: {
   };
 }
 
+export async function rollbackDraftRelease(input: {
+  api: ReleaseApi;
+  channel: ReleaseChannel;
+  version: string;
+  tag: string;
+  sourceSha: string;
+  releaseId: number;
+  stableLatestBefore: string | null;
+}): Promise<ReleaseTransactionReceipt> {
+  const reference = await input.api.reference(input.tag);
+  if (!reference || await input.api.referenceCommit(reference) !== input.sourceSha) {
+    throw new Error("rollback refused because the release tag is not owned by this transaction");
+  }
+  const draft = await input.api.release(input.releaseId);
+  assertRelease({
+    release: draft,
+    tag: input.tag,
+    draft: true,
+    prerelease: input.channel === "dev",
+    expectedNames: expectedNames(input.channel, input.version, input.tag, input.sourceSha),
+  });
+  const latestBefore = (await input.api.latestStable())?.tag_name ?? null;
+  if (latestBefore !== input.stableLatestBefore) {
+    throw new Error("stable latest changed before draft rollback");
+  }
+  await input.api.deleteDraft(input.releaseId);
+  await input.api.deleteReference(input.tag);
+  if (await input.api.reference(input.tag)) {
+    throw new Error("release tag still exists after draft rollback");
+  }
+  const latestAfter = (await input.api.latestStable())?.tag_name ?? null;
+  if (latestAfter !== input.stableLatestBefore) {
+    throw new Error("stable latest changed during draft rollback");
+  }
+  return {
+    schema: "atlcli.github-release-transaction/v1",
+    operation: "rollback-draft",
+    releaseId: draft.id,
+    releaseUrl: draft.html_url,
+    channel: input.channel,
+    tag: input.tag,
+    sourceSha: input.sourceSha,
+    draft: true,
+    prerelease: input.channel === "dev",
+    makeLatest: false,
+    immutable: false,
+    assets: assetReceipt(draft.assets),
+    stableLatestBefore: input.stableLatestBefore,
+    stableLatestAfter: latestAfter,
+    run: actionsRun(),
+  };
+}
+
 function value(args: string[], name: string): string | undefined {
   const index = args.indexOf(name);
   return index < 0 ? undefined : args[index + 1];
@@ -659,9 +713,14 @@ if (import.meta.main) {
       ...common,
       releaseId: Number(required("--release-id")),
     });
+  } else if (command === "rollback-draft") {
+    result = await rollbackDraftRelease({
+      ...common,
+      releaseId: Number(required("--release-id")),
+    });
   } else {
     throw new Error(
-      "command must be create-draft, download-draft, download-native-asset, publish-draft, or verify-published",
+      "command must be create-draft, download-draft, download-native-asset, publish-draft, rollback-draft, or verify-published",
     );
   }
   const output = canonicalJson(result);

--- a/scripts/ci/workflow-policy.test.ts
+++ b/scripts/ci/workflow-policy.test.ts
@@ -159,14 +159,19 @@ describe("CI workflow policy", () => {
       "resolve-source",
       "publication-decision",
       "eligible-source",
-      "verify-downloaded-draft",
-      "native-cli-consumer",
       "verify-published",
     ]) {
       expect(block(dev, new RegExp(`^ {2}${name}:\\s*$`), 2)).not.toContain("contents: write");
     }
     expect(block(dev, /^ {2}create-draft:\s*$/, 2)).toContain("contents: write");
+    expect(block(dev, /^ {2}verify-downloaded-draft:\s*$/, 2)).toContain("contents: write");
+    expect(block(dev, /^ {2}native-cli-consumer:\s*$/, 2)).toContain("contents: write");
     expect(block(dev, /^ {2}publish-draft:\s*$/, 2)).toContain("contents: write");
+    const rollback = block(dev, /^ {2}rollback-unpublished-draft:\s*$/, 2);
+    expect(rollback).toContain("contents: write");
+    expect(rollback).toContain("always()");
+    expect(rollback).toContain("needs.publish-draft.result != 'success'");
+    expect(rollback).toContain("github-release-transaction.ts rollback-draft");
     expect(dev).not.toContain("id-token: write");
     expect(dev).not.toContain("attestations: write");
     expect(dev).not.toContain("softprops/action-gh-release");
@@ -302,7 +307,8 @@ describe("CI workflow policy", () => {
     expect(create!.indexOf(devCleanup)).toBeLessThan(
       create!.indexOf("github-release-transaction.ts create-draft"),
     );
-    expect(verify).toContain("contents: read");
+    expect(verify).toContain("contents: write");
+    expect(verify).toContain("GitHub exposes draft releases only to repository writers");
     expect(verify).toContain("github-release-transaction.ts download-draft");
     expect(verify).toContain("verify-release-artifacts.ts --dir downloaded");
     for (const suite of ["worker", "jobs", "research", "rovo", "palette"]) {
@@ -320,7 +326,8 @@ describe("CI workflow policy", () => {
     }
     expect(native).toContain("github-release-transaction.ts download-native-asset");
     expect(native).toContain("verify-native-cli.ts");
-    expect(native).toContain("contents: read");
+    expect(native).toContain("contents: write");
+    expect(native).toContain("not present while the downloaded CLI itself executes");
     expect(publish).toContain(
       "needs: [resolve-source, publication-decision, create-draft, verify-downloaded-draft, native-cli-consumer]",
     );
@@ -329,7 +336,7 @@ describe("CI workflow policy", () => {
     expect(published).toContain("contents: read");
     expect(published).toContain("github-release-transaction.ts verify-published");
     expect(published).toContain("verify-release-artifacts.ts --dir published-download");
-    expect(dev.match(/contents: write/g)).toHaveLength(2);
+    expect(dev.match(/contents: write/g)).toHaveLength(5);
     expect(dev).not.toContain("--clobber");
     expect(dev).toContain('gh release verify "$DEV_TAG"');
     expect(dev).toContain('gh release verify-asset "$DEV_TAG" published-download/build-metadata.json');


### PR DESCRIPTION
## Summary
- grant the two trusted draft-consumer jobs the GitHub permission required to read private draft releases
- keep the token out of native CLI execution
- safely remove only the transaction-owned draft and tag when pre-publication consumer proof fails

## Proof
- bun run test scripts/ci/github-release-transaction.test.ts scripts/ci/workflow-policy.test.ts scripts/bun-version-pin.test.ts scripts/release.test.ts
- bun run typecheck
- git diff --check

Live diagnosis: run 31677078344 uploaded all 10 draft assets, then GitHub returned 403 to contents:read tokens for the private draft. The unpublished draft/tag were verified and removed before this change.