### PR TITLE
test(ci): allow headroom for Astro consumer builds

### DIFF
--- a/packages/web-publish-astro/src/astro-consumer.test.ts
+++ b/packages/web-publish-astro/src/astro-consumer.test.ts
@@ -7,6 +7,7 @@ import { pathToFileURL } from "node:url";
 
 const workspaceRoot = resolve(import.meta.dir, "../../..");
 const fixtureDirectory = resolve(import.meta.dir, "../fixtures/astro-consumer");
+const CONSUMER_BUILD_TIMEOUT_MS = 60_000;
 
 function isWithinOutputRoot(outputDirectory: string, candidate: string): boolean {
   const relativePath = relative(resolve(outputDirectory), resolve(candidate));
@@ -81,7 +82,7 @@ test("Astro consumer harness loads structured pages and emits a private inventor
     expect(text).not.toContain("/_image");
     expect(text).not.toMatch(/(?:atlassian\.net|confluence|cloudId|tenant)/iu);
   }
-}, 30_000);
+}, CONSUMER_BUILD_TIMEOUT_MS);
 
 test("Astro builds root, nested-directory, and nested-portable URL profiles", async () => {
   const cases = [
@@ -108,7 +109,7 @@ test("Astro builds root, nested-directory, and nested-portable URL profiles", as
       await rm(resolve(fixtureDirectory, fixture.inventory), { force: true });
     }));
   }
-}, 30_000);
+}, CONSUMER_BUILD_TIMEOUT_MS);
 
 test("directory-index and portable-file servers crawl every generated route, link, and asset", async () => {
   const cases = [
@@ -226,7 +227,7 @@ test("the built Pagefind client searches the static index through its main-threa
   } finally {
     Object.defineProperty(globalThis, "fetch", { configurable: true, value: originalFetch });
   }
-}, 30_000);
+}, CONSUMER_BUILD_TIMEOUT_MS);
 
 test("packed integration builds a clean Astro project with fetch disabled", async () => {
   const root = await mkdtemp(join(tmpdir(), "atlcli-web-publish-astro-packed-"));

--- a/packages/web-publish-starlight/src/starlight-renderer.test.ts
+++ b/packages/web-publish-starlight/src/starlight-renderer.test.ts
@@ -19,6 +19,7 @@ const workspaceRoot = resolve(packageRoot, "../..");
 const fixture = resolve(packageRoot, "fixtures/starlight");
 const plainExperienceFixture = resolve(packageRoot, "fixtures/plain-experience");
 const publishedConsumerFixture = resolve(packageRoot, "fixtures/published-consumer");
+const CONSUMER_BUILD_TIMEOUT_MS = 60_000;
 
 function isWithinOutputRoot(outputDirectory: string, candidate: string): boolean {
   const relativePath = relative(resolve(outputDirectory), resolve(candidate));
@@ -90,7 +91,7 @@ test("a Starlight consumer presents ExportBlock document bodies with static sear
   expect(topic).toContain('href="/guide/"');
   expect(topic).toContain('href="/"');
   expect(await stat(resolve(fixture, "dist/404.html"))).toBeDefined();
-}, 30_000);
+}, CONSUMER_BUILD_TIMEOUT_MS);
 
 test("a bundle-driven Starlight consumer owns source, graph landing, and trusted 404 output", async () => {
   await run(["bun", "run", "build", "--filter=@atlcli/web-publish-astro"], workspaceRoot);
@@ -144,7 +145,7 @@ test("a bundle-driven Starlight consumer owns source, graph landing, and trusted
   ]);
   expect(inventory.labelLandings).toEqual([expect.objectContaining({ kind: "label", slug: "guide", pathname: "publish/topics/guide/" })]);
   expect(inventory.projectPages).toEqual([{ kind: "project", pathname: "404/" }]);
-}, 30_000);
+}, CONSUMER_BUILD_TIMEOUT_MS);
 
 test("a deliberately small plain-Astro experience uses the same contract without a second dispatcher", async () => {
   const negotiation = negotiatePublicationExperienceV1(
@@ -173,7 +174,7 @@ test("a deliberately small plain-Astro experience uses the same contract without
   expect(source).toContain("ExportDocument");
   expect(source).not.toContain("exportBlockKind");
   expect(source).not.toContain("switch (");
-}, 30_000);
+}, CONSUMER_BUILD_TIMEOUT_MS);
 
 test("the production Starlight output satisfies static asset and search-index budgets", async () => {
   await run(["bun", "run", "build"], publishedConsumerFixture);
@@ -189,7 +190,7 @@ test("the production Starlight output satisfies static asset and search-index bu
   expect(measurement.fontBytes).toBeGreaterThanOrEqual(0);
   expect(measurement.transformedImageBytes).toBeGreaterThanOrEqual(0);
   expect(measurement.pageCount).toBeGreaterThanOrEqual(2);
-}, 30_000);
+}, CONSUMER_BUILD_TIMEOUT_MS);
 
 test("a trusted Starlight override changes heading presentation without changing content, assets, security output, or index routes", async () => {
   await run(["bun", "run", "build"], fixture);
@@ -245,7 +246,7 @@ test("a trusted Starlight override changes heading presentation without changing
   } finally {
     Object.defineProperty(globalThis, "fetch", { configurable: true, value: originalFetch });
   }
-}, 30_000);
+}, CONSUMER_BUILD_TIMEOUT_MS);
 
 test("the generated Pagefind indexes cover excerpts, anchors, facets, languages, diacritics, and no-result states", async () => {
   await run(["bun", "run", "build"], publishedConsumerFixture);
@@ -348,7 +349,7 @@ test("the generated Pagefind indexes cover excerpts, anchors, facets, languages,
     if (previousLocation) Object.defineProperty(globalThis, "location", previousLocation);
     else Reflect.deleteProperty(globalThis, "location");
   }
-}, 30_000);
+}, CONSUMER_BUILD_TIMEOUT_MS);
 
 test("a packed Starlight consumer builds from the published package boundary without network access", async () => {
   const root = await mkdtemp(resolve(tmpdir(), "atlcli-starlight-packed-"));

--- a/scripts/ci/consumer-build-timeout-policy.test.ts
+++ b/scripts/ci/consumer-build-timeout-policy.test.ts
@@ -1,0 +1,17 @@
+import { expect, test } from "bun:test";
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+
+const files = [
+  "packages/web-publish-starlight/src/starlight-renderer.test.ts",
+  "packages/web-publish-astro/src/astro-consumer.test.ts",
+];
+
+test("real Astro consumer builds have bounded runner headroom", async () => {
+  for (const file of files) {
+    const source = await readFile(resolve(import.meta.dir, "../..", file), "utf8");
+    expect(source).toContain("const CONSUMER_BUILD_TIMEOUT_MS = 60_000;");
+    expect(source).not.toContain("}, 30_000);");
+    expect(source).toContain("}, CONSUMER_BUILD_TIMEOUT_MS);");
+  }
+});


### PR DESCRIPTION
## Summary
- raise bounded Astro/Starlight consumer-build integration timeouts from 30s to 60s
- apply the same budget consistently across the two consumer suites
- add a regression policy test preventing the brittle 30s limit from returning

## Evidence
- live release preflight run 31679586853: the first Starlight build hit exactly 30s and was terminated, while the remaining 13 tests passed
- focused local Starlight consumer build passed in 14.0s
- timeout policy test passed
- bun run typecheck passed

The release remained blocked before artifact production and created no tag or release.