### PR TITLE
test(ci): allow headroom for export benchmark

### DIFF
--- a/scripts/bench/run-export-job-baseline.test.ts
+++ b/scripts/bench/run-export-job-baseline.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const roots: string[] = [];
+const EXPORT_BENCHMARK_TIMEOUT_MS = 120_000;
 const script = fileURLToPath(
   new URL("./run-export-job-baseline.ts", import.meta.url),
 );
@@ -76,5 +77,5 @@ describe("POST-QUEUE Node export benchmark", () => {
         counts: { pages: 50, imageAssets: 10, diagramAssets: 5 },
       });
     }
-  }, 30_000);
+  }, EXPORT_BENCHMARK_TIMEOUT_MS);
 });

--- a/scripts/ci/consumer-build-timeout-policy.test.ts
+++ b/scripts/ci/consumer-build-timeout-policy.test.ts
@@ -15,3 +15,13 @@ test("real Astro consumer builds have bounded runner headroom", async () => {
     expect(source).toContain("}, CONSUMER_BUILD_TIMEOUT_MS);");
   }
 });
+
+test("the real 50-page export benchmark has bounded heavy-render headroom", async () => {
+  const source = await readFile(
+    resolve(import.meta.dir, "../bench/run-export-job-baseline.test.ts"),
+    "utf8",
+  );
+  expect(source).toContain("const EXPORT_BENCHMARK_TIMEOUT_MS = 120_000;");
+  expect(source).toContain("}, EXPORT_BENCHMARK_TIMEOUT_MS);");
+  expect(source).not.toContain("}, 30_000);");
+});


### PR DESCRIPTION
## Summary
- give the real 50-page DOCX/PDF benchmark a bounded 120s runner budget instead of 30s
- keep all result, artifact, durability, page-count, and format assertions unchanged
- extend the timeout regression policy

## Proof
- live preflight run 31681344713 hit exactly 30000.32ms in this benchmark
- local real benchmark + policy: 3 passed
- bun run typecheck passed

The failed release remained blocked before artifacts and created no tag or release.