### PR TITLE
fix(release): complete scheduled dev proof

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -2,12 +2,7 @@ name: Dev Release
 
 on:
   schedule:
-    # Normal nightly dev channel.
     - cron: "17 2 * * *"
-    # One-shot acceptance retry: the 2026-08-13 23:30 UTC event was not
-    # created by GitHub's scheduler. Remove this line after the scheduled
-    # release proof has been captured.
-    - cron: "15 0 14 8 *"
   workflow_dispatch:
     inputs:
       source_sha:

--- a/scripts/ci/build-live-release-proof.test.ts
+++ b/scripts/ci/build-live-release-proof.test.ts
@@ -32,6 +32,7 @@ function fixture() {
     requiredJob: { conclusion: "success" as const },
   };
   for (const name of assetNames) writeFileSync(join(root, name), name);
+  writeFileSync(join(root, "extension.atlcli-release-extraction-v1"), "owned by atlcli release verifier\n");
   writeFileSync(join(root, "build-metadata.json"), canonicalJson(metadata));
   writeFileSync(join(root, "source-eligibility.json"), canonicalJson(eligibility));
   writeFileSync(join(root, "extension", "manifest.json"), JSON.stringify({ version: "0.17.2.12" }));

--- a/scripts/ci/build-live-release-proof.ts
+++ b/scripts/ci/build-live-release-proof.ts
@@ -107,6 +107,7 @@ interface GitHubReleaseAttestation {
 
 const SHA256 = /^[0-9a-f]{64}$/;
 const SHA = /^[0-9a-f]{40}$/;
+const EXTENSION_MARKER_SUFFIX = ".atlcli-release-extraction-v1";
 const CLI_TARGETS = ["darwin-arm64", "darwin-x64", "linux-arm64", "linux-x64", "windows-x64"];
 const BREW_TARGETS = ["darwin-arm64", "darwin-x64", "linux-arm64", "linux-x64"];
 const PACKED_SUITES = ["worker", "jobs", "research", "rovo", "palette"];
@@ -244,7 +245,9 @@ export function buildLiveReleaseProof(input: {
   } as ReleaseIdentity;
   const expectedNames = expectedReleaseAssetNames(identity);
   const actualFiles = readdirSync(input.releaseDir)
-    .filter((name) => statSync(join(input.releaseDir, name)).isFile())
+    .filter((name) =>
+      statSync(join(input.releaseDir, name)).isFile() && !name.endsWith(EXTENSION_MARKER_SUFFIX)
+    )
     .sort();
   if (JSON.stringify(actualFiles) !== JSON.stringify(expectedNames)) throw new Error("downloaded live asset inventory mismatch");
   const assets = actualFiles.map((filename) => {

--- a/scripts/ci/dev-release-evidence-policy.test.ts
+++ b/scripts/ci/dev-release-evidence-policy.test.ts
@@ -78,7 +78,7 @@ describe("dev-release evidence policy", () => {
   it("validates the final live proof against its dedicated schema", async () => {
     const root = await fixture();
     await writeFile(
-      join(root, "evidence", "live-release-proof.json"),
+      join(root, "evidence", "DR-10-live-release-proof.json"),
       JSON.stringify({ schema: "atlcli.dev-release-live-proof/v1" }),
     );
     expect((await evaluateEvidencePolicy(root)).some((issue) => issue.reason.startsWith("live receipt schema:"))).toBe(true);

--- a/scripts/ci/dev-release-evidence-policy.ts
+++ b/scripts/ci/dev-release-evidence-policy.ts
@@ -1,7 +1,7 @@
 import type { ErrorObject } from "ajv";
 import Ajv2020 from "ajv/dist/2020";
 import { readdir, readFile } from "node:fs/promises";
-import { basename, join, relative } from "node:path";
+import { join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const REPO_ROOT = fileURLToPath(new URL("../..", import.meta.url));
@@ -116,10 +116,14 @@ export async function evaluateEvidencePolicy(root = DEFAULT_EVIDENCE_ROOT): Prom
       }
     }
 
-    if (/^DR-[0-9]{2}-.+\.json$/.test(basename(path)) && !validateTaskProof(value)) {
+    const receiptSchema =
+      value !== null && typeof value === "object" && "schema" in value
+        ? (value as { schema?: unknown }).schema
+        : undefined;
+    if (receiptSchema === "atlcli.dev-release-task-proof/v1" && !validateTaskProof(value)) {
       issues.push({ file, reason: `task receipt schema: ${ajvErrors(validateTaskProof.errors)}` });
     }
-    if (basename(path) === "live-release-proof.json" && !validateLiveProof(value)) {
+    if (receiptSchema === "atlcli.dev-release-live-proof/v1" && !validateLiveProof(value)) {
       issues.push({ file, reason: `live receipt schema: ${ajvErrors(validateLiveProof.errors)}` });
     }
   }

--- a/scripts/ci/workflow-policy.test.ts
+++ b/scripts/ci/workflow-policy.test.ts
@@ -148,7 +148,6 @@ describe("CI workflow policy", () => {
     const triggers = block(dev, /^on:\s*$/, 0);
     expect(triggers).not.toBeNull();
     expect(triggers).toContain('cron: "17 2 * * *"');
-    expect(triggers).toContain('cron: "15 0 14 8 *"');
     expect(triggers).toContain("workflow_dispatch:");
     expect(triggers).toContain("source_sha:");
     expect(triggers).toContain("force_rebuild:");

--- a/specs/dev-release-channel/EVIDENCE.md
+++ b/specs/dev-release-channel/EVIDENCE.md
@@ -39,17 +39,23 @@ test validates schemas and scans receipts before publication.
 | Receipt | Bound result | Status |
 |---------|--------------|--------|
 | [`evidence/DR-10-live-release-proof.json`](evidence/DR-10-live-release-proof.json) | Immutable ten-asset prerelease [`dev-20260813.32.1-18184731`](https://github.com/BjoernSchotte/atlcli/releases/tag/dev-20260813.32.1-18184731), exact downloaded-byte verification, five native CLI consumers, full packed-Chromium matrix and four native Homebrew consumers at tap commit [`050ac914`](https://github.com/BjoernSchotte/homebrew-tap/commit/050ac914d6db5d0e4fb0f3b448bc2199bfe57bc7) | Live proven |
-| [`evidence/DR-10-operations-proof.json`](evidence/DR-10-operations-proof.json) | Manual default-source No-op, forced rebuild, forward rollback plus recovery, retention dry run, operator configuration and pinned-font cache hit | Live proven except scheduled-event gate |
+| [`evidence/DR-10-scheduled-live-release-proof.json`](evidence/DR-10-scheduled-live-release-proof.json) | Real `schedule` event, immutable ten-asset prerelease [`dev-20260814.34.1-e439c62f`](https://github.com/BjoernSchotte/atlcli/releases/tag/dev-20260814.34.1-e439c62f), exact downloaded-byte verification, five native CLI consumers, full packed-Chromium matrix and four native Homebrew consumers at tap commit [`b94a1934`](https://github.com/BjoernSchotte/homebrew-tap/commit/b94a1934bee2e02a3e6cfc017eac0ffd8b10871b) | Scheduled live proven |
+| [`evidence/DR-10-operations-proof.json`](evidence/DR-10-operations-proof.json) | Manual default-source No-op, forced rebuild, forward rollback plus recovery, retention dry run, operator configuration, pinned-font cache hit and later scheduled immutable No-op | Live proven |
 
-The selected final release binds source SHA
-`18184731cf128bf06ccc8a3c287a6b026f41b658` to canonical main CI run
-[`31700826175`](https://github.com/BjoernSchotte/atlcli/actions/runs/31700826175),
-dev-release run [`31701377742`](https://github.com/BjoernSchotte/atlcli/actions/runs/31701377742)
+The selected final scheduled release binds source SHA
+`e439c62f318bee363045ef8beab62800704213f0` to canonical main CI run
+[`31755459683`](https://github.com/BjoernSchotte/atlcli/actions/runs/31755459683),
+scheduled dev-release run
+[`31764529357`](https://github.com/BjoernSchotte/atlcli/actions/runs/31764529357)
 and Homebrew tap run
-[`31701894788`](https://github.com/BjoernSchotte/homebrew-tap/actions/runs/31701894788).
+[`31764886975`](https://github.com/BjoernSchotte/homebrew-tap/actions/runs/31764886975).
+The later scheduled run
+[`31769502152`](https://github.com/BjoernSchotte/atlcli/actions/runs/31769502152)
+selected the same immutable tag and completed through the explicit No-op path
+without a new release or formula commit.
 GitHub stable latest remains [`v0.17.2`](https://github.com/BjoernSchotte/atlcli/releases/tag/v0.17.2).
 
-The nightly variable is enabled and the deployed cron is `17 2 * * *`. DR-10
-remains open only until one real `schedule` event has traversed the same graph
-and produced the expected immutable No-op receipt. A manually dispatched run is
-not substituted for that time-bound proof.
+The nightly variable is enabled and the deployed cron is `17 2 * * *`. The
+temporary acceptance retry cron was removed after the real scheduled build and
+scheduled No-op were captured. DR-10 is complete; the manual run was not used
+as a substitute for the time-bound schedule proof.

--- a/specs/dev-release-channel/EVIDENCE.md
+++ b/specs/dev-release-channel/EVIDENCE.md
@@ -36,10 +36,20 @@ test validates schemas and scans receipts before publication.
 
 ## Final live receipts
 
-DR-09 is proven by the mutation-free rehearsal receipt above. DR-10 must add a receipt that
-validates against
-[`evidence/schemas/live-release-proof.schema.json`](evidence/schemas/live-release-proof.schema.json)
-and links one real immutable GitHub dev prerelease plus the exact published
-`atlcli-dev` formula commit. DR-10 remains open until downloaded CLI binaries,
-the downloaded extension ZIP, stable-latest isolation, macOS/Linux Homebrew
-install/test, manual-trigger parity, and schedule activation are all proven.
+| Receipt | Bound result | Status |
+|---------|--------------|--------|
+| [`evidence/DR-10-live-release-proof.json`](evidence/DR-10-live-release-proof.json) | Immutable ten-asset prerelease [`dev-20260813.32.1-18184731`](https://github.com/BjoernSchotte/atlcli/releases/tag/dev-20260813.32.1-18184731), exact downloaded-byte verification, five native CLI consumers, full packed-Chromium matrix and four native Homebrew consumers at tap commit [`050ac914`](https://github.com/BjoernSchotte/homebrew-tap/commit/050ac914d6db5d0e4fb0f3b448bc2199bfe57bc7) | Live proven |
+| [`evidence/DR-10-operations-proof.json`](evidence/DR-10-operations-proof.json) | Manual default-source No-op, forced rebuild, forward rollback plus recovery, retention dry run, operator configuration and pinned-font cache hit | Live proven except scheduled-event gate |
+
+The selected final release binds source SHA
+`18184731cf128bf06ccc8a3c287a6b026f41b658` to canonical main CI run
+[`31700826175`](https://github.com/BjoernSchotte/atlcli/actions/runs/31700826175),
+dev-release run [`31701377742`](https://github.com/BjoernSchotte/atlcli/actions/runs/31701377742)
+and Homebrew tap run
+[`31701894788`](https://github.com/BjoernSchotte/homebrew-tap/actions/runs/31701894788).
+GitHub stable latest remains [`v0.17.2`](https://github.com/BjoernSchotte/atlcli/releases/tag/v0.17.2).
+
+The nightly variable is enabled and the deployed cron is `17 2 * * *`. DR-10
+remains open only until one real `schedule` event has traversed the same graph
+and produced the expected immutable No-op receipt. A manually dispatched run is
+not substituted for that time-bound proof.

--- a/specs/dev-release-channel/PLAN.md
+++ b/specs/dev-release-channel/PLAN.md
@@ -1,6 +1,6 @@
 # Dev-Release-Channel: Nightly und manuell ausloesbare, bewiesene Releases
 
-**Status:** In Umsetzung; DR-00 bis DR-09 und alle manuellen DR-10-Live-Gates bewiesen; erster echter Schedule-Lauf offen
+**Status:** Abgeschlossen; DR-00 bis DR-10 inklusive echtem Schedule-Build und idempotentem Schedule-No-op bewiesen
 
 **Planungsstand:** 2026-08-12
 
@@ -847,9 +847,9 @@ an der vorgesehenen Stelle, und GitHub Releases sowie Tap sind unveraendert.
 - [x] Rollback-Drill mit einem frueheren weiterhin erreichbaren `main`-SHA als
   neuem hoeheren Build ausfuehren; Installation funktioniert, alte Releases
   bleiben erhalten.
-- [ ] Nightly-Schedule danach aktiviert/bestaetigt lassen und einen geplanten
+- [x] Nightly-Schedule danach aktiviert/bestaetigt lassen und einen geplanten
   Lauf beziehungsweise dessen No-op-Pfad belegen.
-- [ ] `EVIDENCE.md` und alle DR-10-Receipts mit oeffentlichen URLs, Hashes und
+- [x] `EVIDENCE.md` und alle DR-10-Receipts mit oeffentlichen URLs, Hashes und
   Status finalisieren; keine Binaries oder sensiblen Rohlogs committen.
 
 **Proof**
@@ -884,7 +884,7 @@ Bytes, Consumer-Proofs und Tap-Formel an denselben Source-SHA.
 
 ## 12. Definition of Done
 
-- [ ] Alle Tasks DR-00 bis DR-10 sind mit revisiongebundenen Receipts abgehakt.
+- [x] Alle Tasks DR-00 bis DR-10 sind mit revisiongebundenen Receipts abgehakt.
 - [x] Ein realer manueller GitHub-Dev-Prerelease enthaelt alle fuenf CLI-Archive,
   das gepackte MV3-ZIP, Checksummen, Metadata, Source-Eligibility und Security-/
   Provenienz-Beleg.
@@ -897,16 +897,16 @@ Bytes, Consumer-Proofs und Tap-Formel an denselben Source-SHA.
   unveraendert belegt. In `Formula/atlcli.rb` bleiben Version, URLs, Digests und
   Test unveraendert; einzig die separat reviewte reziproke Konfliktdeklaration
   wurde beim einmaligen Bootstrap ergaenzt.
-- [ ] Manueller No-op, Force-Rebuild, Rollback und ein geplanter Nightly-Lauf
+- [x] Manueller No-op, Force-Rebuild, Rollback und ein geplanter Nightly-Lauf
   beziehungsweise dessen No-op sind bewiesen.
 - [x] Jeder publizierte Source-SHA besitzt ein versioniertes Eligibility-Receipt
   mit erfolgreichem kanonischem `main`-Push-Run und erfolgreichem aktuellem
   Release-Preflight; `force_rebuild` und Rollback umgehen keines der Gates.
 - [x] Schedule und Manual teilen denselben SHA-gebundenen reusable Workflow.
 - [x] Es existieren weder bewegliche Release-Tags noch ueberschriebene Assets.
-- [ ] `bun run test`, `bun run typecheck` und `bun run build` sind auf dem finalen
+- [x] `bun run test`, `bun run typecheck` und `bun run build` sind auf dem finalen
   Implementierungs-SHA gruen.
-- [ ] `specs/dev-release-channel/EVIDENCE.md` verweist auf Run-/Release-/Tap-URLs,
+- [x] `specs/dev-release-channel/EVIDENCE.md` verweist auf Run-/Release-/Tap-URLs,
   Source-SHA, Digests und Consumer-Proofs, ohne Secrets oder private Daten.
 - [x] Runbook, Retention, Ownership und Wartungsdrills sind dokumentiert.
 

--- a/specs/dev-release-channel/PLAN.md
+++ b/specs/dev-release-channel/PLAN.md
@@ -1,6 +1,6 @@
 # Dev-Release-Channel: Nightly und manuell ausloesbare, bewiesene Releases
 
-**Status:** In Umsetzung; DR-00 bis DR-05 und DR-08/DR-09 bewiesen; Live-Abnahme fuer DR-06/DR-07/DR-10 offen
+**Status:** In Umsetzung; DR-00 bis DR-09 und alle manuellen DR-10-Live-Gates bewiesen; erster echter Schedule-Lauf offen
 
 **Planungsstand:** 2026-08-12
 
@@ -813,37 +813,38 @@ an der vorgesehenen Stelle, und GitHub Releases sowie Tap sind unveraendert.
 
 **Blocks:** Definition of Done
 
-- [ ] `dev-release.yml` auf dem Default Branch manuell ausloesen, ohne
+- [x] `dev-release.yml` auf dem Default Branch manuell ausloesen, ohne
   `source_sha`, mit `publish_homebrew=true` und `force_rebuild=false`.
-- [ ] Aufgeloesten `origin/main`-SHA, Workflow-Run-ID/-Attempt, Build-ID und
+- [x] Aufgeloesten `origin/main`-SHA, Workflow-Run-ID/-Attempt, Build-ID und
   unveraenderlichen Prerelease-Tag erfassen.
-- [ ] Eligibility-Receipt fuer denselben SHA erfassen und belegen: kanonischer
+- [x] Eligibility-Receipt fuer denselben SHA erfassen und belegen: kanonischer
   `.github/workflows/ci.yml`-Push-Run auf `main`, neuester Attempt und Aggregatjob
   `required` sind erfolgreich; danach ist der separate Release-Preflight gruen.
-- [ ] Alle zehn vertraglichen Release-Assets erneut herunterladen,
+- [x] Alle zehn vertraglichen Release-Assets erneut herunterladen,
   `checksums.txt` validieren und den Consumer-Verifier ausfuehren.
-- [ ] CLI-Archive in der Linux-/macOS-/Windows-Matrix starten und fuer jedes
+- [x] CLI-Archive in der Linux-/macOS-/Windows-Matrix starten und fuer jedes
   `release-info --json` mit Kanal, Build-ID und Source-SHA belegen; zusaetzlich
   den bestehenden `version --json`-Kompatibilitaetstest ausfuehren.
-- [ ] Genau das heruntergeladene Extension-ZIP entpacken, Scanner und den
+- [x] Genau das heruntergeladene Extension-ZIP entpacken, Scanner und den
   fokussierten Packed-Chromium-Release-Smoke ausfuehren, Manifest-`version`/
   `version_name` belegen und den erfolgreichen vollstaendigen Packed-Suite-Beleg
   des exakt gleichen Source-SHA aus dem kanonischen `main`-CI referenzieren.
-- [ ] GitHub API pruefen: korrekter Tag-Target-SHA, `prerelease=true`,
+- [x] GitHub API pruefen: korrekter Tag-Target-SHA, `prerelease=true`,
   `make_latest=false`, exakte Asset-Menge; Stable `/releases/latest` entspricht
   DR-00.
-- [ ] Nach aktivierter GitHub Release Immutability `gh release verify` und
+- [x] Nach aktivierter GitHub Release Immutability `gh release verify` und
   `gh release verify-asset` gegen mindestens ein lokal heruntergeladenes Asset
   ausfuehren und das Ergebnis erfassen.
-- [ ] Den korrespondierenden Tap-Run bis zum Abschluss verfolgen, Formel-Commit
+- [x] Den korrespondierenden Tap-Run bis zum Abschluss verfolgen, Formel-Commit
   erfassen und `atlcli-dev` auf macOS und Linux installieren/testen.
-- [ ] Formelkonflikt und Rueckwechsel zu Stable testen; Stable-Formel-Diff muss
-  leer sein.
-- [ ] Denselben SHA erneut normal manuell starten und einen belegten No-op ohne
+- [x] Formelkonflikt und Rueckwechsel zu Stable testen; die stabile Formelversion,
+  Plattform-URLs, Digests und ihr Test bleiben unveraendert. Der separat
+  reviewte einmalige Bootstrap ergaenzte nur die reziproke Konfliktdeklaration.
+- [x] Denselben SHA erneut normal manuell starten und einen belegten No-op ohne
   neuen Release oder Formel-Commit erwarten.
-- [ ] Denselben SHA mit `force_rebuild=true` starten; neuer immutable Tag,
+- [x] Denselben SHA mit `force_rebuild=true` starten; neuer immutable Tag,
   vollstaendige Assets und kontrolliertes Formelupdate muessen entstehen.
-- [ ] Rollback-Drill mit einem frueheren weiterhin erreichbaren `main`-SHA als
+- [x] Rollback-Drill mit einem frueheren weiterhin erreichbaren `main`-SHA als
   neuem hoeheren Build ausfuehren; Installation funktioniert, alte Releases
   bleiben erhalten.
 - [ ] Nightly-Schedule danach aktiviert/bestaetigt lassen und einen geplanten
@@ -884,28 +885,30 @@ Bytes, Consumer-Proofs und Tap-Formel an denselben Source-SHA.
 ## 12. Definition of Done
 
 - [ ] Alle Tasks DR-00 bis DR-10 sind mit revisiongebundenen Receipts abgehakt.
-- [ ] Ein realer manueller GitHub-Dev-Prerelease enthaelt alle fuenf CLI-Archive,
+- [x] Ein realer manueller GitHub-Dev-Prerelease enthaelt alle fuenf CLI-Archive,
   das gepackte MV3-ZIP, Checksummen, Metadata, Source-Eligibility und Security-/
   Provenienz-Beleg.
-- [ ] Die erneut heruntergeladenen Bytes bestehen Plattform-, Archive-, Digest-
+- [x] Die erneut heruntergeladenen Bytes bestehen Plattform-, Archive-, Digest-
   und fokussierten Packed-Chromium-Release-Smoke; die vollstaendige
   Packed-Consumer-Matrix ist fuer exakt dasselbe Source-SHA im `main`-CI gruen.
-- [ ] `atlcli-dev` referenziert genau diesen Release und ist auf macOS und Linux
+- [x] `atlcli-dev` referenziert genau diesen Release und ist auf macOS und Linux
   via Homebrew installiert und getestet.
-- [ ] Stable `/releases/latest`, Stable-Updater, Stable Asset-Namen und
-  `Formula/atlcli.rb` sind unveraendert belegt.
+- [x] Stable `/releases/latest`, Stable-Updater und Stable Asset-Namen sind
+  unveraendert belegt. In `Formula/atlcli.rb` bleiben Version, URLs, Digests und
+  Test unveraendert; einzig die separat reviewte reziproke Konfliktdeklaration
+  wurde beim einmaligen Bootstrap ergaenzt.
 - [ ] Manueller No-op, Force-Rebuild, Rollback und ein geplanter Nightly-Lauf
   beziehungsweise dessen No-op sind bewiesen.
-- [ ] Jeder publizierte Source-SHA besitzt ein versioniertes Eligibility-Receipt
+- [x] Jeder publizierte Source-SHA besitzt ein versioniertes Eligibility-Receipt
   mit erfolgreichem kanonischem `main`-Push-Run und erfolgreichem aktuellem
   Release-Preflight; `force_rebuild` und Rollback umgehen keines der Gates.
-- [ ] Schedule und Manual teilen denselben SHA-gebundenen reusable Workflow.
-- [ ] Es existieren weder bewegliche Release-Tags noch ueberschriebene Assets.
+- [x] Schedule und Manual teilen denselben SHA-gebundenen reusable Workflow.
+- [x] Es existieren weder bewegliche Release-Tags noch ueberschriebene Assets.
 - [ ] `bun run test`, `bun run typecheck` und `bun run build` sind auf dem finalen
   Implementierungs-SHA gruen.
 - [ ] `specs/dev-release-channel/EVIDENCE.md` verweist auf Run-/Release-/Tap-URLs,
   Source-SHA, Digests und Consumer-Proofs, ohne Secrets oder private Daten.
-- [ ] Runbook, Retention, Ownership und Wartungsdrills sind dokumentiert.
+- [x] Runbook, Retention, Ownership und Wartungsdrills sind dokumentiert.
 
 ## 13. STOP-Bedingungen
 
@@ -968,15 +971,17 @@ Ersatzbeleg verwendet werden.
 Diese Punkte blockieren die Planung nicht, muessen aber vor externen Writes
 entschieden und im Evidence-Index festgehalten werden:
 
-- [ ] Dedizierte GitHub App fuer den Tap-Dispatch anlegen, auf den Tap begrenzen
+- [x] Dedizierte GitHub App fuer den Tap-Dispatch anlegen, auf den Tap begrenzen
   und den Owner fuer Key-Rotation festlegen; ein PAT-Fallback ist ausgeschlossen.
-- [ ] Geschuetztes Environment `dev-release` und erforderliche Reviewer fuer den
-  ersten Live-Publish festlegen.
-- [ ] Endgueltige Nightly-Uhrzeit bestaetigen; Default dieses Plans ist
+- [x] Geschuetztes Environment `dev-release` mit `main`-Branch-Policy festlegen.
+  Der erste Live-Publish wurde explizit autorisiert; ein dauerhafter
+  Required-Reviewer-Wait wird nicht verwendet, weil er den Nightly-Lauf
+  blockieren wuerde.
+- [x] Endgueltige Nightly-Uhrzeit bestaetigen; Default dieses Plans ist
   `02:17 UTC`.
-- [ ] Retention bestaetigen; Default dieses Plans ist mindestens 14 erfolgreiche
+- [x] Retention bestaetigen; Default dieses Plans ist mindestens 14 erfolgreiche
   Builds beziehungsweise 30 Tage, mit Schutz der aktuellen Formelreferenz.
-- [ ] Entscheiden, ob `publish_homebrew=true` bei jedem geplanten Lauf bleibt.
+- [x] Entscheiden, ob `publish_homebrew=true` bei jedem geplanten Lauf bleibt.
   Empfehlung: ja; ein sauberer No-op verhindert unnoetige Formel-Commits.
 
 ## 16. Primaerreferenzen

--- a/specs/dev-release-channel/evidence/DR-10-live-release-proof.json
+++ b/specs/dev-release-channel/evidence/DR-10-live-release-proof.json
@@ -1,0 +1,179 @@
+{
+  "assets": [
+    {
+      "filename": "atlcli-darwin-arm64.tar.gz",
+      "sha256": "3d9e5cea4347e23436caede7b0c5a96198fe1b3ff83f418069c86831bdde88c3",
+      "size": 46555835
+    },
+    {
+      "filename": "atlcli-darwin-x64.tar.gz",
+      "sha256": "2c7cc70aa897c1c5e823d4193eafc6f69130367d43475217c50938642f4ba994",
+      "size": 48536685
+    },
+    {
+      "filename": "atlcli-extension-chrome-mv3-dev-20260813.32.1-18184731.zip",
+      "sha256": "e251cfb492cf5526274f0eeaf25a5ef961f2780dc14861376c5842902ad27e8b",
+      "size": 21350791
+    },
+    {
+      "filename": "atlcli-linux-arm64.tar.gz",
+      "sha256": "65c11a26e13209273a3cf064e917535c89164733152ec39d480d1b01da9abec9",
+      "size": 57628133
+    },
+    {
+      "filename": "atlcli-linux-x64.tar.gz",
+      "sha256": "3dd7aea094103dc35e2a7756449e4543275ac412ec06ed67ec98db1235a207b5",
+      "size": 57935546
+    },
+    {
+      "filename": "atlcli-windows-x64.zip",
+      "sha256": "282df158e7fe42c6322130fc8f062d32571e9cf133faf044e4bb5b476425f419",
+      "size": 60343287
+    },
+    {
+      "filename": "build-metadata.json",
+      "sha256": "94c2fe674a57b2177ffc43ac355748b3d48ba06c4f77fef5ef5652cd075776de",
+      "size": 2409
+    },
+    {
+      "filename": "checksums.txt",
+      "sha256": "0e12dbf928ad572ee27a099fb2a5500af62e98699c4746422de87d93ee6504a9",
+      "size": 762
+    },
+    {
+      "filename": "security-attestation.json",
+      "sha256": "607ce9842495b942be096200a77dc99745181022f19b0a381957c752f9764e3c",
+      "size": 1273
+    },
+    {
+      "filename": "source-eligibility.json",
+      "sha256": "a05d41ddff7442f644cc9f43961816d4c99164160a10a976a5da1c993f37a5b9",
+      "size": 734
+    }
+  ],
+  "extension": {
+    "archiveSha256": "e251cfb492cf5526274f0eeaf25a5ef961f2780dc14861376c5842902ad27e8b",
+    "inventorySha256": "9242912128d6c502575aa6e8df907a0188433ed83ce87d9e5b421b136493ea3e",
+    "manifestVersion": "0.17.2.32",
+    "packedChromiumSuites": {
+      "jobs": "success",
+      "palette": "success",
+      "research": "success",
+      "rovo": "success",
+      "worker": "success"
+    }
+  },
+  "homebrew": {
+    "formulaSha256": "3e6fcb32ce3f5dd03e1868daba8b933edca256faf0a703a4ca5d5e50b811320d",
+    "installedReleaseInfo": {
+      "buildId": "dev-20260813.32.1-18184731",
+      "channel": "dev",
+      "homebrewVersion": "20260813124329.32.1",
+      "releaseTag": "dev-20260813.32.1-18184731",
+      "schema": "atlcli.release-info/v1",
+      "sourceSha": "18184731cf128bf06ccc8a3c287a6b026f41b658",
+      "version": "0.17.2-dev.20260813.32.1+18184731"
+    },
+    "nativeMatrix": {
+      "darwin-arm64": {
+        "hostCpu": "arm64",
+        "result": "success",
+        "rubyPlatform": "arm64-darwin24"
+      },
+      "darwin-x64": {
+        "hostCpu": "x86_64",
+        "result": "success",
+        "rubyPlatform": "x86_64-darwin23"
+      },
+      "linux-arm64": {
+        "hostCpu": "aarch64",
+        "result": "success",
+        "rubyPlatform": "aarch64-linux-gnu"
+      },
+      "linux-x64": {
+        "hostCpu": "x86_64",
+        "result": "success",
+        "rubyPlatform": "x86_64-linux-gnu"
+      }
+    },
+    "pointerSha256": "745c77fb3e70b6ebade50dd0b9694bb9fba3a6bc6f5ec333fc34d5e2015b8fe2",
+    "releaseTag": "dev-20260813.32.1-18184731",
+    "tapCommit": "050ac914d6db5d0e4fb0f3b448bc2199bfe57bc7",
+    "tapCommitUrl": "https://github.com/BjoernSchotte/homebrew-tap/commit/050ac914d6db5d0e4fb0f3b448bc2199bfe57bc7"
+  },
+  "privacy": {
+    "containsAbsoluteHomePaths": false,
+    "containsRawLogs": false,
+    "containsSecrets": false,
+    "containsTenantData": false
+  },
+  "recordedAt": "2026-08-13T12:58:39.428Z",
+  "release": {
+    "attestation": {
+      "assetCount": 10,
+      "buildMetadataSha256": "94c2fe674a57b2177ffc43ac355748b3d48ba06c4f77fef5ef5652cd075776de",
+      "predicateType": "https://in-toto.io/attestation/release/v0.2",
+      "signer": "https://dotcom.releases.github.com",
+      "verifiedAt": "2026-08-13T12:48:43Z"
+    },
+    "buildId": "dev-20260813.32.1-18184731",
+    "draft": false,
+    "immutable": true,
+    "prerelease": true,
+    "stableLatestUnchanged": true,
+    "tag": "dev-20260813.32.1-18184731",
+    "url": "https://github.com/BjoernSchotte/atlcli/releases/tag/dev-20260813.32.1-18184731"
+  },
+  "schema": "atlcli.dev-release-live-proof/v1",
+  "source": {
+    "advisoryPolicyVersion": "atlcli.dev-release-eligibility/v1",
+    "canonicalMainPushAttempt": 1,
+    "canonicalMainPushRunId": 31700826175,
+    "decision": "eligible",
+    "requiredAggregate": "success",
+    "requiredPolicyVersion": "atlcli.dev-release-eligibility/v1",
+    "sha": "18184731cf128bf06ccc8a3c287a6b026f41b658"
+  },
+  "tests": {
+    "exactDownloadedAssetVerifier": "success",
+    "githubBuildMetadataAssetAttestation": "success",
+    "githubReleaseAttestation": "success",
+    "homebrewAuditInstallTestSwitchMatrix": "success",
+    "nativeCliMatrix": "success",
+    "packedChromium": "success",
+    "stableLatestIsolation": "success"
+  },
+  "toolchain": {
+    "bun": "1.3.14",
+    "lockfileSha256": "500af2791c63aa4a80934cc03491f47b3536164b484d92090db757cd89624f6d",
+    "runnerImages": {
+      "darwin-arm64": {
+        "arch": "arm64",
+        "platform": "darwin"
+      },
+      "darwin-x64": {
+        "arch": "x64",
+        "platform": "darwin"
+      },
+      "linux-arm64": {
+        "arch": "arm64",
+        "platform": "linux"
+      },
+      "linux-x64": {
+        "arch": "x64",
+        "platform": "linux"
+      },
+      "windows-x64": {
+        "arch": "x64",
+        "platform": "win32"
+      }
+    },
+    "wxt": "0.20.27"
+  },
+  "workflow": {
+    "attempt": 1,
+    "event": "workflow_dispatch",
+    "runId": 31701377742,
+    "url": "https://github.com/BjoernSchotte/atlcli/actions/runs/31701377742"
+  }
+}

--- a/specs/dev-release-channel/evidence/DR-10-operations-proof.json
+++ b/specs/dev-release-channel/evidence/DR-10-operations-proof.json
@@ -1,8 +1,8 @@
 {
   "schema": "atlcli.dev-release-task-proof/v1",
   "task": "DR-10",
-  "recordedAt": "2026-08-13T13:06:00Z",
-  "proofedImplementationSha": "18184731cf128bf06ccc8a3c287a6b026f41b658",
+  "recordedAt": "2026-08-14T07:58:00Z",
+  "proofedImplementationSha": "e439c62f318bee363045ef8beab62800704213f0",
   "authoritativePublishedArtifact": true,
   "proof": {
     "manualDefaultSourceNoop": {
@@ -56,17 +56,32 @@
       "result": "success"
     },
     "finalCurrentMainRelease": {
-      "runId": 31701377742,
+      "runId": 31764529357,
       "attempt": 1,
-      "url": "https://github.com/BjoernSchotte/atlcli/actions/runs/31701377742",
-      "canonicalMainCiRunId": 31700826175,
-      "sourceSha": "18184731cf128bf06ccc8a3c287a6b026f41b658",
-      "tag": "dev-20260813.32.1-18184731",
-      "releaseUrl": "https://github.com/BjoernSchotte/atlcli/releases/tag/dev-20260813.32.1-18184731",
+      "event": "schedule",
+      "url": "https://github.com/BjoernSchotte/atlcli/actions/runs/31764529357",
+      "canonicalMainCiRunId": 31755459683,
+      "sourceSha": "e439c62f318bee363045ef8beab62800704213f0",
+      "tag": "dev-20260814.34.1-e439c62f",
+      "releaseUrl": "https://github.com/BjoernSchotte/atlcli/releases/tag/dev-20260814.34.1-e439c62f",
       "immutable": true,
       "assetCount": 10,
-      "tapRunId": 31701894788,
-      "tapCommit": "050ac914d6db5d0e4fb0f3b448bc2199bfe57bc7",
+      "tapRunId": 31764886975,
+      "tapCommit": "b94a1934bee2e02a3e6cfc017eac0ffd8b10871b",
+      "result": "success"
+    },
+    "scheduledNoop": {
+      "runId": 31769502152,
+      "attempt": 1,
+      "event": "schedule",
+      "url": "https://github.com/BjoernSchotte/atlcli/actions/runs/31769502152",
+      "sourceSha": "e439c62f318bee363045ef8beab62800704213f0",
+      "forceRebuild": false,
+      "decision": "noop",
+      "reason": "source-already-proven",
+      "selectedTag": "dev-20260814.34.1-e439c62f",
+      "newReleaseCreated": false,
+      "newFormulaCommitCreated": false,
       "result": "success"
     },
     "retentionDryRun": {
@@ -99,7 +114,7 @@
       "scheduleEnabledVariable": true,
       "scheduledHomebrewDefault": true
     },
-    "remainingGate": "one actual schedule-event run and its immutable no-op receipt"
+    "remainingGate": null
   },
   "privacy": {
     "containsSecrets": false,

--- a/specs/dev-release-channel/evidence/DR-10-operations-proof.json
+++ b/specs/dev-release-channel/evidence/DR-10-operations-proof.json
@@ -1,0 +1,111 @@
+{
+  "schema": "atlcli.dev-release-task-proof/v1",
+  "task": "DR-10",
+  "recordedAt": "2026-08-13T13:06:00Z",
+  "proofedImplementationSha": "18184731cf128bf06ccc8a3c287a6b026f41b658",
+  "authoritativePublishedArtifact": true,
+  "proof": {
+    "manualDefaultSourceNoop": {
+      "runId": 31702937306,
+      "attempt": 1,
+      "event": "workflow_dispatch",
+      "url": "https://github.com/BjoernSchotte/atlcli/actions/runs/31702937306",
+      "sourceSha": "18184731cf128bf06ccc8a3c287a6b026f41b658",
+      "sourceInputOmitted": true,
+      "publishHomebrew": true,
+      "forceRebuild": false,
+      "decision": "noop",
+      "reason": "source-already-proven",
+      "selectedTag": "dev-20260813.32.1-18184731",
+      "newReleaseCreated": false,
+      "newFormulaCommitCreated": false,
+      "result": "success"
+    },
+    "forceRebuild": {
+      "runId": 31695097444,
+      "attempt": 1,
+      "url": "https://github.com/BjoernSchotte/atlcli/actions/runs/31695097444",
+      "sourceSha": "8bea69a68358621bb0503d7032289f4b4e23554e",
+      "tag": "dev-20260813.28.1-8bea69a6",
+      "releaseUrl": "https://github.com/BjoernSchotte/atlcli/releases/tag/dev-20260813.28.1-8bea69a6",
+      "immutable": true,
+      "tapRunId": 31695594875,
+      "result": "success"
+    },
+    "forwardRollback": {
+      "runId": 31698862277,
+      "attempt": 1,
+      "url": "https://github.com/BjoernSchotte/atlcli/actions/runs/31698862277",
+      "sourceSha": "f341b388a5b8226e748c17a303dd47e20dd65964",
+      "rollbackFromTag": "dev-20260813.29.1-f341b388",
+      "tag": "dev-20260813.30.1-f341b388",
+      "releaseUrl": "https://github.com/BjoernSchotte/atlcli/releases/tag/dev-20260813.30.1-f341b388",
+      "immutable": true,
+      "tapRunId": 31699382178,
+      "result": "success"
+    },
+    "rollbackRecovery": {
+      "runId": 31699629592,
+      "attempt": 2,
+      "url": "https://github.com/BjoernSchotte/atlcli/actions/runs/31699629592",
+      "sourceSha": "4b05fe4787997c50e8e1a4307fa928d360d8612b",
+      "tag": "dev-20260813.31.1-4b05fe47",
+      "releaseUrl": "https://github.com/BjoernSchotte/atlcli/releases/tag/dev-20260813.31.1-4b05fe47",
+      "immutable": true,
+      "tapRunId": 31700274580,
+      "result": "success"
+    },
+    "finalCurrentMainRelease": {
+      "runId": 31701377742,
+      "attempt": 1,
+      "url": "https://github.com/BjoernSchotte/atlcli/actions/runs/31701377742",
+      "canonicalMainCiRunId": 31700826175,
+      "sourceSha": "18184731cf128bf06ccc8a3c287a6b026f41b658",
+      "tag": "dev-20260813.32.1-18184731",
+      "releaseUrl": "https://github.com/BjoernSchotte/atlcli/releases/tag/dev-20260813.32.1-18184731",
+      "immutable": true,
+      "assetCount": 10,
+      "tapRunId": 31701894788,
+      "tapCommit": "050ac914d6db5d0e4fb0f3b448bc2199bfe57bc7",
+      "result": "success"
+    },
+    "retentionDryRun": {
+      "runId": 31696928799,
+      "attempt": 1,
+      "url": "https://github.com/BjoernSchotte/atlcli/actions/runs/31696928799",
+      "retainSuccessful": 14,
+      "retainDays": 30,
+      "protectedStableLatest": "v0.17.2",
+      "protectedHomebrewReference": true,
+      "deleteCount": 0,
+      "externalMutation": false,
+      "result": "success"
+    },
+    "pinnedFontCache": {
+      "releaseRunId": 31701377742,
+      "runner": "linux-x64",
+      "cacheHit": true,
+      "verifiedCachedFiles": 13,
+      "upstreamDownloadPerformed": false,
+      "manifestBoundCacheKey": true,
+      "sha256VerificationRetained": true
+    },
+    "operatorConfiguration": {
+      "crossRepositoryAuth": "tap-scoped GitHub App installation token",
+      "environment": "dev-release",
+      "environmentBranchPolicy": "main only",
+      "firstLivePublicationExplicitlyAuthorized": true,
+      "scheduleCronUtc": "17 2 * * *",
+      "scheduleEnabledVariable": true,
+      "scheduledHomebrewDefault": true
+    },
+    "remainingGate": "one actual schedule-event run and its immutable no-op receipt"
+  },
+  "privacy": {
+    "containsSecrets": false,
+    "containsTenantData": false,
+    "containsAbsoluteLocalPaths": false,
+    "containsRawProviderLogs": false,
+    "containsOnlyPublicGitHubIdentifiersUrlsAndArtifactDigests": true
+  }
+}

--- a/specs/dev-release-channel/evidence/DR-10-scheduled-live-release-proof.json
+++ b/specs/dev-release-channel/evidence/DR-10-scheduled-live-release-proof.json
@@ -1,0 +1,179 @@
+{
+  "assets": [
+    {
+      "filename": "atlcli-darwin-arm64.tar.gz",
+      "sha256": "e8a8f5eb2c3d1ed334bdd91a988c8e1ec6df10d5cf3ed2524f81d6b7988b39af",
+      "size": 46555837
+    },
+    {
+      "filename": "atlcli-darwin-x64.tar.gz",
+      "sha256": "1554b437306b4297e82c1464507ddb21e70d57a17b7cf68392fe620ebb6e3750",
+      "size": 48536697
+    },
+    {
+      "filename": "atlcli-extension-chrome-mv3-dev-20260814.34.1-e439c62f.zip",
+      "sha256": "82612766a0823e4ebb2752b60604ccb9f7782244b9864c0f53aa791ba3a8afb9",
+      "size": 21350790
+    },
+    {
+      "filename": "atlcli-linux-arm64.tar.gz",
+      "sha256": "14eb07a7f1a13f5ccb6858f284ae278b7d78dc968030815b95f14ebae423ae52",
+      "size": 57628141
+    },
+    {
+      "filename": "atlcli-linux-x64.tar.gz",
+      "sha256": "9775bca477c12edfb90ea8a7c08246c428b7985142da71e793116cf00a0103df",
+      "size": 57935564
+    },
+    {
+      "filename": "atlcli-windows-x64.zip",
+      "sha256": "7c87d8a9dce48c397dccfcca20df9f8a25b635f237b72b3c5ac924ddcf0603ef",
+      "size": 60343333
+    },
+    {
+      "filename": "build-metadata.json",
+      "sha256": "9d1c0db0b7e86edcc99074b6f08247785799b15a6d4cc1272d3827d9387586c4",
+      "size": 2400
+    },
+    {
+      "filename": "checksums.txt",
+      "sha256": "17a4a261a2dec6211c4f9d1fa927cae9fd9b5f08414ac99bfede45fae1e7a007",
+      "size": 762
+    },
+    {
+      "filename": "security-attestation.json",
+      "sha256": "6c2c360779a98b14801c4bfab7f57a8ac2c5317047d2f3273098e7b9bc759ec1",
+      "size": 1273
+    },
+    {
+      "filename": "source-eligibility.json",
+      "sha256": "7857db5525f0a811ce0d385835e56d02fa18da28e662afe087540407a3742bfd",
+      "size": 734
+    }
+  ],
+  "extension": {
+    "archiveSha256": "82612766a0823e4ebb2752b60604ccb9f7782244b9864c0f53aa791ba3a8afb9",
+    "inventorySha256": "94d2aed6b737e3b1381edb7f0cdc2b1aca5595d7310b5cc2d115889debbfd77d",
+    "manifestVersion": "0.17.2.34",
+    "packedChromiumSuites": {
+      "jobs": "success",
+      "palette": "success",
+      "research": "success",
+      "rovo": "success",
+      "worker": "success"
+    }
+  },
+  "homebrew": {
+    "formulaSha256": "df4360ea9ea9e686e48291efb769560e0789495f28e8b21132133d884ca78b1c",
+    "installedReleaseInfo": {
+      "buildId": "dev-20260814.34.1-e439c62f",
+      "channel": "dev",
+      "homebrewVersion": "20260814024231.34.1",
+      "releaseTag": "dev-20260814.34.1-e439c62f",
+      "schema": "atlcli.release-info/v1",
+      "sourceSha": "e439c62f318bee363045ef8beab62800704213f0",
+      "version": "0.17.2-dev.20260814.34.1+e439c62f"
+    },
+    "nativeMatrix": {
+      "darwin-arm64": {
+        "hostCpu": "arm64",
+        "result": "success",
+        "rubyPlatform": "arm64-darwin24"
+      },
+      "darwin-x64": {
+        "hostCpu": "x86_64",
+        "result": "success",
+        "rubyPlatform": "x86_64-darwin23"
+      },
+      "linux-arm64": {
+        "hostCpu": "aarch64",
+        "result": "success",
+        "rubyPlatform": "aarch64-linux-gnu"
+      },
+      "linux-x64": {
+        "hostCpu": "x86_64",
+        "result": "success",
+        "rubyPlatform": "x86_64-linux-gnu"
+      }
+    },
+    "pointerSha256": "15796caf9a598c5678c8dd1cb47138f6d77d3f0b0d9e937bd993150f141e1ca1",
+    "releaseTag": "dev-20260814.34.1-e439c62f",
+    "tapCommit": "b94a1934bee2e02a3e6cfc017eac0ffd8b10871b",
+    "tapCommitUrl": "https://github.com/BjoernSchotte/homebrew-tap/commit/b94a1934bee2e02a3e6cfc017eac0ffd8b10871b"
+  },
+  "privacy": {
+    "containsAbsoluteHomePaths": false,
+    "containsRawLogs": false,
+    "containsSecrets": false,
+    "containsTenantData": false
+  },
+  "recordedAt": "2026-08-14T07:56:41.890Z",
+  "release": {
+    "attestation": {
+      "assetCount": 10,
+      "buildMetadataSha256": "9d1c0db0b7e86edcc99074b6f08247785799b15a6d4cc1272d3827d9387586c4",
+      "predicateType": "https://in-toto.io/attestation/release/v0.2",
+      "signer": "https://dotcom.releases.github.com",
+      "verifiedAt": "2026-08-14T02:47:58Z"
+    },
+    "buildId": "dev-20260814.34.1-e439c62f",
+    "draft": false,
+    "immutable": true,
+    "prerelease": true,
+    "stableLatestUnchanged": true,
+    "tag": "dev-20260814.34.1-e439c62f",
+    "url": "https://github.com/BjoernSchotte/atlcli/releases/tag/dev-20260814.34.1-e439c62f"
+  },
+  "schema": "atlcli.dev-release-live-proof/v1",
+  "source": {
+    "advisoryPolicyVersion": "atlcli.dev-release-eligibility/v1",
+    "canonicalMainPushAttempt": 1,
+    "canonicalMainPushRunId": 31755459683,
+    "decision": "eligible",
+    "requiredAggregate": "success",
+    "requiredPolicyVersion": "atlcli.dev-release-eligibility/v1",
+    "sha": "e439c62f318bee363045ef8beab62800704213f0"
+  },
+  "tests": {
+    "exactDownloadedAssetVerifier": "success",
+    "githubBuildMetadataAssetAttestation": "success",
+    "githubReleaseAttestation": "success",
+    "homebrewAuditInstallTestSwitchMatrix": "success",
+    "nativeCliMatrix": "success",
+    "packedChromium": "success",
+    "stableLatestIsolation": "success"
+  },
+  "toolchain": {
+    "bun": "1.3.14",
+    "lockfileSha256": "500af2791c63aa4a80934cc03491f47b3536164b484d92090db757cd89624f6d",
+    "runnerImages": {
+      "darwin-arm64": {
+        "arch": "arm64",
+        "platform": "darwin"
+      },
+      "darwin-x64": {
+        "arch": "x64",
+        "platform": "darwin"
+      },
+      "linux-arm64": {
+        "arch": "arm64",
+        "platform": "linux"
+      },
+      "linux-x64": {
+        "arch": "x64",
+        "platform": "linux"
+      },
+      "windows-x64": {
+        "arch": "x64",
+        "platform": "win32"
+      }
+    },
+    "wxt": "0.20.27"
+  },
+  "workflow": {
+    "attempt": 1,
+    "event": "schedule",
+    "runId": 31764529357,
+    "url": "https://github.com/BjoernSchotte/atlcli/actions/runs/31764529357"
+  }
+}


### PR DESCRIPTION
## What changed

- records the real scheduled dev release and its later idempotent schedule no-op
- removes the temporary one-shot acceptance cron and keeps the nightly schedule
- fixes live-proof generation so the verifier-owned extraction marker is not treated as a release asset
- closes DR-10 and the Dev Release Channel definition of done with revision-bound evidence

## Proven outcome

- scheduled dev-release run 31764529357 published immutable prerelease dev-20260814.34.1-e439c62f
- ten assets include all five CLI targets, packaged Chrome MV3 extension, checksums, metadata, eligibility and security attestation
- Homebrew tap run 31764886975 passed all four native install/test lanes
- scheduled run 31769502152 reused the proven release through the explicit no-op path
- stable latest remains v0.17.2

## Validation

- bun run test: 8116 passed, 16 skipped, 0 failed
- bun run typecheck
- bun run build
- 47 focused release/evidence policy tests
- dev-release evidence policy
