### PR TITLE
refactor(release): reuse exact-sha main quality proof

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -224,12 +224,17 @@ jobs:
           retention-days: 30
 
   preflight:
-    name: SHA-bound current release preflight
+    name: SHA-bound release attestation
     needs: [resolve-source, publication-decision, eligible-source]
     if: needs.publication-decision.outputs.decision == 'create'
     uses: ./.github/workflows/reusable-quality.yml
     with:
       source_sha: ${{ needs.resolve-source.outputs.source_sha }}
+      # Product quality is already fail-closed by eligible-source against the
+      # newest canonical main-push required aggregate for this exact SHA.
+      run_static_quality: false
+      run_tests: false
+      run_astro_platform: false
       emit_security_attestation: true
 
   artifacts:

--- a/scripts/ci/workflow-policy.test.ts
+++ b/scripts/ci/workflow-policy.test.ts
@@ -251,6 +251,10 @@ describe("CI workflow policy", () => {
     expect(preflight).not.toBeNull();
     expect(preflight).toContain("needs: [resolve-source, publication-decision, eligible-source]");
     expect(preflight).toContain("source_sha: ${{ needs.resolve-source.outputs.source_sha }}");
+    expect(preflight).toContain("run_static_quality: false");
+    expect(preflight).toContain("run_tests: false");
+    expect(preflight).toContain("run_astro_platform: false");
+    expect(preflight).toContain("emit_security_attestation: true");
     expect(preflight).not.toContain("always()");
     expect(artifacts).not.toBeNull();
     expect(artifacts).toContain("needs: [resolve-source, publication-decision, eligible-source, preflight]");


### PR DESCRIPTION
## Summary
- keep dev publication fail-closed on the newest canonical main-push CI run and successful required aggregate for the exact source SHA
- stop re-running the full product/Astro/test matrix a second time inside dev release
- retain a fresh SHA-bound security attestation before artifact production
- leave stable release preflight unchanged

## Why
The duplicate matrix added runtime and flake surface without increasing source confidence: the eligibility receipt already binds the exact SHA, main push event, newest attempt, and required aggregate.

## Proof
- 44 eligibility/workflow/timeout policy tests passed
- bun run typecheck passed
- git diff --check passed