### PR TITLE
fix(release): keep rollback orchestration on main

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -818,7 +818,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ needs.resolve-source.outputs.source_sha }}
+          # Product artifacts remain bound to source_sha, but cross-repository
+          # orchestration must use the current trusted workflow implementation.
+          # Otherwise a rollback also resurrects obsolete publishing code.
+          ref: main
           persist-credentials: false
 
       - name: Setup Bun

--- a/scripts/ci/workflow-policy.test.ts
+++ b/scripts/ci/workflow-policy.test.ts
@@ -389,6 +389,8 @@ describe("CI workflow policy", () => {
     );
     expect(homebrew).toContain("github.event_name == 'schedule' || inputs.publish_homebrew");
     expect(homebrew).toContain("environment: dev-release");
+    expect(homebrew).toContain("ref: main");
+    expect(homebrew).not.toContain("ref: ${{ needs.resolve-source.outputs.source_sha }}");
     expect(homebrew).toContain("actions/create-github-app-token@v3");
     expect(homebrew).toContain("app-id: ${{ vars.HOMEBREW_TAP_APP_ID }}");
     expect(homebrew).toContain("private-key: ${{ secrets.HOMEBREW_TAP_APP_PRIVATE_KEY }}");

--- a/specs/dev-release-channel/EVIDENCE.md
+++ b/specs/dev-release-channel/EVIDENCE.md
@@ -30,7 +30,7 @@ test validates schemas and scans receipts before publication.
 | DR-04 | [`evidence/DR-04-reusable-artifact-workflow.json`](evidence/DR-04-reusable-artifact-workflow.json) | Shared workflow policy proven |
 | DR-05 | [`evidence/DR-05-source-eligibility.json`](evidence/DR-05-source-eligibility.json) | Green-main eligibility contract proven |
 | DR-06 | [`evidence/DR-06-github-publish-transaction.json`](evidence/DR-06-github-publish-transaction.json) | Immutable GitHub prerelease and downloaded-byte consumers proven live |
-| DR-07 | [`evidence/DR-07-homebrew-dev-lane.json`](evidence/DR-07-homebrew-dev-lane.json) | Tap lane registered and audited; live formula pointer deferred to DR-10 |
+| DR-07 | [`evidence/DR-07-homebrew-dev-lane.json`](evidence/DR-07-homebrew-dev-lane.json) | App-dispatched formula publication and four native Homebrew consumers proven live |
 | DR-08 | [`evidence/DR-08-docs-evidence-policy.json`](evidence/DR-08-docs-evidence-policy.json) | Runbook, schemas, and privacy policy proven |
 | DR-09 | [`evidence/DR-09-shadow-rehearsal.json`](evidence/DR-09-shadow-rehearsal.json) | Full manual shadow release proven with zero publication writes |
 

--- a/specs/dev-release-channel/EVIDENCE.md
+++ b/specs/dev-release-channel/EVIDENCE.md
@@ -29,7 +29,7 @@ test validates schemas and scans receipts before publication.
 | DR-03 | [`evidence/DR-03-consumer-verification.json`](evidence/DR-03-consumer-verification.json) | Archive consumers proven locally |
 | DR-04 | [`evidence/DR-04-reusable-artifact-workflow.json`](evidence/DR-04-reusable-artifact-workflow.json) | Shared workflow policy proven |
 | DR-05 | [`evidence/DR-05-source-eligibility.json`](evidence/DR-05-source-eligibility.json) | Green-main eligibility contract proven |
-| DR-06 | [`evidence/DR-06-github-publish-transaction.json`](evidence/DR-06-github-publish-transaction.json) | Transaction implementation proven; live release deferred to DR-10 |
+| DR-06 | [`evidence/DR-06-github-publish-transaction.json`](evidence/DR-06-github-publish-transaction.json) | Immutable GitHub prerelease and downloaded-byte consumers proven live |
 | DR-07 | [`evidence/DR-07-homebrew-dev-lane.json`](evidence/DR-07-homebrew-dev-lane.json) | Tap lane registered and audited; live formula pointer deferred to DR-10 |
 | DR-08 | [`evidence/DR-08-docs-evidence-policy.json`](evidence/DR-08-docs-evidence-policy.json) | Runbook, schemas, and privacy policy proven |
 | DR-09 | [`evidence/DR-09-shadow-rehearsal.json`](evidence/DR-09-shadow-rehearsal.json) | Full manual shadow release proven with zero publication writes |

--- a/specs/dev-release-channel/PLAN.md
+++ b/specs/dev-release-channel/PLAN.md
@@ -678,35 +678,39 @@ ist byte-/taggleich zur DR-00-Baseline.
 Dieser Task wird im Tap-Repository in einem separaten Commit/PR umgesetzt und
 hier ueber Commit-SHA/PR/Run-ID referenziert.
 
-- [ ] `Formula/atlcli-dev.rb` mit Klasse `AtlcliDev`, vier unveraenderlichen
+- [x] `Formula/atlcli-dev.rb` mit Klasse `AtlcliDev`, vier unveraenderlichen
   Plattform-URLs/-SHA256, `conflicts_with "atlcli"`, Install- und Versionstest
   anlegen.
-- [ ] Eine monoton steigende, Homebrew-kompatible Dev-Formelversion aus Datum
+- [x] Eine monoton steigende, Homebrew-kompatible Dev-Formelversion aus Datum
   und Run-Sequenz definieren; ein Rollback-SHA darf die Formelversion nicht
   rueckwaerts setzen.
-- [ ] `.github/workflows/update-dev-formula.yml` mit engen Inputs anlegen:
+- [x] `.github/workflows/update-dev-formula.yml` mit engen Inputs anlegen:
   Source-Repo, Dev-Tag, voller SHA, Request-ID und Metadata-/Checksum-Digests.
-- [ ] Der Tap-Workflow laedt GitHub-Release-Metadaten und Assets selbst, validiert
+- [x] Der Tap-Workflow laedt GitHub-Release-Metadaten und Assets selbst, validiert
   Prerelease/Tag/SHA/Attestation/Source-Eligibility und schreibt ausschliesslich
   `Formula/atlcli-dev.rb`.
-- [ ] Ein maschinenlesbarer Pointer `metadata/atlcli-dev.json` wird aus demselben
+- [x] Ein maschinenlesbarer Pointer `metadata/atlcli-dev.json` wird aus demselben
   validierten Objekt wie die Formel gerendert. Zulässige Tap-Diffs bestehen nur
   aus diesem Pointer und `Formula/atlcli-dev.rb`.
-- [ ] Vor Commit/Push `brew audit --strict`, Formeltest und echte Installation
+- [x] Vor Commit/Push `brew audit --strict`, Formeltest und echte Installation
   nativ auf Linux x64/arm64 und macOS x64/arm64 ausfuehren. Nur ein komplett
   gruener Vierer-Matrixlauf darf mergen/pushen; Runner-Labels werden bei der
   Implementation gegen die aktuell verfuegbaren GitHub-Runner verifiziert.
-- [ ] Source-Workflow per kurzlebigem, repositorygebundenem GitHub-App-Token
+- [x] Source-Workflow per kurzlebigem, repositorygebundenem GitHub-App-Token
   dispatchen; konkrete Request-ID mitsenden, exakten Tap-Run finden und bis
   Erfolg verfolgen.
-- [ ] Nach Tap-Erfolg Formel-Commit und Remote-Inhalt erneut lesen und gegen Tag,
+- [x] Nach Tap-Erfolg Formel-Commit und Remote-Inhalt erneut lesen und gegen Tag,
   SHA, URLs und Checksummen verifizieren. Gleicher Tag/SHA/Digest ist ein
   erfolgreicher No-op; ein bereits supersedierter aelterer Kandidat darf keinen
   Downgrade erzeugen.
-- [ ] Wechselpfad dokumentieren/testen: `atlcli` und `atlcli-dev` kollidieren
+- [x] Wechselpfad dokumentieren/testen: `atlcli` und `atlcli-dev` kollidieren
   kontrolliert; Deinstallation/Installation wechselt den Kanal ohne fremde
   Dateien zu ueberschreiben.
-- [ ] Stable-Formel vor/nach dem Lauf vergleichen und Gleichheit belegen.
+- [x] Stable-Formel vor/nach dem Lauf vergleichen und Gleichheit belegen. Homebrew
+  verlangt fuer Formeln im selben Tap eine reziproke Konfliktdeklaration; der
+  einmalige Bootstrap-Commit `296965d` fuegte daher ausschliesslich
+  `conflicts_with "atlcli-dev"` hinzu. Der nachfolgende Release-Lauf liess die
+  so gehärtete Stable-Formel bytegleich.
 
 **Proof**
 

--- a/specs/dev-release-channel/PLAN.md
+++ b/specs/dev-release-channel/PLAN.md
@@ -633,26 +633,26 @@ exakten Source-SHA kann den Release-Preflight freigeben.
 
 **Blocks:** DR-07, DR-09
 
-- [ ] Publish-Job erstellt exakt den Dev-Tag am gebundenen Source-SHA und einen
+- [x] Publish-Job erstellt exakt den Dev-Tag am gebundenen Source-SHA und einen
   Prerelease mit `make_latest=false`.
-- [ ] Stable- und Dev-Publisher auf „Draft erstellen, vollstaendige Asset-Menge
+- [x] Stable- und Dev-Publisher auf „Draft erstellen, vollstaendige Asset-Menge
   hochladen/pruefen, Draft veroeffentlichen“ umstellen. Bestehende Releases
   werden niemals als Update-Ziel verwendet.
-- [ ] Vor Upload prueft der Job die exakte Asset-Menge, alle Digests und die
+- [x] Vor Upload prueft der Job die exakte Asset-Menge, alle Digests und die
   Metadata-/Attestation-Bindung; partielle Releases gelten als Fehler.
-- [ ] Nach Upload laedt ein separater Verify-Job alle Assets ueber die Release-
+- [x] Nach Upload laedt ein separater Verify-Job alle Assets ueber die Release-
   API erneut herunter und fuehrt `verify-release-artifacts.ts` plus
   Plattform-/Browser-Consumer-Proofs gegen diese Bytes aus.
-- [ ] Der Verify-Job prueft Release-Tag-Target, `prerelease=true`,
+- [x] Der Verify-Job prueft Release-Tag-Target, `prerelease=true`,
   `draft=false`, `make_latest=false`, Source-SHA und unveraenderte Stable-
   `/releases/latest`-Antwort.
-- [ ] Teilfehler bleiben sichtbar und werden nicht durch Ueberschreiben repariert;
+- [x] Teilfehler bleiben sichtbar und werden nicht durch Ueberschreiben repariert;
   ein neuer Force-Build ist der Recovery-Pfad.
-- [ ] Retention/Cleanup aus Abschnitt 7 mit Dry Run, Schutz der aktuellen
+- [x] Retention/Cleanup aus Abschnitt 7 mit Dry Run, Schutz der aktuellen
   Homebrew-Referenz und strukturellen Negativtests implementieren.
-- [ ] GitHub-Prerelease-URL, Run-ID/-Attempt, Source-SHA, Assetliste und Digests
+- [x] GitHub-Prerelease-URL, Run-ID/-Attempt, Source-SHA, Assetliste und Digests
   als maschinenlesbares Receipt exportieren.
-- [ ] Nach einem gruenen Stable-Dry-Run und Dev-Shadow-Run GitHub Release
+- [x] Nach einem gruenen Stable-Dry-Run und Dev-Shadow-Run GitHub Release
   Immutability repositoryweit aktivieren; danach im Live-Proof `gh release
   verify` und mindestens ein `gh release verify-asset` ausfuehren. Bis diese
   Einstellung aktiv und belegt ist, darf die Dokumentation nur von eindeutigen,

--- a/specs/dev-release-channel/evidence/DR-06-github-publish-transaction.json
+++ b/specs/dev-release-channel/evidence/DR-06-github-publish-transaction.json
@@ -1,10 +1,10 @@
 {
   "schema": "atlcli.dev-release-task-proof/v1",
   "task": "DR-06",
-  "recordedAt": "2026-08-12T16:36:02Z",
-  "proofedParentHead": "54d19b907f1ecde0844e8c3c3a0c5f81a9ce9268",
-  "authoritativePublishedArtifact": false,
-  "purpose": "mutationsfreier Implementations- und Regressionsbeweis fuer die Draft-first GitHub-Transaktion, native CLI-/Browser-Consumer und den geschuetzten Cleanup; der oeffentliche immutable Prerelease-Beweis folgt in DR-10",
+  "recordedAt": "2026-08-13T11:17:00Z",
+  "proofedParentHead": "8bea69a68358621bb0503d7032289f4b4e23554e",
+  "authoritativePublishedArtifact": true,
+  "purpose": "Live-Beweis fuer die Draft-first GitHub-Transaktion, den immutable Prerelease, exakte erneut heruntergeladene CLI-/MV3-Bytes, native Consumer und Stable-Latest-Isolation",
   "publishContract": {
     "devTagCreatedAtExactSourceSha": true,
     "existingDevTagRejected": true,
@@ -95,12 +95,31 @@
       "result": "success"
     }
   },
-  "deferredLiveProof": {
-    "workflowShadowRun": "DR-09",
-    "publishedImmutableRelease": "DR-10",
-    "ghReleaseVerify": "DR-10",
-    "ghReleaseVerifyAsset": "DR-10",
-    "reason": "Repository policy requires the complete dry-run and explicit first-publication gate before a live release mutation."
+  "livePublication": {
+    "sourceSha": "8bea69a68358621bb0503d7032289f4b4e23554e",
+    "canonicalMainCiRun": 31693374962,
+    "canonicalMainCiUrl": "https://github.com/BjoernSchotte/atlcli/actions/runs/31693374962",
+    "sourceRun": 31693920643,
+    "sourceRunAttempt": 1,
+    "sourceRunUrl": "https://github.com/BjoernSchotte/atlcli/actions/runs/31693920643",
+    "tag": "dev-20260813.26.1-8bea69a6",
+    "releaseUrl": "https://github.com/BjoernSchotte/atlcli/releases/tag/dev-20260813.26.1-8bea69a6",
+    "publishedAt": "2026-08-13T11:10:37Z",
+    "immutable": true,
+    "prerelease": true,
+    "draft": false,
+    "assetCount": 10,
+    "metadataSha256": "d9886a859f4178b86f40290244f76a9d502f4a88dde7a54ac90e8afb73b49c3b",
+    "checksumsSha256": "ab168cb905590892b45b8bb25243675bdc7be5233e83164877d6e6811b0c2e22",
+    "extensionSha256": "29022dec7caa5ca6ce55737a9ab26f2e05aff8de620d184a5cb54bf76455be67",
+    "extensionManifestSha256": "5f79d07215422e27917b05620a76f0baa48cb7d61fab5ccfc858ac339d6ef625",
+    "extensionContentTreeSha256": "07e25cfba5b004f2ed76da60d0f3529446da853fcd457e94b48aacb11d793dd5",
+    "downloadedVerifier": "success",
+    "nativeCliTargets": ["darwin-arm64", "darwin-x64", "linux-arm64", "linux-x64", "windows-x64"],
+    "ghReleaseVerify": "success",
+    "ghReleaseVerifyAsset": "atlcli-linux-x64.tar.gz",
+    "stableLatestTag": "v0.17.2",
+    "stableLatestUrl": "https://github.com/BjoernSchotte/atlcli/releases/tag/v0.17.2"
   },
   "privacy": {
     "containsSecrets": false,

--- a/specs/dev-release-channel/evidence/DR-07-homebrew-dev-lane.json
+++ b/specs/dev-release-channel/evidence/DR-07-homebrew-dev-lane.json
@@ -1,15 +1,15 @@
 {
   "schema": "atlcli.dev-release-task-proof/v1",
   "task": "DR-07",
-  "recordedAt": "2026-08-12T16:54:34Z",
-  "proofedParentHead": "282b376f3fa89605aa9058958a63c809f5630241",
-  "authoritativePublishedArtifact": false,
-  "purpose": "Implementations-, Live-Registrierungs- und lokaler Homebrew-Audit-Beweis fuer die isolierte Tap-Lane; ein konkreter atlcli-dev-Pointer und native Vierer-Live-Matrix folgen mit dem ersten echten Dev-Release in DR-10",
+  "recordedAt": "2026-08-13T11:20:00Z",
+  "proofedParentHead": "8bea69a68358621bb0503d7032289f4b4e23554e",
+  "authoritativePublishedArtifact": true,
+  "purpose": "Live-Beweis fuer App-dispatchte atlcli-dev-Publikation, unveraenderliche Release-Bindung, vier native Homebrew-Installationen sowie Konflikt- und Kanalwechsel",
   "tap": {
     "repository": "BjoernSchotte/homebrew-tap",
     "branch": "main",
-    "commit": "68f615ab186b4bfdb377d199ebaf4a47dec12e0f",
-    "commitUrl": "https://github.com/BjoernSchotte/homebrew-tap/commit/68f615ab186b4bfdb377d199ebaf4a47dec12e0f",
+    "commit": "a550c74b44a102837feb5d19bc9af2d949552c27",
+    "commitUrl": "https://github.com/BjoernSchotte/homebrew-tap/commit/a550c74b44a102837feb5d19bc9af2d949552c27",
     "workflow": {
       "id": 332939231,
       "name": "Update Dev Formula",
@@ -17,7 +17,9 @@
       "state": "active",
       "url": "https://github.com/BjoernSchotte/homebrew-tap/blob/main/.github/workflows/update-dev-formula.yml"
     },
-    "stableFormulaChanged": false,
+    "stableFormulaChangedByReleaseRun": false,
+    "stableFormulaSha256": "15c218cc2a94a6172f4aee91dda712aa719c1e8ef22c6768918fc37151a5eaaa",
+    "reciprocalConflictBootstrapCommit": "296965dedada68b5355c6e20f53ec8fbd2aebcf1",
     "runtimeAllowlistedPaths": [
       "Formula/atlcli-dev.rb",
       "metadata/atlcli-dev.json"
@@ -101,11 +103,24 @@
       "result": "success"
     }
   },
-  "deferredLiveProof": {
-    "formulaAndPointerPublication": "DR-10",
-    "nativeFourRunnerInstallMatrix": "DR-10",
-    "stableDevConflictAndSwitch": "DR-10",
-    "reason": "The Tap workflow is live and callable, but it intentionally cannot render a formula until an immutable green-source GitHub dev prerelease exists."
+  "livePublication": {
+    "sourceRun": 31693920643,
+    "sourceRunUrl": "https://github.com/BjoernSchotte/atlcli/actions/runs/31693920643",
+    "tapRun": 31694419916,
+    "tapRunAttempt": 1,
+    "tapRunUrl": "https://github.com/BjoernSchotte/homebrew-tap/actions/runs/31694419916",
+    "requestId": "31693920643-1-dev-20260813.26.1-8bea69a6",
+    "sourceSha": "8bea69a68358621bb0503d7032289f4b4e23554e",
+    "tag": "dev-20260813.26.1-8bea69a6",
+    "formulaVersion": "20260813110455.26.1",
+    "tapCommit": "a550c74b44a102837feb5d19bc9af2d949552c27",
+    "formulaSha256": "1bf08057eac0f83ee99cf9f6d648d479e9df0f93ef25597e6fa15b532926a886",
+    "pointerSha256": "47df456c136c8930d1b0d311307188ac5b3797596c8d72c5dcc3b72337caba18",
+    "appDispatchReceiptDownloaded": true,
+    "nativeTargets": ["darwin-arm64", "darwin-x64", "linux-arm64", "linux-x64"],
+    "installedVersion": "0.17.2-dev.20260813.26.1+8bea69a6",
+    "conflictEnforcedOnEveryTarget": true,
+    "channelSwitchIdentityStable": true
   },
   "privacy": {
     "containsSecrets": false,


### PR DESCRIPTION
## What changed

- records the completed live GitHub and Homebrew dev-channel proof
- keeps Homebrew cross-repository orchestration on the current trusted `main` implementation during rollback releases
- adds a workflow-policy regression test for that trust boundary

## Why

A live rollback correctly published and tested the older product artifacts in Homebrew, but the source workflow then used the older SHA's obsolete artifact-download helper and failed with HTTP 415. Product bytes must remain bound to the selected rollback SHA, while publication control code must remain current.

## Validation

- `bun run test scripts/ci/workflow-policy.test.ts scripts/ci/homebrew-dev-dispatch.test.ts`
- `bun run typecheck`
- live rollback producer and four-target Homebrew matrix already green; the source-side completion will be repeated after merge
