### PR TITLE
ci(release): schedule one-shot dev build

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -2,7 +2,9 @@ name: Dev Release
 
 on:
   schedule:
-    - cron: "17 2 * * *"
+    # One-shot live acceptance run: 2026-08-13 14:00 UTC. Restore the regular
+    # nightly schedule after the resulting schedule-event receipt is captured.
+    - cron: "0 14 13 8 *"
   workflow_dispatch:
     inputs:
       source_sha:

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -2,9 +2,9 @@ name: Dev Release
 
 on:
   schedule:
-    # One-shot live acceptance run: 2026-08-13 14:00 UTC. Restore the regular
+    # One-shot live acceptance run: 2026-08-13 23:30 UTC. Restore the regular
     # nightly schedule after the resulting schedule-event receipt is captured.
-    - cron: "0 14 13 8 *"
+    - cron: "30 23 13 8 *"
   workflow_dispatch:
     inputs:
       source_sha:

--- a/scripts/ci/workflow-policy.test.ts
+++ b/scripts/ci/workflow-policy.test.ts
@@ -147,7 +147,7 @@ describe("CI workflow policy", () => {
     const dev = await workflow("dev-release.yml");
     const triggers = block(dev, /^on:\s*$/, 0);
     expect(triggers).not.toBeNull();
-    expect(triggers).toContain('cron: "0 14 13 8 *"');
+    expect(triggers).toContain('cron: "30 23 13 8 *"');
     expect(triggers).toContain("workflow_dispatch:");
     expect(triggers).toContain("source_sha:");
     expect(triggers).toContain("force_rebuild:");

--- a/scripts/ci/workflow-policy.test.ts
+++ b/scripts/ci/workflow-policy.test.ts
@@ -147,7 +147,7 @@ describe("CI workflow policy", () => {
     const dev = await workflow("dev-release.yml");
     const triggers = block(dev, /^on:\s*$/, 0);
     expect(triggers).not.toBeNull();
-    expect(triggers).toContain('cron: "17 2 * * *"');
+    expect(triggers).toContain('cron: "0 14 13 8 *"');
     expect(triggers).toContain("workflow_dispatch:");
     expect(triggers).toContain("source_sha:");
     expect(triggers).toContain("force_rebuild:");


### PR DESCRIPTION
## What changed

Pins the dev-release cron to a single calendar occurrence on 2026-08-13 at 14:00 UTC and updates the structural workflow-policy assertion.

## Why

This produces one real GitHub schedule-event release independently of the local laptop for final DR-10 acceptance. The regular 02:17 UTC nightly schedule will be restored after the receipt is inspected.

## Validation

- bun run test scripts/ci/workflow-policy.test.ts
- git diff --check