### PR TITLE
fix(release): download tap receipt with GitHub media type

### DIFF
--- a/scripts/ci/homebrew-dev-dispatch.test.ts
+++ b/scripts/ci/homebrew-dev-dispatch.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import JSZip from "jszip";
 import {
   dispatchAndVerifyHomebrewDev,
+  GitHubTapApi,
   type TapApi,
 } from "./homebrew-dev-dispatch";
 
@@ -86,6 +87,22 @@ async function fixtureApi(options: { conclusion?: string; duplicate?: boolean; d
 }
 
 describe("Homebrew dev cross-repository dispatch", () => {
+  test("downloads the Actions artifact with GitHub's versioned API media type", async () => {
+    const request = Object.assign(async (url: RequestInfo | URL, init?: RequestInit) => {
+      expect(url).toBe("https://api.github.test/artifact.zip");
+      expect(new Headers(init?.headers).get("Accept")).toBe("application/vnd.github+json");
+      expect(init?.redirect).toBe("follow");
+      return new Response(new Uint8Array([1, 2, 3]));
+    }, { preconnect: () => {} }) as typeof fetch;
+    const api = new GitHubTapApi("test-token", request);
+    await expect(api.downloadArtifact({
+      id: 9,
+      name: "receipt",
+      expired: false,
+      archive_download_url: "https://api.github.test/artifact.zip",
+    })).resolves.toEqual(new Uint8Array([1, 2, 3]));
+  });
+
   test("correlates one successful run and verifies its exact committed bytes", async () => {
     const receipt = await dispatchAndVerifyHomebrewDev({
       api: await fixtureApi(),

--- a/scripts/ci/homebrew-dev-dispatch.ts
+++ b/scripts/ci/homebrew-dev-dispatch.ts
@@ -241,7 +241,7 @@ export class GitHubTapApi implements TapApi {
 
   async downloadArtifact(artifact: WorkflowArtifact): Promise<Uint8Array> {
     const response = await this.request(artifact.archive_download_url, {
-      headers: this.headers("application/octet-stream"),
+      headers: this.headers(),
       redirect: "follow",
     });
     if (!response.ok) throw new Error(`GitHub tap artifact download failed: ${response.status}`);


### PR DESCRIPTION
## What changed

- use GitHub's versioned API media type when downloading the Tap publication artifact
- add a regression test for the exact request headers and redirect behavior

## Why

The live GitHub App dispatch completed the Homebrew Tap workflow successfully, but GitHub rejected the subsequent artifact download with HTTP 415 because the client requested application/octet-stream.

## Validation

- bun run test scripts/ci/homebrew-dev-dispatch.test.ts scripts/ci/workflow-policy.test.ts
- bun run typecheck
- live Tap run 31691341942 completed successfully; the post-dispatch source verification will be rerun after merge