### PR TITLE
fix(release): reuse pinned font cache

### DIFF
--- a/.github/workflows/reusable-release-artifacts.yml
+++ b/.github/workflows/reusable-release-artifacts.yml
@@ -64,6 +64,12 @@ jobs:
         with:
           bun-version: ${{ env.BUN_VERSION }}
 
+      - name: Restore pinned PDF fonts
+        uses: actions/cache@v6
+        with:
+          path: packages/pdf/.fonts
+          key: ${{ runner.os }}-pdf-fonts-v1-${{ hashFiles('packages/pdf/src/runtime-assets.ts', 'packages/pdf/scripts/ensure-fonts.ts') }}
+
       - name: Install frozen dependencies
         run: bash scripts/ci/install-frozen-dependencies.sh
 
@@ -117,6 +123,12 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Restore pinned PDF fonts
+        uses: actions/cache@v6
+        with:
+          path: packages/pdf/.fonts
+          key: ${{ runner.os }}-pdf-fonts-v1-${{ hashFiles('packages/pdf/src/runtime-assets.ts', 'packages/pdf/scripts/ensure-fonts.ts') }}
 
       - name: Install frozen dependencies
         run: bash scripts/ci/install-frozen-dependencies.sh

--- a/scripts/ci/workflow-policy.test.ts
+++ b/scripts/ci/workflow-policy.test.ts
@@ -137,6 +137,10 @@ describe("CI workflow policy", () => {
     expect(reusable).not.toContain("${{ github.run_id }}-${{ github.run_attempt }}-extension");
     expect(reusable).not.toContain("release-bundle-${{ inputs.channel }}-${{ inputs.source_sha }}-${{ github.run_id }}-${{ github.run_attempt }}");
     expect(reusable).not.toMatch(/download-artifact@v8\n\s+with:\n\s+path:/);
+    const fontCacheKey = "key: ${{ runner.os }}-pdf-fonts-v1-${{ hashFiles('packages/pdf/src/runtime-assets.ts', 'packages/pdf/scripts/ensure-fonts.ts') }}";
+    expect(reusable.split("- name: Restore pinned PDF fonts")).toHaveLength(3);
+    expect(reusable.split("uses: actions/cache@v6")).toHaveLength(3);
+    expect(reusable.split(fontCacheKey)).toHaveLength(3);
   });
 
   it("uses one fail-closed scheduled and manual dev-release graph", async () => {


### PR DESCRIPTION
## What changed

- restores the existing SHA-bound PDF font cache in all CLI release builders
- restores the same cache in the extension release builder
- keeps `fonts:ensure` as a mandatory digest verification step
- adds workflow-policy coverage for both cache consumers and the exact manifest-derived key

## Why

A live dev recovery run was fail-closed by a transient `ECONNRESET` while five parallel release builders downloaded the same immutable Adobe font set. Normal CI already caches these 5.6 MB of pinned assets; the reusable release producer did not.

Warm release runs now avoid upstream font downloads. A cold cache still downloads once per cache population and `fonts:ensure` validates all 13 files against their committed SHA-256 values.

## Validation

- `bun run test scripts/ci/workflow-policy.test.ts` — 32 pass
- `bun run typecheck`
- live recovery failure showed no publication write before the producer gate
