### PR TITLE
ci(release): restore nightly schedule and retry live acceptance

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -2,9 +2,7 @@ name: Dev Release
 
 on:
   schedule:
-    # One-shot live acceptance run: 2026-08-13 23:30 UTC. Restore the regular
-    # nightly schedule after the resulting schedule-event receipt is captured.
-    - cron: "30 23 13 8 *"
+    - cron: "17 2 * * *"
   workflow_dispatch:
     inputs:
       source_sha:

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -2,7 +2,12 @@ name: Dev Release
 
 on:
   schedule:
+    # Normal nightly dev channel.
     - cron: "17 2 * * *"
+    # One-shot acceptance retry: the 2026-08-13 23:30 UTC event was not
+    # created by GitHub's scheduler. Remove this line after the scheduled
+    # release proof has been captured.
+    - cron: "15 0 14 8 *"
   workflow_dispatch:
     inputs:
       source_sha:

--- a/scripts/ci/workflow-policy.test.ts
+++ b/scripts/ci/workflow-policy.test.ts
@@ -148,6 +148,7 @@ describe("CI workflow policy", () => {
     const triggers = block(dev, /^on:\s*$/, 0);
     expect(triggers).not.toBeNull();
     expect(triggers).toContain('cron: "17 2 * * *"');
+    expect(triggers).toContain('cron: "15 0 14 8 *"');
     expect(triggers).toContain("workflow_dispatch:");
     expect(triggers).toContain("source_sha:");
     expect(triggers).toContain("force_rebuild:");

--- a/scripts/ci/workflow-policy.test.ts
+++ b/scripts/ci/workflow-policy.test.ts
@@ -147,7 +147,7 @@ describe("CI workflow policy", () => {
     const dev = await workflow("dev-release.yml");
     const triggers = block(dev, /^on:\s*$/, 0);
     expect(triggers).not.toBeNull();
-    expect(triggers).toContain('cron: "30 23 13 8 *"');
+    expect(triggers).toContain('cron: "17 2 * * *"');
     expect(triggers).toContain("workflow_dispatch:");
     expect(triggers).toContain("source_sha:");
     expect(triggers).toContain("force_rebuild:");


### PR DESCRIPTION
## Summary
- restore the regular `17 2 * * *` nightly dev-release schedule
- add a one-shot `2026-08-14 00:15 UTC` acceptance retry after GitHub did not create the earlier 23:30 event
- keep workflow-policy coverage for both schedule entries

## Verification
- `bun run test scripts/ci/workflow-policy.test.ts scripts/bun-version-pin.test.ts`
- full local `bun run test`: 8,116 pass, 16 skip, 0 fail
- `bun run typecheck`
- `bun run build`

The one-shot line will be removed after a real `schedule` event is captured; the regular nightly line remains.