### PR TITLE
ci(release): focus downloaded asset smoke

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -529,15 +529,11 @@ jobs:
       - name: Install Chromium for downloaded packed consumers
         run: bunx playwright install --with-deps chromium
 
-      - name: Run every packed extension consumer against downloaded bytes
+      - name: Run packed extension release smoke against downloaded bytes
         env:
           ATLCLI_EXTENSION_OUTPUT_DIR: ${{ github.workspace }}/downloaded/extension
         run: |
           bun run --cwd apps/extension test:worker-extension-browser:prebuilt
-          bun run --cwd apps/extension test:jobs-extension-browser:prebuilt
-          bun run --cwd apps/extension test:research-extension-browser:prebuilt
-          bun run --cwd apps/extension test:rovo-extension-browser:prebuilt
-          bun run --cwd apps/extension test:palette-extension-browser:prebuilt
 
       - name: Upload downloaded consumer receipts
         uses: actions/upload-artifact@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -231,15 +231,11 @@ jobs:
       - name: Install Chromium for downloaded stable extension
         run: bunx playwright install --with-deps chromium
 
-      - name: Run packed consumers against downloaded stable extension
+      - name: Run packed extension release smoke against downloaded stable extension
         env:
           ATLCLI_EXTENSION_OUTPUT_DIR: ${{ github.workspace }}/downloaded/extension
         run: |
           bun run --cwd apps/extension test:worker-extension-browser:prebuilt
-          bun run --cwd apps/extension test:jobs-extension-browser:prebuilt
-          bun run --cwd apps/extension test:research-extension-browser:prebuilt
-          bun run --cwd apps/extension test:rovo-extension-browser:prebuilt
-          bun run --cwd apps/extension test:palette-extension-browser:prebuilt
 
       - name: Upload downloaded stable consumer receipts
         uses: actions/upload-artifact@v7

--- a/scripts/ci/workflow-policy.test.ts
+++ b/scripts/ci/workflow-policy.test.ts
@@ -316,8 +316,9 @@ describe("CI workflow policy", () => {
     expect(verify).toContain("GitHub exposes draft releases only to repository writers");
     expect(verify).toContain("github-release-transaction.ts download-draft");
     expect(verify).toContain("verify-release-artifacts.ts --dir downloaded");
-    for (const suite of ["worker", "jobs", "research", "rovo", "palette"]) {
-      expect(verify).toContain(`test:${suite}-extension-browser:prebuilt`);
+    expect(verify).toContain("test:worker-extension-browser:prebuilt");
+    for (const suite of ["jobs", "research", "rovo", "palette"]) {
+      expect(verify).not.toContain(`test:${suite}-extension-browser:prebuilt`);
     }
     for (const [target, runner] of [
       ["linux-x64", "ubuntu-24.04"],
@@ -362,7 +363,12 @@ describe("CI workflow policy", () => {
     expect(create!.indexOf(stableCleanup)).toBeLessThan(
       create!.indexOf("github-release-transaction.ts create-draft"),
     );
-    expect(block(stable, /^ {2}verify-downloaded-draft:\s*$/, 2)).toContain("download-draft");
+    const verify = block(stable, /^ {2}verify-downloaded-draft:\s*$/, 2);
+    expect(verify).toContain("download-draft");
+    expect(verify).toContain("test:worker-extension-browser:prebuilt");
+    for (const suite of ["jobs", "research", "rovo", "palette"]) {
+      expect(verify).not.toContain(`test:${suite}-extension-browser:prebuilt`);
+    }
     const native = block(stable, /^ {2}native-cli-consumer:\s*$/, 2);
     expect(native).toContain("download-native-asset");
     expect(native).toContain("verify-native-cli.ts");


### PR DESCRIPTION
## Summary
- use the focused packaged-MV3 smoke after downloading dev draft bytes
- apply the same proof boundary to stable draft verification
- prevent reintroduction of duplicate Jobs/Research/Rovo/Palette release runs

## Proof
- bun run test scripts/ci/workflow-policy.test.ts scripts/bun-version-pin.test.ts
- bun run typecheck
- live canceled draft transaction rolled back its exact owned draft and tag